### PR TITLE
Use un-authenticated git URL for synthetics examples

### DIFF
--- a/docs/en/observability/synthetics-quickstart.asciidoc
+++ b/docs/en/observability/synthetics-quickstart.asciidoc
@@ -31,7 +31,7 @@ and change directories into `examples/docker`:
 
 [source,sh]
 ----
-git clone git@github.com:elastic/synthetics.git &&\
+git clone https://github.com/elastic/synthetics.git &&\
 cd examples/docker
 ----
 


### PR DESCRIPTION
The SSH URL only works if you have valid SSH creds w/ push pull which applies to us Elastic employees but no one else