### PR TITLE
[DOCS] Updates Kibana path for Metricbeat

### DIFF
--- a/docs/en/observability/ingest-metrics.asciidoc
+++ b/docs/en/observability/ingest-metrics.asciidoc
@@ -146,7 +146,7 @@ Let's confirm your data is correctly ingested to your cluster.
 include::{beats-repo-dir}/tab-widgets/open-kibana-widget.asciidoc[]
 --
 
-. In the side navigation, click *{kib} > Discover*
+. Open the main menu, then click *Discover*
 +
 . Select `metricbeat-*` as your index pattern. 
 +


### PR DESCRIPTION
Since `Kibana` has been replaced with `Analytics` in the main menu, I removed `Kibana`, and updated to text to match what we use in the Kibana docs.