### PR TITLE
Update link to Heartbeat quick start

### DIFF
--- a/docs/en/uptime/install.asciidoc
+++ b/docs/en/uptime/install.asciidoc
@@ -51,7 +51,7 @@ Uptime requires the setup of monitors in Heartbeat.
 These monitors provide the data you'll be visualizing in the {kibana-ref}/xpack-uptime.html[Uptime app].
 
 For instructions on installing and configuring Heartbeat, see the *Setup Instructions* in {kib}.
-Additional information is available in {heartbeat-ref}/heartbeat-configuration.html[Configure Heartbeat].
+Additional information is available in {heartbeat-ref}/heartbeat-installation-configuration.html[{heartbeat} quick start].
 
 [role="screenshot"]
 image::images/uptime-setup.png[Installation instructions on the Uptime page in Kibana]


### PR DESCRIPTION
Starting in 7.9, the Beats getting started guides are refactored and reduced to a single page. 

Follow-up to elastic/beats#19302.