### PR TITLE
Add settings info for metrics alerts

### DIFF
--- a/docs/en/observability/infrastructure-threshold-alert.asciidoc
+++ b/docs/en/observability/infrastructure-threshold-alert.asciidoc
@@ -81,3 +81,13 @@ These variables must use the structure of `{{context.[Variable Name].condition[N
 - `context.value.condition[X]`: This variable resolves to the detected value of conditions 0, 1, 2, etc.
 - `context.value.threshold[X]`: This variable resolves to the threshold values of conditions 0, 1, 2, and so on.
 - `context.value.metric[X]`: This variable resolves to the monitored metric of conditions 0, 1, 2, and so on.
+
+[[infra-alert-settings]]
+== Settings
+
+With infrastructure threshold alerts, it's not possible to set an explicit index pattern as part of the configuration. The index pattern is instead inferred from
+*Metrics indices* on the <<configure-settings,Settings>> page of the {metrics-app}.
+
+With each execution of the alert check, the *Metrics indices* setting is checked, but it is not stored when the alert is created.
+
+The *Timestamp* field that is set under *Settings* determines which field is used for timestamps in queries.

--- a/docs/en/observability/logs-threshold-alert.asciidoc
+++ b/docs/en/observability/logs-threshold-alert.asciidoc
@@ -9,7 +9,6 @@ To use the alerting functionality you need to {kibana-ref}/alerting-getting-star
 [role="screenshot"]
 image::images/log-threshold-alert.png[Log threshold alert configuration]
 
-[discrete]
 [[fields-comparators-logs]]
 == Fields and comparators
 
@@ -58,9 +57,8 @@ When group by fields are selected, but no documents are containing the selected 
 [role="screenshot"]
 image::images/log-threshold-alert-group-by.png[Log threshold alert group by]
 
-[discrete]
 [[chart-previews]]
-=== Chart previews
+== Chart previews
 
 To determine how many log entries would match each part of your configuration, you can view a chart preview for each condition. This is useful for determining how many log entries would match each part of your configuration. When a group by is set, the chart displays a bar per group. To view the preview, select the arrow next to the condition.
 
@@ -69,9 +67,8 @@ image::images/log-threshold-alert-chart-previews.png[Log threshold chart preview
 
 The shaded area denotes the threshold that has been selected.
 
-[discrete]
 [[ratio-alerts]]
-=== Ratio alerts
+== Ratio alerts
 
 To understand how one query compares to another query, create a ratio alert. This type of alert is triggered when a ratio value meets a specific threshold. The ratio threshold value is the document count of the first query (query A), divided by the document count of the second query (query B).
 
@@ -85,17 +82,6 @@ image::images/log-threshold-alert-ratio.png[Log threshold ratio alert]
 As it is not possible to divide by 0, when the document count of query A or query B is 0, it results in an undefined/indeterminate ratio. In this scenario, no alert is triggered.
 =====
 
-[discrete]
-[[settings]]
-=== Settings
-
-With log threshold alerts, it's not possible to set an explicit index pattern as part of the configuration. The index pattern is instead inferred from  *Log indices* on the *Settings* page of the {logs-app}.
-
-With each execution of the alert check, the *Log indices* setting is checked; however, it is not stored when the alert is created.
-
-The *Timestamp* field set under *Settings* is used for determining which field we use for timestamps in queries.
-
-[discrete]
 [[action-types-logs]]
 == Action types
 
@@ -106,7 +92,7 @@ image::images/action-type-logs.png[Alert action types]
 
 [discrete]
 [[es-queries]]
-==== Elasticsearch queries (advanced)
+=== Elasticsearch queries (advanced)
 
 When an alert check is performed, a query is built based on the alert configuration. For the vast majority of cases it shouldn't be necessary to know what these queries are. However, to determine an optimal configuration or to aid with debugging, it might be useful to see the structure of these queries. Below is an example {es} query for the following configuration:
 
@@ -243,3 +229,13 @@ image::images/log-threshold-alert-es-query-grouped.png[Log threshold grouped Ela
 ----------------------------------
 <1> Taken from the *Log indices* setting
 <2> Taken from the *Timestamp* setting
+
+[[settings]]
+== Settings
+
+With log threshold alerts, it's not possible to set an explicit index pattern as part of the configuration. The index pattern is instead inferred from *Log indices*
+on the <<configure-data-sources,Settings>> page of the {logs-app}.
+
+With each execution of the alert check, the *Log indices* setting is checked, but it is not stored when the alert is created.
+
+The *Timestamp* field that is set under *Settings* determines which field is used for timestamps in queries.

--- a/docs/en/observability/metrics-threshold-alert.asciidoc
+++ b/docs/en/observability/metrics-threshold-alert.asciidoc
@@ -85,3 +85,13 @@ These variables must use the structure of `{{context.[Variable Name].condition[N
 - `context.value.condition[X]`: This variable resolves to the detected value of conditions 0, 1, 2, and so on.
 - `context.value.threshold[X]`: This variable resolves to the threshold values of conditions 0, 1, 2, and so on.
 - `context.value.metric[X]`: This variable resolves to the monitored metric of conditions 0, 1, 2, and so on.
+
+[[metrics-alert-settings]]
+== Settings
+
+With metrics threshold alerts, it's not possible to set an explicit index pattern as part of the configuration. The index pattern is instead inferred from
+*Metrics indices* on the <<configure-settings,Settings>> page of the {metrics-app}.
+
+With each execution of the alert check, the *Metrics indices* setting is checked, but it is not stored when the alert is created.
+
+The *Timestamp* field that is set under *Settings* determines which field is used for timestamps in queries.


### PR DESCRIPTION
Currently in the **Create a logs threshold alert** topic we have a [Settings](https://www.elastic.co/guide/en/observability/current/logs-threshold-alert.html#settings) section describing that it's not possible to set an explicit index pattern as part of the configuration. 

This PR adds the Settings content to both the Infrastructure threshold alert and the metrics threshold alert.

Preview:
https://observability-docs_291.docs-preview.app.elstc.co/guide/en/observability/master/metrics-threshold-alert.html
