### PR TITLE
[7.x] [Alerting] Changed alerting managment links due to the upcoming changes in the alerting docs. (#528)

### DIFF
--- a/docs/en/observability/create-alerts.asciidoc
+++ b/docs/en/observability/create-alerts.asciidoc
@@ -3,7 +3,7 @@
 
 Alerting allows you to detect complex conditions within the Logs, Metrics, and Uptime apps
 and trigger actions when those conditions are met. Alerting can be centrally managed from
-the {kibana-ref}/managing-alerts-and-actions.html[{kib} Management UI] and provides
+the {kibana-ref}/alert-management.html[{kib} Management UI] and provides
 a set of built-in {kibana-ref}/action-types.html[actions] and alert-types for you to use.
 
 Extend your alerts by connecting them to actions that use built-in integrations for email,


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [Alerting] Changed alerting managment links due to the upcoming changes in the alerting docs. (#528)