### PR TITLE
[7.9] [docs] Add steps for making agent persistent on macos (#105)

### DIFF
--- a/docs/en/ingest-management/troubleshooting.asciidoc
+++ b/docs/en/ingest-management/troubleshooting.asciidoc
@@ -14,6 +14,7 @@ following GitHub repositories:
 
 Contact us in the {im-forum}[discuss forum]. Your feedback is very valuable to us.
 
+//TODO: Break this into two separate files: Common problems and FAQ. It's getting too long.
 
 **Common problems:**
 
@@ -186,7 +187,6 @@ icon and select *Run As Administrator*).
 d:\tools\psexec.exe -sid "C:\Program Files\Elastic-Agent\elastic-agent.exe" run
 ----
 
-
 [discrete]
 [[agent-hangs-while-unenrolling]]
 == {agent} hangs while unenrolling
@@ -199,7 +199,6 @@ If this happens, select **Force unenroll** from the *Actions* menu in {fleet}.
 
 This will invalidate all API keys related to the agent and change the status to
 `inactive` so that the agent no longer appears in {fleet}. 
-
 
 [discrete]
 [[enrolled-agent-not-showing-up]]
@@ -283,15 +282,18 @@ run {agent}.
 [[i-rebooted-my-host]]
 == How do I restart {agent} after rebooting my host?
 
-On Windows, if you used Powershell to install {agent} as a service, the agent
+On Windows, if you used PowerShell to install {agent} as a service, the agent
 should still be running after rebooting the host.
 
-On macOS and Linux, you need to restart {agent} from the command line after
-rebooting the host.
+On Linux, if you used the DEB or RPM packages, the agent should still be running
+after rebooting the host. 
+
+On macOS, you need to restart {agent} from the command line after
+rebooting the host, or follow the steps described in
+<<elastic-agent-install-service-macos>> to run the agent as a service. 
 
 Support for installing {agent} as a service on all supported systems will be
-available in a future release. To achieve this in the meantime, you can add the
-start command to a user's startup profile.
+available in a future release.
 
 [discrete]
 [[what-is-the-endpoint-package]]


### PR DESCRIPTION
Backports the following commits to 7.9:
 - [docs] Add steps for making agent persistent on macos (#105)