### PR TITLE
Override banner until docs are ready

### DIFF
--- a/docs/en/observability/page_header.html
+++ b/docs/en/observability/page_header.html
@@ -1,0 +1,1 @@
+You are looking at preliminary documentation for a future release. 


### PR DESCRIPTION
The observability guide won't be ready until 7.9 and therefore `master` is marked as the current branch. This is a really confusing experience for users because all the content is marked as "coming". It might help to have a simple statement (without links) at the top of each page until the guide is ready.

Note: Creating this initially as a draft to make sure the doc build still supports overriding the default banner.