### PR TITLE
Add info about namespace length limit

### DIFF
--- a/docs/en/ingest-management/fleet-overview.asciidoc
+++ b/docs/en/ingest-management/fleet-overview.asciidoc
@@ -104,12 +104,13 @@ the indices are more compact with faster autocomplete. And as an added
 bonus, the Discover page only shows relevant fields.
 
 _Namespaces_ are user-defined strings that allow you to group data any way you
-like. For example, you might group your data by environment (`prod`, `QA`) or by
-team name. Using a namespace makes it easier to search the data from a given
-source by using index patterns, or to give users permissions to data by
-assigning an index pattern to user roles. Many of our customers already organize
-their indices this way, and now we are providing this best practice as a
-default.
+like. A namespace can be up to 100 bytes in length (multi-byte characters will
+count toward this limit faster). For example, you might group your data by
+environment (`prod`, `QA`) or by team name. Using a namespace makes it easier to
+search the data from a given source by using index patterns, or to give users
+permissions to data by assigning an index pattern to user roles. Many of our
+customers already organize their indices this way, and now we are providing this
+best practice as a default.
 
 When searching your data in {kib}, you can use an
 {kibana-ref}/index-patterns.html[index pattern] to search across all or some of

--- a/docs/en/ingest-management/fleet-overview.asciidoc
+++ b/docs/en/ingest-management/fleet-overview.asciidoc
@@ -108,9 +108,7 @@ like. A namespace can be up to 100 bytes in length (multi-byte characters will
 count toward this limit faster). For example, you might group your data by
 environment (`prod`, `QA`) or by team name. Using a namespace makes it easier to
 search the data from a given source by using index patterns, or to give users
-permissions to data by assigning an index pattern to user roles. Many of our
-customers already organize their indices this way, and now we are providing this
-best practice as a default.
+permissions to data by assigning an index pattern to user roles.
 
 When searching your data in {kib}, you can use an
 {kibana-ref}/index-patterns.html[index pattern] to search across all or some of


### PR DESCRIPTION
Add documentation about namespace length limit introduced in https://github.com/elastic/kibana/pull/78522. The length is based on bytes, I borrowed wording from [ES create index API docs](https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-create-index.html#indices-create-api-path-params).