### PR TITLE
Update links to Uptime app content

### DIFF
--- a/docs/en/uptime/install.asciidoc
+++ b/docs/en/uptime/install.asciidoc
@@ -48,7 +48,7 @@ Install {kib}, start it up, and open up the web interface:
 === Step 3: Install and configure Heartbeat
 
 Uptime requires the setup of monitors in Heartbeat.
-These monitors provide the data you'll be visualizing in the {kibana-ref}/xpack-uptime.html[Uptime app].
+These monitors provide the data you'll be visualizing in the {observability-guide}/monitor-uptime.html[Uptime app].
 
 For instructions on installing and configuring Heartbeat, see the *Setup Instructions* in {kib}.
 Additional information is available in {heartbeat-ref}/heartbeat-installation-configuration.html[{heartbeat} quick start].
@@ -71,4 +71,4 @@ The Uptime app requires a +heartbeat-{major-version-only}*+ index pattern.
 If you have configured a different index pattern, you can use {ref}/indices-aliases.html[index aliases] to ensure data is recognized by the Uptime app.
 
 After you install and configure Heartbeat,
-the {kibana-ref}/xpack-uptime.html[Uptime app] is automatically populated with the Heartbeat monitors.
+the {observability-guide}/monitor-uptime.html[Uptime app] is automatically populated with the Heartbeat monitors.

--- a/docs/en/uptime/overview.asciidoc
+++ b/docs/en/uptime/overview.asciidoc
@@ -33,7 +33,7 @@ Elastic Uptime uses Elasticsearch to store monitoring data from Heartbeat in Ela
 You can use Kibana to search, view, and interact with data stored in Elasticsearch.
 You can easily perform advanced data analysis and visualize your data in a variety of charts, tables, and maps.
 
-The {kibana-ref}/xpack-uptime.html[Elasticsearch Uptime app] in Kibana provides a dedicated user interface for viewing uptime data and identifying problem areas.
+The {observability-guide}/monitor-uptime.html[Uptime app] in Kibana provides a dedicated user interface for viewing uptime data and identifying problem areas.
 
 [float]
 === Example deployments


### PR DESCRIPTION
Due to build failures on the [Kibana docs PR](https://github.com/elastic/kibana/pull/79978), this PR updates links to the Logs app content. 

This update gives us the opportunity to link directly to the Logs app content in the Observability guide, rather than to the new content in the Kibana PR. 

Doc build failures are expected until the following PR is merged:

https://github.com/elastic/observability-docs/pull/162

### Related PRs

https://github.com/elastic/kibana/pull/79978