### PR TITLE
Remove sync time across apps content from What's new

### DIFF
--- a/docs/en/observability/whats-new.asciidoc
+++ b/docs/en/observability/whats-new.asciidoc
@@ -217,16 +217,6 @@ their key metrics in a given cluster or region, giving you an overview of all yo
 image::images/aws-fargate-metrics.png[AWS Fargate metrics]
 
 [discrete]
-== Sync time across {observability} apps
-
-Previously, when switching between the {observability} apps using the side navigation in {kib},
-the time range selection did not always persist.
-
-In {minor-version}, we have improved the workflow to ensure that the time range is preserved within
-the application as you navigate. This dramatically improves the speed and efficiency of
-investigation workflows across logs, metrics, traces, and other types of data.
-
-[discrete]
 == {kib} alerting framework (GA)
 
 For {minor-version}, we are delighted to announce the {kib} alerting framework's general availability.


### PR DESCRIPTION
As per notification from @tbragin, this PR removes content relating to synchronizing time across apps from the 7.11 What's new. When it's ready, it's due for the 7.12 release. 

**HTML preview**: https://observability-docs_370.docs-preview.app.elstc.co/guide/en/observability/7.11/whats-new.html