### PR TITLE
Move v7.8 Elastic Agent docs to the observability-docs repo

### DIFF
--- a/docs/en/ingest-management/elastic-agent/elastic-agent-command-line.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/elastic-agent-command-line.asciidoc
@@ -1,0 +1,24 @@
+[[elastic-agent-cmd-options]]
+[role="xpack"]
+= Command line options
+
+experimental[]
+
+include::elastic-agent.asciidoc[tag=experimental-warning]
+
+The `elastic-agent run` command provides flags that alter the behavior of an
+agent:
+
+`-path.home`::
+The home directory of the {agent}. `path.home` determines the location of the
+configuration files and data directory.
+
+`-c`::
+The configuration file to load. If not specified, {agent} uses
+`{path.home}/elastic-agent.yml`.
+
+`-path.data`::
+The data directory used by {agent} to store downloaded artifacts. Also stores
+logs for any {beats} started and managed by {agent}.
++
+If not specified, {agent} uses `{path.home}/data`.

--- a/docs/en/ingest-management/elastic-agent/elastic-agent-configuration-example.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/elastic-agent-configuration-example.asciidoc
@@ -1,0 +1,14 @@
+[[elastic-agent-configuration-example]]
+[role="xpack"]
+= Configuration example
+
+experimental[]
+
+include::elastic-agent.asciidoc[tag=experimental-warning]
+
+The following example shows a full list of configuration options:
+
+[source,yaml]
+----
+include::elastic-agent_configuration_example.yml[]
+----

--- a/docs/en/ingest-management/elastic-agent/elastic-agent-configuration.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/elastic-agent-configuration.asciidoc
@@ -1,0 +1,115 @@
+[[elastic-agent-configuration]]
+[role="xpack"]
+= Configuration settings
+
+experimental[]
+
+include::elastic-agent.asciidoc[tag=experimental-warning]
+
+By default {agent} runs in standalone mode to ingest system data and send it to
+a local {es} instance running on port 9200. It uses the demo credentials of the
+`elastic` user. It's also configured to monitor all {beats} managed by the Agent
+and send the {beats} logs and metrics to the same {es} instance.
+
+To alter this behavior, configure the output and other configuration settings:
+
+* <<elastic-agent-output-configuration>>
+* <<elastic-agent-monitoring-configuration>>
+* <<elastic-agent-datasource-configuration>>
+
+[discrete]
+[[elastic-agent-output-configuration]]
+== Output settings
+
+Specify one or more outputs. Specifying multiple outputs allows you to pair
+each data source with a different output. 
+
+IMPORTANT: {agent} currently works with the {es} output only.
+
+Example output configuration:
+
+[source,yaml]
+-------------------------------------------------------------------------------------
+outputs:
+  default:
+    type: elasticsearch
+    hosts: [127.0.0.1:9200]
+    username: elastic
+    password: changeme
+
+  monitoring:
+    type: elasticsearch
+    api_key: VuaCfGcBCdbkQm-e5aOx:ui2lp2axTNmsyakw9tvNnw
+    hosts: ["localhost:9200"]
+    ca_sha256: "7lHLiyp4J8m9kw38SJ7SURJP4bXRZv/BNxyyXkCcE/M="
+-------------------------------------------------------------------------------------
+
+This example configures two outputs: `default` and  `monitoring`.
+Notice that they use different authentication methods. The first one uses a
+username and password pair, and the second one contains an API key.
+
+[NOTE]
+==============
+A default output configuration is required.
+==============
+
+[discrete]
+[[elastic-agent-monitoring-configuration]]
+== {beats} monitoring settings
+
+{agent} monitors {beats} by default. To disable or change monitoring 
+settings, set options under `settings.monitoring`:
+
+[source,yaml]
+-------------------------------------------------------------------------------------
+settings.monitoring:
+  # enabled turns on monitoring of running processes
+  enabled: true
+  # enables log monitoring
+  logs: true
+  # enables metrics monitoring
+  metrics: true
+  # specifies output to be used
+  use_output: monitoring
+-------------------------------------------------------------------------------------
+
+
+To disable monitoring, set `settings.monitoring.enabled` to `false`. When set to
+`false`, {beats} monitoring is turned off, and all other options in this section
+are ignored.
+
+To enable monitoring, set `settings.monitoring.enabled` to `true`. Also set the
+`logs` and `metrics` settings to control whether logs, metrics, or both are
+collected. If neither setting is specified, monitoring is disabled. Set
+`use_output` to specify the output to which monitoring events are sent.
+
+[discrete]
+[[elastic-agent-datasource-configuration]]
+== Datasource settings
+
+By default {agent} collects system metrics, such as cpu, memory, network, and
+filesystem metrics, and sends them to the default output. For example:
+
+
+[source,yaml]
+-------------------------------------------------------------------------------------
+datasources:
+  - namespace: default
+    use_output: default
+    inputs:
+      - type: system/metrics
+        streams:
+          - metricset: cpu
+            dataset: system.cpu
+          - metricset: memory
+            dataset: system.memory
+          - metricset: network
+            dataset: system.network
+          - metricset: filesystem
+            dataset: system.filesystem
+-------------------------------------------------------------------------------------
+
+If `use_output` is not specified, the `default` output is used.
+
+//For more examples, see
+//<<elastic-agent-configuration-example,`elastic-agent_configuration_example.yml`>>.

--- a/docs/en/ingest-management/elastic-agent/elastic-agent.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/elastic-agent.asciidoc
@@ -1,0 +1,37 @@
+[[elastic-agent-installation-configuration]]
+[role="xpack"]
+
+= Manage your {agent}s
+
+experimental[]
+
+// tag::experimental-warning[]
+**This experimental release allows you to try out new capabilities. There is no
+migration path for future releases. You must test in a dedicated cluster. Delete
+the cluster when you are done. You will not be able to upgrade the cluster.**
+// end::experimental-warning[]
+
+// tag::agent-install-intro[]
+{agent} is a single, unified agent that you can deploy to hosts or containers to
+collect data and send it to the {stack}. Behind the scenes, {agent} runs the
+{beats} shippers or Endpoint required for your configuration.
+// end::agent-install-intro[]
+
+To learn how to install, configure, and run your {agent}s, see:
+
+* <<elastic-agent-installation>>
+* <<run-elastic-agent>>
+* <<elastic-agent-cmd-options>>
+* <<elastic-agent-configuration>>
+
+include::install-elastic-agent.asciidoc[leveloffset=+1]
+
+include::run-elastic-agent.asciidoc[leveloffset=+1]
+
+include::stop-elastic-agent.asciidoc[leveloffset=+1]
+
+include::elastic-agent-command-line.asciidoc[leveloffset=+1]
+
+include::elastic-agent-configuration.asciidoc[leveloffset=+1]
+
+//include::elastic-agent-configuration-example.asciidoc[leveloffset=+1]

--- a/docs/en/ingest-management/elastic-agent/elastic-agent_configuration_example.yml
+++ b/docs/en/ingest-management/elastic-agent/elastic-agent_configuration_example.yml
@@ -1,0 +1,569 @@
+outputs:
+  default:
+    type: elasticsearch
+    api_key: VuaCfGcBCdbkQm-e5aOx:ui2lp2axTNmsyakw9tvNnw
+    hosts: ["localhost:9200"]
+    ca_sha256: "7lHLiyp4J8m9kw38SJ7SURJP4bXRZv/BNxyyXkCcE/M="
+    # Not supported at first
+    queue:
+      type: disk
+
+  long_term_storage:
+    type: elasticsearch
+    api_key: VuaCfGcBCdbkQm-e5aOx:ui2lp2axTNmsyakw9tvNnw
+    hosts: ["localhost:9200"]
+    ca_sha256: "7lHLiyp4J8m9kw38SJ7SURJP4bXRZv/BNxyyXkCcE/M="
+    queue:
+      type: disk
+
+  monitoring:
+    type: elasticsearch
+    api_key: VuaCfGcBCdbkQm-e5aOx:ui2lp2axTNmsyakw9tvNnw
+    hosts: ["localhost:9200"]
+    ca_sha256: "7lHLiyp4J8m9kw38SJ7SURJP4bXRZv/BNxyyXkCcE/M="
+
+settings.monitoring:
+  use_output: monitoring
+
+# Sets log level. The default log level is info.
+# Available log levels are: error, warning, info, debug
+#logging.level: trace
+
+datasources:
+  # use the nginx package
+  - id?: nginx-x1
+    enabled?: true # default to true
+    title?: "This is a nice title for human"
+    # Package this config group is coming from. On importing, we know where it belongs
+    # The package tells the UI which application to link to
+    package?:
+      name: epm/nginx
+      version: 1.7.0
+    namespace?: prod
+    constraints?:
+      # Contraints look are not final
+      - os.platform: { in: "windows" }
+      - agent.version: { ">=": "8.0.0" }
+    use_output: long_term_storage
+    inputs:
+      - type: logs
+        processors?:
+        streams:
+          - id?: {id}
+            enabled?: true # default to true
+            dataset: nginx.acccess
+            paths: /var/log/nginx/access.log
+          - id?: {id}
+            enabled?: true # default to true
+            dataset: nginx.error
+            paths: /var/log/nginx/error.log
+      - type: nginx/metrics
+        streams:
+          - id?: {id}
+            enabled?: true # default to true
+            dataset: nginx.stub_status
+            metricset: stub_status
+
+  #################################################################################################
+  # Custom Kafka datasource
+  - id: kafka-x1
+    title: "Consume data from kafka"
+    namespace?: prod
+    use_output: long_term_storage
+    inputs:
+      - type: kafka
+        host: localhost:6566
+        streams:
+          - dataset: foo.dataset
+            topic: foo
+            processors:
+             - extract_bro_specifics
+
+
+  #################################################################################################
+  # System EPM package
+  - id?: system
+    title: Collect system information and metrics
+    package:
+      name: epm/system
+      version: 1.7.0
+    inputs:
+      - type: system/metrics
+        streams:
+         - id?: {id}
+           enabled?: false # default true
+           metricset: cpu
+           dataset: system.cpu
+           metrics: ["percentages", "normalized_percentages"]
+           period: 10s
+         - metricset: memory
+           dataset: system.memory
+           period: 10s
+         - metricset: diskio
+           dataset: system.diskio
+           period: 10s
+         - metricset: load
+           dataset: system.load
+           period: 10s
+         - metricset: memory
+           dataset: system.memory
+           period: 10s
+         - metricset: process
+           dataset: system.process
+           processes: ["firefox*"]
+           include_top_n:
+              by_cpu: 5      # include top 5 processes by CPU
+              by_memory: 5   # include top 5 processes by memory
+           period: 10s
+         - metricset: process_summary
+           dataset: system.process_summary
+           period: 10s
+         - metricset: uptime
+           dataset: system.uptime
+           period: 15m
+         - metricset: socket_summary
+           dataset: system.socket_summary
+           period: 10s
+         - metricset: filesystem
+           dataset: system.filesystem
+           period: 10s
+         - metricset: raid
+           dataset: system.raid
+           period: 10s
+         - metricset: socket
+           dataset: system.socket
+           period: 10s
+         - metricset: service
+           dataset: system.service
+           period: 10s
+         - metricset: fsstat
+           dataset: system.fsstat
+           period: 10s
+         - metricset: foo
+           dataset: system.foo
+           period: 10s
+
+
+  #################################################################################################
+  # Elasticsearch package example
+  - id?: my-endpoint
+    title: Collect Elasticsearch information
+    package:
+      name: epm/elasticsearch
+      version: 1.7.0
+    inputs:
+        - type: log
+          streams:
+          - id?: {id}
+            enabled?: true # default to true
+            dataset: elasticsearch.audit
+            paths: [/var/log/elasticsearch/*_access.log, /var/log/elasticsearch/*_audit.log]
+          - id?: {id}
+            enabled?: true
+            dataset: elasticsearch.deprecation
+            paths: [/var/log/elasticsearch/*_deprecation.log]
+          - id?: {id}
+            enabled?: true
+            dataset: elasticsearch.gc
+            paths: [/var/log/elasticsearch/*_gc.log, /var/log/elasticsearch/*_gc.log.[0-9]*]
+          - id?: {id}
+            enabled?: true
+            dataset: elasticsearch.server
+            paths: [/var/log/elasticsearch/*.log]
+          - id?: {id}
+            enabled?: true
+            dataset: elasticsearch.slowlog
+            paths: [/var/log/elasticsearch/*_index_search_slowlog.log, /var/log/elasticsearch/*_index_indexing_slowlog.log]
+        - type: elasticsearch/metrics
+          hosts: ["http://localhost:9200"]
+          hosts: ["http://localhost:9200"]
+          # api_key: xxxx
+          # username: elastic
+          # password: changeme
+          # ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
+          # ssl.ca_sha256: BxZ...
+          # ssl.certificate: ...
+          # ssl.key: ...
+          xpack.enabled: true
+          streams:
+          - id?: {id}
+            metricset: ccr
+            dataset: elasticseach.ccr
+            period: 10s
+          - id?: {id}
+            metricset: cluster_stats
+            dataset: elasticseach.cluster_stats
+            period: 10s
+          - id?: {id}
+            metricset: enrich
+            dataset: elasticseach.enrich
+            period: 10s
+          - id?: {id}
+            metricset: index
+            dataset: elasticseach.index
+            period: 10s
+          - id?: {id}
+            metricset: index_recovery
+            dataset: elasticseach.index_recovery
+            active_only: true
+            period: 10s
+          - id?: {id}
+            metricset: ml_jobs
+            dataset: elasticseach.ml_jobs
+            period: 10s
+          - id?: {id}
+            metricset: node_stats
+            dataset: elasticseach.node_stats
+            period: 10s
+          - id?: {id}
+            metricset: shard
+            dataset: elasticseach.shard
+            period: 10s
+
+  #################################################################################################
+  # AWS module
+  - id?: my-aws
+    title: Collect AWS
+    package:
+      name: epm/aws
+      version: 1.7.0
+    inputs:
+        # Looking at the AWS modules, I believe each fileset need to be in their own
+        # buckets?
+        - type: s3
+          credential_profile_name: fb-aws
+          #shared_credential_file: /etc/filebeat/aws_credentials
+          streams:
+          - id?: {id}
+            dataset: aws.s3
+            queue_url: https://sqs.myregion.amazonaws.com/123456/sqs-queue
+          - id?: {id}
+            dataset: aws.s3access
+            queue_url: https://sqs.myregion.amazonaws.com/123456/sqs-queue
+          - id?: {id}
+            dataset: aws.vpcflow
+            queue_url: https://sqs.myregion.amazonaws.com/123456/sqs-queue
+          - id?: {id}
+            dataset: aws.cloudtrail
+            queue_url: https://sqs.myregion.amazonaws.com/123456/sqs-queue
+       - type: aws/metrics
+         access_key_id: '${AWS_ACCESS_KEY_ID:""}'
+         secret_access_key: '${AWS_SECRET_ACCESS_KEY:""}'
+         session_token: '${AWS_SESSION_TOKEN:""}'
+         #credential_profile_name: test-mb
+         #shared_credential_file: ...
+         streams:
+          - id?: {id}
+            metricset: usage
+            dataset: aws.usage
+            period: 5m
+          - id?: {id}
+            metricset: cloudwatch
+            dataset: aws.cloudwatch
+            period: 5m
+            name: ["CPUUtilization", "DiskWriteOps"]
+            tags.resource_type_filter: ec2:instance
+            #dimensions:
+            #  - name: InstanceId
+            #    value: i-0686946e22cf9494a
+            statistic: ["Average", "Maximum"]
+          - id?: {id}
+            metricset: ebs
+            dataset: aws.ebs
+            period: 5m
+          - id?: {id}
+            metricset: ec2
+            dataset: aws.ec2
+            period: 5m
+          - id?: {id}
+            metricset: elb
+            dataset: aws.elb
+            period: 5m
+          - id?: {id}
+            metricset: sns
+            dataset: aws.sns
+            period: 5m
+          - id?: {id}
+            metricset: sqs
+            dataset: aws.sqs
+            period: 5m
+          - id?: {id}
+            metricset: rds
+            dataset: aws.rds
+            period: 5m
+          - id?: {id}
+            metricset: billing
+            dataset: aws.billing
+            period: 12h
+          - id?: {id}
+            metricset: billing
+            dataset: aws.billing
+            period: 12h
+          - id?: {id}
+            metricset: s3_daily_storage
+            dataset: aws.s3_daily_storage
+            period: 24h
+          - id?: {id}
+            metricset: s3_request
+            dataset: aws.s3_request
+            period: 24h
+
+
+  #################################################################################################
+  # Kubernetes
+  - id?: my-kubernetes
+    title: Collect Kubernetes
+    package:
+      name: epm/kubernetes
+      version: 1.7.0
+    inputs:
+      - type: kubernetes-node/metrics
+        hosts: ["localhost:10250"]
+        bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+        ssl.certificate_authorities:
+          - /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
+        # username: "user"
+        # password: "secret"
+        # If kube_config is not set, KUBECONFIG environment variable will be checked
+        # and if not present it will fall back to InCluster
+        # kube_config: ~/.kube/config
+        streams:
+          - id?: {id}
+            metricset: node
+            dataset: kubernetes.node
+            period: 10s
+          - id?: {id}
+            metricset: system
+            dataset: kubernetes.system
+            period: 10s
+          - id?: {id}
+            metricset: pod
+            dataset: kubernetes.pod
+            period: 10s
+          - id?: {id}
+            metricset: container
+            dataset: kubernetes.container
+            period: 10s
+          - id?: {id}
+            metricset: container
+            dataset: kubernetes.container
+            period: 10s
+          - id?: {id}
+            metricset: event
+            dataset: kubernetes.event
+            period: 10s
+      - type: kubernetes-state/metrics
+        hosts: ["kube-state-metrics:8080"]
+        streams:
+          - id?: {id}
+            metricset: state_node
+            dataset: kubernetes.node
+            period: 10s
+          - id?: {id}
+            metricset: state_deployment
+            dataset: kubernetes.deployment
+            period: 10s
+          - id?: {id}
+            metricset: state_replicaset
+            dataset: kubernetes.replicaset
+            period: 10s
+          - id?: {id}
+            metricset: state_statefulset
+            dataset: kubernetes.statefulset
+            period: 10s
+          - id?: {id}
+            metricset: state_pod
+            dataset: kubernetes.pod
+            period: 10s
+          - id?: {id}
+            metricset: state_container
+            dataset: kubernetes.container
+            period: 10s
+          - id?: {id}
+            metricset: state_container
+            dataset: kubernetes.container
+            period: 10s
+          - id?: {id}
+            metricset: state_cronjob
+            dataset: kubernetes.cronjob
+            period: 10s
+          - id?: {id}
+            metricset: state_resourcequota
+            dataset: kubernetes.resourcequota
+            period: 10s
+          - id?: {id}
+            metricset: state_service
+            dataset: kubernetes.service
+            period: 10s
+          - id?: {id}
+            metricset: state_persistentvolume
+            dataset: kubernetes.persistentvolume
+            period: 10s
+          - id?: {id}
+            metricset: state_persistentvolumeclaim
+            dataset: kubernetes.persistentvolumeclaim
+            period: 10s
+
+  #################################################################################################
+  # Docker
+  - id?: my-docker
+    title: Collect docker
+    package:
+      name: epm/docker
+      version: 1.7.0
+    inputs:
+      - type: docker/metrics
+        hosts: ["localhost:10250"]
+        #labels.dedot: false
+
+        # To connect to Docker over TLS you must specify a client and CA certificate.
+        #ssl:
+          #certificate_authority: "/etc/pki/root/ca.pem"
+          #certificate:           "/etc/pki/client/cert.pem"
+          #key:                   "/etc/pki/client/cert.key"
+        streams:
+          - id?: {id}
+            metricset: container
+            dataset: docker.container
+            period: 10s
+          - id?: {id}
+            metricset: cpu
+            dataset: docker.cpu
+            period: 10s
+          - id?: {id}
+            metricset: diskio
+            dataset: docker.diskio
+            period: 10s
+          - id?: {id}
+            metricset: event
+            dataset: docker.event
+            period: 10s
+          - id?: {id}
+            metricset: healthcheck
+            dataset: docker.healthcheck
+            period: 10s
+          - id?: {id}
+            metricset: info
+            dataset: docker.info
+            period: 10s
+          - id?: {id}
+            metricset: memory
+            dataset: docker.memory
+            period: 10s
+          - id?: {id}
+            metricset: network
+            dataset: docker.network
+            period: 10s
+
+#################################################################################################
+### Suricata
+#
+ - id?: suricata-x1
+   title: Suricata's data
+   namespace?: "abc"
+   package:
+     name: suricata
+     version: x.x.x
+   inputs:
+     - type: log
+       streams:
+         -  id?: {id}
+            type: "typeX"
+            dataset: suricata.logs
+            path: /var/log/surcata/eve.json
+
+#################################################################################################
+### suggestion 1
+ - id?: myendpoint-x1
+   title: Endpoint configuration
+   namespace?: "canada"
+   package:
+     name: endpoint
+     version: xxx
+   inputs:
+     - type: endpoint # Reserved key word
+       streams:
+         - type: malware
+           detect: true
+           prevent: false
+           notify_user: false
+           threshold: recommended
+           platform: windows
+
+        - type: eventing
+          api: true
+          clr: false
+          dll_and_driver_load: false
+          dns: true
+          file: false
+          platform: windows
+
+       - type: malware
+         detect: true
+         prevent: false
+         notify_user: false
+         threshold: recommended
+         platform: mac
+
+      - type: eventing
+        api: true
+        clr: false
+        dll_and_driver_load: false
+        dns: true
+        file: false
+        platform: mac
+
+       - type: malware
+         detect: true
+         prevent: false
+         notify_user: false
+         threshold: recommended
+         platform: linux
+
+      - type: eventing
+        api: true
+        clr: false
+        dll_and_driver_load: false
+        dns: true
+        file: false
+        platform: linux
+
+#################################################################################################
+### suggestion 2
+ - id?: myendpoint-1
+   title: Endpoint configuration
+   namespace?: "canada"
+   package:
+     name: epm/endpoint # This establish the link with the package and will allow to link it to endpoint app.
+     version: xxx
+   inputs:
+     - type: endpoint # Reserved key word
+       windows:
+            eventing:
+                api: true
+                clr: false
+                dll_and_driver_load: false
+                dns: true
+                 ...
+                file: false
+            malware:
+                detect: true
+                prevent: false
+                notify_user: false
+                threshold: recommended
+        mac:
+            eventing:
+                file: true
+                network: false
+                process: false
+                ...
+            malware:
+               detect: true
+               prevent: false
+               notify_user: false
+               threshold: recommended
+         linux:
+            eventing:
+                file: true
+                network: false
+                process: false

--- a/docs/en/ingest-management/elastic-agent/install-elastic-agent.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/install-elastic-agent.asciidoc
@@ -1,0 +1,87 @@
+[[elastic-agent-installation]]
+[role="xpack"]
+= Install {agent}
+
+experimental[]
+
+include::elastic-agent.asciidoc[tag=experimental-warning]
+
+Download and install the Agent on each system you want to monitor.
+
+//TODO: Replace with tabbed panel when the code is stable. 
+
+// tag::install-elastic-agent[]
+
+To download and install {elastic-agent}, use the commands that work with your
+system:
+
+*mac:*
+
+ifeval::["{release-state}"=="unreleased"]
+
+Version {version} of {agent} has not yet been released.
+
+endif::[]
+
+ifeval::["{release-state}"!="unreleased"]
+
+["source","sh",subs="attributes"]
+----
+curl -L -O https://artifacts.elastic.co/downloads/beats/elastic-agent/elastic-agent-{version}-darwin-x86_64.tar.gz
+tar xzvf elastic-agent-{version}-darwin-x86_64.tar.gz
+----
+
+endif::[]
+
+*linux:*
+
+ifeval::["{release-state}"=="unreleased"]
+
+Version {version} of {agent} has not yet been released.
+
+endif::[]
+
+ifeval::["{release-state}"!="unreleased"]
+
+["source","sh",subs="attributes"]
+----
+curl -L -O https://artifacts.elastic.co/downloads/beats/elastic-agent/elastic-agent-{version}-linux-x86_64.tar.gz
+tar xzvf elastic-agent-{version}-linux-x86_64.tar.gz
+----
+
+endif::[]
+
+*win:*
+
+ifeval::["{release-state}"=="unreleased"]
+
+Version {version} of {agent} has not yet been released.
+
+endif::[]
+
+ifeval::["{release-state}"!="unreleased"]
+
+. Download the {agent} Windows zip file from the
+https://www.elastic.co/downloads/elastic-agent[downloads page].
+
+. Extract the contents of the zip file into `C:\Program Files`.
+
+. Rename the `elastic-agent-<version>-windows` directory to `Elastic-Agent`.
+
+. Open a PowerShell prompt as an Administrator (right-click the PowerShell icon and select *Run As Administrator*).
+
+. From the PowerShell prompt, run the following commands to install Filebeat as a
+Windows service:
++
+[source,shell]
+----
+PS > cd 'C:\Program Files\Elastic-Agent'
+PS C:\Program Files\Elastic-Agent> .\install-service-elastic-agent.ps1
+----
+
+NOTE: If script execution is disabled on your system, you need to set the execution policy for the current session to allow the script to run. For example: `PowerShell.exe -ExecutionPolicy UnRestricted -File .\install-service-elastic-agent.ps1`.
+
+endif::[]
+
+// end::install-elastic-agent[]
+

--- a/docs/en/ingest-management/elastic-agent/run-elastic-agent.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/run-elastic-agent.asciidoc
@@ -1,0 +1,69 @@
+[[run-elastic-agent]]
+[role="xpack"]
+= Run {agent}
+
+experimental[]
+
+include::elastic-agent.asciidoc[tag=experimental-warning]
+
+{agent} runs in two modes: standalone or fleet. The two modes differ in how you
+configure and manage the Agent.
+
+[discrete]
+[[fleet-mode]]
+== Run in {fleet} mode
+
+With _fleet mode_, you manage {agent} remotely. The Agent uses a trusted {kib}
+instance to retrieve configurations and report Agent events. This trusted {kib}
+instance must have {ingest-manager} and {fleet} enabled.
+
+To create a trusted communication channel between {agent} and {kib}, enroll the
+Agent to {fleet}.
+
+To enroll an {agent} to {fleet}:
+
+. Stop the Agent, if it's already running.
+
+. Go the **{fleet}** tab in {ingest-manager}, and click **Enroll new agent** to
+generate a token. See <<ingest-management-getting-started>> for detailed steps.
+
+. Enroll the Agent:
++
+[source,shell]
+----
+./elastic-agent enroll http://localhost:5601 $token
+----
++
+Where `$token` is an enrollment token acquired from {fleet}.
+
+To start {agent}, run:
+[source,shell]
+----
+./elastic-agent run
+----
+
+[discrete]
+[[standalone-mode]]
+== Run in standalone mode (default)
+
+With _standalone mode_, you manually configure and manage the Agent locally.
+Each Agent is configured to be in standalone mode by default after installation.
+
+If {agent} is installed as an auto-starting service, it will run automatically
+when you restart your system.
+
+To start {agent} manually, run:
+
+[source,shell]
+----
+./elastic-agent run
+----
+
+If no configuration file is specified, {agent} uses the default configuration,
+`elastic-agent.yml`, which is located in the same directory as {agent}. Specify
+the `-c` flag to use a different configuration file.
+
+For configuration options, see <<elastic-agent-configuration>>.
+
+//<<elastic-agent-configuration-example,`elastic-agent_configuration_example.yml`>>
+

--- a/docs/en/ingest-management/elastic-agent/stop-elastic-agent.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/stop-elastic-agent.asciidoc
@@ -1,0 +1,47 @@
+[[stop-elastic-agent]]
+[role="xpack"]
+= Stop {agent}
+
+experimental[]
+
+include::elastic-agent.asciidoc[tag=experimental-warning]
+
+To stop {agent} and its related executables, stop the {agent} process. Use the
+commands that work for your system. 
+
+//TODO: Replace with tabbed panel when it's out of experimental phase.
+
+*Windows:*
+
+If you installed the Agent as a service, stop the service. If
+necessary, use Task Manager on Windows to stop {agent}. This will kill the
+{agent} process and any sub-processes it created (such as {beats}).
+
+*Linux or macOS:*
+
+Run the following command to get the ID of the `elastic-agent` process:
+
+[source,shell]
+----
+ps | grep elastic-agent
+----
+
+Then kill the process:
+
+[source,shell]
+----
+kill -9 PID
+----
+
+Where `PID` is the ID of the `elastic-agent` process.
+
+*Systemd:*
+
+The DEB and RPM packages include a service unit for Linux systems with systemd.
+On these systems, you can manage {agent} by using systemd commands. Use
+`systemctl` to stop the Agent:
+
+[source,shell]
+----
+systemctl stop elastic-agent
+----

--- a/docs/en/ingest-management/getting-started.asciidoc
+++ b/docs/en/ingest-management/getting-started.asciidoc
@@ -141,9 +141,9 @@ image::images/kibana-ingest-manager-configurations-default-with-nginx.png[{inges
 [[install-run-elastic-agent]]
 == Step 3: Install and run {agent}
 
-include::{beats-repo-dir}/x-pack/elastic-agent/docs/elastic-agent.asciidoc[tag=agent-install-intro]
+include::elastic-agent/elastic-agent.asciidoc[tag=agent-install-intro]
 
-include::{beats-repo-dir}/x-pack/elastic-agent/docs/install-elastic-agent.asciidoc[tag=install-elastic-agent]
+include::elastic-agent/install-elastic-agent.asciidoc[tag=install-elastic-agent]
 
 To configure {agent}, you can use the {ingest-manager} app in {kib} (see
 <<agent-fleet-mode,{fleet} mode>>), or configure it manually (see

--- a/docs/en/ingest-management/index.asciidoc
+++ b/docs/en/ingest-management/index.asciidoc
@@ -14,7 +14,7 @@ include::ingest-management-limitations.asciidoc[leveloffset=+2]
 
 include::getting-started.asciidoc[leveloffset=+1]
 
-include::{beats-repo-dir}/x-pack/elastic-agent/docs/elastic-agent.asciidoc[leveloffset=+1]
+include::elastic-agent/elastic-agent.asciidoc[leveloffset=+1]
 
 include::troubleshooting.asciidoc[leveloffset=+1]
 


### PR DESCRIPTION
This PR moves v7.8 of the Elastic Agents docs to the observability-docs repo where other related docs live.

Related PR: https://github.com/elastic/beats/pull/23249