### PR TITLE
[7.x] Update snippet for cloning and running the synthetics-quickstart (#339)

### DIFF
--- a/docs/en/observability/synthetics-quickstart.asciidoc
+++ b/docs/en/observability/synthetics-quickstart.asciidoc
@@ -32,7 +32,7 @@ and change directories into `examples/docker`:
 [source,sh]
 ----
 git clone https://github.com/elastic/synthetics.git &&\
-cd examples/docker
+cd synthetics/examples/docker
 ----
 
 There are two files in `synthetics/examples/docker` that you'll need to edit:
@@ -140,8 +140,8 @@ Don't forget to update the example with your {es} credentials.
 [source,sh,subs="attributes"]
 ----
 sh run.sh {version} \
-  -E cloud.id=<cloud-id> \
-  -E cloud.auth=elastic:<cloud-pass>
+  '-E cloud.id=<cloud-id>' \
+  '-E cloud.auth=elastic:<cloud-pass>'
 ----
 
 If you aren't using {ecloud}, replace `-E cloud.id` and `-E cloud.auth` with your Elasticsearch hosts,
@@ -150,9 +150,9 @@ username, and password:
 [source,sh,subs="attributes"]
 ----
 sh run.sh {version} \
-  -E output.elasticsearch.hosts=["localhost:9200"] \
-  -E output.elasticsearch.username=elastic \
-  -E output.elasticsearch.password=changeme \
+  '-E output.elasticsearch.hosts=["localhost:9200"]' \
+  '-E output.elasticsearch.username=elastic' \
+  '-E output.elasticsearch.password=changeme'
 ----
 
 [discrete]


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Update snippet for cloning and running the synthetics-quickstart (#339)