### PR TITLE
[7.x] hardcode-synthetics-docker-image-to-7.10.0 (#346)

### DIFF
--- a/docs/en/observability/synthetics-quickstart.asciidoc
+++ b/docs/en/observability/synthetics-quickstart.asciidoc
@@ -137,9 +137,13 @@ Do not run any scripts that you don't trust.
 Use the following command to run the provided sample tests (or your own).
 Don't forget to update the example with your {es} credentials.
 
+// Right now we do not publish docker images for patch releases
+// Docker pull should reference only the .0 bugfix of the minor
+// We can accomplish this with the following attribute `{minor-version}.0`
+
 [source,sh,subs="attributes"]
 ----
-sh run.sh {version} \
+sh run.sh {minor-version}.0 \
   '-E cloud.id=<cloud-id>' \
   '-E cloud.auth=elastic:<cloud-pass>'
 ----
@@ -149,7 +153,7 @@ username, and password:
 
 [source,sh,subs="attributes"]
 ----
-sh run.sh {version} \
+sh run.sh {minor-version}.0 \
   '-E output.elasticsearch.hosts=["localhost:9200"]' \
   '-E output.elasticsearch.username=elastic' \
   '-E output.elasticsearch.password=changeme'


### PR DESCRIPTION
Backports the following commits to 7.x:
 - hardcode-synthetics-docker-image-to-7.10.0 (#346)