### PR TITLE
fix Filebeat config step 5 labels

### DIFF
--- a/docs/en/observability/monitor-k8s/monitor-k8s-logs.asciidoc
+++ b/docs/en/observability/monitor-k8s/monitor-k8s-logs.asciidoc
@@ -161,8 +161,19 @@ filebeat.autodiscover:
               kubernetes.labels.app: "nginx"
           config:
             - module: nginx
-              fileset.stdout: access
-              fileset.sterr: error
+              access:
+                input:
+                  type: container
+                  stream: stdout
+                  paths:
+                    - /var/log/containers/*${data.kubernetes.container.id}.log
+              error:
+                input:
+                  type: container
+                  stream: stderr
+                  paths:
+                    - /var/log/containers/*${data.kubernetes.container.id}.log
+
 ------------------------------------------------
 
 This is good, but requires advanced knowledge of the workloads running in


### PR DESCRIPTION
the proposed config for Filebeat with auto discover and labels is not working as the `fileset` settings is only working (and [documented](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-autodiscover-hints.html) ) on annotations with auto discover and hints but not with simple auto discover  on labels.

the commit propose a config that is working but a better solution might be available.