### PR TITLE
[7.x] Remove standalone suffix from the documentation. (#29)

### DIFF
--- a/docs/en/ingest-management/getting-started.asciidoc
+++ b/docs/en/ingest-management/getting-started.asciidoc
@@ -219,7 +219,7 @@ To configure {agent} manually:
 Agent configurations list, click the default config.
 
 . Select the **YAML** tab to see the configuration for {agent}. Copy the
-content and put it into a file named `elastic-agent-standalone.yml` on the
+content and put it into a file named `elastic-agent.yml` on the
 system where {agent} is installed.
 +
 [role="screenshot"]
@@ -255,7 +255,7 @@ datasources:
 +
 [source,shell]
 ----
-./elastic-agent -c elastic-agent-standalone.yml run
+./elastic-agent run
 ----
 
 [float]


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Remove standalone suffix from the documentation. (#29)