### PR TITLE
[7.x] docs: Add quickstart videos (#324)

### DIFF
--- a/docs/en/observability/analyze-metrics.asciidoc
+++ b/docs/en/observability/analyze-metrics.asciidoc
@@ -9,14 +9,22 @@ the {metrics-app} with data. For more information, see <<ingest-metrics,Ingest m
 
 The {metrics-app} in {kib} enables you to visualize infrastructure metrics
 to help diagnose problematic spikes, identify high resource utilization,
-automatically discover and track pods, and unify your metrics 
-with logs and APM data in {es}. 
+automatically discover and track pods, and unify your metrics
+with logs and APM data in {es}.
 
 Using {metricbeat} modules, you can ingest and analyze
 metrics from servers, Docker containers, Kubernetes orchestrations, explore and
 analyze Prometheus-style metrics or application telemetries, and many more.
 
-To view the {metrics-app}, go to *Observability > Metrics*. 
-
-[role="screenshot"]
-image::images/metrics-app.png[Metrics app in Kibana]
+++++
+<script type="text/javascript" async src="https://play.vidyard.com/embed/v4.js"></script>
+<img
+  style="width: 100%; margin: auto; display: block;"
+  class="vidyard-player-embed"
+  src="https://play.vidyard.com/XEFrGuQrWqYjgB9XqfgzSH.jpg"
+  data-uuid="XEFrGuQrWqYjgB9XqfgzSH"
+  data-v="4"
+  data-type="inline"
+/>
+</br>
+++++

--- a/docs/en/observability/apm.asciidoc
+++ b/docs/en/observability/apm.asciidoc
@@ -6,7 +6,17 @@ It allows you to monitor software services and applications in real time, by
 collecting detailed performance information on response time for incoming requests,
 database queries, calls to caches, external HTTP requests, and more.
 
-[role="screenshot"]
-image::images/apm-app-landing.png[APM app in Kibana]
+++++
+<script type="text/javascript" async src="https://play.vidyard.com/embed/v4.js"></script>
+<img
+  style="width: 100%; margin: auto; display: block;"
+  class="vidyard-player-embed"
+  src="https://play.vidyard.com/wRx7KPY4ajh4ktyLhLJLox.jpg"
+  data-uuid="wRx7KPY4ajh4ktyLhLJLox"
+  data-v="4"
+  data-type="inline"
+/>
+</br>
+++++
 
 To learn more, see {apm-overview-ref-v}[APM Overview].

--- a/docs/en/observability/monitor-logs.asciidoc
+++ b/docs/en/observability/monitor-logs.asciidoc
@@ -3,7 +3,7 @@
 
 The {logs-app} in {kib} enables you to search, filter, and tail all your logs
 ingested into {es}. Instead of having to log into different servers, change
-directories, and tail individual files, all your logs are available in the {logs-app}. 
+directories, and tail individual files, all your logs are available in the {logs-app}.
 
 Using {filebeat} {filebeat-ref}/filebeat-modules.html[modules], you can ingest
 logs from Kubernetes, MySQL, and many more data sources. Log events are indexed
@@ -14,7 +14,17 @@ for quick navigation. You can also use machine learning to detect specific log
 anomalies automatically and categorize log messages to quickly identify patterns in your
 log events.
 
-To view the {logs-app}, go to *Observability > Logs*.
+++++
+<script type="text/javascript" async src="https://play.vidyard.com/embed/v4.js"></script>
+<img
+  style="width: 100%; margin: auto; display: block;"
+  class="vidyard-player-embed"
+  src="https://play.vidyard.com/ZWSdKk4waG1bKf7oRa6Dvq.jpg"
+  data-uuid="ZWSdKk4waG1bKf7oRa6Dvq"
+  data-v="4"
+  data-type="inline"
+/>
+</br>
+++++
 
-[role="screenshot"]
-image::images/logs-app.png[Logs app in Kibana]
+To view the {logs-app}, go to *Observability > Logs*.

--- a/docs/en/observability/user-experience.asciidoc
+++ b/docs/en/observability/user-experience.asciidoc
@@ -11,8 +11,18 @@ all of which can impact how your application performs on end-user machines.
 Powered by the APM Real user monitoring (RUM) agent, all it takes is a few lines of code to begin
 surfacing key user experience metrics.
 
-[role="screenshot"]
-image::images/user-experience-tab.png[User experience tab]
+++++
+<script type="text/javascript" async src="https://play.vidyard.com/embed/v4.js"></script>
+<img
+  style="width: 100%; margin: auto; display: block;"
+  class="vidyard-player-embed"
+  src="https://play.vidyard.com/eVQoHfHNgGxBeuAZ5rCtXq.jpg"
+  data-uuid="eVQoHfHNgGxBeuAZ5rCtXq"
+  data-v="4"
+  data-type="inline"
+/>
+</br>
+++++
 
 [discrete]
 [[why-user-experience]]


### PR DESCRIPTION
Backports the following commits to 7.x:
 - docs: Add quickstart videos (#324)