### PR TITLE
[7.12] Add missing links to APM integration (#451)

### DIFF
--- a/docs/en/ingest-management/getting-started-traces.asciidoc
+++ b/docs/en/ingest-management/getting-started-traces.asciidoc
@@ -19,11 +19,11 @@ For feedback and questions, please contact us in the {forum}[discuss forum].
 * Please read the <<fleet-limitations,Fleet limitations>>.
 
 * The APM integration is experimental and has a number of known limitations.
-// Please read the list of {}/apm-integration-limitations.html[known limitations].
+Please read the list of {apm-server-ref-v}/apm-integration.html[known limitations].
 
 * You need {es} for storing and searching your data, and {kib} for visualizing and
 managing it. You can use our
-https://www.elastic.co/cloud/elasticsearch-service[hosted {ess}]
+{ess-product}[hosted {ess}]
 on {ecloud} (recommended), or self-manage the {stack} on your own hardware.
 +
 Here's what you need for each deployment type:
@@ -203,9 +203,8 @@ You should see application performance monitoring data flowing into the {stack}!
 
 NOTE: The built-in `apm_user` role is not compatible with the APM integration
 as it only provides read access to `apm-*` indices.
-
-// To do:
-// Link the above note to the data-streams docs in apm-server
+For a list of indices users need access to, see
+{apm-server-ref-v}/apm-integration-data-streams.html[APM data streams]
 
 [role="screenshot"]
 image::images/kibana-apm-sample-data.png[APM app with data]

--- a/docs/en/ingest-management/getting-started.asciidoc
+++ b/docs/en/ingest-management/getting-started.asciidoc
@@ -20,7 +20,7 @@ Before you begin, please read <<fleet-limitations>>.
 
 You need {es} for storing and searching your data, and {kib} for visualizing and
 managing it. You can use our
-https://www.elastic.co/cloud/elasticsearch-service[hosted {ess}]
+{ess-product}[hosted {ess}]
 on {ecloud} (recommended), or self-manage the {stack} on your own hardware.
 
 Here's what you need for each deployment type:

--- a/docs/en/ingest-management/tab-widgets/prereq.asciidoc
+++ b/docs/en/ingest-management/tab-widgets/prereq.asciidoc
@@ -1,5 +1,5 @@
 // tag::cloud[]
-* Access to a deployment of our https://www.elastic.co/cloud/elasticsearch-service[hosted {ess}]
+* Access to a deployment of our {ess-product}[hosted {ess}]
 on {ecloud}. The {ess} is available on AWS, GCP, and Azure. {ess-trial}[Try it out for free].
 
 * User with the superuser role. See {ref}/built-in-roles.html[Built-in roles].


### PR DESCRIPTION
Backports the following commits to 7.12:
 - Add missing links to APM integration (#451)