### PR TITLE
Change links to refactored Beats getting started docs

### DIFF
--- a/docs/en/ingest-management/troubleshooting.asciidoc
+++ b/docs/en/ingest-management/troubleshooting.asciidoc
@@ -244,7 +244,7 @@ from sending the data.
 Although it's redundant to install stand-alone {metricbeat}, you might want to
 try installing it to see if it's able to send data successfully to {es}. For
 more information, see
-{metricbeat-ref}/metricbeat-getting-started.html[Get started with {metricbeat}].
+{metricbeat-ref}/metricbeat-installation-configuration.html[{metricbeat} quick start].
 
 If {metricbeat} is able to send data to {es}, there is possibly a bug or
 problem with {agent}, and you should report it.

--- a/docs/en/logs/logs-installation.asciidoc
+++ b/docs/en/logs/logs-installation.asciidoc
@@ -70,7 +70,7 @@ image::images/add-data.png[Add log data]
 ==== Install {filebeat} yourself
 
 If you want to install {filebeat} the old fashioned way, follow the instructions in {filebeat-ref}/filebeat-installation-configuration.html[{filebeat} quick start] and enable modules for the logs you want to collect.
-If there is no module for the logs you want to collect, see {filebeat-ref}/configuration-filebeat-options.html[Conifgure inputs].
+If there is no module for the logs you want to collect, see {filebeat-ref}/configuration-filebeat-options.html[Configure inputs].
 
 [float]
 === Enable {filebeat} modules

--- a/docs/en/logs/logs-installation.asciidoc
+++ b/docs/en/logs/logs-installation.asciidoc
@@ -69,8 +69,8 @@ image::images/add-data.png[Add log data]
 [float]
 ==== Install {filebeat} yourself
 
-If your data source doesn't have a {filebeat} module, or if you want to install one the old fashioned way, follow the instructions in {filebeat-ref}/filebeat-modules-quickstart.html[{filebeat} modules quick start] and enable modules for the logs you want to collect.
-If there is no module for the logs you want to collect, see the {filebeat-ref}/filebeat-getting-started.html[{filebeat} getting started] to learn how to configure inputs.
+If you want to install {filebeat} the old fashioned way, follow the instructions in {filebeat-ref}/filebeat-installation-configuration.html[{filebeat} quick start] and enable modules for the logs you want to collect.
+If there is no module for the logs you want to collect, see {filebeat-ref}/configuration-filebeat-options.html[Conifgure inputs].
 
 [float]
 === Enable {filebeat} modules

--- a/docs/en/metrics/metrics-installation.asciidoc
+++ b/docs/en/metrics/metrics-installation.asciidoc
@@ -62,7 +62,7 @@ image::images/add-data.png[Add metrics data]
 [float]
 ==== Install {metricbeat} yourself
 
-If your data source doesn't have a {metricbeat} module, or if you want to install one the old fashioned way, follow the instructions in {metricbeat-ref}/metricbeat-getting-started.html[{metricbeat} getting started] and enable modules for the metrics you want to collect.
+If your data source doesn't have a {metricbeat} module, or if you want to install one the old fashioned way, follow the instructions in {metricbeat-ref}/metricbeat-installation-configuration.html[{metricbeat} quick start] and enable modules for the metrics you want to collect.
 
 [float]
 === Enable {metricbeat} modules


### PR DESCRIPTION
Updates links to reflect changes added in elastic/beats#19302.

This change applies to 7.9 and later.

@EamonnTP Hope these changes don't conflict with the ones you're making.  My fix isn't meant to replace yours; just made minimal changes so the linking makes more sense.