### PR TITLE
[7.10] Update security note for configuring uptime settings (#485)

### DIFF
--- a/docs/en/observability/configure-uptime-settings.asciidoc
+++ b/docs/en/observability/configure-uptime-settings.asciidoc
@@ -13,9 +13,8 @@ different uptime use cases and domains, use different settings in other spaces.
 +
 [IMPORTANT]
 =====
-To modify items on this page, you must have the {kibana-ref}/space-rbac-tutorial.html[`all`]
-privilege granted to your role. The `all` privilege grants cluster administration operations, like snapshotting,
-node shutdown/restart, settings update, rerouting, or managing users and roles.
+To modify items on this page, you must have the {kibana-ref}/kibana-privileges.html[`all`] Uptime
+privilege granted to your role.
 =====
 
 [[configure-uptime-indices]]


### PR DESCRIPTION
Backports the following commits to 7.10:
 - Update security note for configuring uptime settings (#485)