### PR TITLE
Update backports to auto-merge after checks pass

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -1,6 +1,6 @@
 {
   "upstream": "elastic/observability-docs",
-  "branches": [{ "name": "7.x", "checked": true }, "7.11", "6.8"],
+  "branches": [{ "name": "7.x", "checked": true }, "7.12", "7.11", "6.8"],
   "labels": ["backport"],
   "autoMerge": true,
   "autoMergeMethod": "squash"

--- a/.backportrc.json
+++ b/.backportrc.json
@@ -1,5 +1,8 @@
 {
   "upstream": "elastic/observability-docs",
-  "branches": [{ "name": "7.x", "checked": true }, "7.11", "7.10", "7.9", "7.8", "7.7", "7.6", "7.5", "7.4", "7.3", "7.2", "7.1", "7.0"],
-  "labels": ["backport"]
+  "branches": [{ "name": "7.x", "checked": true }, "7.11", "6.8"],
+  "labels": ["backport"],
+  "autoMerge": true,
+  "autoMergeMethod": "squash"
+}
 }

--- a/.backportrc.json
+++ b/.backportrc.json
@@ -5,4 +5,3 @@
   "autoMerge": true,
   "autoMergeMethod": "squash"
 }
-}


### PR DESCRIPTION
The latest release of the backport tool (thanks, Søren!) provides an option to auto-merge backports **after** all PR checks successfully pass. You can specify that a backport shouldn't be auto-merged with the autoMerge flag: `--autoMerge=false`.

This has already been added to the `kibana` and `apm-server` repo. How does @elastic/obs-docs feel about adding this feature to the `observability-docs` repo?