### PR TITLE
[7.9] document limits on Cloud for 7.9 (#98)

### DIFF
--- a/docs/en/ingest-management/ingest-management-limitations.asciidoc
+++ b/docs/en/ingest-management/ingest-management-limitations.asciidoc
@@ -15,12 +15,22 @@ This feature has additional limitations at the current time:
 
 *   Support for a limited number of integrations (more coming soon)
 *   Support for only {filebeat}, {metricbeat}, and Endpoint Security
-*   We recommend you enroll no more than 1000 Agents
 *   No output to {ls}, Kafka, or other remote clusters
 *   No proxy support in {agent}
 *   Requires internet access for {kib} to download integration packages
 *   No support for advanced {beats} settings like multiline, processors, and so
 on
 *   No support for Kubernetes or Docker autodiscovery
+*   On {ecloud}, there's a limit to the number of enrolled {agent}s that a
+single {kib} instance can handle:
++
+[%header]
+|===
+|{kib} instance size {ess-icon} |Max. number of {agent}s
+|8gb| 1000
+|4gb| 750
+|1gb| 500
+|===
 
-We encourage you to give feedback and report issues in our {im-forum}[discuss forum].
+Beta releases are not officially supported, but we encourage you to
+report issues in our {im-forum}[discuss forum].


### PR DESCRIPTION
Backports the following commits to 7.9:
 - document limits on Cloud for 7.9  (#98)