### PR TITLE
Add Fleet user guide to quick links

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -22,7 +22,7 @@ pipeline {
       when { changeRequest() }
       steps {
         deleteDir()
-        githubPrComment(message: "A docs preview will be available soon: </br> - [HTML diff](https://observability-docs_${CHANGE_ID}.docs-preview.app.elstc.co/diff) </br> - [Observability guide](https://observability-docs_${CHANGE_ID}.docs-preview.app.elstc.co/guide/en/observability/master/index.html)")
+        githubPrComment(message: "A documentation preview will be available soon:</br><ul><li>📚 [HTML diff](https://observability-docs_${CHANGE_ID}.docs-preview.app.elstc.co/diff)</li><li>📘 [Fleet User Guide](https://observability-docs_${CHANGE_ID}.docs-preview.app.elstc.co/guide/en/fleet/master/index.html)</li><li>📙 [Observability Guide](https://observability-docs_${CHANGE_ID}.docs-preview.app.elstc.co/guide/en/observability/master/index.html)</li></ui>")
       }
     }
   }


### PR DESCRIPTION
This PR adds a link to the Fleet User Guide to each `apmmachine` comment. See below for an example.

<sup>Oh, and it also adds emojis<sup>because I like emojis</sup></sup>