### PR TITLE
Create CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# GitHub CODEOWNERS definition
+# Automatically add the obs-docs team as a reviewer to all documentaiton PRs
+# For more info, see https://help.github.com/articles/about-codeowners/
+
+/docs/ @elastic/obs-docs

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Within this repo, the `/docs/en/` directory is structured as follows:
 
 ## Reviews
 
-When you open a pull request, please tag **[@obs-docs](https://github.com/orgs/elastic/teams/obs-docs)** as a reviewer.
+All documentation pull requests automatically add the **[@obs-docs](https://github.com/orgs/elastic/teams/obs-docs)** team as a reviewer.
 
 ## Backporting
 


### PR DESCRIPTION
This PR adds a GitHub [CODEOWNERS](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners) definition to the observability-docs repo. If merged, this PR would automatically add the @elastic/obs-docs team as a reviewer to all documentation PRs (except draft PRs). Note that the addition of this file does not mean the obs-docs team is required to review a PR before it can be merged. 

Inspiration: https://github.com/elastic/kibana/blob/master/.github/CODEOWNERS