### PR TITLE
Fix broken link

### DIFF
--- a/docs/en/observability/monitor-java-app.asciidoc
+++ b/docs/en/observability/monitor-java-app.asciidoc
@@ -1469,7 +1469,7 @@ Results show that only twenty requests were sent, which makes sense
 given the processing time.
 +
 Now let’s build a visualization using
-https://www.elastic.co/guide/en/kibana/current/lens.html[Lens], a
+{kibana-ref}/dashboard.html#lens[Lens], a
 tool in {kib} allowing create visualizations easily.
 +
 [role="screenshot"]

--- a/docs/en/observability/monitor-java-app.asciidoc
+++ b/docs/en/observability/monitor-java-app.asciidoc
@@ -1469,8 +1469,7 @@ Results show that only twenty requests were sent, which makes sense
 given the processing time.
 +
 Now let’s build a visualization using
-{kibana-ref}/dashboard.html#lens[Lens], a
-tool in {kib} allowing create visualizations easily.
+{kibana-ref}/dashboard.html#lens[Lens] in {kib}.
 +
 [role="screenshot"]
 image:./images/monitor-java-app-metrics-kibana-create-visualization-open-files.png[Lens


### PR DESCRIPTION
This PR fixes a broken link to the Lens section in the Kibana docs.

NOTE: The fix is required only for the master, 7.x, and 7.10 branches.

### HTML preview:

https://observability-docs_217.docs-preview.app.elstc.co/guide/en/observability/master/monitor-java-app.html

### Related issue:

https://github.com/elastic/observability-docs/issues/215
https://github.com/elastic/docs/pull/1994
