### PR TITLE
Rename sections in observability guide

### DIFF
--- a/docs/en/observability/analyze-metrics.asciidoc
+++ b/docs/en/observability/analyze-metrics.asciidoc
@@ -1,5 +1,5 @@
 [[analyze-metrics]]
-= Analyze metrics
+= Metrics monitoring
 
 [NOTE]
 =====

--- a/docs/en/observability/create-alerts.asciidoc
+++ b/docs/en/observability/create-alerts.asciidoc
@@ -1,5 +1,5 @@
 [[create-alerts]]
-= Create alerts
+= Alerting
 
 Alerting allows you to detect complex conditions within the Logs, Metrics, and Uptime apps
 and trigger actions when those conditions are met. Alerting can be centrally managed from

--- a/docs/en/observability/monitor-logs.asciidoc
+++ b/docs/en/observability/monitor-logs.asciidoc
@@ -1,5 +1,5 @@
 [[monitor-logs]]
-= Monitor logs
+= Log monitoring
 
 The {logs-app} in {kib} enables you to search, filter, and tail all your logs
 ingested into {es}. Instead of having to log into different servers, change

--- a/docs/en/observability/monitor-uptime.asciidoc
+++ b/docs/en/observability/monitor-uptime.asciidoc
@@ -1,5 +1,5 @@
 [[monitor-uptime]]
-= Monitor uptime data
+= Uptime monitoring
 
 [NOTE]
 =====


### PR DESCRIPTION
The section names that we currently use are not really the terms that users search on when looking for our docs.

To align our docs better with industry standard terminology and provide a better structure for including topics like synthetics monitoring, I've renamed the major sections.