### PR TITLE
[7.x] Clarify where to run examples (#289)

### DIFF
--- a/docs/en/observability/synthetics-create-test.asciidoc
+++ b/docs/en/observability/synthetics-create-test.asciidoc
@@ -250,7 +250,7 @@ npm install -g @elastic/synthetics
 
 Now it's time to write your tests:
 
-. Create a new Node.js project.
+. Create a new NPM/Node.js project.
 . Create a `javascript` or `typescript` file that imports your tests.
 All synthetic test files must use the `.journey.ts` or `.journey.js` file extension.
 . Compile everything together.
@@ -261,17 +261,27 @@ If you'd like to test it locally, clone the repo, and install the example:
 
 [source,sh]
 ----
+# Check out the synthetics repo and included examples
 git clone git@github.com:elastic/synthetics.git &&\
-cd examples/todos/ &&\
+cd synthetics/examples/todos/ &&\
+# Install all required dependencies for the todos example
 npm install
 ----
 
-From the root of the `synthetics` repo, you can now run the provided tests.
-Any files matching the filename `*.journey.*` will be run.
+You are now inside the a synthetics test-suite, which is also an NPM project.
+You can now run the provided tests; all files matching the filename `*.journey.*`
+will be run.
+
+Please note, you must run the following commands from within the `examples/todos` folder.
+The `todos` folder has its own `package.json`, which makes it its own NPM project. If you
+run these commands outside the `todos` folder you can run into confusing situations with
+NPM's module resolution that can cause this command to not work.
 
 [source,sh]
 ----
-npx @elastic/synthetics examples/todos
+# Run tests on the current directory. Please note the dot `.` which indicates 
+# that we want to run tests on the current directory
+npx @elastic/synthetics .
 ----
 
 Once you have your tests up and running, follow the steps in the <<synthetics-quickstart,quickstart guide>>


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Clarify where to run examples (#289)