### PR TITLE
[7.11] Add privileges required to run Elastic Agent standalone (#344)

### DIFF
--- a/docs/en/ingest-management/elastic-agent/run-elastic-agent-standalone.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/run-elastic-agent-standalone.asciidoc
@@ -48,6 +48,7 @@ deployment.
 . Modify `ES_USERNAME` and `ES_PASSWORD` in the outputs section of
 `elastic-agent.yml` to use your {es} credentials. For example:
 +
+--
 [source,yaml]
 ----
 [...]
@@ -56,10 +57,31 @@ outputs:
     type: elasticsearch
     hosts:
       - 'http://localhost:9200'
-    username: ES_USERNAME
+    username: ES_USERNAME <1>
     password: ES_PASSWORD
 [...]
 ----
+<1> This user must have the privileges shown in the following example.
+
+To create a role that has the privileges needed by the {agent} user, go to
+**Management > Dev Tools** in {kib} and run:
+
+[source,console]
+----
+POST /_security/role/standalone_agent
+{
+  "cluster": ["monitor"],
+  "indices": [
+    {
+      "names": ["logs-*", "metrics-*", "events-*", ".ds-logs-*", ".ds-metrics-*", ".ds-events-*"],
+      "privileges": ["write", "create_index", "indices:admin/auto_create"]
+    }
+  ]
+}
+----
+
+Make sure you assign this role to the user in {kib}.
+--
 
 . From the agent directory, run the appropriate command to install {agent} as a
 managed service and start the service:


### PR DESCRIPTION
Backports the following commits to 7.11:
 - Add privileges required to run Elastic Agent standalone (#344)