### PR TITLE
docs: add logs app video

### DIFF
--- a/docs/en/observability/tail-logs.asciidoc
+++ b/docs/en/observability/tail-logs.asciidoc
@@ -8,6 +8,24 @@ along with the power of search.
 Click *Stream Live* to view a continuous flow of log messages in real time, or
 click *Stop streaming* to view historical logs from a specified time range.
 
+// Conditionally display a video depending on what the
+// current documentation version is.
+
+ifeval::["{is-current-version}"=="true"]
+++++
+<script type="text/javascript" async src="https://play.vidyard.com/embed/v4.js"></script>
+<img
+  style="width: 100%; margin: auto; display: block;"
+  class="vidyard-player-embed"
+  src="https://play.vidyard.com/TSusZfvvRvg78qRaeYTfey.jpg"
+  data-uuid="TSusZfvvRvg78qRaeYTfey"
+  data-v="4"
+  data-type="inline"
+/>
+</br>
+++++
+endif::[]
+
 [[filter-logs]]
 == Filter logs
 
@@ -18,14 +36,14 @@ For example, enter `host.hostname : "host1"` to see only the information for `ho
 Additionally, click *Highlights* and enter a term you would like to locate within the log events. The Logs
 histogram, located to the right, highlights the number of discovered terms and when the log event was ingested.
 This helps you quickly jump between potential areas of interest in large amounts of logs, or from a high level,
-view when a large number of events occurred. 
+view when a large number of events occurred.
 
 [[inspect-log-event]]
 == Inspect log event details
 
 When you have searched and filtered your logs for a specific log event, you may want to examine the
 metadata and the structured fields associated with that event. To view the *Log event document details* fly-out,
-hover over the log event, click *View actions for line*, and then select *View details*. To further enhance 
+hover over the log event, click *View actions for line*, and then select *View details*. To further enhance
 the workflow of monitoring logs, the icons next to each field value enable you to filter the logs per that value.
 
 [role="screenshot"]
@@ -38,7 +56,7 @@ Once your logs are filtered, and you find an interesting log line, the real cont
 what happened before and after that log line within that data source. For example, you are running
 containerized applications on a Kubernetes cluster, you filter the logs for the term `error`, and you find an
 interesting error log line. The context you want is what happened before and after the error line within the
-logs of this container and application. 
+logs of this container and application.
 
 Hover over the log event, click *View actions for line*, and then select *View in context*. The context is
 preserved and helps you find the root cause as soon as possible.


### PR DESCRIPTION
Add video about the logs app to `current` documentation.

Part of https://github.com/elastic/observability-docs/issues/389.