### PR TITLE
[7.10] Update what's new links

### DIFF
--- a/docs/en/observability/whats-new.asciidoc
+++ b/docs/en/observability/whats-new.asciidoc
@@ -25,12 +25,12 @@ by https://www.elastic.co/start[downloading them].
 In {minor-version}, we are delighted to announce the release of User Experience monitoring
 capabilities featuring Google Core Web Vitals. These Core Web Vitals are based on metrics
 that score three crucial areas of user experience: loading performance, visual stability,
-and interactivity. Core Web Vitals are set to become the leading performance measurement in Google ranking factors. 
+and interactivity. Core Web Vitals are set to become the leading performance measurement in Google ranking factors.
 
 In addition to Core Web Vitals, we provide several other data points to help you understand
 how users are experiencing your website. You can filter and break down data to focus
 on the parts of your website or groups of users who are having a poor experience.
-For more information, see <<user-experience,User experience>>.
+For more information, see {observability-guide}/user-experience.html[User experience].
 
 [role="screenshot"]
 image::images/user-experience-tab.png[User experience monitoring]
@@ -80,11 +80,11 @@ image::images/fleet-agents.png[Fleet]
 Along with all of these new features, you can now:
 
 * Configure a proxy in Fleet to access the internet. This feature is crucial if you run Fleet inside a
-secure network and you need access to the Elastic Package Registry. 
+secure network and you need access to the Elastic Package Registry.
 * Provide additional configuration for the {es} output, such as custom certificates.
 * Increase the recommended number of agents per {kib} node from 1000 to 8000.
 * Configure inputs with variables and conditions, which is a foundation for our future work on autodiscovery
-for Kubernetes and Docker. 
+for Kubernetes and Docker.
 
 [discrete]
 == Anomaly detection for hosts and Kubernetes pods
@@ -103,7 +103,8 @@ when the CPU suddenly spikes to 50%, it may be a more worrisome signal than when
 We have also included a historical timeline in the {metrics-app} to help you see the full alert and anomaly
 timeline across your resource pool, making it easy to spot temporal trends and patterns during an incident
 investigation. You can use the timeline to explore the state of your infrastructure at the point in time the
-incident occurred. For more information, see <<inspect-metric-anomalies,Inspect metric anomalies>>.
+incident occurred. For more information,
+see {observability-guide}/inspect-metric-anomalies.html[Inspect metric anomalies].
 
 [role="screenshot"]
 image::images/anomaly-detect-host.png[Anomaly detection for hosts and Kubernetes pods]
@@ -139,7 +140,7 @@ When creating threshold-based alerts, you may want to weigh them by another metr
 introduced logs ratio alerting in the {logs-app}. For example, when detecting a genuine web server timeout problem
 (504 gateway timeout errors), you can weigh them with the number of requests it handles. To help achieve this, you
 create a ratio threshold like `Ratio between error code 504 to the overall number of response codes is higher than a threshold`.
-For more information, see <<logs-threshold-alert,Alerting>>.
+For more information, see {observability-guide}/logs-threshold-alert.html[Alerting].
 
 [role="screenshot"]
 image::images/log-ratio-alerting.png[Log ratio alerting]
@@ -149,7 +150,7 @@ image::images/log-ratio-alerting.png[Log ratio alerting]
 
 We have also included an alert chart preview. When creating a threshold alert, you want to set a value that
 triggers when it detects an outlier. The alert chart preview enables you to visualize the threshold overlaid on
-top of historical data. For more information, see <<logs-threshold-alert,Alerting>>.
+top of historical data. For more information, see {observability-guide}/logs-threshold-alert.html[Alerting].
 
 [role="screenshot"]
 image::images/alert-chart-preview.png[Alert chart preview]
@@ -160,7 +161,7 @@ image::images/alert-chart-preview.png[Alert chart preview]
 In 7.6.0, we introduced https://www.elastic.co/blog/elastic-logs-7-6-0-released[log categorization], a powerful tool
 that works well with machine-generated unstructured data and not as much for free-form text.
 In {minor-version}, we have added the ability to identify inadequate datasets for categorization. On the Categories
-page of the {logs-app}, a warning is displayed describing the specific dataset that is a misfit for categorization 
+page of the {logs-app}, a warning is displayed describing the specific dataset that is a misfit for categorization
 and provides a link to configure the job for filtering that dataset.
 
 [role="screenshot"]


### PR DESCRIPTION
## Summary

This PR updates the 7.10 What's new content to use cross-doc links instead of local links. This change is required because the content is reused in the stack-docs installation and upgrade guide.

For https://github.com/elastic/stack-docs/pull/1437