### PR TITLE
[docs] Update docs to reflect support for Endpoint integration

### DIFF
--- a/docs/en/ingest-management/troubleshooting.asciidoc
+++ b/docs/en/ingest-management/troubleshooting.asciidoc
@@ -33,7 +33,6 @@ Contact us in the {im-forum}[discuss forum]. Your feedback is very valuable to u
 * <<where-is-the-data-agent-is-sending>>
 * <<i-deleted-my-agent>>
 * <<i-rebooted-my-host>>
-* <<what-is-the-endpoint-package>>
 
 [discrete]
 [[ingest-manager-not-in-kibana]]
@@ -269,15 +268,3 @@ rebooting the host.
 Support for installing {agent} as a service on all supported systems will be
 available in a future release. To achieve this in the meantime, you can add the
 start command to a user's startup profile.
-
-[discrete]
-[[what-is-the-endpoint-package]]
-== What is the Endpoint integration shown in {ingest-manager}?
-
-In 7.8, the Endpoint integration is non-functional. It cannot be used yet. It
-exists as an artifact of the current feature development. Please watch for
-announcements during upcoming release cycles. As a teaser, Endpoint is the
-integration that will allow the Elastic Security app to have a dedicated
-executable running like {beats} to protect the host and respond to detected
-security concerns. Endpoint will be managed by {agent} in the same way that
-{beats} are managed.


### PR DESCRIPTION
Removes content about Endpoint that is no longer required in the troubleshooting docs because the Endpoint integration will function in 7.9.