### PR TITLE
[WIP] Add platform tabs to ingest management docs

### DIFF
--- a/docs/en/ingest-management/getting-started.asciidoc
+++ b/docs/en/ingest-management/getting-started.asciidoc
@@ -89,8 +89,6 @@ for {ingest-manager}, {ingest-management} is successfully enabled.
 [role="screenshot"]
 image::images/kibana-ingest-manager-start.png[{ingest-manager} app in {kib}]
 
-//TODO: Add tabbed panel when the code is stable.
-
 [float]
 [[install-integration]]
 == Step 2: Install an integration and create a data source
@@ -178,22 +176,17 @@ image::images/kibana-ingest-manager-fleet-enrol.png[{ingest-manager} app showing
 
 . In the directory where you installed {agent}, paste the command to enroll the
 Agent. Note that this command will overwrite the `elastic-agent.yml` file in
-that directory.
+that directory. 
 +
-["source","sh",subs="attributes"]
-----
-./elastic-agent enroll KIBANA_URL ENROLLMENT_KEY
-
-The {agent} is currently in Experimental and should not be used in production
-This will replace your current settings. Do you want to continue? [Y/n]:
-----
+--
+include::{beats-repo-dir}/x-pack/elastic-agent/docs/tab-widgets/enroll-linux-mac-win-widget.asciidoc[]
+--
 
 . Run the Agent:
 +
-[source,shell]
-----
-./elastic-agent run
-----
+--
+include::{beats-repo-dir}/x-pack/elastic-agent/docs/tab-widgets/run-linux-mac-win-widget.asciidoc[]
+--
 
 . In the {ingest-manager} app, click **Continue** to go to the **{fleet}**
 tab, where you should see the newly enrolled Agent.
@@ -253,10 +246,9 @@ datasources:
 
 . Run {agent}:
 +
-[source,shell]
-----
-./elastic-agent run
-----
+--
+include::{beats-repo-dir}/x-pack/elastic-agent/docs/tab-widgets/run-standalone-linux-mac-win-widget.asciidoc[]
+--
 
 [float]
 [[view-data]]
@@ -268,6 +260,9 @@ dashboards corresponding to the data type that is sent.
 
 [role="screenshot"]
 image::images/kibana-ingest-manager-datastreams.png[{ingest-manager} app showing data streams list]
+
+// Add Javascript and CSS for tabbed panels
+include::{libbeat-dir}/tab-widgets/code.asciidoc[]
 
 //Adding this section for future use. Might be premature to add this for the
 //experimental release.

--- a/docs/en/ingest-management/index.asciidoc
+++ b/docs/en/ingest-management/index.asciidoc
@@ -1,12 +1,16 @@
 :doctype: book
 :beats-repo-dir: {beats-root}
 :im-forum: https://discuss.elastic.co/tags/c/elastic-stack/81/stack-ingest-management
+:libbeat-dir: {beats-repo-dir}/libbeat/docs
 
 = Ingest Management Guide
 
 include::{docs-root}/shared/versions/stack/{source_branch}.asciidoc[]
 
 include::{docs-root}/shared/attributes.asciidoc[]
+
+//TODO: Remove override before merging PR
+:release-state: released
 
 include::ingest-management-overview.asciidoc[leveloffset=+1]
 

--- a/docs/en/ingest-management/tab-widgets/enable-ingest-manager-widget.asciidoc
+++ b/docs/en/ingest-management/tab-widgets/enable-ingest-manager-widget.asciidoc
@@ -1,0 +1,40 @@
+++++
+<div class="tabs" data-tab-group="host">
+  <div role="tablist" aria-label="Spin up">
+    <button role="tab"
+            aria-selected="true"
+            aria-controls="cloud-tab-spinup"
+            id="cloud-spinup">
+      Elasticsearch Service
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="self-managed-tab-spinup"
+            id="self-managed-spinup"
+            tabindex="-1">
+      Self-managed
+    </button>
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="cloud-tab-spinup"
+       aria-labelledby="cloud-spinup">
+++++
+
+include::enable-ingest-manager.asciidoc[tag=cloud]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="self-managed-tab-spinup"
+       aria-labelledby="self-managed-spinup"
+       hidden="">
+++++
+
+include::enable-ingest-manager.asciidoc[tag=self-managed]
+
+++++
+  </div>
+</div>
+++++

--- a/docs/en/ingest-management/tab-widgets/enable-ingest-manager.asciidoc
+++ b/docs/en/ingest-management/tab-widgets/enable-ingest-manager.asciidoc
@@ -1,0 +1,59 @@
+// tag::cloud[]
+To enable {ingest-manager} on {ecloud}:
+
+. Go to your deployment in the user console.
+
+. Under the deployment name in the side navigation, click **Edit**.
+
+. In the {kib} section, expand **User setting overrides** and enter the
+following setting:
++
+[source,yaml]
+----
+xpack.ingestManager.enabled: true
+----
+
+. Click **Save**.
+
+{kib} will restart automatically. When {kib} is available, refresh the browser
+to see the {ingest-manager} app in the navigation menu.
+// end::cloud[]
+
+// tag::self-managed[]
+To enable {ingest-manager} on a self-managed cluster:
+
+. In the {es} configuration file, `config/elasticsearch.yml`, set the following
+security settings to enable security and API keys:
++
+[source,yaml]
+----
+xpack.security.enabled: true
+xpack.security.authc.api_key.enabled: true
+----
+
+. In the {kib} configuration file, `config/kibana.yml`, enable {ingest-manager}
+and specify user credentials:
++
+[source,yaml]
+----
+xpack.ingestManager.enabled: true
+xpack.ingestManager.fleet.tlsCheckDisabled: true <1>
+xpack.security.enabled: true
+elasticsearch.username: "elastic" <2>
+elasticsearch.password: "abc123iUnbRftkABC123"
+----
+<1> This setting is not required if you configure TLS checking.
+<2> Specify a user who is authorized to use {ingest-manager}.
+
+[TIP]
+=====
+To set up passwords, you can use the documented {es} APIs or the
+`elasticsearch-setup-passwords` command. For example:
+
+`./bin/elasticsearch-setup-passwords auto`
+
+After running the command, copy the Elastic user name to the {kib} config file.
+Then restart {kib}.
+=====
+
+// end::self-managed[]

--- a/docs/en/ingest-management/troubleshooting.asciidoc
+++ b/docs/en/ingest-management/troubleshooting.asciidoc
@@ -43,63 +43,7 @@ Contact us in the {im-forum}[discuss forum]. Your feedback is very valuable to u
 In 7.8, the {ingest-manager} app is experimental. You must enable the app to
 see it in {kib}.
 
-//TODO: Add platform tabs when the tabbed panel widget is stable (possibly after
-// 7.8)
-
-**To enable {ingest-manager} on {ecloud}:**
-
-. Go to your deployment in the user console.
-
-. Under the deployment name in the side navigation, click **Edit**.
-
-. In the {kib} section, expand **User setting overrides** and enter the
-following setting:
-+
-[source,yaml]
-----
-xpack.ingestManager.enabled: true
-----
-
-. Click **Save**.
-
-{kib} will restart automatically. When {kib} is available, refresh the browser
-to see the {ingest-manager} app in the navigation menu.
-
-**To enable {ingest-manager} on a self-managed cluster:**
-
-. In the {es} configuration file, `config/elasticsearch.yml`, set the following
-security settings to enable security and API keys:
-+
-[source,yaml]
-----
-xpack.security.enabled: true
-xpack.security.authc.api_key.enabled: true
-----
-
-. In the {kib} configuration file, `config/kibana.yml`, enable {ingest-manager}
-and specify user credentials:
-+
-[source,yaml]
-----
-xpack.ingestManager.enabled: true
-xpack.ingestManager.fleet.tlsCheckDisabled: true <1>
-xpack.security.enabled: true
-elasticsearch.username: "elastic" <2>
-elasticsearch.password: "abc123iUnbRftkABC123"
-----
-<1> This setting is not required if you configure TLS checking.
-<2> Specify a user who is authorized to use {ingest-manager}.
-
-[TIP]
-=====
-To set up passwords, you can use the documented {es} APIs or the
-`elasticsearch-setup-passwords` command. For example:
-
-`./bin/elasticsearch-setup-passwords auto`
-=====
-
-After running the command, copy the Elastic user name to the {kib} config file.
-Then restart {kib}.
+include::tab-widgets/enable-ingest-manager-widget.asciidoc[]
 
 [float]
 [[ingest-management-setup-fails]]
@@ -169,22 +113,9 @@ xpack.encryptedSavedObjects.encryptionKey: "something_at_least_32_characters"
 If {agent} was successfully enrolled, but doesn't show up in the {fleet} list,
 it might not be started. You need to start the Agent.
 
-// TODO: This should be single sourced. Update it when we add the tabbed widget
-// (probably after 7.8).
+To start the Agent, run:
 
-On linux and macOS hosts, run:
-
-[source,shell]
-----
-./elastic-agent run
-----
-
-On Windows hosts, run:
-
-[source,shell]
-----
-elastic-agent.exe run
-----
+include::{beats-repo-dir}/x-pack/elastic-agent/docs/tab-widgets/run-linux-mac-win-widget.asciidoc[]
 
 [float]
 [[where-are-the-agent-logs]]
@@ -304,3 +235,6 @@ integration that will allow the Elastic Security app to have a dedicated
 executable running like {beats} to protect the host and respond to detected
 security concerns. Endpoint will be managed by {agent} in the same way that
 {beats} are managed.
+
+// Add Javascript and CSS for tabbed panels
+include::{libbeat-dir}/tab-widgets/code.asciidoc[]


### PR DESCRIPTION
Replaces https://github.com/elastic/stack-docs/pull/1217

Adds tabbed panels for displaying platform-specific commands and info.

This must be merged at the same time as https://github.com/elastic/beats/pull/19382.

