### PR TITLE
[docs] Add info about SYSTEM user requirement to the ingest Getting Started

### DIFF
--- a/docs/en/ingest-management/getting-started.asciidoc
+++ b/docs/en/ingest-management/getting-started.asciidoc
@@ -2,6 +2,8 @@
 [role="xpack"]
 = Get started with ingest management
 
+:release-state: released
+
 ++++
 <titleabbrev>Get started</titleabbrev>
 ++++
@@ -190,10 +192,16 @@ This will replace your current settings. Do you want to continue? [Y/n]:
 
 . Run the Agent:
 +
+--
+// tag::run-agent[]
 [source,shell]
 ----
-./elastic-agent run
+./elastic-agent run <1>
 ----
+<1> On Windows, you must run {agent} under the SYSTEM account if you plan
+to use the {elastic-endpoint} integration.
+// end::run-agent[]
+--
 
 . In the {ingest-manager} app, click **Continue** to go to the **{fleet}**
 tab, where you should see the newly enrolled Agent.
@@ -253,10 +261,9 @@ datasources:
 
 . Run {agent}:
 +
-[source,shell]
-----
-./elastic-agent run
-----
+--
+include::getting-started.asciidoc[tag=run-agent]
+--
 
 [discrete]
 [[view-data]]

--- a/docs/en/ingest-management/getting-started.asciidoc
+++ b/docs/en/ingest-management/getting-started.asciidoc
@@ -2,8 +2,6 @@
 [role="xpack"]
 = Get started with ingest management
 
-:release-state: released
-
 ++++
 <titleabbrev>Get started</titleabbrev>
 ++++


### PR DESCRIPTION
## What does this PR do?

Updates ingest management docs to indicate that the agent must be run under the SYSTEM user to use the Endpoint integration.

## Why is it important?

Users will run into a "Agent process is not root/admin or validation failed" error on Win if they don't run under SYSTEM.

## Related issues

- Closes elastic/beats#19955
- Related to https://github.com/elastic/beats/pull/20172

(I'm also writing a troubleshooting topic with more detail. I'll add the link here when it's ready.)

Note that the current docs do not show platform-specific commands. I will fix that...just waiting for the final design of our tabbed panel widget to avoid having to redo the work.