### PR TITLE
Add branchLabelMapping to the backport tool

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -3,6 +3,7 @@
   "branches": [{ "name": "7.x", "checked": true }, "7.12", "7.11", "6.8"],
   "branchLabelMapping": {
     "^v(\\d+).(\\d+).\\d+$": "$1.$2",
+    "^v8.0.0$": "master",
     ".*": "7.x"
   },
   "labels": ["backport"],

--- a/.backportrc.json
+++ b/.backportrc.json
@@ -1,6 +1,10 @@
 {
   "upstream": "elastic/observability-docs",
   "branches": [{ "name": "7.x", "checked": true }, "7.12", "7.11", "6.8"],
+  "branchLabelMapping": {
+    "^v(\\d+).(\\d+).\\d+$": "$1.$2",
+    ".*": "7.x"
+  },
   "labels": ["backport"],
   "autoMerge": true,
   "autoMergeMethod": "squash"


### PR DESCRIPTION
Sorry, just found one more improvement I'd like to propose: branch label matching.

When using the backport tool, `7.x` has always automatically been checked. This PR allows PR labels to also automatically check boxes. For example, if a PR has the `v7.12.0` label, `7.12` will be checked in the backport tool. If you're cherry-picking to `master`, just add the `v8.0.0` label and `master` will be checked.