### PR TITLE
Update security note for configuring uptime settings

### DIFF
--- a/docs/en/observability/configure-uptime-settings.asciidoc
+++ b/docs/en/observability/configure-uptime-settings.asciidoc
@@ -13,9 +13,8 @@ different uptime use cases and domains, use different settings in other spaces.
 +
 [IMPORTANT]
 =====
-To modify items on this page, you must have the {kibana-ref}/space-rbac-tutorial.html[`all`]
-privilege granted to your role. The `all` privilege grants cluster administration operations, like snapshotting,
-node shutdown/restart, settings update, rerouting, or managing users and roles.
+To modify items on this page, you must have the {kibana-ref}/kibana-privileges.html[`all`] Uptime
+privilege granted to your role.
 =====
 
 [[configure-uptime-indices]]


### PR DESCRIPTION
Updates the security authorization note for configuring uptime settings.

The existing note is pointing to a tutorial that we wish to replace as part of https://github.com/elastic/kibana/pull/94158.

This updates the link to point to a more appropriate location, and adjusts the note text to indicate that this privilege does not in fact grant cluster administration operations.