### PR TITLE
[docs] Use discrete tags instead of float

### DIFF
--- a/tutorial-template.asciidoc
+++ b/tutorial-template.asciidoc
@@ -1,6 +1,6 @@
-This template can be used for creating tutorials within the Observability documentation.
-This should give you a format to follow and make it easier for you to get started writing
-your tutorial. You can use this asciidoc template as a framework, replacing the text with your own. 
+// This template can be used for creating tutorials within the Observability documentation.
+// This should give you a format to follow and make it easier for you to get started writing
+// your tutorial. You can use this asciidoc template as a framework, replacing the text with your own. 
 
 // The title of your tutorial should focus on what the reader will achieve.
 // For example, How to ingest custom data into Elasticsearch.
@@ -14,17 +14,17 @@ your tutorial. You can use this asciidoc template as a framework, replacing the 
 Introduce the reader to what they will do in this tutorial and provide a list
 of what the reader will learn. If required, include links to topics within the Observability docs. 
 
-When you have finished this tutorial, you will be familiar with:
+In this tutorial, you learn how to:
 
 // This is an ordered list and each item is using a shared attribute for the
 // product name. Shared attributes can be found here: https://github.com/elastic/docs/blob/master/shared/attributes.asciidoc
-. Installing {es}
-. Installing {kib}
-. Installing {filebeat}
+. Install {es}
+. Install {kib}
+. Install {filebeat}
 
 
-// This float marker is placed before an anchor id so that each section in this file remains on the same page when converted to HTML.
-[float]
+// This discrete marker is placed before an anchor id so that each section in this file remains on the same page when converted to HTML.
+[discrete]
 [[what-you-need]]
 // The section heading. 
 == What you need
@@ -33,7 +33,7 @@ Use this section to tell the reader what they will need, or any prerequisite kno
 they require to complete the tutorial.
 
 
-[float]
+[discrete]
 [[the-first-step]]
 == Step 1: The first step
 
@@ -53,6 +53,7 @@ as a hint for the syntax highlighter. For example:
 To display a sample file, specify the source format. For example:
 
 [source,json]
+----
 {
     "sample_id": ENT,
     "sample_name": "String",
@@ -61,6 +62,7 @@ To display a sample file, specify the source format. For example:
     "speaker": "String",
     "text_entry": "String",
 }
+----
 
 To include an image, save it in a folder in the repo, and
 include it by using an `image::` statement. For example:
@@ -69,20 +71,20 @@ include it by using an `image::` statement. For example:
 image::myimages/my-image.png[Alt text for the image]
 
 
-[float]
+[discrete]
 [[the-next-step]]
 == Step 2: The next step
 
 Step 2 should follow logically from the first step. Try not to double back on content covered in Step 1.
 A good approach would be to work through the task, noting the steps in order as you do.
 
-[float]
+[discrete]
 [[add-more-steps]]
 == Step 3: Add more steps
 
 Add as many steps as you need to guide the reader through the process.
 
-[float]
+[discrete]
 [[learn-more]]
 == Learn more
 


### PR DESCRIPTION
Changes:

- Fixed the tutorial template to use `discrete` instead of `float` tags (preferred for asciidoctor--see https://asciidoctor.org/docs/asciidoc-asciidoctor-diffs/#blocks).
- Commented out introductory text (allows you to build template without errors).
- Made a couple of minor tweaks to phrasing.

Also, the "What you need" and "Learn more" sections are a little different from what other tutorials in our library use. We're really all over the floor in terms of consistency, but I think it might be worth presenting this format to the larger doc group to get some feedback before we start writing tutorials.

In other docs, I see mostly "Before you begin" or "Prerequisites", and "Next steps" or "What's next?" but I haven't done a thorough inventory.

@EamonnTP @bmorelli25 WDYT?

