### PR TITLE
Conditionally display videos in current version

### DIFF
--- a/docs/en/observability/analyze-metrics.asciidoc
+++ b/docs/en/observability/analyze-metrics.asciidoc
@@ -16,6 +16,10 @@ Using {metricbeat} modules, you can ingest and analyze
 metrics from servers, Docker containers, Kubernetes orchestrations, explore and
 analyze Prometheus-style metrics or application telemetries, and many more.
 
+// Conditionally display a screenshot or video depending on what the
+// current documentation version is.
+
+ifeval::["{is-current-version}"=="true"]
 ++++
 <script type="text/javascript" async src="https://play.vidyard.com/embed/v4.js"></script>
 <img
@@ -28,3 +32,9 @@ analyze Prometheus-style metrics or application telemetries, and many more.
 />
 </br>
 ++++
+endif::[]
+
+ifeval::["{is-current-version}"=="false"]
+[role="screenshot"]
+image::images/metrics-app.png[Metrics app in Kibana]
+endif::[]

--- a/docs/en/observability/apm.asciidoc
+++ b/docs/en/observability/apm.asciidoc
@@ -6,6 +6,10 @@ It allows you to monitor software services and applications in real time, by
 collecting detailed performance information on response time for incoming requests,
 database queries, calls to caches, external HTTP requests, and more.
 
+// Conditionally display a screenshot or video depending on what the
+// current documentation version is.
+
+ifeval::["{is-current-version}"=="true"]
 ++++
 <script type="text/javascript" async src="https://play.vidyard.com/embed/v4.js"></script>
 <img
@@ -18,5 +22,11 @@ database queries, calls to caches, external HTTP requests, and more.
 />
 </br>
 ++++
+endif::[]
+
+ifeval::["{is-current-version}"=="false"]
+[role="screenshot"]
+image::images/apm-app-landing.png[APM app in Kibana]
+endif::[]
 
 To learn more, see {apm-overview-ref-v}[APM Overview].

--- a/docs/en/observability/monitor-logs.asciidoc
+++ b/docs/en/observability/monitor-logs.asciidoc
@@ -14,6 +14,10 @@ for quick navigation. You can also use machine learning to detect specific log
 anomalies automatically and categorize log messages to quickly identify patterns in your
 log events.
 
+// Conditionally display a screenshot or video depending on what the
+// current documentation version is.
+
+ifeval::["{is-current-version}"=="true"]
 ++++
 <script type="text/javascript" async src="https://play.vidyard.com/embed/v4.js"></script>
 <img
@@ -26,5 +30,11 @@ log events.
 />
 </br>
 ++++
+endif::[]
+
+ifeval::["{is-current-version}"=="false"]
+[role="screenshot"]
+image::images/logs-app.png[Logs app in Kibana]
+endif::[]
 
 To view the {logs-app}, go to *Observability > Logs*.

--- a/docs/en/observability/user-experience.asciidoc
+++ b/docs/en/observability/user-experience.asciidoc
@@ -11,6 +11,10 @@ all of which can impact how your application performs on end-user machines.
 Powered by the APM Real user monitoring (RUM) agent, all it takes is a few lines of code to begin
 surfacing key user experience metrics.
 
+// Conditionally display a screenshot or video depending on what the
+// current documentation version is.
+
+ifeval::["{is-current-version}"=="true"]
 ++++
 <script type="text/javascript" async src="https://play.vidyard.com/embed/v4.js"></script>
 <img
@@ -23,6 +27,12 @@ surfacing key user experience metrics.
 />
 </br>
 ++++
+endif::[]
+
+ifeval::["{is-current-version}"=="false"]
+[role="screenshot"]
+image::images/user-experience-tab.png[User experience tab]
+endif::[]
 
 [discrete]
 [[why-user-experience]]


### PR DESCRIPTION
## Summary

This PR conditionally displays videos in the observability guide when `is-current-version == true`. When `false`, backup screenshots are displayed instead. I've looked at this a million different ways, and this is by far the easiest way to accomplish this. This PR requires two lines in the `elastic/docs` repo to be changed on each minor release.

## Related

* This PR is a follow-up to https://github.com/elastic/observability-docs/pull/324. 
* For #323

This PR requires an additional change in the `elastic/docs` repo before merging: https://github.com/elastic/docs/pull/2044