### PR TITLE
Update description of Endpoint integration in troubleshooting

### DIFF
--- a/docs/en/ingest-management/troubleshooting.asciidoc
+++ b/docs/en/ingest-management/troubleshooting.asciidoc
@@ -295,15 +295,15 @@ start command to a user's startup profile.
 
 [discrete]
 [[what-is-the-endpoint-package]]
-== What is the Endpoint integration shown in {ingest-manager}?
+== What is the Elastic {endpoint-sec} integration in {ingest-manager}?
 
-In 7.8, the Endpoint integration is non-functional. It cannot be used yet. It
-exists as an artifact of the current feature development. Please watch for
-announcements during upcoming release cycles. As a teaser, Endpoint is the
-integration that will allow the Elastic Security app to have a dedicated
-executable running like {beats} to protect the host and respond to detected
-security concerns. Endpoint will be managed by {agent} in the same way that
-{beats} are managed.
+The Elastic {endpoint-sec} integration provides protection on your {agent}
+controlled host. The integration monitors your host for security-related events,
+allowing for investigation of security data through the Elastic Security
+application in {kib}. The Elastic {endpoint-sec} integration is managed by
+{agent} in in the same way as other integrations. Try it out! For more
+information, see the {security-guide}/index.html[Elastic Security solution
+documentation].
 
 // Add Javascript and CSS for tabbed panels
 include::tab-widgets/code.asciidoc[]


### PR DESCRIPTION
Updates the troubleshooting description about Endpoint to address feedback in https://github.com/elastic/observability-docs/issues/90.

(Changes made after discussion with writers on the Elastic Security team.)

Replaces https://github.com/elastic/observability-docs/pull/71