### PR TITLE
Move content about how to stop Elastic Agent

### DIFF
--- a/docs/en/ingest-management/troubleshooting.asciidoc
+++ b/docs/en/ingest-management/troubleshooting.asciidoc
@@ -32,7 +32,6 @@ Contact us in the {im-forum}[discuss forum]. Your feedback is very valuable to u
 * <<what-is-my-agent-config>>
 * <<where-is-the-data-agent-is-sending>>
 * <<i-deleted-my-agent>>
-* <<i-need-to-stop-agent>>
 * <<i-rebooted-my-host>>
 * <<what-is-the-endpoint-package>>
 
@@ -254,30 +253,8 @@ problem with {agent}, and you should report it.
 == How do I restore an {agent} that I deleted from {fleet}?
 
 It's ok, we've got your back! The data is still in {es}. To add {agent}
-to {fleet} again, stop the Agent, re-enroll the {agent} on the host, then run
-{agent}.
-
-[discrete]
-[[i-need-to-stop-agent]]
-== How do I stop {agent} and all processes running on my host?
-
-To stop {agent} and its related executables, stop the {agent} process.
-
-On Windows, if you installed the Agent as a service, stop the service. If
-necessary, use Task Manager on Windows to stop {agent}. This will kill the
-{agent} process and any sub-processes it created (such as {beats}).
-
-On Linux or macOS, run the following command to get the ID of the
-`elastic-agent` process:
-
-[source,shell]
-----
-ps | grep elastic-agent
-----
-
-Then kill the process.
-
-
+to {fleet} again, <<stop-elastic-agent>>, re-enroll it on the host, then
+run {agent}.
 
 [discrete]
 [[i-rebooted-my-host]]


### PR DESCRIPTION
Moves content about stopping Elastic Agent to a more prominent location that's easier to discover through a search.

Requires https://github.com/elastic/beats/pull/19971.

(Build won't pass until after 19971 is merged.)
