### PR TITLE
[7.x] Clean up heading tags in ingest management docs (#46)

### DIFF
--- a/docs/en/ingest-management/getting-started.asciidoc
+++ b/docs/en/ingest-management/getting-started.asciidoc
@@ -20,7 +20,7 @@ do not enable or use {ingest-management} in a production environment.
 
 For feedback and questions, please contact us in the {im-forum}[discuss forum].
 
-[float]
+[discrete]
 [[ingest-manager-prereqs]]
 == Prerequisites
 
@@ -59,7 +59,7 @@ at least 32 characters. For example:
 `xpack.encryptedSavedObjects.encryptionKey: "something_at_least_32_characters"`. {fleet}
 requires this setting in order to save API keys and encrypt them in {kib}.
 
-[float]
+[discrete]
 [[enable-ingest-management]]
 == Step 1: Enable {ingest-management}
 
@@ -91,7 +91,7 @@ image::images/kibana-ingest-manager-start.png[{ingest-manager} app in {kib}]
 
 //TODO: Add tabbed panel when the code is stable.
 
-[float]
+[discrete]
 [[install-integration]]
 == Step 2: Install an integration and create a data source
 
@@ -142,7 +142,7 @@ Note that the `system-1` data source has been created by default.
 [role="screenshot"]
 image::images/kibana-ingest-manager-configurations-default-with-nginx.png[{ingest-manager} app showing default Agent configuration with nginx-1 datasource]
 
-[float]
+[discrete]
 [[install-run-elastic-agent]]
 == Step 3: Install and run {agent}
 
@@ -154,7 +154,7 @@ To configure {agent}, you can use the {ingest-manager} app in {kib} (see
 <<agent-fleet-mode,{fleet} mode>>), or configure it manually (see
 <<agent-standalone-mode, Standalone mode>>).
 
-[float]
+[discrete]
 [[agent-fleet-mode]]
 === {fleet} mode
 
@@ -209,7 +209,7 @@ connect to {es}. The {agent} will continue to run, but will not be able to send
 data. It will show this error instead:
 `invalid api key to authenticate with fleet`.
 
-[float]
+[discrete]
 [[agent-standalone-mode]]
 === Standalone mode (manual configuration)
 
@@ -258,7 +258,7 @@ datasources:
 ./elastic-agent run
 ----
 
-[float]
+[discrete]
 [[view-data]]
 == Step 4: View your data
 
@@ -272,7 +272,7 @@ image::images/kibana-ingest-manager-datastreams.png[{ingest-manager} app showing
 //Adding this section for future use. Might be premature to add this for the
 //experimental release.
 
-//[float]
+//[discrete]
 //== What's next?
 
 //Now that you have your logs streaming into {es}, learn how to unify your logs,

--- a/docs/en/ingest-management/ingest-management-overview.asciidoc
+++ b/docs/en/ingest-management/ingest-management-overview.asciidoc
@@ -4,7 +4,7 @@
 
 experimental[]
 
-[float]
+[discrete]
 [[elastic-agent]]
 == {agent}
 
@@ -13,7 +13,7 @@ other types of data to each host. A single Agent makes it easier and faster
 to deploy monitoring across your infrastructure. The Agent's single, unified
 configuration makes it easier to add integrations for new data sources.
 
-[float]
+[discrete]
 [[ingest-manager]]
 == {ingest-manager}
 
@@ -27,7 +27,7 @@ within seconds.
 [role="screenshot"]
 image::images/integrations.png[Integrations page]
 
-[float]
+[discrete]
 [[configuring-integrations]]
 == {integrations} in {ingest-manager}
 
@@ -54,7 +54,7 @@ If you prefer infrastructure as code, you may use YAML files and APIs.
 can also do using the API. This makes it easy to automate and integrate with
 other systems.
 
-[float]
+[discrete]
 [[central-management]]
 == Central management in {fleet}
 
@@ -73,7 +73,7 @@ Agents receive the update during their next check-in. You no longer have to
 distribute configuration updates yourself using SSH, Ansible playbooks, or other
 configuration methods.
 
-[float]
+[discrete]
 [[data-streams]]
 === Data streams make index management easier
 

--- a/docs/en/ingest-management/troubleshooting.asciidoc
+++ b/docs/en/ingest-management/troubleshooting.asciidoc
@@ -36,7 +36,7 @@ Contact us in the {im-forum}[discuss forum]. Your feedback is very valuable to u
 * <<i-rebooted-my-host>>
 * <<what-is-the-endpoint-package>>
 
-[float]
+[discrete]
 [[ingest-manager-not-in-kibana]]
 == The {ingest-manager} app is not listed in the {kib} side navigation
 
@@ -101,7 +101,7 @@ To set up passwords, you can use the documented {es} APIs or the
 After running the command, copy the Elastic user name to the {kib} config file.
 Then restart {kib}.
 
-[float]
+[discrete]
 [[ingest-management-setup-fails]]
 == The `/api/ingest_management/setup` endpoint returns an error because it can't reach the package registry
 
@@ -110,7 +110,7 @@ an external service called the {package-registry}. For this to work, the {kib}
 server must be able to connect to `https://epr-experimental.elastic.co` on port
 443.
 
-[float]
+[discrete]
 [[ingest-manager-app-crashes]]
 == The {ingest-manager} app in {kib} crashes
 
@@ -120,7 +120,7 @@ to the **Network** tab, and refresh the page. One of the requests to the
 message doesn't give you enough information to fix the problem, please contact
 us in the {im-forum}[discuss forum].
 
-[float]
+[discrete]
 [[agent-enrollment-timeout]]
 == {agent} enrollment fails on the host with `Client.Timeout exceeded` message
 
@@ -149,7 +149,7 @@ that you used to enroll {agent} on your host.
 .. If the secret doesn't match, create a new enrollment token and use the new
 token when you run the `elastic-agent enroll` command.
 
-[float]
+[discrete]
 [[es-apikey-failed]]
 == {es} authentication service fails with `Authentication using apikey failed` message
 
@@ -162,7 +162,7 @@ property in the `kibana.yml` configuration file. For example:
 xpack.encryptedSavedObjects.encryptionKey: "something_at_least_32_characters"
 ----
 
-[float]
+[discrete]
 [[enrolled-agent-not-showing-up]]
 == Why doesn't my enrolled Agent show up in the {ingest-manager} app?
 
@@ -186,7 +186,7 @@ On Windows hosts, run:
 elastic-agent.exe run
 ----
 
-[float]
+[discrete]
 [[where-are-the-agent-logs]]
 == Where does {agent} store logs after startup?
 
@@ -195,7 +195,7 @@ When started successfully, {metricbeat} logs are stored in
 path does not exist, the Agent was unable to start {metricbeat}, which is a
 higher level problem to triage.
 
-[float]
+[discrete]
 [[what-is-my-agent-config]]
 == What configuration is the {agent} running?
 
@@ -216,7 +216,7 @@ The `action_store.yml` contains the entire, unencrypted configuration:
 This file also shows the version of all packages used by the current
 configuration.
 
-[float]
+[discrete]
 [[where-is-the-data-agent-is-sending]]
 == Why can't I see the data {agent} is sending?
 
@@ -249,7 +249,7 @@ more information, see
 If {metricbeat} is able to send data to {es}, there is possibly a bug or
 problem with {agent}, and you should report it.
 
-[float]
+[discrete]
 [[i-deleted-my-agent]]
 == How do I restore an {agent} that I deleted from {fleet}?
 
@@ -257,7 +257,7 @@ It's ok, we've got your back! The data is still in {es}. To add {agent}
 to {fleet} again, stop the Agent, re-enroll the {agent} on the host, then run
 {agent}.
 
-[float]
+[discrete]
 [[i-need-to-stop-agent]]
 == How do I stop {agent} and all processes running on my host?
 
@@ -279,7 +279,7 @@ Then kill the process.
 
 
 
-[float]
+[discrete]
 [[i-rebooted-my-host]]
 == How do I restart {agent} after rebooting my host?
 
@@ -293,7 +293,7 @@ Support for installing {agent} as a service on all supported systems will be
 available in a future release. To achieve this in the meantime, you can add the
 start command to a user's startup profile.
 
-[float]
+[discrete]
 [[what-is-the-endpoint-package]]
 == What is the Endpoint integration shown in {ingest-manager}?
 


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Clean up heading tags in ingest management docs (#46)