### PR TITLE
Add coming tags for incomplete topics

### DIFF
--- a/docs/en/observability/observability-introduction.asciidoc
+++ b/docs/en/observability/observability-introduction.asciidoc
@@ -2,21 +2,32 @@
 [role="xpack"]
 == What is Elastic Observability? 
 
+coming[a future update]
 //TODO: Add content
 
 
 [[observability-get-started]]
 == Get started with the {stack}
 
+coming[a future update]
+
 To get started...
 
 === Hosted Elasticsearch Service
 
+coming[a future update]
+
 === Install the {stack} yourself
+
+coming[a future update]
 
 === Run the {stack} on Docker
 
+coming[a future update]
+
 === Run the {stack} on Kubernetes
+
+coming[a future update]
 
 [float]
 ==== Step 1: Install {es}
@@ -27,10 +38,20 @@ To get started...
 [[observability-add-data]]
 == Add observability data 
 
+coming[a future update]
+
 === Instrument applications
+
+coming[a future update]
 
 === Ingest logs
 
+coming[a future update]
+
 === Ingest metrics
 
+coming[a future update]
+
 === Ingest uptime data
+
+coming[a future update]

--- a/docs/en/observability/observability-ui.asciidoc
+++ b/docs/en/observability/observability-ui.asciidoc
@@ -3,6 +3,8 @@
 
 == Monitor observable environments
 
+coming[a future update]
+
 Displayed on the Observability *Overview* page are a wide variety of chart
 visualizations that provide you with analytical information on what is
 happening within your environments.
@@ -12,11 +14,20 @@ observable; APM, logs, metrics, and uptime.
 
 === Services, transactions, and error rates
 
+coming[a future update]
+
 === Log rates
+
+coming[a future update]
 
 === System metrics
 
+coming[a future update]
+
 === Systems availability 
+
+coming[a future update]
 
 === Alerts 
 
+coming[a future update]


### PR DESCRIPTION
We need to mark these topics as "coming" because they are shown under the current tag.

Note that the tag renders as:
![image](https://user-images.githubusercontent.com/14206422/86284276-68be9e00-bb97-11ea-81a6-c3f2de85bc4d.png)
