### PR TITLE
Mention command for generating encryption keys

### DIFF
--- a/docs/en/ingest-management/tab-widgets/prereq.asciidoc
+++ b/docs/en/ingest-management/tab-widgets/prereq.asciidoc
@@ -29,9 +29,11 @@ service] must be enabled.
 (`xpack.security.authc.api_key.enabled: true`)
 
 * In the {kib} configuration, the saved objects encryption key
-(`xpack.encryptedSavedObjects.encryptionKey`) must be set to any alphanumeric
-value of at least 32 characters. {fleet} requires this setting in order to save
-API keys and encrypt them in {kib}.
+must be set. {fleet} requires this setting in order to save API keys and encrypt
+them in {kib}. You can either set `xpack.encryptedSavedObjects.encryptionKey` to
+an alphanumeric value of at least 32 characters, or run the
+{kibana-ref}/kibana-encryption-keys.html[`kibana-encryption-keys` command] to
+generate the key. 
 
 **Example security settings**
 


### PR DESCRIPTION
Adds pointer to docs about generating encryption keys.

Related issue: https://github.com/elastic/kibana/pull/82838. I [said we would add this info](https://github.com/elastic/kibana/pull/82838#issuecomment-730027156), but lost track of the change.

(writers: try to ignore the passive voice. :-) it works better with the current bulleted list structure)