### PR TITLE
[7.x] [docs] Add info about SYSTEM user requirement to the ingest Getting Started (#65)

### DIFF
--- a/docs/en/ingest-management/getting-started.asciidoc
+++ b/docs/en/ingest-management/getting-started.asciidoc
@@ -190,10 +190,16 @@ This will replace your current settings. Do you want to continue? [Y/n]:
 
 . Run the Agent:
 +
+--
+// tag::run-agent[]
 [source,shell]
 ----
-./elastic-agent run
+./elastic-agent run <1>
 ----
+<1> On Windows, you must run {agent} under the SYSTEM account if you plan
+to use the {elastic-endpoint} integration.
+// end::run-agent[]
+--
 
 . In the {ingest-manager} app, click **Continue** to go to the **{fleet}**
 tab, where you should see the newly enrolled Agent.
@@ -253,10 +259,9 @@ datasources:
 
 . Run {agent}:
 +
-[source,shell]
-----
-./elastic-agent run
-----
+--
+include::getting-started.asciidoc[tag=run-agent]
+--
 
 [discrete]
 [[view-data]]


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [docs] Add info about SYSTEM user requirement to the ingest Getting Started (#65)