### PR TITLE
docs: add whats new tagged region

### DIFF
--- a/docs/en/observability/whats-new.asciidoc
+++ b/docs/en/observability/whats-new.asciidoc
@@ -13,3 +13,9 @@ coming[8.0.0]
 // https://www.elastic.co/blog/elastic-observability-7-6-0-released[7.6] |
 // https://www.elastic.co/blog/elastic-observability-7-5-0-released[7.5] |
 // https://www.elastic.co/blog/elastic-observability-update-7-4-0[7.4]
+
+// tag::whats-new[]
+
+// What's new content goes in here.
+
+// end::whats-new[]


### PR DESCRIPTION
Adds a "what's new" tagged region to `master` and `7.x`.

Related: https://github.com/elastic/observability-docs/pull/216/files