### PR TITLE
[7.x] docs: link to apm server ref (#138)

### DIFF
--- a/docs/en/observability/install-observability.asciidoc
+++ b/docs/en/observability/install-observability.asciidoc
@@ -2,7 +2,7 @@
 [[install-observability]]
 = Get started
 
-To use Elastic Observability, you need {es} for storing and searching your 
+To use Elastic Observability, you need {es} for storing and searching your
 data, and {kib} for visualizing and managing it.
 
 [float]
@@ -15,9 +15,9 @@ include::{docs-root}/shared/cloud/ess-getting-started.asciidoc[]
 [[self-manage]]
 == Self manage
 
-Alternatively, you can install and self manage {stack-gs}/get-started-elastic-stack.html#install-elasticsearch[{es}], 
-{stack-gs}/get-started-elastic-stack.html#install-kibana[Kibana], and 
-{apm-get-started-ref}/apm-server.html[APM server]. 
-First see the https://www.elastic.co/support/matrix[Elastic Support Matrix] for information about 
-supported operating systems and product compatibility. We recommend you use the same 
+Alternatively, you can install and self manage {stack-gs}/get-started-elastic-stack.html#install-elasticsearch[{es}],
+{stack-gs}/get-started-elastic-stack.html#install-kibana[Kibana], and
+{apm-server-ref-v}/installing.html[APM server].
+First see the https://www.elastic.co/support/matrix[Elastic Support Matrix] for information about
+supported operating systems and product compatibility. We recommend you use the same
 version of {es}, {kib}, and APM Server.


### PR DESCRIPTION
Backports the following commits to 7.x:
 - docs: link to apm server ref (#138)