### PR TITLE
docs: update preview comment

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -22,7 +22,7 @@ pipeline {
       when { changeRequest() }
       steps {
         deleteDir()
-        githubPrComment(message: "A docs preview will be available soon: </br> - [HTML diff](https://observability-docs_${CHANGE_ID}.docs-preview.app.elstc.co/diff) </br> - [Observability guide](https://observability-docs_${CHANGE_ID}.docs-preview.app.elstc.co/guide/en/observability/current/index.html)")
+        githubPrComment(message: "A docs preview will be available soon: </br> - [HTML diff](https://observability-docs_${CHANGE_ID}.docs-preview.app.elstc.co/diff) </br> - [Observability guide](https://observability-docs_${CHANGE_ID}.docs-preview.app.elstc.co/guide/en/observability/master/index.html)")
       }
     }
   }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -22,7 +22,7 @@ pipeline {
       when { changeRequest() }
       steps {
         deleteDir()
-        githubPrComment(message: "Docs preview will be available at: `https://observability-docs_${CHANGE_ID}.docs-preview.app.elstc.co/guide/en/observability/current/index.html`")
+        githubPrComment(message: "A docs preview will be available soon: </br> - [HTML diff](https://observability-docs_${CHANGE_ID}.docs-preview.app.elstc.co/diff) </br> - [Observability guide](https://observability-docs_${CHANGE_ID}.docs-preview.app.elstc.co/guide/en/observability/current/index.html)")
       }
     }
   }


### PR DESCRIPTION
This PR updates the documentation preview comment:

* Turns the preview into a link so that it's easily clickable
* Maps the preview link to `master` instead of `current`
* Adds a link to the HTML diff which is useful for debugging purposes.

**Current:**

<img width="499" alt="Screen Shot 2020-07-08 at 9 49 58 AM" src="https://user-images.githubusercontent.com/5618806/86947279-6a8ce200-c100-11ea-95f9-0521e8afd835.png">

**Proposed:**
<img width="288" alt="Screen Shot 2020-07-08 at 9 47 35 AM" src="https://user-images.githubusercontent.com/5618806/86947276-68c31e80-c100-11ea-8b6e-bd7bdd01be35.png">