### PR TITLE
[7.x] docs: make it clear that docker is the only option (#283)

### DIFF
--- a/docs/en/observability/synthetic-monitoring.asciidoc
+++ b/docs/en/observability/synthetic-monitoring.asciidoc
@@ -30,13 +30,10 @@ bottom line or customers' experience.
 [[how-synthetics-works]]
 == How does it work?
 
-While there are different ways to utilize Elastic's synthetic monitoring,
-the easiest is with our provided Docker image:
-
 // Operational use case screenshot
 image::images/synthetics-overview.png[Synthetics overview]
 
-In this use-case, Docker spins up Heartbeat, which has the `@elastic/synthetics` package installed.
+A provided Docker image spins up Heartbeat, which has the `@elastic/synthetics` package installed.
 Heartbeat handles the scheduling of test runs and supervises the execution of the
 `@elastic/synthetics` package.
 `@elastic/synthetics` runs your tests by invoking the Playwright library and starting a new


### PR DESCRIPTION
Backports the following commits to 7.x:
 - docs: make it clear that docker is the only option (#283)