### PR TITLE
Add placeholder file for release notes

### DIFF
--- a/docs/en/ingest-management/index.asciidoc
+++ b/docs/en/ingest-management/index.asciidoc
@@ -44,3 +44,6 @@ include::commands.asciidoc[leveloffset=+1]
 include::troubleshooting.asciidoc[leveloffset=+1]
 
 include::faq.asciidoc[leveloffset=+1]
+
+include::release-notes.asciidoc[leveloffset=+1]
+

--- a/docs/en/ingest-management/release-notes.asciidoc
+++ b/docs/en/ingest-management/release-notes.asciidoc
@@ -1,0 +1,8 @@
+[[release-notes]]
+= Release notes
+
+This section summarizes the changes in each release.
+
+* <<release-notes-7.13.0>>
+
+include::release-notes/release-notes-7.13.asciidoc[]

--- a/docs/en/ingest-management/release-notes/release-notes-7.13.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-7.13.asciidoc
@@ -1,0 +1,99 @@
+// Use these for links to issue and pulls. 
+:kib-issue: https://github.com/elastic/kibana/issues/
+:kib-pull: https://github.com/elastic/kibana/pull/
+:agent-issue: https://github.com/elastic/beats/issues/
+:agent-pull: https://github.com/elastic/beats/pull/
+
+//QUESTION: Any other repos that are needed here? ^^
+
+[[release-notes-7.13.0]]
+== {fleet} and {agent} 7.13.0
+
+Review important information about the {fleet} and {agent} 7.13.x releases.
+
+// Add link to changelogs for Beats/Agent and Kibana.
+
+//QUESTION: Should we add Fleet Server as a separate area below?
+
+[discrete]
+[[security-updates-7.13.0]]
+=== Security updates
+
+{fleet}::
+* add info
+
+{agent}::
+* add info
+
+[discrete]
+[[known-issues-7.13.0]]
+=== Known issues
+
+{fleet}::
+* The `fleet_enroll` role and user are no longer needed for central management
+of {agent}s in {kib}. If the role and user were set up in a previous release,
+remove them now to avoid them being orphaned in the cluster. {kib-pull}https://github.com/elastic/kibana/pull/98745[#98745]
+
+{agent}::
+* add info
+
+[discrete]
+[[breaking-changes-7.13.0]]
+=== Breaking changes
+
+Breaking changes can prevent your application from optimal operation and
+performance. Before you upgrade, review the breaking changes, then mitigate the
+impact to your application.
+
+{fleet}::
+* add info
+
+{agent}::
+* add info
+
+[discrete]
+[[deprecations-7.13.0]]
+=== Deprecations
+
+The following functionality is deprecated in 7.13.0, and will be removed in
+8.0.0. Deprecated functionality does not have an immediate impact on your
+application, but we strongly recommend you make the necessary updates after you
+upgrade to 7.13.0.
+
+{fleet}::
+* add info
+
+{agent}::
+* add info
+
+[discrete]
+[[new-features-7.13.0]]
+=== New features
+
+The 7.13.0 release adds the following new and notable features.
+
+{fleet}::
+* add info
+
+{agent}::
+* add info
+
+[discrete]
+[[enhancements-7.13.0]]
+=== Enhancements
+
+{fleet}::
+* add info
+
+{agent}::
+* add info
+
+[discrete]
+[[bug-fixes-7.13.0]]
+=== Bug fixes
+
+{fleet}::
+* add info
+
+{agent}::
+* add info


### PR DESCRIPTION
Please review the structure.  There are different ways to pivot this information. I've followed the general format of the ES and Kibana release notes, but there were some discrepancies. 

I'm assuming we want a separate file for each release (as they do for Elasticsearch). Please comment and let me know what would work best for contributors.

I noticed that the Kibana docs also include Fleet items, so we'll need to decide how to handle that. Do we duplicate what they have?

@mostlyjason and @ph Please take a look.