### PR TITLE
[7.x] Use un-authenticated git URL for synthetics examples (#279)

### DIFF
--- a/docs/en/observability/synthetics-quickstart.asciidoc
+++ b/docs/en/observability/synthetics-quickstart.asciidoc
@@ -31,7 +31,7 @@ and change directories into `examples/docker`:
 
 [source,sh]
 ----
-git clone git@github.com:elastic/synthetics.git &&\
+git clone https://github.com/elastic/synthetics.git &&\
 cd examples/docker
 ----
 


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Use un-authenticated git URL for synthetics examples (#279)