### PR TITLE
Update FAQ from action_store.yml to state.yml

### DIFF
--- a/docs/en/ingest-management/faq.asciidoc
+++ b/docs/en/ingest-management/faq.asciidoc
@@ -59,7 +59,7 @@ fleet:
   enabled: true
 ----
 
-The `action_store.yml` file (located under `data/elastic-agent-*`) contains the
+The `state.yml` file (located under `data/elastic-agent-*`) contains the
 entire, unencrypted policy.
 
 * To see the {es} location, look at the `hosts` setting under `outputs`. For


### PR DESCRIPTION
I believe the configuration items mention here as being found in action_store.yml are now in state.yml, based on what I see on my 7.12.1 Elastic Agent install and what I see in https://github.com/elastic/beats/pull/23452

(This is my first PR on Elastic docs, I'll say in advance I appreciate your patience and guidance on how to do this correctly!) 
