### PR TITLE
Explain where to add tutorials

### DIFF
--- a/docs/en/templates/tutorial-template.asciidoc
+++ b/docs/en/templates/tutorial-template.asciidoc
@@ -1,6 +1,9 @@
-// This template can be used for creating tutorials within the Observability documentation.
-// This should give you a format to follow and make it easier for you to get started writing
-// your tutorial. You can use this asciidoc template as a framework, replacing the text with your own. 
+// Use this template to create tutorials within the Observability documentation.
+// Replace the text with your own. 
+
+// To add your tutorial to the doc build, put your .asciidoc file in
+// observability-docs/docs/en/observability and update tutorials.asciidoc to include
+// your tutorial. Remember to update the jump list and includes.
 
 // The title of your tutorial should focus on what the reader will achieve.
 // For example, How to ingest custom data into Elasticsearch.


### PR DESCRIPTION
Adds a brief explanation to tutorial template to help users understand how to get tutorials into the doc build.

Also pruned the opening description because I don't think we need to explain the value of using a template. 