### PR TITLE
[7.x] [docs] Promote ingest management to beta (#70)

### DIFF
--- a/docs/en/ingest-management/getting-started.asciidoc
+++ b/docs/en/ingest-management/getting-started.asciidoc
@@ -6,17 +6,10 @@
 <titleabbrev>Get started</titleabbrev>
 ++++
 
-experimental[]
+beta[]
 
 This guide describes how to get started with the new {ingest-management}
 capabilities available in this release.
-
-// tag::experimental-warning[]
-This early release of {ingest-management} is experimental. We invite you to
-install and test these capabilities **in a test environment**. You might run
-into problems and need to modify your setup to get this feature running. Please
-do not enable or use {ingest-management} in a production environment.
-// end::experimental-warning[]
 
 For feedback and questions, please contact us in the {im-forum}[discuss forum].
 
@@ -26,7 +19,7 @@ For feedback and questions, please contact us in the {im-forum}[discuss forum].
 
 Before you begin, please read <<ingest-management-limitations>>.
 
-To use this **experimental** release of {ingest-management}, you need:
+To use this **beta** release of {ingest-management}, you need:
 
 * An {es} cluster and {kib} (version 7.8) with a basic license.
 You can use our https://www.elastic.co/cloud/elasticsearch-service[hosted {ess}]
@@ -184,7 +177,6 @@ that directory.
 ----
 ./elastic-agent enroll KIBANA_URL ENROLLMENT_KEY
 
-The {agent} is currently in Experimental and should not be used in production
 This will replace your current settings. Do you want to continue? [Y/n]:
 ----
 
@@ -275,7 +267,7 @@ dashboards corresponding to the data type that is sent.
 image::images/kibana-ingest-manager-datastreams.png[{ingest-manager} app showing data streams list]
 
 //Adding this section for future use. Might be premature to add this for the
-//experimental release.
+//beta release.
 
 //[discrete]
 //== What's next?

--- a/docs/en/ingest-management/ingest-management-limitations.asciidoc
+++ b/docs/en/ingest-management/ingest-management-limitations.asciidoc
@@ -2,15 +2,7 @@
 [role="xpack"]
 = Limitations of this release
 
-experimental[]
-
-This is an experimental release and there is no migration path for future
-releases, so **YOU MUST TEST IN A DEDICATED CLUSTER.** In a future release, we
-plan to add support for a new way of managing rolling indices that will make the
-experience easier for users. However, any data stored in this release will not
-be migrated in our next release, and you must wipe any data and settings changed
-in {kib} and {es} to avoid future conflicts. We recommend using a dedicated test
-cluster or deployment that can be deleted when you are done.
+beta[]
 
 {ingest-manager} is currently only available to users with the
 {ref}/built-in-roles.html[superuser role]. This role is necessary to create
@@ -32,5 +24,5 @@ on
 *   No custom index templates or pipelines
 *   No support for Kubernetes or Docker autodiscovery
 
-Experimental releases are not officially supported, but we encourage you to
+Beta releases are not officially supported, but we encourage you to
 report issues in our {im-forum}[discuss forum].

--- a/docs/en/ingest-management/ingest-management-overview.asciidoc
+++ b/docs/en/ingest-management/ingest-management-overview.asciidoc
@@ -2,7 +2,7 @@
 [role="xpack"]
 = Ingest management overview
 
-experimental[]
+beta[]
 
 [discrete]
 [[elastic-agent]]

--- a/docs/en/ingest-management/troubleshooting.asciidoc
+++ b/docs/en/ingest-management/troubleshooting.asciidoc
@@ -2,9 +2,7 @@
 [role="xpack"]
 = Troubleshooting
 
-experimental[]
-
-include::getting-started.asciidoc[tag=experimental-warning]
+beta[]
 
 We have collected the most common known problems and frequently asked questions
 here. If your question isn't answered here, please review open issues in the
@@ -39,8 +37,8 @@ Contact us in the {im-forum}[discuss forum]. Your feedback is very valuable to u
 [[ingest-manager-not-in-kibana]]
 == The {ingest-manager} app is not listed in the {kib} side navigation
 
-In 7.8, the {ingest-manager} app is experimental. You must enable the app to
-see it in {kib}.
+The {ingest-manager} app is enabled by default. If you are unable to 
+see the app in {kib}, make sure it's enabled.
 
 //TODO: Add platform tabs when the tabbed panel widget is stable (possibly after
 // 7.8)
@@ -106,8 +104,7 @@ Then restart {kib}.
 
 In order to install {integrations}, the {ingest-manager} app needs to connect to
 an external service called the {package-registry}. For this to work, the {kib}
-server must be able to connect to `https://epr-experimental.elastic.co` on port
-443.
+server must be able to connect to `https://epr.elastic.co` on port 443.
 
 [discrete]
 [[ingest-manager-app-crashes]]


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [docs] Promote ingest management to beta (#70)