### PR TITLE
Fix URL for Elastic Package Registry

### DIFF
--- a/docs/en/ingest-management/faq.asciidoc
+++ b/docs/en/ingest-management/faq.asciidoc
@@ -110,7 +110,7 @@ available in a future release.
 == Does {agent} or {kib} download integration packages?
 
 {agent} does not download integration packages. When you add an integration in
-{ingest-manager}, {kib} connects to the {package-registry} at `epr.elastic.co`,
+{ingest-manager}, {kib} connects to the {package-registry} at `epr-7-9.elastic.co`,
 downloads the integration package, and stores its assets in {es}. This means
 that you no longer have to run a manual setup command to load integrations as
 you did previously with {beats} modules.
@@ -138,7 +138,7 @@ the {beats} managed by {agent} are set up and run differently from standalone
 For example, standalone {beats} use modules and require you to run a setup
 command on the host to load assets, such as ingest pipelines and dashboards. In
 contrast, {beats} managed by {agent} use integration packages that {kib}
-downloads from the {package-registry} at `epr.elastic.co`. This means that
+downloads from the {package-registry} at `epr-7-9.elastic.co`. This means that
 {agent} does not need extra privileges to set up assets because
 {ingest-manager} manages the assets.
 

--- a/docs/en/ingest-management/troubleshooting.asciidoc
+++ b/docs/en/ingest-management/troubleshooting.asciidoc
@@ -83,7 +83,7 @@ Then restart {kib}.
 
 In order to install {integrations}, the {ingest-manager} app needs to connect to
 an external service called the {package-registry}. For this to work, the {kib}
-server must be able to connect to `https://epr.elastic.co` on port 443.
+server must be able to connect to `https://epr-7-9.elastic.co` on port 443.
 
 [discrete]
 [[ingest-manager-app-crashes]]


### PR DESCRIPTION
Changes the URL of the Elastic Package Registry to include version info for 7.9 only.

@ruflin From what I understand, we only want to document this for 7.9, not other releases. Please let me know if that's not correct.