### PR TITLE
[DOCS] Updates Kibana path for Filebeat

### DIFF
--- a/docs/en/observability/ingest-logs.asciidoc
+++ b/docs/en/observability/ingest-logs.asciidoc
@@ -180,7 +180,7 @@ Let's confirm your data is correctly streaming to your cloud instance.
 include::{beats-repo-dir}/tab-widgets/open-kibana-widget.asciidoc[]
 --
 
-. In the side navigation, click *{kib} > Discover*.
+. Open the main menu, then click *Discover*.
 +
 . Select `filebeat-*` as your index pattern.
 +


### PR DESCRIPTION
Since `Kibana` has been replaced with `Analytics` in the main menu, I removed `Kibana`, and updated to text to match what we use in the Kibana docs.