### PR TITLE
Remove prerelease banner

### DIFF
--- a/docs/en/observability/page_header.html
+++ b/docs/en/observability/page_header.html
@@ -1,1 +1,0 @@
-You are looking at preliminary documentation for a future release. 


### PR DESCRIPTION
Closes https://github.com/elastic/observability-docs/issues/83

I know the docs are still a work-in-progress, but I think we should remove this banner:

![image](https://user-images.githubusercontent.com/14206422/90945295-d8ebe200-e3d8-11ea-9cb8-67119bcc3ddb.png)

