### PR TITLE
[7.x] Update FAQ from action_store.yml to state.yml (#648)

### DIFF
--- a/docs/en/ingest-management/faq.asciidoc
+++ b/docs/en/ingest-management/faq.asciidoc
@@ -59,7 +59,7 @@ fleet:
   enabled: true
 ----
 
-The `action_store.yml` file (located under `data/elastic-agent-*`) contains the
+The `state.yml` file (located under `data/elastic-agent-*`) contains the
 entire, unencrypted policy.
 
 * To see the {es} location, look at the `hosts` setting under `outputs`. For


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Update FAQ from action_store.yml to state.yml (#648)