### PR TITLE
Template for tutorial-type guides

### DIFF
--- a/tutorial-template.asciidoc
+++ b/tutorial-template.asciidoc
@@ -4,8 +4,10 @@ your tutorial. You can use this asciidoc template as a framework, replacing the 
 
 // The title of your tutorial should focus on what the reader will achieve.
 // For example, How to ingest custom data into Elasticsearch.
-// The anchor id name, in this case [[tutorial-title]], must be unique and can only be used once in a doc. You can link to any ID within a document. For example,
-// if you need to link to this section from elsewhere, you would use <<tutorial-title>> as the reference. 
+// The anchor id name, in this case [[tutorial-title]], must be unique and can only be used once in a doc. 
+// The anchor id name should be the same as the file name.
+// You can link to any ID within a document. For example, if you need to link to this section from elsewhere,
+// you would use <<tutorial-title>> as the reference. 
 [[tutorial-title]]
 = Tutorial title
 
@@ -41,14 +43,14 @@ down into as many steps as are needed.
 To highlight a command within a sentence, use this format: `sample command`.
 
 To include code or command blocks, use a code block. Specify the source language, as we use the language 
-as a hint for the syntax highlighter. For example; 
+as a hint for the syntax highlighter. For example:
 
 [source,shell]
 ----
 ./elastic-agent -c elastic-agent-standalone.yml run
 ----
 
-To include a sample file, specify the source format. For example:
+To display a sample file, specify the source format. For example:
 
 [source,json]
 {
@@ -60,12 +62,11 @@ To include a sample file, specify the source format. For example:
     "text_entry": "String",
 }
 
-To include an image, save it in a folder in the Observability-docs repo, and
-include it using a path relative to the document where the `image::` statement appears. For example, 
-this image is saved in the `images` directory:
+To include an image, save it in a folder in the repo, and
+include it by using an `image::` statement. For example:
 
 [role="screenshot"]
-image::images/my-image.png[Alt text]
+image::myimages/my-image.png[Alt text for the image]
 
 
 [float]
@@ -91,6 +92,6 @@ for further reading. This can be a bulleted list of links or a set of steps the 
 // This first bullet point is an external link to the web site
 * https://www.elastic.co/blog/kubernetes-observability-tutorial-k8s-monitoring-application-performance-with-elastic-apm[Kubernetes blog]
 // Using the `{logs-guide}` shared attribute, this second bullet point is an internal link to a page within the Logs monitoring guide.
-// Shared attributes can be found here: https://github.com/elastic/docs/blob/master/shared/attributes.asciidoc 
+// Shared attributes for all Elastic docs can be found here: https://github.com/elastic/docs/blob/master/shared/attributes.asciidoc 
 *  {logs-guide}/logs-overview.html[Monitoring logs]
 

--- a/tutorial-template.asciidoc
+++ b/tutorial-template.asciidoc
@@ -1,0 +1,96 @@
+This template can be used for creating tutorials within the Observability documentation.
+This should give you a format to follow and make it easier for you to get started writing
+your tutorial. You can use this asciidoc template as a framework, replacing the text with your own. 
+
+// The title of your tutorial should focus on what the reader will achieve.
+// For example, How to ingest custom data into Elasticsearch.
+// The anchor id name, in this case [[tutorial-title]], must be unique and can only be used once in a doc. You can link to any ID within a document. For example,
+// if you need to link to this section from elsewhere, you would use <<tutorial-title>> as the reference. 
+[[tutorial-title]]
+= Tutorial title
+
+Introduce the reader to what they will do in this tutorial and provide a list
+of what the reader will learn. If required, include links to topics within the Observability docs. 
+
+When you have finished this tutorial, you will be familiar with:
+
+// This is an ordered list and each item is using a shared attribute for the
+// product name. Shared attributes can be found here: https://github.com/elastic/docs/blob/master/shared/attributes.asciidoc
+. Installing {es}
+. Installing {kib}
+. Installing {filebeat}
+
+
+// This float marker is placed before a section header so that each section in this file remains on the same page when converted to HTML.
+[float]
+[[what-you-need]]
+// The section heading. 
+== What you need
+
+Use this section to tell the reader what they will need, or any prerequisite knowledge
+they require to complete the tutorial.
+
+
+[float]
+[[the-first-step]]
+== Step 1: The first step
+
+Break your tutorial down into discrete steps that the reader can follow. A task should be broken 
+down into as many steps as are needed.
+
+To highlight a command within a sentence, use this format: `sample command`.
+
+To include code or command blocks, use a code block. Specify the source language, as we use the language 
+as a hint for the syntax highlighter. For example; 
+
+[source,shell]
+----
+./elastic-agent -c elastic-agent-standalone.yml run
+----
+
+To include a sample file, specify the source format. For example:
+
+[source,json]
+{
+    "sample_id": ENT,
+    "sample_name": "String",
+    "sample_number": INT,
+    "line_number": "String",
+    "speaker": "String",
+    "text_entry": "String",
+}
+
+To include an image, save it in a folder in the Observability-docs repo, and
+include it using a path relative to the document where the `image::` statement appears. For example, 
+this image is saved in the `images` directory:
+
+[role="screenshot"]
+image::images/my-image.png[Alt text]
+
+
+[float]
+[[the-next-step]]
+== Step 2: The next step
+
+Step 2 should follow logically from the first step. Try not to double back on content covered in Step 1.
+A good approach would be to work through the task, noting the steps in order as you do.
+
+[float]
+[[add-more-steps]]
+== Step 3: Add more steps
+
+Add as many steps as you need to guide the reader through the process.
+
+[float]
+[[learn-more]]
+== Learn more
+
+Now that the reader has completed your tutorial, provide a list of resources, or related features,
+for further reading. This can be a bulleted list of links or a set of steps the reader should take next.
+
+// This first bullet point is an external link to the web site
+* https://www.elastic.co/blog/kubernetes-observability-tutorial-k8s-monitoring-application-performance-with-elastic-apm[Kubernetes blog]
+// Using the `{logs-guide}` shared attribute, this second bullet point is an internal link to a page within the Logs monitoring guide.
+// Shared attributes can be found here: https://github.com/elastic/docs/blob/master/shared/attributes.asciidoc 
+*  {logs-guide}/logs-overview.html[Monitoring logs]
+

--- a/tutorial-template.asciidoc
+++ b/tutorial-template.asciidoc
@@ -21,7 +21,7 @@ When you have finished this tutorial, you will be familiar with:
 . Installing {filebeat}
 
 
-// This float marker is placed before a section header so that each section in this file remains on the same page when converted to HTML.
+// This float marker is placed before an anchor id so that each section in this file remains on the same page when converted to HTML.
 [float]
 [[what-you-need]]
 // The section heading. 


### PR DESCRIPTION
This PR adds a template for guidance when creating tutorial-type guides within the Observability documentation. 

For the time being, I have placed the file outside of the docs directory. 

### Related issue

https://github.com/elastic/observability-dev/issues/664