### PR TITLE
7.12 Synthetics Docs Changes

### DIFF
--- a/docs/en/observability/ingest-logs.asciidoc
+++ b/docs/en/observability/ingest-logs.asciidoc
@@ -180,7 +180,7 @@ Let's confirm your data is correctly streaming to your cloud instance.
 include::{beats-repo-dir}/tab-widgets/open-kibana-widget.asciidoc[]
 --
 
-. In the side navigation, click *{kib} > Discover*.
+. Open the main menu, then click *Discover*.
 +
 . Select `filebeat-*` as your index pattern.
 +

--- a/docs/en/observability/synthetics-command-reference.asciidoc
+++ b/docs/en/observability/synthetics-command-reference.asciidoc
@@ -48,8 +48,9 @@ Shows help for the `npx @elastic/synthetics` command.
 *`--journey-name <name>`*::
 Filters by journey name.
 
-*`--json`*::
-Output information as NDJSON (Newline delimited JSON) for every event.
+*`--reporter`*::
+One of `junit`, `default`, or `json`. Use the JUnit reporter to provide easily parsed output to CI
+servers like Jenkins.
 
 *`--no-headless`*::
 Runs with the browser in headful mode.

--- a/docs/en/observability/synthetics-create-test.asciidoc
+++ b/docs/en/observability/synthetics-create-test.asciidoc
@@ -214,13 +214,15 @@ heartbeat.monitors:
   id: my-monitor
   name: My Monitor
   schedule: "@every 1m"
-  script: |-
-    step("load homepage", async () => {
-        await page.goto('https://www.elastic.co');
-    });
-    step("hover over products menu", async () => {
-        await page.hover('css=[data-nav-item=products]');
-    });
+  source:
+    inline:
+      script: |-
+        step("load homepage", async () => {
+            await page.goto('https://www.elastic.co');
+        });
+        step("hover over products menu", async () => {
+            await page.hover('css=[data-nav-item=products]');
+        });
 ----
 
 That's it! You can either spin up Heartbeat yourself, or jump to <<synthetics-quickstart-step-three>>

--- a/docs/en/observability/synthetics-quickstart.asciidoc
+++ b/docs/en/observability/synthetics-quickstart.asciidoc
@@ -26,7 +26,7 @@ and a packaged todo application with a custom suite of tests.
 == Step 1: Pull the latest synthetics docker image
 
 Elastic Synthetics is regularly updated during this experimental phase, even within the same version.
-You'll want to ensure you're running the latest docker image by running the below command.{synthetics-image}
+You'll want to ensure you're running the latest docker image by running the command below .
 
 [source,sh,subs="attributes"]
 ----

--- a/docs/en/observability/synthetics-quickstart.asciidoc
+++ b/docs/en/observability/synthetics-quickstart.asciidoc
@@ -1,3 +1,5 @@
+:synthetics-image: docker.elastic.co/beats/heartbeat:{version}
+
 [[synthetics-quickstart]]
 = Quickstart: Synthetic monitoring via Docker
 
@@ -21,48 +23,32 @@ and a packaged todo application with a custom suite of tests.
 
 [discrete]
 [[synthetics-quickstart-step-one]]
-== Step 1: Clone the `elastic/synthetics` repository
+== Step 1: Pull the latest synthetics docker image
 
-This template pulls the Elastic synthetics image, builds your synthetic tests,
-schedules and runs them with Heartbeat, and sends the resulting data to the Elastic Stack.
+Elastic Synthetics is regularly updated during this experimental phase, even within the same version.
+You'll want to ensure you're running the latest docker image by running the below command.{synthetics-image}
 
-Clone the https://github.com/elastic/synthetics[elastic/synthetics] repository
-and change directories into `examples/docker`:
-
-[source,sh]
+[source,sh,subs="attributes"]
 ----
-git clone https://github.com/elastic/synthetics.git &&\
-cd synthetics/examples/docker
+docker pull {synthetics-image}
 ----
 
-There are two files in `synthetics/examples/docker` that you'll need to edit:
-
-[source,sh]
-----
-synthetics
-  |- examples
-     |- docker
-        |- heartbeat.docker.yml <1>
-        |- run.sh <2>
-----
-<1> `heartbeat.docker.yml` is your Heartbeat configuration file.
-This is where you'll configure your synthetic test suites.
-<2> `run.sh` provides the main `docker run` command that pulls the
-Elastic synthetics image and runs Heartbeat.
 
 [discrete]
 [[synthetics-quickstart-step-two]]
-== Step 2: Update `heartbeat.docker.yml`
+== Step 2: Create a heartbeat.yml configuration file
 
 There are two ways to configure a synthetic test.
 Let's take a quick look at each.
 
 Run an inline test::
 
-If you're running an inline, browser based test, you can use the traditional Heartbeat flow to completely
-configure your synthetic testing directly in `heartbeat.docker.yml`.
-An example is provided:
-+
+If you're running an inline browser based test, you can use the traditional Heartbeat flow to completely
+configure your synthetic testing directly in a file named `heartbeat.yml` as shown below. 
+
+You'll need to setup your elasticsearch credentials for either an https://www.elastic.co/guide/en/beats/heartbeat/current/configure-cloud-id.html[Elastic Cloud ID] or another https://www.elastic.co/guide/en/beats/heartbeat/current/elasticsearch-output.html[Elasticsearch Cluster] in
+the `heartbeat.yml` file. The example below demonstrates using https://cloud.elastic.co[Elastic Cloud] credentials.
+
 [source,yml]
 ----
 heartbeat.monitors:
@@ -70,69 +56,63 @@ heartbeat.monitors:
   id: my-monitor <1>
   name: My Monitor
   schedule: "@every 1m"
-  script: |- <2>
-    step("load homepage", async () => {
-        await page.goto('https://www.elastic.co');
-    });
-    step("hover over products menu", async () => {
-        await page.hover('css=[data-nav-item=products]');
-    });
+  source:
+    inline:
+      script: |- <2>
+        step("load homepage", async () => {
+            await page.goto('https://www.elastic.co');
+        });
+        step("hover over products menu", async () => {
+            await page.hover('css=[data-nav-item=products]');
+        });
 ----
 <1> Each `monitor` gets its own ID in the {uptime-app} and, therefore its own schedule entry.
 This allows tests to be run in parallel and analyzed separately.
 <2> In this example, a synthetic test is defined inline. This is a two-step script that first loads
 a homepage and then hovers over a product menu. See <<synthetics-syntax>> for more information.
 
+
 Run a test suite::
 
 If you'd like to run multiple tests, you'd probably be better off creating a library of tests defined
 outside of `heartbeat.docker.yml`.
 This, for example, allows your tests to live with your application or in a separate Git repository.
-+
+
 [source,yml]
 ----
-heartbeat.synthetic_suites: <1>
 - name: Todos
-  path: "/opt/examples/todos" <2>
+  id: todos
+  type: browser
   schedule: "@every 1m"
+  source:
+    local:
+      path: "/opt/examples/todos" <1>
 ----
-<1> Specify the name, path, and schedule of your test suite.
-<2> In this example, our library of synthetic tests live in the `/examples/todos` directory of `elastic/synthetics`.
+<1> In this example, our library of synthetic tests come from https://github.com/elastic/synthetics/tree/master/examples/todos[our todos example]. The path shown here corresponds to the path heartbeat will look at inside the docker container.
+
 Heartbeat will attempt to run all files in that directory with the extension `.journey.ts` or `.journey.js`.
 See <<synthetics-syntax>> for more information.
 
 [discrete]
 [[synthetics-quickstart-step-three]]
-== Step 3: Run `run.sh`
+== Step 3: Run the container
 
-`run.sh` pulls the Elastic/synthetics image, shares your configuration details and test suites with Heartbeat,
-and provides the location of your {es} instance.
+WARNING: Elastic synthetics runs Chromium without the extra protection of its process https://chromium.googlesource.com/chromium/src/+/master/docs/linux/sandboxing.md[sandbox] for greater compatibility with Linux server distributions. Add the `sandbox: true` option to a given browser
+monitor to enable sandboxing. This may require using a https://github.com/elastic/synthetics/blob/master/examples/docker/seccomp_profile.json[custom seccomp policy] with docker, which brings its own additional risks. This is generally safe when run against sites whose content you trust,
+and with a recent version of Elastic synthetics and chromium.
 
-WARNING: Running a Chrome browser requires elevated privileges.
-Synthetic monitoring scripts can escape the docker container.
-It is recommend to run your tests on a separate box.
-Do not run any scripts that you don’t trust.
-
-[source,sh]
+[source,sh,subs="+attributes"]
 ----
-#...
 docker run \
   --rm \
   --name=heartbeat \
   --user=heartbeat \
-  --net=host \
-  --security-opt seccomp=seccomp_profile.json \ <1>
-  --volume="$(pwd)/heartbeat.docker.yml:/usr/share/heartbeat/heartbeat.yml:ro" \ <2>
-  --volume="$(pwd)/../../:/opt/elastic-synthetics:rw" \ <3>
-  $IMAGE \
-  --strict.perms=false -e \
-  $HEARTBEAT_ARGS
-#...
+  --volume="$PWD/heartbeat.yml:/usr/share/heartbeat/heartbeat.yml:ro" \ <1>
+  --volume="$PWD/PATH/TO/todos-example:/opt/todos:ro" \ <2>
+  {synthetics-image} heartbeat
 ----
-<1> Running a Chrome browser requires elevated privileges.
-Do not run any scripts that you don't trust.
-<2> Provides your `heartbeat.docker.yml` file as a volume.
-<3> Provides the `elastic-synthetics` repo as a volume.
+<1> Provides your `heartbeat.docker.yml` file as a volume.
+<2> Provides the `todos` example as a volume. Replace the first path the location of your local copy of the todos example.
 
 Use the following command to run the provided sample tests (or your own).
 Don't forget to update the example with your {es} credentials.

--- a/docs/en/observability/synthetics-quickstart.asciidoc
+++ b/docs/en/observability/synthetics-quickstart.asciidoc
@@ -1,4 +1,4 @@
-:synthetics-image: docker.elastic.co/beats/heartbeat:{version}
+:synthetics-image: docker.elastic.co/beats/{heartbeat}:{version}
 
 [[synthetics-quickstart]]
 = Quickstart: Synthetic monitoring via Docker
@@ -35,12 +35,12 @@ docker pull {synthetics-image}
 
 [discrete]
 [[synthetics-quickstart-step-two]]
-== Step 2: Create a heartbeat.yml configuration file
+== Step 2: Create a {heartbeat}.yml configuration file
 
 There are two ways to configure a synthetic test. The config file below demonstrates both.
 The first entry in `heartbeat.monitors` uses the `inline` source type, where the entire synthetic journey is directly embedded in the yaml file.
 The second method, uses the `local` source type, which points to a local directory containing multiple tests.
-For test suites Heartbeat will attempt to run all files in that directory with the extension `.journey.ts` or `.journey.js`.
+For test suites {heartbeat} will attempt to run all files in that directory with the extension `.journey.ts` or `.journey.js`.
 See <<synthetics-syntax>> for more information.
 
 To start, download or clone a local copy of https://github.com/elastic/synthetics/tree/master/examples/todos[our todos example suite] from our synthetics repo to your
@@ -74,17 +74,17 @@ heartbeat.monitors:
 This allows tests to be run in parallel and analyzed separately.
 <2> In this example, a synthetic test is defined inline. This is a two-step script that first loads
 a homepage and then hovers over a product menu. See <<synthetics-syntax>> for more information.
-<3> In this example, our library of synthetic tests come from https://github.com/elastic/synthetics/tree/master/examples/todos[our todos example]. The path shown here corresponds to the path heartbeat will look at inside the docker container.
+<3> In this example, our library of synthetic tests come from https://github.com/elastic/synthetics/tree/master/examples/todos[our todos example]. The path shown here corresponds to the path {heartbeat} will look at inside the docker container.
 <4> Note that this path is local to the docker container, not the host system. You can have the todos files anywhere you like on the host, and map them to `/opt/todos` in the container.
 
 [discrete]
 [[synthetics-quickstart-step-three]]
 == Step 3: Run the container, connecting it to Elasticsearch
 
-Before we proceed, you'll need to retrieve your Elasticsearch credentials for either an https://www.elastic.co/guide/en/beats/heartbeat/current/configure-cloud-id.html[Elastic Cloud ID] or another https://www.elastic.co/guide/en/beats/heartbeat/current/elasticsearch-output.html[Elasticsearch Cluster].
+Before we proceed, you'll need to retrieve your Elasticsearch credentials for either an https://www.elastic.co/guide/en/beats/{heartbeat}/current/configure-cloud-id.html[Elastic Cloud ID] or another https://www.elastic.co/guide/en/beats/heartbeat/current/elasticsearch-output.html[Elasticsearch Cluster].
 
 WARNING: Elastic synthetics runs Chromium without the extra protection of its process https://chromium.googlesource.com/chromium/src/+/master/docs/linux/sandboxing.md[sandbox] for greater compatibility with Linux server distributions. Add the `sandbox: true` option to a given browser
-monitor in heartbeat to enable sandboxing. This may require using a https://github.com/elastic/synthetics/blob/master/examples/docker/seccomp_profile.json[custom seccomp policy] with docker, which brings its own additional risks. This is generally safe when run against sites whose content you trust,
+monitor in {heartbeat} to enable sandboxing. This may require using a https://github.com/elastic/synthetics/blob/master/examples/docker/seccomp_profile.json[custom seccomp policy] with docker, which brings its own additional risks. This is generally safe when run against sites whose content you trust,
 and with a recent version of Elastic synthetics and chromium.
 
 The example below, run from the `examples/todos` directory shows how to run synthetics tests indexing data into Elasticsearch.
@@ -97,11 +97,11 @@ Run the script below to start running your synthetics tests. You'll need to inse
 ----
 docker run \
   --rm \
-  --name=heartbeat \
-  --user=heartbeat \
-  --volume="$PWD/heartbeat.yml:/usr/share/heartbeat/heartbeat.yml:ro" \
+  --name={heartbeat} \
+  --user={heartbeat} \
+  --volume="$PWD/{heartbeat}.yml:/usr/share/heartbeat/heartbeat.yml:ro" \
   --volume="$PWD:/opt/todos:ro" \
-  {synthetics-image} heartbeat -e \
+  {synthetics-image} {heartbeat} -e \
   -E cloud.id=cloud-id \
   -E cloud.auth=elastic:cloud-pass
 ----
@@ -113,19 +113,19 @@ username, and password:
 ----
 docker run \
   --rm \
-  --name=heartbeat \
-  --user=heartbeat \
-  --volume="$PWD/heartbeat.yml:/usr/share/heartbeat/heartbeat.yml:ro" \
+  --name={heartbeat} \
+  --user={heartbeat} \
+  --volume="$PWD/{heartbeat}.yml:/usr/share/heartbeat/heartbeat.yml:ro" \
   --volume="$PWD:/opt/todos:ro" \
-  {synthetics-image} heartbeat -e \
+  {synthetics-image} {heartbeat} -e \
   -E output.elasticsearch.hosts=["localhost:9200"] \
   -E output.elasticsearch.username=elastic \
   -E output.elasticsearch.password=changeme
 ----
 
-Note the two `--volume` options, which mount local directories into the container. The first mounts the `heartbeat.yml` file configured above,
-into Heartbeat's expected location for `heartbeat.yml`. The second mounts the test suite into the VM in the same location listed in the `source`
-section of our `heartbeat.yml`.
+Note the two `--volume` options, which mount local directories into the container. The first mounts the `{heartbeat}.yml` file configured above,
+into {heartbeat}'s expected location for `{heartbeat}.yml`. The second mounts the test suite into the VM in the same location listed in the `source`
+section of our `{heartbeat}.yml`.
 
 
 [discrete]

--- a/docs/en/observability/synthetics-quickstart.asciidoc
+++ b/docs/en/observability/synthetics-quickstart.asciidoc
@@ -33,28 +33,18 @@ You'll want to ensure you're running the latest docker image by running the belo
 docker pull {synthetics-image}
 ----
 
-
 [discrete]
 [[synthetics-quickstart-step-two]]
 == Step 2: Create a heartbeat.yml configuration file
 
-There are two ways to configure a synthetic test.
-Let's take a quick look at each in a single config file.
-
-Run some simple tests::
-
-The example below shows two different ways of running a synthetics test. The `inline` source type,
-is the first, where the entire synthetic journey is directly embedded in the yaml file.
-The second method, is to use the `local` source type which points to a local directory containing multiple tests.
+There are two ways to configure a synthetic test. The config file below demonstrates both.
+The first entry in `heartbeat.monitors` uses the `inline` source type, where the entire synthetic journey is directly embedded in the yaml file.
+The second method, uses the `local` source type, which points to a local directory containing multiple tests.
 For test suites Heartbeat will attempt to run all files in that directory with the extension `.journey.ts` or `.journey.js`.
 See <<synthetics-syntax>> for more information.
 
-To run the example below, copy the contents into a file named `heartbeat.yml`, and download or clone a local copy 
-of our https://github.com/elastic/synthetics/tree/master/examples/todos[our todos example suite] which we'll share with the
-docker container.
-
-You'll need to setup your Elasticsearch credentials for either an https://www.elastic.co/guide/en/beats/heartbeat/current/configure-cloud-id.html[Elastic Cloud ID] or another https://www.elastic.co/guide/en/beats/heartbeat/current/elasticsearch-output.html[Elasticsearch Cluster] in
-the `heartbeat.yml` file. The example below demonstrates using https://cloud.elastic.co[Elastic Cloud] credentials.
+To start, download or clone a local copy of https://github.com/elastic/synthetics/tree/master/examples/todos[our todos example suite] from our synthetics repo to your
+local machine, and navigate to the `examples/todos` folder. We'll work inside that folder going forward.
 
 [source,yml]
 ----
@@ -79,10 +69,6 @@ heartbeat.monitors:
   source:
     local: <3>
       path: "/opt/todos" <4>
-
-# Cloud elasticsearch credentials
-cloud.id: YOUR-CLOUD-ID
-cloud.auth: YOUR-CLOUD-AUTH
 ----
 <1> Each `monitor` gets its own ID in the {uptime-app} and, therefore its own schedule entry.
 This allows tests to be run in parallel and analyzed separately.
@@ -93,15 +79,20 @@ a homepage and then hovers over a product menu. See <<synthetics-syntax>> for mo
 
 [discrete]
 [[synthetics-quickstart-step-three]]
-== Step 3: Run the container
+== Step 3: Run the container, connecting it to Elasticsearch
+
+Before we proceed, you'll need to retrieve your Elasticsearch credentials for either an https://www.elastic.co/guide/en/beats/heartbeat/current/configure-cloud-id.html[Elastic Cloud ID] or another https://www.elastic.co/guide/en/beats/heartbeat/current/elasticsearch-output.html[Elasticsearch Cluster].
 
 WARNING: Elastic synthetics runs Chromium without the extra protection of its process https://chromium.googlesource.com/chromium/src/+/master/docs/linux/sandboxing.md[sandbox] for greater compatibility with Linux server distributions. Add the `sandbox: true` option to a given browser
 monitor in heartbeat to enable sandboxing. This may require using a https://github.com/elastic/synthetics/blob/master/examples/docker/seccomp_profile.json[custom seccomp policy] with docker, which brings its own additional risks. This is generally safe when run against sites whose content you trust,
 and with a recent version of Elastic synthetics and chromium.
 
-You can run the sample config by changing directories into your local copy of the https://github.com/elastic/synthetics/tree/master/examples/todos[todos example], and copying
-your `heartbeat.yml` into that folder (or by changing the paths in the script below).
+The example below, run from the `examples/todos` directory shows how to run synthetics tests indexing data into Elasticsearch.
 
+Run the script below to start running your synthetics tests. You'll need to insert your actual `cloud.id` and `cloud.auth` values to successfully index data to your cluster.
+
+// NOTE: We do NOT use <1> references in the below example, because they create whitespace after the trailing \
+// when copied into a shell, which creates mysterious errors when copy and pasting!
 [source,sh,subs="+attributes"]
 ----
 docker run \
@@ -111,11 +102,9 @@ docker run \
   --volume="$PWD/heartbeat.yml:/usr/share/heartbeat/heartbeat.yml:ro" \
   --volume="$PWD:/opt/todos:ro" \
   {synthetics-image} heartbeat -e \
-  '-E cloud.id=<cloud-id>' \
-  '-E cloud.auth=elastic:<cloud-pass>'
+  -E cloud.id=cloud-id \
+  -E cloud.auth=elastic:cloud-pass
 ----
-
-Note the two `--volume` options which mount local directories into the container. The first mounts the `heartbeat.yml` file you've configured
 
 If you aren't using {ecloud}, replace `-E cloud.id` and `-E cloud.auth` with your Elasticsearch hosts,
 username, and password:
@@ -129,10 +118,15 @@ docker run \
   --volume="$PWD/heartbeat.yml:/usr/share/heartbeat/heartbeat.yml:ro" \
   --volume="$PWD:/opt/todos:ro" \
   {synthetics-image} heartbeat -e \
-  '-E output.elasticsearch.hosts=["localhost:9200"]' \
-  '-E output.elasticsearch.username=elastic' \
-  '-E output.elasticsearch.password=changeme'
+  -E output.elasticsearch.hosts=["localhost:9200"] \
+  -E output.elasticsearch.username=elastic \
+  -E output.elasticsearch.password=changeme
 ----
+
+Note the two `--volume` options which mount local directories into the container. The first mounts the `heartbeat.yml` file you've configured,
+into the expected location for `heartbeat.yml` for heartbeat, the second mounts the suite into the VM in the same location listed in the `source`
+section of our `heartbeat.yml`.
+
 
 [discrete]
 [[synthetics-quickstart-step-five]]

--- a/docs/en/observability/synthetics-quickstart.asciidoc
+++ b/docs/en/observability/synthetics-quickstart.asciidoc
@@ -39,14 +39,21 @@ docker pull {synthetics-image}
 == Step 2: Create a heartbeat.yml configuration file
 
 There are two ways to configure a synthetic test.
-Let's take a quick look at each.
+Let's take a quick look at each in a single config file.
 
-Run an inline test::
+Run some simple tests::
 
-If you're running an inline browser based test, you can use the traditional Heartbeat flow to completely
-configure your synthetic testing directly in a file named `heartbeat.yml` as shown below. 
+The example below shows two different ways of running a synthetics test. The `inline` source type,
+is the first, where the entire synthetic journey is directly embedded in the yaml file.
+The second method, is to use the `local` source type which points to a local directory containing multiple tests.
+For test suites Heartbeat will attempt to run all files in that directory with the extension `.journey.ts` or `.journey.js`.
+See <<synthetics-syntax>> for more information.
 
-You'll need to setup your elasticsearch credentials for either an https://www.elastic.co/guide/en/beats/heartbeat/current/configure-cloud-id.html[Elastic Cloud ID] or another https://www.elastic.co/guide/en/beats/heartbeat/current/elasticsearch-output.html[Elasticsearch Cluster] in
+To run the example below, copy the contents into a file named `heartbeat.yml`, and download or clone a local copy 
+of our https://github.com/elastic/synthetics/tree/master/examples/todos[our todos example suite] which we'll share with the
+docker container.
+
+You'll need to setup your Elasticsearch credentials for either an https://www.elastic.co/guide/en/beats/heartbeat/current/configure-cloud-id.html[Elastic Cloud ID] or another https://www.elastic.co/guide/en/beats/heartbeat/current/elasticsearch-output.html[Elasticsearch Cluster] in
 the `heartbeat.yml` file. The example below demonstrates using https://cloud.elastic.co[Elastic Cloud] credentials.
 
 [source,yml]
@@ -65,41 +72,35 @@ heartbeat.monitors:
         step("hover over products menu", async () => {
             await page.hover('css=[data-nav-item=products]');
         });
-----
-<1> Each `monitor` gets its own ID in the {uptime-app} and, therefore its own schedule entry.
-This allows tests to be run in parallel and analyzed separately.
-<2> In this example, a synthetic test is defined inline. This is a two-step script that first loads
-a homepage and then hovers over a product menu. See <<synthetics-syntax>> for more information.
-
-
-Run a test suite::
-
-If you'd like to run multiple tests, you'd probably be better off creating a library of tests defined
-outside of `heartbeat.docker.yml`.
-This, for example, allows your tests to live with your application or in a separate Git repository.
-
-[source,yml]
-----
 - name: Todos
   id: todos
   type: browser
   schedule: "@every 1m"
   source:
-    local:
-      path: "/opt/examples/todos" <1>
-----
-<1> In this example, our library of synthetic tests come from https://github.com/elastic/synthetics/tree/master/examples/todos[our todos example]. The path shown here corresponds to the path heartbeat will look at inside the docker container.
+    local: <3>
+      path: "/opt/todos" <4>
 
-Heartbeat will attempt to run all files in that directory with the extension `.journey.ts` or `.journey.js`.
-See <<synthetics-syntax>> for more information.
+# Cloud elasticsearch credentials
+cloud.id: YOUR-CLOUD-ID
+cloud.auth: YOUR-CLOUD-AUTH
+----
+<1> Each `monitor` gets its own ID in the {uptime-app} and, therefore its own schedule entry.
+This allows tests to be run in parallel and analyzed separately.
+<2> In this example, a synthetic test is defined inline. This is a two-step script that first loads
+a homepage and then hovers over a product menu. See <<synthetics-syntax>> for more information.
+<3> In this example, our library of synthetic tests come from https://github.com/elastic/synthetics/tree/master/examples/todos[our todos example]. The path shown here corresponds to the path heartbeat will look at inside the docker container.
+<4> Note that this path is local to the docker container, not the host system. You can have the todos files anywhere you like on the host, and map them to `/opt/todos` in the container.
 
 [discrete]
 [[synthetics-quickstart-step-three]]
 == Step 3: Run the container
 
 WARNING: Elastic synthetics runs Chromium without the extra protection of its process https://chromium.googlesource.com/chromium/src/+/master/docs/linux/sandboxing.md[sandbox] for greater compatibility with Linux server distributions. Add the `sandbox: true` option to a given browser
-monitor to enable sandboxing. This may require using a https://github.com/elastic/synthetics/blob/master/examples/docker/seccomp_profile.json[custom seccomp policy] with docker, which brings its own additional risks. This is generally safe when run against sites whose content you trust,
+monitor in heartbeat to enable sandboxing. This may require using a https://github.com/elastic/synthetics/blob/master/examples/docker/seccomp_profile.json[custom seccomp policy] with docker, which brings its own additional risks. This is generally safe when run against sites whose content you trust,
 and with a recent version of Elastic synthetics and chromium.
+
+You can run the sample config by changing directories into your local copy of the https://github.com/elastic/synthetics/tree/master/examples/todos[todos example], and copying
+your `heartbeat.yml` into that folder (or by changing the paths in the script below).
 
 [source,sh,subs="+attributes"]
 ----
@@ -107,33 +108,27 @@ docker run \
   --rm \
   --name=heartbeat \
   --user=heartbeat \
-  --volume="$PWD/heartbeat.yml:/usr/share/heartbeat/heartbeat.yml:ro" \ <1>
-  --volume="$PWD/PATH/TO/todos-example:/opt/todos:ro" \ <2>
-  {synthetics-image} heartbeat
-----
-<1> Provides your `heartbeat.docker.yml` file as a volume.
-<2> Provides the `todos` example as a volume. Replace the first path the location of your local copy of the todos example.
-
-Use the following command to run the provided sample tests (or your own).
-Don't forget to update the example with your {es} credentials.
-
-// Right now we do not publish docker images for patch releases
-// Docker pull should reference only the .0 bugfix of the minor
-// We can accomplish this with the following attribute `{minor-version}.0`
-
-[source,sh,subs="attributes"]
-----
-sh run.sh {minor-version}.0 \
+  --volume="$PWD/heartbeat.yml:/usr/share/heartbeat/heartbeat.yml:ro" \
+  --volume="$PWD:/opt/todos:ro" \
+  {synthetics-image} heartbeat -e \
   '-E cloud.id=<cloud-id>' \
   '-E cloud.auth=elastic:<cloud-pass>'
 ----
+
+Note the two `--volume` options which mount local directories into the container. The first mounts the `heartbeat.yml` file you've configured
 
 If you aren't using {ecloud}, replace `-E cloud.id` and `-E cloud.auth` with your Elasticsearch hosts,
 username, and password:
 
 [source,sh,subs="attributes"]
 ----
-sh run.sh {minor-version}.0 \
+docker run \
+  --rm \
+  --name=heartbeat \
+  --user=heartbeat \
+  --volume="$PWD/heartbeat.yml:/usr/share/heartbeat/heartbeat.yml:ro" \
+  --volume="$PWD:/opt/todos:ro" \
+  {synthetics-image} heartbeat -e \
   '-E output.elasticsearch.hosts=["localhost:9200"]' \
   '-E output.elasticsearch.username=elastic' \
   '-E output.elasticsearch.password=changeme'

--- a/docs/en/observability/synthetics-quickstart.asciidoc
+++ b/docs/en/observability/synthetics-quickstart.asciidoc
@@ -1,4 +1,4 @@
-:synthetics-image: docker.elastic.co/beats/{heartbeat}:{version}
+:synthetics-image: docker.elastic.co/beats/heartbeat:{version}
 
 [[synthetics-quickstart]]
 = Quickstart: Synthetic monitoring via Docker
@@ -35,7 +35,7 @@ docker pull {synthetics-image}
 
 [discrete]
 [[synthetics-quickstart-step-two]]
-== Step 2: Create a {heartbeat}.yml configuration file
+== Step 2: Create a heartbeat.yml configuration file
 
 There are two ways to configure a synthetic test. The config file below demonstrates both.
 The first entry in `heartbeat.monitors` uses the `inline` source type, where the entire synthetic journey is directly embedded in the yaml file.
@@ -81,7 +81,7 @@ a homepage and then hovers over a product menu. See <<synthetics-syntax>> for mo
 [[synthetics-quickstart-step-three]]
 == Step 3: Run the container, connecting it to Elasticsearch
 
-Before we proceed, you'll need to retrieve your Elasticsearch credentials for either an https://www.elastic.co/guide/en/beats/{heartbeat}/current/configure-cloud-id.html[Elastic Cloud ID] or another https://www.elastic.co/guide/en/beats/heartbeat/current/elasticsearch-output.html[Elasticsearch Cluster].
+Before we proceed, you'll need to retrieve your Elasticsearch credentials for either an https://www.elastic.co/guide/en/beats/heartbeat/current/configure-cloud-id.html[Elastic Cloud ID] or another https://www.elastic.co/guide/en/beats/heartbeat/current/elasticsearch-output.html[Elasticsearch Cluster].
 
 WARNING: Elastic synthetics runs Chromium without the extra protection of its process https://chromium.googlesource.com/chromium/src/+/master/docs/linux/sandboxing.md[sandbox] for greater compatibility with Linux server distributions. Add the `sandbox: true` option to a given browser
 monitor in {heartbeat} to enable sandboxing. This may require using a https://github.com/elastic/synthetics/blob/master/examples/docker/seccomp_profile.json[custom seccomp policy] with docker, which brings its own additional risks. This is generally safe when run against sites whose content you trust,
@@ -97,11 +97,11 @@ Run the script below to start running your synthetics tests. You'll need to inse
 ----
 docker run \
   --rm \
-  --name={heartbeat} \
-  --user={heartbeat} \
-  --volume="$PWD/{heartbeat}.yml:/usr/share/heartbeat/heartbeat.yml:ro" \
+  --name=heartbeat \
+  --user=heartbeat \
+  --volume="$PWD/heartbeat.yml:/usr/share/heartbeat/heartbeat.yml:ro" \
   --volume="$PWD:/opt/todos:ro" \
-  {synthetics-image} {heartbeat} -e \
+  {synthetics-image} heartbeat -e \
   -E cloud.id=cloud-id \
   -E cloud.auth=elastic:cloud-pass
 ----
@@ -113,19 +113,19 @@ username, and password:
 ----
 docker run \
   --rm \
-  --name={heartbeat} \
-  --user={heartbeat} \
-  --volume="$PWD/{heartbeat}.yml:/usr/share/heartbeat/heartbeat.yml:ro" \
+  --name=heartbeat \
+  --user=heartbeat \
+  --volume="$PWD/heartbeat.yml:/usr/share/heartbeat/heartbeat.yml:ro" \
   --volume="$PWD:/opt/todos:ro" \
-  {synthetics-image} {heartbeat} -e \
+  {synthetics-image} heartbeat -e \
   -E output.elasticsearch.hosts=["localhost:9200"] \
   -E output.elasticsearch.username=elastic \
   -E output.elasticsearch.password=changeme
 ----
 
-Note the two `--volume` options, which mount local directories into the container. The first mounts the `{heartbeat}.yml` file configured above,
-into {heartbeat}'s expected location for `{heartbeat}.yml`. The second mounts the test suite into the VM in the same location listed in the `source`
-section of our `{heartbeat}.yml`.
+Note the two `--volume` options, which mount local directories into the container. The first mounts the `heartbeat.yml` file configured above,
+into {heartbeat}'s expected location for `heartbeat.yml`. The second mounts the test suite into the VM in the same location listed in the `source`
+section of our `heartbeat.yml`.
 
 
 [discrete]


### PR DESCRIPTION
Updated for the 7.12.0 release. You'll want to test this by substituting `7.12.0-SNAPSHOT` as the version in any docker commands, since 8.0.0 isn't as relevant to actual users. When the release goes live the version will be the same, but without `SNAPSHOT`.

This includes significant changes to the config syntax.