### PR TITLE
[7.x] [Docs]Ingest Manager quick start guide type (#106)

### DIFF
--- a/docs/en/ingest-management/getting-started.asciidoc
+++ b/docs/en/ingest-management/getting-started.asciidoc
@@ -83,7 +83,7 @@ image::images/kibana-ingest-manager-integrations-list-installed.png[{ingest-mana
 . Select the **Configurations** tab, and in the list of agent configurations,
 click **Default config**.
 +
-The newly added Nginx integration should appear under **Ingegrations**.
+The newly added Nginx integration should appear under **Integrations**.
 Note that the `system-1` integration has been created by default.
 +
 [role="screenshot"]


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [Docs]Ingest Manager quick start guide type (#106)