### PR TITLE
[7.12] Refactor files to prep for book changing chunk level

### DIFF
--- a/docs/en/ingest-management/elastic-agent/elastic-agent-capabilities.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/elastic-agent-capabilities.asciidoc
@@ -1,3 +1,4 @@
+[discrete]
 [[capabilities]]
 == Capabilities
 
@@ -77,12 +78,14 @@ inputs:
         condition: ${host.platform} != 'windows'
 ----
 
-[supported-capabilities]
+[discrete]
+[[supported-capabilities]]
 === Supported capabilities
 
 You can use capabilities to modify the congestion of outputs, inputs or upgrade the capability of {agent}.
 
-[capabilities-inputs]
+[discrete]
+[[capabilities-inputs]]
 ==== Inputs
 
 For inputs, you can the `input` key containing an expression.
@@ -95,7 +98,8 @@ capabilities:
   input: system/*
 ----
 
-[capabilities-outputs]
+[discrete]
+[[capabilities-outputs]]
 ==== Outputs
 
 For outputs, you can use the `output` key containing an expression.
@@ -108,7 +112,8 @@ capabilities:
   output: kafka
 ----
 
-[capabilities-upgrade]
+[discrete]
+[[capabilities-upgrade]]
 ==== Upgrade
 
 For an upgrade, you can use the `output` key containing an expression that allows a specific upgrade to version `8.0.0`. `${version}` is the target version.

--- a/docs/en/ingest-management/elastic-agent/elastic-agent-conditions.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/elastic-agent-conditions.asciidoc
@@ -1,3 +1,4 @@
+[discrete]
 [[conditions]]
 == Conditions
 
@@ -46,6 +47,7 @@ inputs:
         condition: ${host.platform} != 'windows'
 ----
 
+[discrete]
 [[condition-syntax]]
 === Condition syntax
 
@@ -76,6 +78,7 @@ manipulate the values.
 
 * Booleans `true` and `false`
 
+[discrete]
 [[condition-examples]]
 === Condition examples
 

--- a/docs/en/ingest-management/elastic-agent/elastic-agent-configuration.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/elastic-agent-configuration.asciidoc
@@ -108,6 +108,7 @@ inputs:
 
 If `use_output` is not specified, the `default` output is used.
 
+[discrete]
 == Reference yaml
 
 The {agent} installation includes an `elastic-agent.reference.yml` file that

--- a/docs/en/ingest-management/elastic-agent/elastic-agent-debug-input-configs.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/elastic-agent-debug-input-configs.asciidoc
@@ -1,3 +1,4 @@
+[discrete]
 [[debug-configs]]
 == Debugging 
 

--- a/docs/en/ingest-management/elastic-agent/elastic-agent-functions.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/elastic-agent-functions.asciidoc
@@ -1,9 +1,11 @@
+[discrete]
 [[condition-function-reference]]
 == Function reference
 
 
 The condition syntax supports the following functions.
 
+[discrete]
 [[add-function]]
 === `add`
 `add(Number, Number) Number`
@@ -16,6 +18,7 @@ add(1, 2) == 3
 add(5, ${foo}) >= 5
 ----
 
+[discrete]
 [[arrayContains-function]]
 === `arrayContains`
 
@@ -28,6 +31,7 @@ Usage:
 arrayContains(${docker.labels}, 'monitor')
 ----
 
+[discrete]
 [[concat-function]]
 === `concat`
 
@@ -43,6 +47,7 @@ concat("foo", "bar") == "foobar"
 concat(${var1}, ${var2}) != "foobar"
 ----
 
+[discrete]
 [[divide-function]]
 === `divide`
 
@@ -56,6 +61,7 @@ divide(25, 5) > 0
 divide(${var1}, ${var2}) > 7
 ----
 
+[discrete]
 [[endsWith-function]]
 === `endsWith`
 
@@ -70,6 +76,7 @@ endsWith("hello world", "hello") == true
 endsWith(${var1}, "hello") != true
 ----
 
+[discrete]
 [[hasKey-function]]
 === `hasKey`
 
@@ -82,6 +89,7 @@ Usage:
 hasKey(${host}, "platform")
 ----
 
+[discrete]
 [[indexOf-function]]
 === `indexOf`
 
@@ -97,6 +105,7 @@ indexOf("hello", "llo") == 2
 indexOf(${var1}, "hello") >= 0
 ----
 
+[discrete]
 [[length-function]]
 === `length`
 
@@ -111,6 +120,7 @@ length(${docker.labels}) > 0
 length(${host}) > 2
 ----
 
+[discrete]
 [[match-function]]
 === `match`
 
@@ -128,6 +138,7 @@ match("hello world", "^hello") == true
 match(${var1}, "world$") == true
 ----
 
+[discrete]
 [[modulo-function]]
 === `modulo`
 
@@ -141,6 +152,7 @@ modulo(25, 5) > 0
 modulo(${var1}, ${var2}) == 0
 ----
 
+[discrete]
 [[multiply-function]]
 === `multiply`
 
@@ -154,6 +166,7 @@ multiply(5, 5) == 25
 multiple(${var1}, ${var2}) > x
 ----
 
+[discrete]
 [[number-function]]
 === `number`
 
@@ -167,6 +180,7 @@ number("42") == 42
 number(${var1}) == 42
 ----
 
+[discrete]
 [[startsWith-function]]
 === `startsWith`
 
@@ -180,6 +194,7 @@ startsWith("hello world", "hello") == true
 startsWith(${var1}, "hello") != true
 ----
 
+[discrete]
 [[string-function]]
 === `string`
 
@@ -193,6 +208,7 @@ string(42) == "42"
 string(${var1}) == "42"
 ----
 
+[discrete]
 [[stringContains-function]]
 === `stringContains`
 
@@ -206,6 +222,7 @@ stringContains("hello world", "hello") == true
 stringContains(${var1}, "hello") != true
 ----
 
+[discrete]
 [[subtract-function]]
 === `subtract`
 

--- a/docs/en/ingest-management/elastic-agent/elastic-agent-providers.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/elastic-agent-providers.asciidoc
@@ -1,3 +1,4 @@
+[discrete]
 [[providers]]
 == Providers
 
@@ -10,6 +11,7 @@ For example, if a provider named `foo` provides
 `{"foo" : {"key1": "value1", "key2": "value2"}}`. To reference the keys, you
 would use `{{foo.key1}}` and `{{foo.key2}}`.
 
+[discrete]
 === Provider configuration
 
 The provider configuration is specified under the top-level `providers`
@@ -45,6 +47,7 @@ providers:
 {agent} supports two broad types of providers: <<context-providers,context>> and
 <<dynamic-providers,dynamic>>.
 
+[discrete]
 [[context-providers]]
 === Context providers
 
@@ -62,6 +65,7 @@ understanding across projects is the same.
 
 {agent} supports the following context providers:
 
+[discrete]
 [[local-provider]]
 ==== Local
 
@@ -75,6 +79,7 @@ providers:
       foo: bar
 ----
 
+[discrete]
 [[agent-provider]]
 ==== Agent provider
 
@@ -109,6 +114,7 @@ Provides information about the {agent}. The available keys are:
 |===
 
 
+[discrete]
 [[host-provider]]
 ==== Host provider
 
@@ -138,6 +144,7 @@ Provides information about the current host. The available keys are:
 |Host MAC addresses
 |===
 
+[discrete]
 [[env-provider]]
 ==== Env Provider
 
@@ -152,6 +159,7 @@ foo=bar elastic-agent run
 
 You can reference the environment variable as `${env.foo}`.
 
+[discrete]
 [[dynamic-providers]]
 === Dynamic Providers
 
@@ -160,6 +168,7 @@ key/value mapping is combined with the previous context provider's key/value
 mapping to provide a new unique key/value mapping that is used to generate a
 configuration.
 
+[discrete]
 [[local-dynamic-provider]]
 ==== Local dynamic provider
 
@@ -202,6 +211,7 @@ inputs:
    - paths: "/var/key3/app.log"
 ----
 
+[discrete]
 [[docker-provider]]
 ==== Docker Provider
 

--- a/docs/en/ingest-management/elastic-agent/elastic-agent-variable-substitution.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/elastic-agent-variable-substitution.asciidoc
@@ -1,3 +1,4 @@
+[discrete]
 [[variable-substitution]]
 == Variable substitution
 
@@ -66,6 +67,7 @@ inputs:
     path: "/var/log/foo"
 ----
 
+[discrete]
 === Alternative variables and constants
 
 Variable substitution can also define alternative variables or a constant.

--- a/docs/en/ingest-management/elastic-agent/uninstall-elastic-agent.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/uninstall-elastic-agent.asciidoc
@@ -4,6 +4,7 @@
 
 beta[]
 
+[discrete]
 == Uninstall on macOS, Linux, and Windows
 
 To uninstall {agent}, run the `uninstall` command from the directory where
@@ -21,6 +22,7 @@ stops and uninstalls any managed programs, such as {beats} and
 
 If you run into problems, see <<fleet-troubleshooting>>.
 
+[discrete]
 == Uninstall on DEB or RPM
 
 The `uninstall` command is not supported for DEB or RPM installations. To

--- a/docs/en/ingest-management/elastic-agent/upgrade-elastic-agent.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/upgrade-elastic-agent.asciidoc
@@ -34,6 +34,7 @@ the {kib} version is lower than the agent version.
 [role="screenshot"]
 image::images/fleet-agents.png[Upgrade menu for bulk upgrade in {fleet}]
 
+[discrete]
 [[upgrade-standalone]]
 == Upgrade standalone agents
 

--- a/docs/en/ingest-management/index.asciidoc
+++ b/docs/en/ingest-management/index.asciidoc
@@ -24,7 +24,7 @@ include::{docs-root}/shared/attributes.asciidoc[]
 
 include::fleet-overview.asciidoc[leveloffset=+1]
 
-include::fleet-limitations.asciidoc[leveloffset=+2]
+include::fleet-limitations.asciidoc[leveloffset=+1]
 
 include::getting-started.asciidoc[leveloffset=+1]
 


### PR DESCRIPTION
This PR is required before we can merge elastic/docs#2097.

Note that some of the file refactoring you'll see in other branches is not present in this PR because it's already implemented in another open PR. I just want to make the minimal changes needed to switch over the chunk level. The other refactoring will be backported after https://github.com/elastic/observability-docs/pull/424 is merged. 