### PR TITLE
Add Elasticsearch output settings to Elastic Agent docs

### DIFF
--- a/docs/en/ingest-management/elastic-agent/configuration/outputs/output-configuration.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/outputs/output-configuration.asciidoc
@@ -1,0 +1,39 @@
+[discrete]
+[[elastic-agent-output-configuration]]
+== Output settings
+
+Specify one or more outputs. Specifying multiple outputs allows you to pair
+each data source with a different output.
+
+IMPORTANT: {agent} currently works with the {es} output only.
+
+Example output configuration:
+
+[source,yaml]
+-------------------------------------------------------------------------------------
+outputs:
+  default:
+    type: elasticsearch
+    hosts: [127.0.0.1:9200]
+    username: elastic
+    password: changeme
+
+  monitoring:
+    type: elasticsearch
+    api_key: VuaCfGcBCdbkQm-e5aOx:ui2lp2axTNmsyakw9tvNnw
+    hosts: ["localhost:9200"]
+    ca_sha256: "7lHLiyp4J8m9kw38SJ7SURJP4bXRZv/BNxyyXkCcE/M="
+-------------------------------------------------------------------------------------
+
+This example configures two outputs: `default` and  `monitoring`.
+Notice that they use different authentication methods. The first one uses a
+username and password pair, and the second one contains an API key.
+
+[NOTE]
+==============
+A default output configuration is required.
+==============
+
+
+include::output-elasticsearch.asciidoc[]
+

--- a/docs/en/ingest-management/elastic-agent/configuration/outputs/output-elasticsearch.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/outputs/output-elasticsearch.asciidoc
@@ -1,0 +1,586 @@
+:output-type: elasticsearch
+
+[[elasticsearch-output]]
+== {es} output
+
+The `elasticsearch` output sends events directly to {es} by using the
+{es} HTTP API.
+
+*Compatibility:* This output works with all compatible versions of {es}. See the
+https://www.elastic.co/support/matrix#matrix_compatibility[Elastic Support
+Matrix].
+
+Example configuration:
+
+//TODO: Provide a example that shows more of the settings users are likely to
+//change.
+
+[source,yaml]
+----
+output.elasticsearch:
+  hosts: ["https://myEShost:9200"] <1>
+----
+<1> To enable SSL, add `https` to all URLs defined under __hosts__.
+
+The `elasticsearch` output supports the following settings, grouped by category.
+Many of these settings have sensible defaults that allow you to run {agent} with
+minimal configuration.
+
+<<output-elasticsearch-commonly-used-settings>>::
+Settings frequently changed for this input type.
+
+<<output-elasticsearch-authentication-settings>>::
+Settings for authenticating with {es}.
+
+<<output-elasticsearch-data-parsing-settings>>::
+Settings used to parse, filter, and transform data.
+
+<<output-elasticsearch-http-settings>>::
+Settings that modify the HTTP request sent to {es}.
+
+<<output-elasticsearch-performance-tuning-settings>>::
+Settings that control timeouts and other behavior that affects performance.
+
+
+//QUESTION: Do we still support all the ways to authenticate against ES, or
+//is token-based authentication the only way?
+
+[[output-elasticsearch-commonly-used-settings]]
+=== Commonly used settings
+
+[cols="2*<a"]
+|===
+| Settings | Description
+
+//QUESTION: I've removed index and indices because I don't think it makes sense
+//to document these settings for agent. Let me know if that's not correct.
+
+// =============================================================================
+
+// tag::enabled-setting[]
+|
+[id="output-{output-type}-enabled-setting"]
+`enabled`
+
+| (boolean) Enables or disables the output. If set to `false`, the output is
+disabled.
+
+*Default:* `enabled`
+
+// end::enabled-setting[]
+
+// =============================================================================
+
+// tag::escape_html-setting[]
+
+//QUESTION: What category would you put this in? Didn't fit in any other, so I
+//put it here.
+|
+[id="output-{output-type}-escape_html-setting"]
+`escape_html`
+
+| (boolean) Configures escaping of HTML in strings. Set to `true` to enable
+escaping.
+
+*Default:* `false`
+// end::escape_html-setting[]
+
+// =============================================================================
+
+// tag::hosts-setting[]
+|
+[id="output-{output-type}-hosts-setting"]
+`hosts`
+
+| (list) The list of {es} nodes to connect to. The events are distributed to
+these nodes in round robin order. If one node becomes unreachable, the event is
+automatically sent to another node. Each {es} node can be defined as a `URL` or
+`IP:PORT`. For example: `http://192.15.3.2`, `https://es.found.io:9230` or
+`192.24.3.2:9300`. If no port is specified, `9200` is used.
+
+NOTE: When a node is defined as an `IP:PORT`, the _scheme_ and _path_ are taken
+from the `protocol` and `path` settings. 
+
+[source,yaml]
+------------------------------------------------------------------------------
+output.elasticsearch:
+  hosts: ["10.45.3.2:9220", "10.45.3.1:9230"] <1>
+  protocol: https
+  path: /elasticsearch
+------------------------------------------------------------------------------
+
+In the previous example, the {es} nodes are available at
+`https://10.45.3.2:9220/elasticsearch` and
+`https://10.45.3.1:9230/elasticsearch`.
+// end::hosts-setting[]
+
+// =============================================================================
+
+//QUESTION: Is this setting still valid for agent? If so, what  category should
+//it be under?
+
+// tag::ilm-setting[]
+|
+[id="output-{output-type}-ilm-setting"]
+`ilm`
+
+| Configuration options for index lifecycle management.
+
+//See <<ilm>> for more information.
+
+// end::ilm-setting[]
+
+// =============================================================================
+
+// tag::protocol-setting[]
+|
+[id="output-{output-type}-protocol-setting"]
+`protocol`
+
+| (string) The name of the protocol {es} is reachable on. The options are:
+`http` or `https`. The default is `http`. However, if you specify a URL for
+`hosts`, the value of `protocol` is overridden by whatever scheme you specify in
+the URL.
+// end::protocol-setting[]
+
+// =============================================================================
+
+// tag::proxy_url-setting[]
+|
+[id="output-{output-type}-proxy_url-setting"]
+`proxy_url`
+
+| (string) The URL of the proxy to use when connecting to the {es} servers. The
+value may be either a complete URL or a "host[:port]", in which case the "http"
+scheme is assumed. If a value is not specified through the configuration file
+then proxy environment variables are used. See the
+https://golang.org/pkg/net/http/#ProxyFromEnvironment[Go documentation]
+for more information about the environment variables.
+// end::proxy_url-setting[]
+
+// =============================================================================
+
+|===
+
+[[output-elasticsearch-authentication-settings]]
+=== Authentication settings
+
+Settings for authenticating with {es}.
+
+When sending data to a secured cluster through the `elasticsearch`
+output, {agent} can use any of the following authentication methods:
+
+* Basic authentication credentials (username and password).
+* Token-based (API key) authentication.
+* Public Key Infrastructure (PKI) certificates.
+
+//QUESTION: Why isn't kerberos covered here?
+
+The following examples show how to configure authentication by using these
+methods.
+
+*Basic authentication:*
+
+["source","yaml",subs="attributes,callouts"]
+----
+output.elasticsearch:
+  hosts: ["https://myEShost:9200"]
+  username: "your-username"
+  password: "your-password"
+----
+
+*API key authentication:*
+
+["source","yaml",subs="attributes,callouts"]
+----
+output.elasticsearch:
+  hosts: ["https://myEShost:9200"]
+  api_key: "KnR6yE41RrSowb0kQ0HWoA"
+----
+
+*PKI certificate authentication:*
+
+["source","yaml",subs="attributes,callouts"]
+----
+output.elasticsearch:
+  hosts: ["https://myEShost:9200"]
+  ssl.certificate: "/etc/pki/client/cert.pem"
+  ssl.key: "/etc/pki/client/cert.key"
+----
+
+
+//See <<securing-communication-elasticsearch>> for details on each authentication method.
+
+[cols="2*<a"]
+|===
+| Settings | Description
+
+// tag::api_key-setting[]
+|
+[id="output-{output-type}-api_key-setting"]
+`api_key`
+
+| (string) Instead of using a username and password, you can use API keys to
+secure communication with {es}. The value must be the ID of the API key and the
+API key joined by a colon: `id:api_key`.
+// end::api_key-setting[]
+
+// =============================================================================
+
+// tag::kerberos-setting[]
+|
+[id="output-{output-type}-kerberos-setting"]
+`kerberos`
+
+| Configuration options for Kerberos authentication.
+
+//See <<configuration-kerberos>> for more information.
+// end::kerberos-setting[]
+
+// =============================================================================
+
+// tag::password-setting[]
+|
+[id="output-{output-type}-password-setting"]
+`password`
+
+| (string) The basic authentication password for connecting to {es}.
+// end::password-setting[]
+
+// =============================================================================
+
+// tag::ssl-setting[]
+|
+[id="output-{output-type}-ssl-setting"]
+`ssl`
+
+| Configuration options for SSL parameters like the certificate authority to use
+for HTTPS-based connections. If the `ssl` section is missing, the host CAs are
+used for HTTPS connections to {es}.
+
+//See the <<securing-communication-elasticsearch,secure communication with {es}>> guide
+//or <<configuration-ssl,SSL configuration reference>> for more information.
+// end::ssl-setting[]
+
+// =============================================================================
+
+// tag::username-setting[]
+|
+[id="output-{output-type}-username-setting"]
+`username`
+
+| (string) The basic authentication username for connecting to {es}.
+
+This user needs the privileges required to publish events to {es}.
+//To create a user like this, see <<privileges-to-publish-events>>.
+// end::username-setting[]
+
+// =============================================================================
+
+|===
+
+[[output-elasticsearch-data-parsing-settings]]
+=== Data parsing, filtering, and manipulation settings
+Settings used to parse, filter, and transform data.
+
+//TODO: Add an brief intro about ingest pipelines.
+
+[cols="2*<a"]
+|===
+| Settings | Description
+
+// tag::pipeline-setting[]
+|
+[id="output-{output-type}-pipeline-setting"]
+`pipeline`
+
+| (string) A format string value that specifies the ingest node pipeline to
+write events to.
+
+[source,yaml]
+------------------------------------------------------------------------------
+output.elasticsearch:
+  hosts: ["http://localhost:9200"]
+  pipeline: my_pipeline_id
+------------------------------------------------------------------------------
+
+//For more information, see <<configuring-ingest-node>>.
+
+You can set the ingest node pipeline dynamically by using a format string to
+access any event field. For example, this configuration uses a custom field,
+`fields.log_type`, to set the pipeline for each event:
+
+[source,yaml]
+------------------------------------------------------------------------------
+output.elasticsearch:
+  hosts: ["http://localhost:9200"]
+  pipeline: "%{[fields.log_type]}_pipeline"
+------------------------------------------------------------------------------
+
+With this configuration, all events with `log_type: normal` are sent to a
+pipeline named `normal_pipeline`, and all events with `log_type: critical` are
+sent to a pipeline named `critical_pipeline`.
+
+TIP: To learn how to add custom fields to events, see the `fields` option.
+
+See the `pipelines` setting for other ways to set the ingest node pipeline
+dynamically.
+// end::pipelines-setting[]
+
+// =============================================================================
+
+// tag::pipelines-setting[]
+|
+[id="output-{output-type}-pipelines-setting"]
+`pipelines`
+
+| An array of pipeline selector rules. Each rule specifies the ingest node
+pipeline to use for events that match the rule. During publishing, {agent}
+uses the first matching rule in the array. Rules can contain conditionals,
+format string-based fields, and name mappings. If the `pipelines` setting is
+missing or no rule matches, the `pipeline` setting is used.
+
+Rule settings:
+
+*`pipeline`*:: The pipeline format string to use. If this string contains field
+references, such as `%{[fields.name]}`, the fields must exist, or the rule
+fails.
+
+*`mappings`*:: A dictionary that takes the value returned by `pipeline` and maps
+it to a new name.
+
+*`default`*:: The default string value to use if `mappings` does not find a
+match.
+
+*`when`*:: A condition that must succeed in order to execute the current rule.
+
+All the conditions supported by processors are also supported here.
+
+The following example sends events to a specific pipeline based on whether the
+`message` field contains the specified string:
+
+[source,yaml]
+------------------------------------------------------------------------------
+output.elasticsearch:
+  hosts: ["http://localhost:9200"]
+  pipelines:
+    - pipeline: "warning_pipeline"
+      when.contains:
+        message: "WARN"
+    - pipeline: "error_pipeline"
+      when.contains:
+        message: "ERR"
+------------------------------------------------------------------------------
+
+
+The following example sets the pipeline by taking the name returned by the
+`pipeline` format string and mapping it to a new name that's used for the
+pipeline:
+
+[source,yaml]
+------------------------------------------------------------------------------
+output.elasticsearch:
+  hosts: ["http://localhost:9200"]
+  pipelines:
+    - pipeline: "%{[fields.log_type]}"
+      mappings:
+        critical: "sev1_pipeline"
+        normal: "sev2_pipeline"
+      default: "sev3_pipeline"
+------------------------------------------------------------------------------
+
+
+With this configuration, all events with `log_type: critical` are sent to
+`sev1_pipeline`, all events with `log_type: normal` are sent to a
+`sev2_pipeline`, and all other events are sent to `sev3_pipeline`.
+
+//For more information about ingest node pipelines, see
+//<<configuring-ingest-node>>.
+// end::pipelines-setting[]
+
+// =============================================================================
+
+|===
+
+[[output-elasticsearch-http-settings]]
+=== HTTP settings
+
+Settings that modify the HTTP requests sent to {es}.
+
+[cols="2*<a"]
+|===
+| Settings | Description
+
+
+// tag::headers-setting[]
+|
+[id="output-{output-type}-headers-setting"]
+`headers`
+
+| Custom HTTP headers to add to each request created by the {es} output.
+Example:
+
+[source,yaml]
+------------------------------------------------------------------------------
+output.elasticsearch.headers:
+  X-My-Header: Header contents
+------------------------------------------------------------------------------
+
+Specify multiple header values for the same header name by separating them with
+a comma.
+// end::headers-setting[]
+
+// =============================================================================
+
+// tag::parameters-setting[]
+|
+[id="output-{output-type}-parameters-setting"]
+`parameters`
+
+| Dictionary of HTTP parameters to pass within the url with index operations.
+// end::parameters-setting[]
+
+// =============================================================================
+
+// tag::path-setting[]
+|
+[id="output-{output-type}-path-setting"]
+`path`
+
+| (string) An HTTP path prefix that is prepended to the HTTP API calls. This is
+useful for the cases where {es} listens behind an HTTP reverse proxy that
+exports the API under a custom prefix.
+// end::path-setting[]
+
+// =============================================================================
+
+|===
+
+[[output-elasticsearch-performance-tuning-settings]]
+=== Performance tuning settings
+
+Settings that may affect performance.
+
+
+[cols="2*<a"]
+|===
+| Settings | Description
+
+// tag::backoff.init-setting[]
+|
+[id="output-{output-type}-backoff.init-setting"]
+`backoff.init`
+
+| (string) The number of seconds to wait before trying to reconnect to {es}
+after a network error. After waiting `backoff.init` seconds, {agent} tries to
+reconnect. If the attempt fails, the backoff timer is increased exponentially up
+to `backoff.max`. After a successful connection, the backoff timer is reset.
+
+*Default:* `1s`
+// end::backoff.init-setting[]
+
+// =============================================================================
+
+// tag::backoff.max-setting[]
+|
+[id="output-{output-type}-backoff.max-setting"]
+`backoff.max`
+
+| (string) The maximum number of seconds to wait before attempting to connect to
+{es} after a network error.
+
+*Default:* `60s`
+// end::backoff.max-setting[]
+
+// =============================================================================
+
+// tag::bulk_max_size-setting[]
+|
+[id="output-{output-type}-bulk_max_size-setting"]
+`bulk_max_size`
+
+| (int) The maximum number of events to bulk in a single {es} bulk API index
+request. 
+
+Events can be collected into batches. {agent} will split batches larger than
+`bulk_max_size` into multiple batches.
+
+Specifying a larger batch size can improve performance by lowering the overhead
+of sending events. However big batch sizes can also increase processing times,
+which might result in API errors, killed connections, timed-out publishing
+requests, and, ultimately, lower throughput.
+
+Setting `bulk_max_size` to values less than or equal to 0 disables the
+splitting of batches. When splitting is disabled, the queue decides on the
+number of events to be contained in a batch.
+
+*Default:* `50`
+// end::bulk_max_size-setting[]
+
+// =============================================================================
+
+// tag::compression_level-setting[]
+|
+[id="output-{output-type}-compression_level-setting"]
+`compression_level`
+
+| (int) The gzip compression level. Set this value to `0` to disable compression.
+The compression level must be in the range of `1` (best speed) to `9` (best
+compression).
+
+Increasing the compression level reduces network usage but increases CPU usage.
+
+*Default:* `0`
+// end::compression_level-setting[]
+
+// =============================================================================
+
+// tag::max_retries-setting[]
+|
+[id="output-{output-type}-max_retries-setting"]
+`max_retries`
+
+| (int) The number of times to retry publishing an event after a publishing
+failure. After the specified number of retries, the events are typically
+dropped.
+
+Set `max_retries` to a value less than 0 to retry until all events are published.
+
+*Default:* `3`
+// end::max_retries-setting[]
+
+// =============================================================================
+
+// tag::timeout-setting[]
+|
+[id="output-{output-type}-timeout-setting"]
+`timeout`
+
+| (int) The http request timeout in seconds for the {es} request.
+
+*Default:* `90`
+
+//QUESTION: Is this really an int? Seems weird that all other durations are
+//strings like 90s.
+
+// end::timeout-setting[]
+
+// =============================================================================
+
+// tag::worker-setting[]
+|
+[id="output-{output-type}-worker-setting"]
+`worker`
+
+| (int) The number of workers per configured host publishing events to {es}.
+This is best used with load balancing mode enabled. Example: If you have two
+hosts and three workers, in total six workers are started (three for each host).
+
+*Default:* `1`
+// end::worker-setting[]
+
+// =============================================================================
+
+|===
+
+:output-type!: 

--- a/docs/en/ingest-management/elastic-agent/elastic-agent-configuration.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/elastic-agent-configuration.asciidoc
@@ -15,41 +15,11 @@ described in <<installation-layout>>.
 TIP: To get started quickly, you can use {fleet} to generate a standalone
 configuration. For more information, see <<run-elastic-agent-standalone>>.
 
-[discrete]
-[[elastic-agent-output-configuration]]
-== Output settings
+//TODO: Revisit this topic after merging
+// https://github.com/elastic/observability-docs/pull/424.
 
-Specify one or more outputs. Specifying multiple outputs allows you to pair
-each data source with a different output.
-
-IMPORTANT: {agent} currently works with the {es} output only.
-
-Example output configuration:
-
-[source,yaml]
--------------------------------------------------------------------------------------
-outputs:
-  default:
-    type: elasticsearch
-    hosts: [127.0.0.1:9200]
-    username: elastic
-    password: changeme
-
-  monitoring:
-    type: elasticsearch
-    api_key: VuaCfGcBCdbkQm-e5aOx:ui2lp2axTNmsyakw9tvNnw
-    hosts: ["localhost:9200"]
-    ca_sha256: "7lHLiyp4J8m9kw38SJ7SURJP4bXRZv/BNxyyXkCcE/M="
--------------------------------------------------------------------------------------
-
-This example configures two outputs: `default` and  `monitoring`.
-Notice that they use different authentication methods. The first one uses a
-username and password pair, and the second one contains an API key.
-
-[NOTE]
-==============
-A default output configuration is required.
-==============
+// include output settings
+include::configuration/outputs/output-configuration.asciidoc[]
 
 [discrete]
 [[elastic-agent-monitoring-configuration]]


### PR DESCRIPTION
First pass at adding the settings.

Todo:

- [ ] Fix examples to use correct syntax for agent config.
- [ ] Remove settings that are not valid for agent config.
- [ ] Add types where they are missing.
- [ ] Add into about enrollment tokens?
- [ ] Fix structure of config overview topic (elastic-agent-configuration.asciidoc) after all related PRs are merged.