### PR TITLE
[7.13] tuts: single source Filebeat and Metricbeat instructions (#633)

### DIFF
--- a/docs/en/observability/index.asciidoc
+++ b/docs/en/observability/index.asciidoc
@@ -12,10 +12,12 @@ include::{docs-root}/shared/attributes.asciidoc[]
 :apm-java-ref-v:       https://www.elastic.co/guide/en/apm/agent/java/{apm-java-branch}
 :apm-go-ref-v:         https://www.elastic.co/guide/en/apm/agent/go/{apm-go-branch}
 :apm-dotnet-ref-v:     https://www.elastic.co/guide/en/apm/agent/dotnet/{apm-dotnet-branch}
-:beats-root:           {docdir}/../../../../beats
-:beats-repo-dir:       {beats-root}/libbeat/docs
+
 :apm-server-root:      {docdir}/../../../../apm-server
+:beats-root:           {docdir}/../../../../beats
+
 :apm-repo-dir:         {apm-server-root}/docs
+:beats-repo-dir:       {beats-root}/libbeat/docs
 :shared:               {observability-docs-root}/docs/en/shared
 
 // What is Observability?

--- a/docs/en/observability/monitor-aws.asciidoc
+++ b/docs/en/observability/monitor-aws.asciidoc
@@ -136,106 +136,9 @@ To monitor {aws} using the {stack}, you need two main components:
 an Elastic deployment to store and analyze the data and an agent to collect and
 ship the data.
 
-On a new terminal window, download and install {filebeat}.
-
-include::{beats-repo-dir}/tab-widgets/install-widget-filebeat.asciidoc[]
-
-{filebeat} comes with predefined assets for parsing,
-indexing, and visualizing your data.
-Run the following command to load these assets. It may take a few minutes.
-
-[source,bash]
-----
-./filebeat setup -e -E 'cloud.id=YOUR_DEPLOYMENT_CLOUD_ID' -E 'cloud.auth=elastic:YOUR_SUPER_SECRET_PASS'
-----
-
-[IMPORTANT]
-====
-Setting up {filebeat} is an admin-level task that requires extra privileges.
-As a best practice, {filebeat-ref}/privileges-to-setup-beats.html[use an administrator role to set up]
-and a more restrictive role for event publishing (which you will do next).
-====
-
-[discrete]
-==== Configure the {filebeat} output
-
-Next, you are going to configure the {filebeat} output to ship data to {ess}.
-
-Use the {filebeat} keystore to store {filebeat-ref}/keystore.html[secure
-settings]. Store the Cloud ID in the keystore.
-[source,bash]
-----
-./filebeat keystore create
-echo -n "<Your Deployment Cloud ID>" | ./filebeat keystore add CLOUD_ID --stdin
-----
-
-To store logs in {es} with minimal permissions, create an API key to send
-data from {filebeat} to {ess}. Log into {kib} (you can do so from the Cloud
-Console without typing in any permissions) and select *Management* -> *Dev
-Tools*. Send the following request:
-
-[source,console]
-----
-POST /_security/api_key
-{
-  "name": "filebeat-monitor-gcp",
-  "role_descriptors": {
-    "filebeat_writer": {
-      "cluster": [
-        "monitor",
-        "read_ilm",
-        "cluster:admin/ingest/pipeline/get",
-        "cluster:admin/ingest/pipeline/put"
-      ],
-      "index": [
-        {
-          "names": ["filebeat-*"],
-          "privileges": ["view_index_metadata", "create_doc"]
-        }
-      ]
-    }
-  }
-}
-----
-
-The response contains an `api_key` and an `id` field, which can be stored in
-the {filebeat} keystore in the following format: `id:api_key`.
-
-[source,bash]
-----
-echo -n "IhrJJHMB4JmIUAPLuM35:1GbfxhkMT8COBB4JWY3pvQ" | ./filebeat keystore add ES_API_KEY --stdin
-----
-
-[NOTE]
-=====
-Make sure you specify the `-n` parameter; otherwise, you will have painful
-debugging sessions due to adding a newline at the end of your API key.
-=====
-
-To see if both settings have been stored, run the following command:
-
-[source,bash]
-----
-./filebeat keystore list
-----
-
-To configure {filebeat} to output to {ess}, edit the `filebeat.yml`
-configuration file. Add the following lines to the end of the file.
-
-[source,yml]
-----
-cloud.id: ${CLOUD_ID}
-output.elasticsearch:
-  api_key: ${ES_API_KEY}
-----
-
-Finally, test if the configuration is working. If it is not working,
-verify that you used the right credentials and, if necessary, add them again.
-
-[source,bash]
-----
-./filebeat test output
-----
+:leveloffset: +3
+include::{shared}/install-configure-filebeat.asciidoc[]
+:leveloffset: -3
 
 [discrete]
 [[aws-step-five]]
@@ -418,113 +321,13 @@ Please see https://www.elastic.co/guide/en/beats/metricbeat/current/metricbeat-m
 
 [discrete]
 [[aws-step-eight]]
-=== Step 8: Install {metricbeat}
+=== Step 8: Install and configure {metricbeat}
 
-On a new terminal window, download and install {metricbeat}.
+In a new terminal window, run the following commands.
 
-include::{beats-repo-dir}/tab-widgets/install-widget-metricbeat.asciidoc[]
-
-[discrete]
-==== Set up the assets
-
-Similar to {filebeat}, {metricbeat} comes with predefined assets for parsing,
-indexing, and visualizing your data. Run the following command to load these
-assets. It may take a few minutes.
-
-[NOTE]
-=====
-Substitute the Cloud ID from your deployment in the following command. To find
-your Cloud ID, click on your https://cloud.elastic.co/deployments[deployment].
-=====
-[source,bash]
-----
-./metricbeat setup -e -E 'cloud.id=YOUR_DEPLOYMENT_CLOUD_ID' -E 'cloud.auth=elastic:YOUR_SUPER_SECRET_PASS'
-----
-[IMPORTANT]
-====
-Setting up {metricbeat} is an admin-level task that requires extra privileges.
-As a best practice, {metricbeat-ref}/privileges-to-setup-beats.html[use an administrator role to set up],
-and a more restrictive role for event publishing (which you will do next).
-====
-
-[discrete]
-==== Configure the {metricbeat} output
-
-Next, you are going to configure {metricbeat} output to {ess}.
-
-. Use the {metricbeat} keystore to store
-{metricbeat-ref}/keystore.html[secure settings].
-Store the Cloud ID in the keystore.
-+
-[source,bash]
-----
-./metricbeat keystore create
-echo -n "<Your Deployment Cloud ID>" | ./metricbeat keystore add CLOUD_ID --stdin
-----
-
-. To store metrics in {es} with minimal permissions, create an API key to send
-data from {metricbeat} to {ess}. Log into Kibana (you can do so from the Cloud
-Console without typing in any permissions) and select *Management* -> *Dev
-Tools*. Send the following request:
-+
-[source,console]
-----
-POST /_security/api_key
-{
-  "name": "metricbeat-monitor-gcp",
-  "role_descriptors": {
-    "metricbeat_writer": {
-      "cluster": ["monitor", "read_ilm"],
-      "index": [
-        {
-          "names": ["metricbeat-*"],
-          "privileges": ["view_index_metadata", "create_doc"]
-        }
-      ]
-    }
-  }
-}
-----
-
-. The response contains an `api_key` and an `id` field, which can be stored in
-the {metricbeat} keystore in the following format: `id:api_key`.
-+
-[source,bash]
-----
-echo -n "IhrJJHMB4JmIUAPLuM35:1GbfxhkMT8COBB4JWY3pvQ" | ./metricbeat keystore add ES_API_KEY --stdin
-----
-+
-[NOTE]
-=====
-Make sure you specify the `-n` parameter; otherwise, you will have
-painful debugging sessions due to adding a newline at the end of
-your API key.
-=====
-
-. To see if both settings have been stored, run the following command:
-+
-[source,bash]
-----
-./metricbeat keystore list
-----
-
-. To configure {metricbeat} to output to {ess}, edit the `metricbeat.yml`
-configuration file. Add the following lines to the end of the file.
-+
-[source,yml]
-----
-cloud.id: ${CLOUD_ID}
-output.elasticsearch:
-  api_key: ${ES_API_KEY}
-----
-
-. Finally, test if the configuration is working. If it is not working,
-verify if you used the right credentials and add them again.
-+
-[source,bash]
-----
-./metricbeat test output
-----
+:leveloffset: +3
+include::{shared}/install-configure-metricbeat.asciidoc[]
+:leveloffset: -3
 
 Now that the output is working, you are going to set up the {aws} module.
 

--- a/docs/en/observability/monitor-azure.asciidoc
+++ b/docs/en/observability/monitor-azure.asciidoc
@@ -7,6 +7,7 @@ In this {tutorial}, you'll learn how to monitor your Microsoft Azure deployments
 using Elastic Observability: Logs and Metrics.
 
 [discrete]
+[[azure-what-you-learn]]
 === What you'll learn
 
 You'll learn how to:
@@ -19,6 +20,7 @@ Azure module] and view those metrics in {kib}.
 Azure module] and view those logs in {kib}.
 
 [discrete]
+[[azure-before-you-begin]]
 === Before you begin
 
 Create a deployment using our hosted {ess} on {ess-trial}[{ecloud}].
@@ -27,6 +29,7 @@ and {kib} for visualizing and managing your data.
 For more information, see <<spin-up-stack,Spin up the Elastic Stack>>.
 
 [discrete]
+[[azure-step-one]]
 === Step 1: Create an Azure service principal and set permissions
 
 The https://docs.microsoft.com/en-us/rest/api/monitor/[Azure Monitor REST API]
@@ -101,11 +104,8 @@ image:monitor-azure-add-role-assignment.png[Add role assignment]
 access to your subscription.
 
 [discrete]
+[[azure-step-two]]
 === Step 2: Install and configure {metricbeat}
-
-To monitor Microsoft Azure using the {stack}, you need two main components:
-an Elastic deployment to store and analyze the data and an agent to collect
-and ship the data.
 
 [NOTE]
 ====
@@ -113,125 +113,23 @@ This {tutorial} assumes the Elastic cluster is already running. Make sure you
 have your *cloud ID* and your *credentials* on hand.
 ====
 
+To monitor Microsoft Azure using the {stack}, you need two main components:
+an Elastic deployment to store and analyze the data and an agent to collect
+and ship the data.
+
 Two agents can be used to monitor Azure: {metricbeat} is used to
 monitor metrics, and {filebeat} to monitor logs. You can run the agents on any
 machine. This {tutorial} uses a small Azure instance, *B2s* (2 vCPUs,
 4 GB memory), with an Ubuntu distribution.
 
-[discrete]
-==== Install {metricbeat}
-
-After starting and connecting to the Azure instance, download and install
-{metricbeat}.
-
-include::{beats-repo-dir}/tab-widgets/install-widget-metricbeat.asciidoc[]
-
-[discrete]
-==== Set up assets
-
-{metricbeat} comes with predefined assets for parsing, indexing, and visualizing
-your data. From the {metricbeat} directory, run the following command to load
-these assets.
-It may take a few minutes.
-
-[NOTE]
-=====
-Substitute the Cloud ID from your deployment in the following command. To find
-your Cloud ID, click on your https://cloud.elastic.co/deployments[deployment].
-=====
-[source,bash]
-----
-./metricbeat setup -e -E 'cloud.id=YOUR_DEPLOYMENT_CLOUD_ID' -E 'cloud.auth=elastic:YOUR_SUPER_SECRET_PASS'
-----
-[IMPORTANT]
-====
-Setting up {metricbeat} is an admin-level task that requires extra privileges.
-As a best practice, {metricbeat-ref}/privileges-to-setup-beats.html[use an administrator role to set up],
-and a more restrictive role for event publishing (which you will do next).
-====
-
-[discrete]
-==== Configure {metricbeat} output
-
-Next, you are going to configure {metricbeat} output to {ess}.
-
-. Use the {metricbeat} keystore to store
-{metricbeat-ref}/keystore.html[secure settings].
-Store the Cloud ID in the keystore.
-+
-[source,bash]
-----
-./metricbeat keystore create
-echo -n "<Your Deployment Cloud ID>" | ./metricbeat keystore add CLOUD_ID --stdin
-----
-
-. To store metrics in {es} with minimal permissions, create an API key to send
-data from {metricbeat} to {ess}. Log into Kibana (you can do so from the Cloud
-Console without typing in any permissions) and select *Management* -> *Dev
-Tools*. Send the following request:
-+
-[source,console]
-----
-POST /_security/api_key
-{
-  "name": "metricbeat-monitor-azure",
-  "role_descriptors": {
-    "metricbeat_writer": {
-      "cluster": ["monitor", "read_ilm"],
-      "index": [
-        {
-          "names": ["metricbeat-*"],
-          "privileges": ["view_index_metadata", "create_doc"]
-        }
-      ]
-    }
-  }
-}
-----
-
-. The response contains an `api_key` and an `id` field, which can be stored in
-the {metricbeat} keystore in the following format: `id:api_key`.
-+
-[source,bash]
-----
-echo -n "IhrJJHMB4JmIUAPLuM35:1GbfxhkMT8COBB4JWY3pvQ" | ./metricbeat keystore add ES_API_KEY --stdin
-----
-+
-[NOTE]
-=====
-Make sure you specify the `-n` parameter; otherwise, you will have
-painful debugging sessions due to adding a newline at the end of
-your API key.
-=====
-
-. To see if both settings have been stored, run the following command:
-+
-[source,bash]
-----
-./metricbeat keystore list
-----
-
-. To configure {metricbeat} to output to {ess}, edit the `metricbeat.yml`
-configuration file. Add the following lines to the end of the file.
-+
-[source,yml]
-----
-cloud.id: ${CLOUD_ID}
-output.elasticsearch:
-  api_key: ${ES_API_KEY}
-----
-
-. Finally, test if the configuration is working. If it is not working,
-verify if you used the right credentials and add them again.
-+
-[source,bash]
-----
-./metricbeat test output
-----
+:leveloffset: +3
+include::{shared}/install-configure-metricbeat.asciidoc[]
+:leveloffset: -3
 
 Now that the output is working, you are going to set up the input (Azure).
 
 [discrete]
+[[azure-step-three]]
 === Step 3: Configure {metricbeat} Azure module
 
 To collect metrics from Microsoft Azure, use the
@@ -359,128 +257,20 @@ image:monitor-azure-billing-overview-dashboard.png[{metricbeat} azure compute
 vms overview dashboard]
 
 [discrete]
+[[azure-step-four]]
 === Step 4: Install and configure {filebeat}
 
 Now that {metricbeat} is up and running, configure {filebeat} to collect Azure
 logs.
 
-[discrete]
-==== Install {filebeat}
-
-On a new terminal window connected to the Azure instance, download and install
-{filebeat}.
-
-include::{beats-repo-dir}/tab-widgets/install-widget-filebeat.asciidoc[]
-
-[discrete]
-==== Set up assets
-
-Similar to {metricbeat}, {filebeat} comes with predefined assets for parsing,
-indexing, and visualizing your data.
-Run the following command to load these assets. It may take a few minutes.
-
-[source,bash]
-----
-./filebeat setup -e -E 'cloud.id=YOUR_DEPLOYMENT_CLOUD_ID' -E 'cloud.auth=elastic:YOUR_SUPER_SECRET_PASS'
-----
-
-[IMPORTANT]
-====
-Setting up {filebeat} is an admin-level task that requires extra privileges.
-As a best practice, {filebeat-ref}/privileges-to-setup-beats.html[use an administrator role to set up]
-and a more restrictive role for event publishing (which you will do next).
-====
-
-[discrete]
-==== Configure {filebeat} output
-
-Next, you are going to configure {filebeat} output to {ess}.
-
-. Use the {filebeat} keystore to store {filebeat-ref}/keystore.html[secure
-settings]. Store the Cloud ID in the keystore.
-+
-[source,bash]
-----
-./filebeat keystore create
-echo -n "<Your Deployment Cloud ID>" | ./filebeat keystore add CLOUD_ID --stdin
-----
-
-. To store logs in {es} with minimal permissions, create an API key to send
-data from {filebeat} to {ess}. Log into {kib} (you can do so from the Cloud
-Console without typing in any permissions) and select *Management* -> *Dev
-Tools*. Send the following request:
-+
-[source,console]
-----
-POST /_security/api_key
-{
-  "name": "filebeat-monitor-azure",
-  "role_descriptors": {
-    "filebeat_writer": {
-      "cluster": [
-        "monitor",
-        "read_ilm",
-        "cluster:admin/ingest/pipeline/get", <1>
-        "cluster:admin/ingest/pipeline/put" <1>
-      ],
-      "index": [
-        {
-          "names": ["filebeat-*"],
-          "privileges": ["view_index_metadata", "create_doc"]
-        }
-      ]
-    }
-  }
-}
-----
-+
-<1> {filebeat} needs extra cluster permissions to publish logs, which differs
-from the {metricbeat} configuration used previously. You can find more
-details {filebeat-ref}/feature-roles.html[here].
-
-. The response contains an `api_key` and an `id` field, which can be stored in
-the {filebeat} keystore in the following format: `id:api_key`.
-+
-[source,bash]
-----
-echo -n "IhrJJHMB4JmIUAPLuM35:1GbfxhkMT8COBB4JWY3pvQ" | ./filebeat keystore add ES_API_KEY --stdin
-----
-+
-[NOTE]
-=====
-Make sure you specify the `-n` parameter; otherwise, you will have
-painful debugging sessions due to adding a newline at the end of
-your API key.
-=====
-
-. To see if both settings have been stored, run the following command:
-+
-[source,bash]
-----
-./filebeat keystore list
-----
-
-. To configure {filebeat} to output to {ess}, edit the `filebeat.yml`
-configuration file. Add the following lines to the end of the file.
-+
-[source,yml]
-----
-cloud.id: ${CLOUD_ID}
-output.elasticsearch:
-  api_key: ${ES_API_KEY}
-----
-
-. Finally, test if the configuration is working. If it is not working,
-verify that you used the right credentials and, if necessary, add them again.
-+
-[source,bash]
-----
-./filebeat test output
-----
+:leveloffset: +3
+include::{shared}/install-configure-filebeat.asciidoc[]
+:leveloffset: -3
 
 Now that the output is working, you are going to set up the input (Azure).
 
 [discrete]
+[[azure-step-five]]
 === Step 5: Create an event hub and configure diagnostics settings
 
 // New-AzResourceGroup –Name monitor-azure-resource-group –Location northeurope
@@ -526,7 +316,7 @@ an appropriate region.
 New-AzEventHub -ResourceGroupName monitor-azure-resource-group `
   -NamespaceName monitor-azure-namespace `
   -EventHubName monitor-azure-event-hub `
-  -MessageRetentionInDays 3
+  -MessageRetentionInDays 3 `
 ----
 +
 [NOTE]
@@ -560,6 +350,7 @@ event hub.
 ====
 
 [discrete]
+[[azure-step-six]]
 === Step 6: Configure {filebeat} Azure module
 
 There are 2 configuration values that you need to get from the Azure portal:

--- a/docs/en/observability/monitor-gcp.asciidoc
+++ b/docs/en/observability/monitor-gcp.asciidoc
@@ -82,129 +82,23 @@ in an accessible place to use later.
 [discrete]
 === Step 2: Install and configure {metricbeat}
 
-To monitor {gcp} using the {stack}, you need two main components:
-an Elastic deployment to store and analyze the data and an agent to collect
-and ship the data.
-
 [NOTE]
 ====
 This {tutorial} assumes the Elastic cluster is already running. Make sure you have your *cloud ID* and your *credentials* on hand.
 ====
+
+To monitor {gcp} using the {stack}, you need two main components:
+an Elastic deployment to store and analyze the data and an agent to collect
+and ship the data.
 
 Two agents can be used to monitor {gcp}: {metricbeat} is used to
 monitor metrics, and {filebeat} to monitor logs. You can run the agents on any
 machine. This {tutorial} uses a small {gcp} instance, e2-small (2 vCPUs,
 2 GB memory), with an Ubuntu distribution.
 
-[discrete]
-==== Install {metricbeat}
-
-After starting and connecting to the GCP instance, download and install
-{metricbeat}.
-
-include::{beats-repo-dir}/tab-widgets/install-widget-metricbeat.asciidoc[]
-
-[discrete]
-==== Set up assets
-
-{metricbeat} comes with predefined assets for parsing, indexing, and visualizing
-your data. Run the following command to load these assets.
-It may take a few minutes.
-
-[NOTE]
-=====
-Substitute the Cloud ID from your deployment in the following command. To find
-your Cloud ID, click on your https://cloud.elastic.co/deployments[deployment].
-=====
-[source,bash]
-----
-./metricbeat setup -e -E 'cloud.id=YOUR_DEPLOYMENT_CLOUD_ID' -E 'cloud.auth=elastic:YOUR_SUPER_SECRET_PASS'
-----
-[IMPORTANT]
-====
-Setting up {metricbeat} is an admin-level task that requires extra privileges.
-As a best practice, {metricbeat-ref}/privileges-to-setup-beats.html[use an administrator role to set up],
-and a more restrictive role for event publishing (which you will do next).
-====
-
-[discrete]
-==== Configure {metricbeat} output
-
-Next, you are going to configure {metricbeat} output to {ess}.
-
-. Use the {metricbeat} keystore to store
-{metricbeat-ref}/keystore.html[secure settings].
-Store the Cloud ID in the keystore.
-+
-[source,bash]
-----
-./metricbeat keystore create
-echo -n "<Your Deployment Cloud ID>" | ./metricbeat keystore add CLOUD_ID --stdin
-----
-
-. To store metrics in {es} with minimal permissions, create an API key to send
-data from {metricbeat} to {ess}. Log into Kibana (you can do so from the Cloud
-Console without typing in any permissions) and select *Management* -> *Dev
-Tools*. Send the following request:
-+
-[source,console]
-----
-POST /_security/api_key
-{
-  "name": "metricbeat-monitor-gcp",
-  "role_descriptors": {
-    "metricbeat_writer": {
-      "cluster": ["monitor", "read_ilm"],
-      "index": [
-        {
-          "names": ["metricbeat-*"],
-          "privileges": ["view_index_metadata", "create_doc"]
-        }
-      ]
-    }
-  }
-}
-----
-
-. The response contains an `api_key` and an `id` field, which can be stored in
-the {metricbeat} keystore in the following format: `id:api_key`.
-+
-[source,bash]
-----
-echo -n "IhrJJHMB4JmIUAPLuM35:1GbfxhkMT8COBB4JWY3pvQ" | ./metricbeat keystore add ES_API_KEY --stdin
-----
-+
-[NOTE]
-=====
-Make sure you specify the `-n` parameter; otherwise, you will have
-painful debugging sessions due to adding a newline at the end of
-your API key.
-=====
-
-. To see if both settings have been stored, run the following command:
-+
-[source,bash]
-----
-./metricbeat keystore list
-----
-
-. To configure {metricbeat} to output to {ess}, edit the `metricbeat.yml`
-configuration file. Add the following lines to the end of the file.
-+
-[source,yml]
-----
-cloud.id: ${CLOUD_ID}
-output.elasticsearch:
-  api_key: ${ES_API_KEY}
-----
-
-. Finally, test if the configuration is working. If it is not working,
-verify if you used the right credentials and add them again.
-+
-[source,bash]
-----
-./metricbeat test output
-----
+:leveloffset: +3
+include::{shared}/install-configure-metricbeat.asciidoc[]
+:leveloffset: -3
 
 Now that the output is working, you are going to set up the input (GCP).
 
@@ -286,116 +180,11 @@ collect Google Cloud logs.
 [discrete]
 ==== Install {filebeat}
 
-On a new terminal window connected to the GCP instance, download and install
-{filebeat}.
+On a new terminal window, connected to the GCP instance, complete the following steps.
 
-include::{beats-repo-dir}/tab-widgets/install-widget-filebeat.asciidoc[]
-
-[discrete]
-==== Set up assets
-
-Similar to {metricbeat}, {filebeat} comes with predefined assets for parsing,
-indexing, and visualizing your data.
-Run the following command to load these assets. It may take a few minutes.
-
-[source,bash]
-----
-./filebeat setup -e -E 'cloud.id=YOUR_DEPLOYMENT_CLOUD_ID' -E 'cloud.auth=elastic:YOUR_SUPER_SECRET_PASS'
-----
-
-[IMPORTANT]
-====
-Setting up {filebeat} is an admin-level task that requires extra privileges.
-As a best practice, {filebeat-ref}/privileges-to-setup-beats.html[use an administrator role to set up]
-and a more restrictive role for event publishing (which you will do next).
-====
-
-[discrete]
-==== Configure {filebeat} output
-
-Next, you are going to configure {filebeat} output to {ess}.
-
-. Use the {filebeat} keystore to store {filebeat-ref}/keystore.html[secure
-settings]. Store the Cloud ID in the keystore.
-+
-[source,bash]
-----
-./filebeat keystore create
-echo -n "<Your Deployment Cloud ID>" | ./filebeat keystore add CLOUD_ID --stdin
-----
-
-. To store logs in {es} with minimal permissions, create an API key to send
-data from {filebeat} to {ess}. Log into {kib} (you can do so from the Cloud
-Console without typing in any permissions) and select *Management* -> *Dev
-Tools*. Send the following request:
-+
-[source,console]
-----
-POST /_security/api_key
-{
-  "name": "filebeat-monitor-gcp",
-  "role_descriptors": {
-    "filebeat_writer": {
-      "cluster": [
-        "monitor",
-        "read_ilm",
-        "cluster:admin/ingest/pipeline/get", <1>
-        "cluster:admin/ingest/pipeline/put" <1>
-      ],
-      "index": [
-        {
-          "names": ["filebeat-*"],
-          "privileges": ["view_index_metadata", "create_doc"]
-        }
-      ]
-    }
-  }
-}
-----
-+
-<1> {filebeat} needs extra cluster permissions to publish logs, which differs
-from the {metricbeat} configuration used previously. You can find more
-details {filebeat-ref}/feature-roles.html[here].
-
-. The response contains an `api_key` and an `id` field, which can be stored in
-the {filebeat} keystore in the following format: `id:api_key`.
-+
-[source,bash]
-----
-echo -n "IhrJJHMB4JmIUAPLuM35:1GbfxhkMT8COBB4JWY3pvQ" | ./filebeat keystore add ES_API_KEY --stdin
-----
-+
-[NOTE]
-=====
-Make sure you specify the `-n` parameter; otherwise, you will have
-painful debugging sessions due to adding a newline at the end of
-your API key.
-=====
-
-. To see if both settings have been stored, run the following command:
-+
-[source,bash]
-----
-./filebeat keystore list
-----
-
-. To configure {filebeat} to output to {ess}, edit the `filebeat.yml`
-configuration file. Add the following lines to the end of the file.
-+
-[source,yml]
-----
-cloud.id: ${CLOUD_ID}
-output.elasticsearch:
-  api_key: ${ES_API_KEY}
-----
-
-. Finally, test if the configuration is working. If it is not working,
-verify that you used the right credentials and, if necessary, add them again.
-+
-[source,bash]
-----
-./filebeat test output
-----
+:leveloffset: +3
+include::{shared}/install-configure-filebeat.asciidoc[]
+:leveloffset: -3
 
 Now that the output is working, you are going to set up the input ({gcp}).
 

--- a/docs/en/observability/tutorials.asciidoc
+++ b/docs/en/observability/tutorials.asciidoc
@@ -5,22 +5,22 @@ Using Elastic Observability, learn how to analyze log data,
 monitor system and service metrics, instrument code and
 collect performance data, and monitor host availability and endpoints.
 
+* <<monitor-aws, Monitor Amazon Web Services (AWS)>>
+
+* <<monitor-gcp, Monitor Google Cloud Platform (GCP)>>
+
+* <<monitor-java-app,Monitor a Java application>>
+
+* <<monitor-kubernetes, Monitor Kubernetes>>
+
 * <<monitor-azure, Monitor Microsoft Azure>>
 
-* <<monitor-gcp, Monitor Google Cloud Platform>>
-
-* <<monitor-java-app,Monitor a Java application>>.
-
-* <<monitor-kubernetes, Monitor Kubernetes>>.
-
-* <<monitor-aws, Monitor Amazon Web Services (AWS)>>.
-
-include::monitor-azure.asciidoc[]
+include::monitor-aws.asciidoc[]
 
 include::monitor-gcp.asciidoc[]
-
-include::monitor-aws.asciidoc[]
 
 include::monitor-java-app.asciidoc[]
 
 include::monitor-k8s/monitor-k8s.asciidoc[leveloffset=+1]
+
+include::monitor-azure.asciidoc[]

--- a/docs/en/shared/install-configure-filebeat.asciidoc
+++ b/docs/en/shared/install-configure-filebeat.asciidoc
@@ -1,0 +1,113 @@
+[discrete]
+= Install {filebeat}
+
+Download and install {filebeat}.
+
+include::{beats-repo-dir}/tab-widgets/install-widget-filebeat.asciidoc[]
+
+[discrete]
+= Set up assets
+
+{filebeat} comes with predefined assets for parsing, indexing, and visualizing your data.
+Run the following command to load these assets. It may take a few minutes.
+
+[source,bash]
+----
+./filebeat setup -e -E 'cloud.id=YOUR_DEPLOYMENT_CLOUD_ID' -E 'cloud.auth=elastic:YOUR_SUPER_SECRET_PASS' <1>
+----
+<1> Substitute your Cloud ID and an administrator's `username:password` in this command.
+To find your Cloud ID, click on your https://cloud.elastic.co/deployments[deployment].
+
+[IMPORTANT]
+====
+Setting up {filebeat} is an admin-level task that requires extra privileges.
+As a best practice, {filebeat-ref}/privileges-to-setup-beats.html[use an administrator role to set up]
+and a more restrictive role for event publishing (which you will do next).
+====
+
+[discrete]
+= Configure {filebeat} output
+
+Next, you are going to configure {filebeat} output to {ess}.
+
+. Use the {filebeat} keystore to store {filebeat-ref}/keystore.html[secure settings].
+Store the Cloud ID in the keystore.
++
+[source,bash]
+----
+./filebeat keystore create
+echo -n "<Your Deployment Cloud ID>" | ./filebeat keystore add CLOUD_ID --stdin
+----
+
+. To store logs in {es} with minimal permissions, create an API key to send
+data from {filebeat} to {ess}. Log into {kib} (you can do so from the Cloud
+Console without typing in any permissions) and select *Management* -> *Dev
+Tools*. Send the following request:
++
+[source,console]
+----
+POST /_security/api_key
+{
+  "name": "filebeat-monitor-gcp",
+  "role_descriptors": {
+    "filebeat_writer": {
+      "cluster": [
+        "monitor",
+        "read_ilm",
+        "cluster:admin/ingest/pipeline/get", <1>
+        "cluster:admin/ingest/pipeline/put" <1>
+      ],
+      "index": [
+        {
+          "names": ["filebeat-*"],
+          "privileges": ["view_index_metadata", "create_doc"]
+        }
+      ]
+    }
+  }
+}
+----
++
+<1> {filebeat} needs extra cluster permissions to publish logs, which differs
+from the {metricbeat} configuration. You can find more
+details {filebeat-ref}/feature-roles.html[here].
+
+. The response contains an `api_key` and an `id` field, which can be stored in
+the {filebeat} keystore in the following format: `id:api_key`.
++
+[source,bash]
+----
+echo -n "IhrJJHMB4JmIUAPLuM35:1GbfxhkMT8COBB4JWY3pvQ" | ./filebeat keystore add ES_API_KEY --stdin
+----
++
+[NOTE]
+=====
+Make sure you specify the `-n` parameter; otherwise, you will have
+painful debugging sessions due to adding a newline at the end of
+your API key.
+=====
+
+. To see if both settings have been stored, run the following command:
++
+[source,bash]
+----
+./filebeat keystore list
+----
+
+. To configure {filebeat} to output to {ess}, edit the `filebeat.yml`
+configuration file. Add the following lines to the end of the file.
++
+[source,yml]
+----
+cloud.id: ${CLOUD_ID}
+output.elasticsearch:
+  api_key: ${ES_API_KEY}
+----
+
+. Finally, test if the configuration is working. If it is not working,
+verify that you used the right credentials and, if necessary, add them again.
++
+[source,bash]
+----
+./filebeat test output
+----

--- a/docs/en/shared/install-configure-metricbeat.asciidoc
+++ b/docs/en/shared/install-configure-metricbeat.asciidoc
@@ -1,0 +1,104 @@
+[discrete]
+= Install {metricbeat}
+
+Download and install {metricbeat}.
+
+include::{beats-repo-dir}/tab-widgets/install-widget-metricbeat.asciidoc[]
+
+[discrete]
+= Set up assets
+
+{metricbeat} comes with predefined assets for parsing, indexing, and visualizing your data.
+Run the following command to load these assets. It may take a few minutes.
+
+[source,bash]
+----
+./metricbeat setup -e -E 'cloud.id=YOUR_DEPLOYMENT_CLOUD_ID' -E 'cloud.auth=elastic:YOUR_SUPER_SECRET_PASS' <1>
+----
+<1> Substitute your Cloud ID and an administrator's `username:password` in this command.
+To find your Cloud ID, click on your https://cloud.elastic.co/deployments[deployment].
+
+[IMPORTANT]
+====
+Setting up {metricbeat} is an admin-level task that requires extra privileges.
+As a best practice, {metricbeat-ref}/privileges-to-setup-beats.html[use an administrator role to set up],
+and a more restrictive role for event publishing (which you will do next).
+====
+
+[discrete]
+= Configure {metricbeat} output
+
+Next, you are going to configure {metricbeat} output to {ess}.
+
+. Use the {metricbeat} keystore to store {metricbeat-ref}/keystore.html[secure settings].
+Store the Cloud ID in the keystore.
++
+[source,bash]
+----
+./metricbeat keystore create
+echo -n "<Your Deployment Cloud ID>" | ./metricbeat keystore add CLOUD_ID --stdin
+----
+
+. To store metrics in {es} with minimal permissions, create an API key to send
+data from {metricbeat} to {ess}. Log into Kibana (you can do so from the Cloud
+Console without typing in any permissions) and select *Management* -> *Dev
+Tools*. Send the following request:
++
+[source,console]
+----
+POST /_security/api_key
+{
+  "name": "metricbeat-monitor",
+  "role_descriptors": {
+    "metricbeat_writer": {
+      "cluster": ["monitor", "read_ilm"],
+      "index": [
+        {
+          "names": ["metricbeat-*"],
+          "privileges": ["view_index_metadata", "create_doc"]
+        }
+      ]
+    }
+  }
+}
+----
+
+. The response contains an `api_key` and an `id` field, which can be stored in
+the {metricbeat} keystore in the following format: `id:api_key`.
++
+[source,bash]
+----
+echo -n "IhrJJHMB4JmIUAPLuM35:1GbfxhkMT8COBB4JWY3pvQ" | ./metricbeat keystore add ES_API_KEY --stdin
+----
++
+[NOTE]
+=====
+Make sure you specify the `-n` parameter; otherwise, you will have
+painful debugging sessions due to adding a newline at the end of
+your API key.
+=====
+
+. To see if both settings have been stored, run the following command:
++
+[source,bash]
+----
+./metricbeat keystore list
+----
+
+. To configure {metricbeat} to output to {ess}, edit the `metricbeat.yml`
+configuration file. Add the following lines to the end of the file.
++
+[source,yml]
+----
+cloud.id: ${CLOUD_ID}
+output.elasticsearch:
+  api_key: ${ES_API_KEY}
+----
+
+. Finally, test if the configuration is working. If it is not working,
+verify if you used the right credentials and add them again.
++
+[source,bash]
+----
+./metricbeat test output
+----


### PR DESCRIPTION
Backports the following commits to 7.13:
 - tuts: single source Filebeat and Metricbeat instructions (#633)