### PR TITLE
[docs] Add troubleshooting topic about running under SYSTEM for Endpoint

### DIFF
--- a/docs/en/ingest-management/troubleshooting.asciidoc
+++ b/docs/en/ingest-management/troubleshooting.asciidoc
@@ -22,6 +22,7 @@ Contact us in the {im-forum}[discuss forum]. Your feedback is very valuable to u
 * <<ingest-manager-app-crashes>>
 * <<agent-enrollment-timeout>>
 * <<es-apikey-failed>>
+* <<process-not-root>>
 * <<agent-hangs-while-unenrolling>>
 
 **Frequently asked questions:**
@@ -155,6 +156,33 @@ property in the `kibana.yml` configuration file. For example:
 ----
 xpack.encryptedSavedObjects.encryptionKey: "something_at_least_32_characters"
 ----
+
+[discrete]
+[[process-not-root]]
+== {agent} fails on Windows with `Agent process is not root/admin or validation failed` message
+
+Make sure the user has administrator-level privileges.
+
+If you're using the {elastic-endpoint} integration, also make sure you're
+running {agent} under the SYSTEM account.
+
+To run {agent} under the SYSTEM account, you can:
+
+. Download https://docs.microsoft.com/en-us/sysinternals/downloads/psexec[PsExec]
+and extract the contents to a folder, for example, `d:\tools`.
+. Open a command prompt as an Administrator (right-click the Command Prompt
+icon and select *Run As Administrator*).
+. From the command prompt, run {agent} under the SYSTEM account:
++
+[source,sh]
+----
+d:\tools\psexec.exe -sid "C:\Program Files\Elastic-Agent\elastic-agent.exe" run
+----
+
+
+TIP: If you install {agent} as a service as described in
+<<elastic-agent-installation>>, the Agent runs under the SYSTEM account by
+default.
 
 [discrete]
 [[agent-hangs-while-unenrolling]]

--- a/docs/en/ingest-management/troubleshooting.asciidoc
+++ b/docs/en/ingest-management/troubleshooting.asciidoc
@@ -159,7 +159,7 @@ xpack.encryptedSavedObjects.encryptionKey: "something_at_least_32_characters"
 
 [discrete]
 [[process-not-root]]
-== {agent} fails on Windows with `Agent process is not root/admin or validation failed` message
+== {agent} fails with `Agent process is not root/admin or validation failed` message
 
 Make sure the user has administrator-level privileges.
 

--- a/docs/en/ingest-management/troubleshooting.asciidoc
+++ b/docs/en/ingest-management/troubleshooting.asciidoc
@@ -161,10 +161,17 @@ xpack.encryptedSavedObjects.encryptionKey: "something_at_least_32_characters"
 [[process-not-root]]
 == {agent} fails with `Agent process is not root/admin or validation failed` message
 
-Make sure the user has administrator-level privileges.
+Make sure the user running {agent} has root privileges. If you're running
+{agent} in the foreground (and not as a service) on Linux or macOS, run the
+agent under the root user, for example, `sudo` or `su`. Some integrations
+require root privileges to collect sensitive data.
 
 If you're using the {elastic-endpoint} integration, also make sure you're
 running {agent} under the SYSTEM account.
+
+TIP: If you install {agent} as a service as described in
+<<elastic-agent-installation>>, {agent} runs under the SYSTEM account by
+default.
 
 To run {agent} under the SYSTEM account, you can:
 
@@ -179,10 +186,6 @@ icon and select *Run As Administrator*).
 d:\tools\psexec.exe -sid "C:\Program Files\Elastic-Agent\elastic-agent.exe" run
 ----
 
-
-TIP: If you install {agent} as a service as described in
-<<elastic-agent-installation>>, the Agent runs under the SYSTEM account by
-default.
 
 [discrete]
 [[agent-hangs-while-unenrolling]]


### PR DESCRIPTION
Adds a troubleshooting topic for users who try to run endpoint under a user other than system.

This is a follow-up to https://github.com/elastic/beats/pull/20172