### PR TITLE
[7.x] Override banner until docs are ready (#79)

### DIFF
--- a/docs/en/observability/page_header.html
+++ b/docs/en/observability/page_header.html
@@ -1,0 +1,1 @@
+You are looking at preliminary documentation for a future release. 


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Override banner until docs are ready (#79)