### PR TITLE
Update installation and standalone agent content

### DIFF
--- a/docs/en/ingest-management/faq.asciidoc
+++ b/docs/en/ingest-management/faq.asciidoc
@@ -19,7 +19,7 @@ it might not be started. Make sure the `elastic-agent` process is running on
 the host. If it's not running, use the <<elastic-agent-run-command,`run`>>
 command to start it.
 
-//REVIEWERS: IS this correct? Or would you use the restart command?
+//TODO: Verify that this is correct. Or would you use the restart command?
 
 [discrete]
 [[where-are-the-agent-logs]]
@@ -96,9 +96,7 @@ run {agent}.
 [[i-rebooted-my-host]]
 == How do I restart {agent} after rebooting my host?
 
-//REVIEWERS: I wasn't sure how to test this section because I can't seem to kill
-//elastic-agent. If I kill the process, it just starts up again. Is that
-//expected behavior? Are the details here correct?
+//TODO: Verify that this works (it didn't work for me on macOS)
 
 {agent} should restart automatically when you reboot your host. If it doesn't,
 you can start it manually by running:

--- a/docs/en/ingest-management/faq.asciidoc
+++ b/docs/en/ingest-management/faq.asciidoc
@@ -15,7 +15,11 @@ Also read <<ingest-management-troubleshooting>>.
 == Why doesn't my enrolled agent show up in the {fleet} app?
 
 If {agent} was successfully enrolled, but doesn't show up in the *Agents* list,
-it might not be started. You need to <<run-elastic-agent,start {agent}>>.
+it might not be started. Make sure the `elastic-agent` process is running on
+the host. If it's not running, use the <<elastic-agent-run-command,`run`>>
+command to start it.
+
+//REVIEWERS: IS this correct? Or would you use the restart command?
 
 [discrete]
 [[where-are-the-agent-logs]]
@@ -92,18 +96,24 @@ run {agent}.
 [[i-rebooted-my-host]]
 == How do I restart {agent} after rebooting my host?
 
-On Windows, if you used PowerShell to install {agent} as a service, the agent
-should still be running after rebooting the host.
+//REVIEWERS: I wasn't sure how to test this section because I can't seem to kill
+//elastic-agent. If I kill the process, it just starts up again. Is that
+//expected behavior? Are the details here correct?
 
-On Linux, if you used the DEB or RPM packages, the agent should still be running
-after rebooting the host. 
+{agent} should restart automatically when you reboot your host. If it doesn't,
+you can start it manually by running:
 
-On macOS, you need to restart {agent} from the command line after
-rebooting the host, or follow the steps described in
-<<elastic-agent-install-service-macos>> to run the agent as a service. 
+[source,shell]
+----
+elastic-agent run
+----
 
-Support for installing {agent} as a service on all supported systems will be
-available in a future release.
+If the process is already running, you can restart it by running:
+
+[source,shell]
+----
+elastic-agent restart
+----
 
 [discrete]
 [[does-agent-download-packages]]

--- a/docs/en/ingest-management/getting-started.asciidoc
+++ b/docs/en/ingest-management/getting-started.asciidoc
@@ -91,7 +91,7 @@ or standalone. What's the difference?
 
 * With <<agent-fleet-mode,_{fleet} mode_>>, you use {fleet} in {kib} to
 define and manage {agent} policies from a central location.
-* With <<agent-standalone-mode,_standalone mode_>>, you configure {agent}
+* With <<run-elastic-agent-standalone,_standalone mode_>>, you configure {agent}
 manually on the system where the agent is installed.
 
 [discrete]
@@ -131,7 +131,7 @@ image::images/kibana-fleet-enroll.png[{fleet} showing agent enrollment page]
 that this command will overwrite the `elastic-agent.yml` file in that directory.
 +
 --
-include::{beats-repo-dir}/x-pack/elastic-agent/docs/tab-widgets/enroll-widget.asciidoc[]
+include::{beats-repo-dir}/x-pack/elastic-agent/docs/tab-widgets/install-widget.asciidoc[]
 --
 
 . In {fleet}, click **Continue** to go to the **Agents**


### PR DESCRIPTION
Updates observability docs to support changes in https://github.com/elastic/beats/pull/22290.

The build here will fail until the beats PR is merged.

