### PR TITLE
Update snippet for cloning and running the synthetics-quickstart

### DIFF
--- a/docs/en/observability/synthetics-quickstart.asciidoc
+++ b/docs/en/observability/synthetics-quickstart.asciidoc
@@ -140,8 +140,8 @@ Don't forget to update the example with your {es} credentials.
 [source,sh,subs="attributes"]
 ----
 sh run.sh {version} \
-  -E cloud.id=<cloud-id> \
-  -E cloud.auth=elastic:<cloud-pass>
+  '-E cloud.id=<cloud-id>' \
+  '-E cloud.auth=elastic:<cloud-pass>'
 ----
 
 If you aren't using {ecloud}, replace `-E cloud.id` and `-E cloud.auth` with your Elasticsearch hosts,
@@ -150,9 +150,9 @@ username, and password:
 [source,sh,subs="attributes"]
 ----
 sh run.sh {version} \
-  -E output.elasticsearch.hosts=["localhost:9200"] \
-  -E output.elasticsearch.username=elastic \
-  -E output.elasticsearch.password=changeme
+  '-E output.elasticsearch.hosts=["localhost:9200"]' \
+  '-E output.elasticsearch.username=elastic' \
+  '-E output.elasticsearch.password=changeme'
 ----
 
 [discrete]

--- a/docs/en/observability/synthetics-quickstart.asciidoc
+++ b/docs/en/observability/synthetics-quickstart.asciidoc
@@ -152,7 +152,7 @@ username, and password:
 sh run.sh {version} \
   -E output.elasticsearch.hosts=["localhost:9200"] \
   -E output.elasticsearch.username=elastic \
-  -E output.elasticsearch.password=changeme \
+  -E output.elasticsearch.password=changeme
 ----
 
 [discrete]

--- a/docs/en/observability/synthetics-quickstart.asciidoc
+++ b/docs/en/observability/synthetics-quickstart.asciidoc
@@ -32,7 +32,7 @@ and change directories into `examples/docker`:
 [source,sh]
 ----
 git clone https://github.com/elastic/synthetics.git &&\
-cd examples/docker
+cd synthetics/examples/docker
 ----
 
 There are two files in `synthetics/examples/docker` that you'll need to edit:


### PR DESCRIPTION
### What


Fixes the cloning snippet, otherwise:

```
$ git clone https://github.com/elastic/synthetics.git &&\
cd examples/docker
Cloning into 'synthetics'...
remote: Enumerating objects: 1600, done.
remote: Total 1600 (delta 0), reused 0 (delta 0), pack-reused 1600
Receiving objects: 100% (1600/1600), 599.57 KiB | 1.66 MiB/s, done.
Resolving deltas: 100% (985/985), done.
cd: no such file or directory: examples/docker
```

Fixes the zsh shell with quoting, otherwise:

```
$ echo $SHELL
/bin/zsh
$ sh run.sh 7.10.2 \
  -E output.elasticsearch.hosts=["localhost:9200"] \
  -E output.elasticsearch.username=elastic \
  -E output.elasticsearch.password=changeme
zsh: no matches found: output.elasticsearch.hosts=[localhost:9200]

$ sh run.sh "7.10.2" \ 
  '-E output.elasticsearch.hosts=["localhost:9200"]' \
  '-E output.elasticsearch.username=elastic' \
  '-E output.elasticsearch.password=changeme'
+ VERSION=7.10.2
+ '[' '!' -z 7.10.2 ']'
+ shift
+ HEARTBEAT_ARGS='-E output.elasticsearch.hosts=["localhost:9200"] -E output.elasticsearch.username=elastic -E output.elasticsearch.password=changeme'
+ '[' -z -E 'output.elasticsearch.hosts=["localhost:9200"]' ']'
run.sh: line 10: [: -E: binary operator expected
+ HEARTBEAT_ARGS='-E output.elasticsearch.hosts=["localhost:9200"] -E output.elasticsearch.username=elastic -E output.elasticsearch.password=changeme'
+ [[ 7.10.2 =~ ^[0-9] ]]
+ IMAGE=docker.elastic.co/experimental/synthetics:7.10.2-synthetics
+++ dirname run.sh
++ cd .
++ pwd
+ SCRIPT_DIR=/tmp/synthetics/examples/docker
+ echo 'Using image '\''docker.elastic.co/experimental/synthetics:7.10.2-synthetics'\'' with extra args: -E output.elasticsearch.hosts=["localhost:9200"] -E output.elasticsearch.username=elastic -E output.elasticsearch.password=changeme'
Using image 'docker.elastic.co/experimental/synthetics:7.10.2-synthetics' with extra args: -E output.elasticsearch.hosts=["localhost:9200"] -E output.elasticsearch.username=elastic -E output.elasticsearch.password=changeme
++ pwd
++ pwd
+ docker run --rm --name=heartbeat --user=heartbeat --net=host --security-opt seccomp=/tmp/synthetics/examples/docker/seccomp_profile.json --volume=/tmp/synthetics/examples/docker/heartbeat.docker.yml:/usr/share/heartbeat/heartbeat.yml:ro --volume=/tmp/synthetics/examples/docker/../../:/opt/elastic-synthetics:rw docker.elastic.co/experimental/synthetics:7.10.2-synthetics --strict.perms=false -e -E 'output.elasticsearch.hosts=["localhost:9200"]' -E output.elasticsearch.username=elastic -E output.elasticsearch.password=changeme

```

Without double quoting no issues with `sh` or `bash` but it fails with `zsh`


Cherry-picks from https://github.com/elastic/observability-docs/pull/333