### PR TITLE
[7.12] docs: add PHP agent info to k8s tutorial (#393)

### DIFF
--- a/docs/en/shared/install-apm-agents-kube/php.asciidoc
+++ b/docs/en/shared/install-apm-agents-kube/php.asciidoc
@@ -1,0 +1,53 @@
+*Install the agent*
+
+Install the PHP agent using one of the https://github.com/elastic/apm-agent-php/releases[published packages].
+
+To use the RPM Package (RHEL/CentOS and Fedora):
+
+[source,php]
+----
+rpm -ivh <package-file>.rpm
+----
+
+To use the DEB package (Debian and Ubuntu):
+
+[source,php]
+----
+dpkg -i <package-file>.deb
+----
+
+To use the APK package (Alpine):
+
+[source,php]
+----
+apk add --allow-untrusted <package-file>.apk
+----
+
+If you can’t find your distribution,
+you can install the agent by {apm-php-ref}/setup.html[building it from the source].
+
+*Configure the agent*
+
+Configure the agent using environment variables:
+
+[source,yml]
+----
+        # ...
+        - name: ELASTIC_APM_SERVER_URL
+          value: "apm-server-url-goes-here" <1>
+        - name: ELASTIC_APM_SECRET_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: apm-secret
+              key: ELASTIC_APM_SECRET_TOKEN <2>
+        - name: ELASTIC_APM_SERVICE_NAME
+          value: "service-name-goes-here" <3>
+----
+<1> Defaults to `http://localhost:8200`
+<2> Pass in `ELASTIC_APM_SECRET_TOKEN` from the `apm-secret` keystore created previously
+<3> Allowed characters: a-z, A-Z, 0-9, -, _, and space
+
+*Learn more in the agent reference*
+
+* {apm-php-ref}/supported-technologies.html[Supported technologies]
+* {apm-php-ref}/configuration.html[Configuration]

--- a/docs/en/shared/install-apm-agents-kube/widget.asciidoc
+++ b/docs/en/shared/install-apm-agents-kube/widget.asciidoc
@@ -32,6 +32,13 @@
     </button>
     <button role="tab"
             aria-selected="false"
+            aria-controls="php-tab-install-kube"
+            id="php-install-kube"
+            tabindex="-1">
+      PHP
+    </button>
+    <button role="tab"
+            aria-selected="false"
             aria-controls="python-tab-install-kube"
             id="python-install-kube"
             tabindex="-1">
@@ -85,6 +92,17 @@ include::dotnet.asciidoc[]
 ++++
 
 include::nodejs.asciidoc[]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="php-tab-install-kube"
+       aria-labelledby="php-install-kube"
+       hidden="">
+++++
+
+include::php.asciidoc[]
 
 ++++
   </div>


### PR DESCRIPTION
Backports the following commits to 7.12:
 - docs: add PHP agent info to k8s tutorial (#393)