### PR TITLE
Add privileges required to run Elastic Agent standalone

### DIFF
--- a/docs/en/ingest-management/elastic-agent/run-elastic-agent-standalone.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/run-elastic-agent-standalone.asciidoc
@@ -48,6 +48,7 @@ deployment.
 . Modify `ES_USERNAME` and `ES_PASSWORD` in the outputs section of
 `elastic-agent.yml` to use your {es} credentials. For example:
 +
+--
 [source,yaml]
 ----
 [...]
@@ -60,9 +61,27 @@ outputs:
     password: ES_PASSWORD
 [...]
 ----
-<1> This user must have `write`, `create_index`, and `indices:admin/auto_create`
-privileges on the following indices: `logs-*`, `metrics-*`, `events-*`,
-`.ds-logs-*`, `.ds-metrics-*`, and `.ds-events-*`.
+<1> This user must have the privileges shown in the following example.
+
+To create a role that has the privileges need by the {agent} user, go to
+**Management > Dev Tools** in {kib} and run:
+
+[source,console]
+----
+POST /_security/role/standalone_agent
+{
+  "cluster": ["monitor"],
+  "indices": [
+    {
+      "names": ["logs-*", "metrics-*", "events-*", ".ds-logs-*", ".ds-metrics-*", ".ds-events-*"],
+      "privileges": ["write", "create_index", "indices:admin/auto_create"]
+    }
+  ]
+}
+----
+
+Make sure you assign this role to the user in {kib}.
+--
 
 . From the agent directory, run the appropriate command to install {agent} as a
 managed service and start the service:

--- a/docs/en/ingest-management/elastic-agent/run-elastic-agent-standalone.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/run-elastic-agent-standalone.asciidoc
@@ -56,10 +56,13 @@ outputs:
     type: elasticsearch
     hosts:
       - 'http://localhost:9200'
-    username: ES_USERNAME
+    username: ES_USERNAME <1>
     password: ES_PASSWORD
 [...]
 ----
+<1> This user must have `write`, `create_index`, and `indices:admin/auto_create`
+privileges on the following indices: `logs-*`, `metrics-*`, `events-*`,
+`.ds-logs-*`, `.ds-metrics-*`, and `.ds-events-*`.
 
 . From the agent directory, run the appropriate command to install {agent} as a
 managed service and start the service:

--- a/docs/en/ingest-management/elastic-agent/run-elastic-agent-standalone.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/run-elastic-agent-standalone.asciidoc
@@ -63,7 +63,7 @@ outputs:
 ----
 <1> This user must have the privileges shown in the following example.
 
-To create a role that has the privileges need by the {agent} user, go to
+To create a role that has the privileges needed by the {agent} user, go to
 **Management > Dev Tools** in {kib} and run:
 
 [source,console]


### PR DESCRIPTION
Closes #287 

See the preview here: https://observability-docs_344.docs-preview.app.elstc.co/guide/en/fleet/master/run-elastic-agent-standalone.html

I think it's a little weird to show the API call inside of the steps, but I think it's Ok since we will hopefully replace the example with the role name when it's available.

TODO:
- [x] Test privileges to confirm that they work as expected.