### PR TITLE
Better Otel Metrics docs

### DIFF
--- a/docs/en/observability/whats-new.asciidoc
+++ b/docs/en/observability/whats-new.asciidoc
@@ -271,6 +271,9 @@ public void createOrder(HttpServletRequest request) {
 }
 ----
 
+The collected metrics are stored in the `apm-\*-metric*` indices.
+Note that the https://www.javadoc.io/doc/io.opentelemetry/opentelemetry-api/latest/io/opentelemetry/api/metrics/DoubleValueRecorder.html[`DoubleValueRecorder`] and https://www.javadoc.io/doc/io.opentelemetry/opentelemetry-api/latest/io/opentelemetry/api/metrics/LongValueObserver.html[`LongValueRecorder`] metrics are not yet supported.
+
 [discrete]
 == Disk spooling for Beats (beta)
 


### PR DESCRIPTION
* Document the indices used to store metrics
* Indicate that `DoubleValueRecorder` and `LongValueRecorder` are not yet supported