### PR TITLE
Strengthen language about ingest management upgrade restriction in 7.8

### DIFF
--- a/docs/en/ingest-management/getting-started.asciidoc
+++ b/docs/en/ingest-management/getting-started.asciidoc
@@ -8,15 +8,10 @@
 
 experimental[]
 
+include::ingest-management-overview.asciidoc[tag=experimental-warning]
+
 This guide describes how to get started with the new {ingest-management}
 capabilities available in this release.
-
-// tag::experimental-warning[]
-This early release of {ingest-management} is experimental. We invite you to
-install and test these capabilities **in a test environment**. You might run
-into problems and need to modify your setup to get this feature running. Please
-do not enable or use {ingest-management} in a production environment.
-// end::experimental-warning[]
 
 For feedback and questions, please contact us in the {im-forum}[discuss forum].
 

--- a/docs/en/ingest-management/ingest-management-limitations.asciidoc
+++ b/docs/en/ingest-management/ingest-management-limitations.asciidoc
@@ -4,13 +4,7 @@
 
 experimental[]
 
-This is an experimental release and there is no migration path for future
-releases, so **YOU MUST TEST IN A DEDICATED CLUSTER.** In a future release, we
-plan to add support for a new way of managing rolling indices that will make the
-experience easier for users. However, any data stored in this release will not
-be migrated in our next release, and you must wipe any data and settings changed
-in {kib} and {es} to avoid future conflicts. We recommend using a dedicated test
-cluster or deployment that can be deleted when you are done.
+include::ingest-management-overview.asciidoc[tag=experimental-warning]
 
 {ingest-manager} is currently only available to users with the
 {ref}/built-in-roles.html[superuser role]. This role is necessary to create

--- a/docs/en/ingest-management/ingest-management-overview.asciidoc
+++ b/docs/en/ingest-management/ingest-management-overview.asciidoc
@@ -4,6 +4,12 @@
 
 experimental[]
 
+// tag::experimental-warning[]
+**This experimental release allows you to try out new capabilities. There is no
+migration path for future releases. You must test in a dedicated cluster. Delete
+the cluster when you are done. You will not be able to upgrade the cluster.**
+// end::experimental-warning[]
+
 [discrete]
 [[elastic-agent]]
 == {agent}

--- a/docs/en/ingest-management/troubleshooting.asciidoc
+++ b/docs/en/ingest-management/troubleshooting.asciidoc
@@ -4,7 +4,7 @@
 
 experimental[]
 
-include::getting-started.asciidoc[tag=experimental-warning]
+include::ingest-management-overview.asciidoc[tag=experimental-warning]
 
 We have collected the most common known problems and frequently asked questions
 here. If your question isn't answered here, please review open issues in the


### PR DESCRIPTION
I don't usually advocate putting things in bold font, but in this case, it might help. We have warnings in the docs, but users aren't seeing them, so I propose that we add this text to every page in the ingest management docs.

![image](https://user-images.githubusercontent.com/14206422/93250262-6c4dd400-f747-11ea-8d44-9d8505dce6d3.png)


TODOs:

- [ ] add this statement to the agent docs after this PR is merged.