### PR TITLE
[7.8] Fix errors in examples (#37)

### DIFF
--- a/docs/en/ingest-management/getting-started.asciidoc
+++ b/docs/en/ingest-management/getting-started.asciidoc
@@ -56,7 +56,7 @@ to `true`. For example, you might want to disable TLS checking if {kib} is
 behind a proxy that terminates the SSL connection.
 - Set `xpack.encryptedSavedObjects.encryptionKey` to any alphanumeric value of
 at least 32 characters. For example:
-`xpack.security.encryptionKey: "something_at_least_32_characters"`. {fleet}
+`xpack.encryptedSavedObjects.encryptionKey: "something_at_least_32_characters"`. {fleet}
 requires this setting in order to save API keys and encrypt them in {kib}.
 
 [float]

--- a/docs/en/ingest-management/troubleshooting.asciidoc
+++ b/docs/en/ingest-management/troubleshooting.asciidoc
@@ -159,7 +159,7 @@ property in the `kibana.yml` configuration file. For example:
 
 [source,yaml]
 ----
-xpack.security.encryptionKey: "something_at_least_32_characters"
+xpack.encryptedSavedObjects.encryptionKey: "something_at_least_32_characters"
 ----
 
 [float]


### PR DESCRIPTION
Backports the following commits to 7.8:
 - Fix errors in examples (#37)