### PR TITLE
[7.x] docs: add tagged region (#223)

### DIFF
--- a/docs/en/observability/whats-new.asciidoc
+++ b/docs/en/observability/whats-new.asciidoc
@@ -13,3 +13,9 @@ coming[7.11.0]
 // https://www.elastic.co/blog/elastic-observability-7-6-0-released[7.6] |
 // https://www.elastic.co/blog/elastic-observability-7-5-0-released[7.5] |
 // https://www.elastic.co/blog/elastic-observability-update-7-4-0[7.4]
+
+// tag::whats-new[]
+
+// What's new content goes in here.
+
+// end::whats-new[]


### PR DESCRIPTION
Backports the following commits to 7.x:
 - docs: add tagged region (#223)