### PR TITLE
[7.13] Get K8s documentation building (#645)

### DIFF
--- a/docs/en/ingest-management/elastic-agent/elastic-agent.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/elastic-agent.asciidoc
@@ -14,8 +14,10 @@ collect data and send it to the {stack}. Behind the scenes, {agent} runs the
 To learn how to install, configure, and run your {agent}s, see:
 
 * <<elastic-agent-installation>>
-* <<run-elastic-agent-standalone>>
 * <<uninstall-elastic-agent>>
+* <<run-elastic-agent-standalone>>
+* <<running-on-kubernetes>>
+* <<running-on-kubernetes-standalone>>
 * <<upgrade-elastic-agent>>
 * <<start-elastic-agent>>
 * <<stop-elastic-agent>>
@@ -25,9 +27,13 @@ To learn how to install, configure, and run your {agent}s, see:
 
 include::install-elastic-agent.asciidoc[leveloffset=+1]
 
+include::uninstall-elastic-agent.asciidoc[leveloffset=+1]
+
 include::run-elastic-agent-standalone.asciidoc[leveloffset=+1]
 
-include::uninstall-elastic-agent.asciidoc[leveloffset=+1]
+include::running-on-kubernetes.asciidoc[leveloffset=+1]
+
+include::running-on-kubernetes-standalone.asciidoc[leveloffset=+1]
 
 include::upgrade-elastic-agent.asciidoc[leveloffset=+1]
 

--- a/docs/en/ingest-management/elastic-agent/running-on-kubernetes-standalone.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/running-on-kubernetes-standalone.asciidoc
@@ -1,9 +1,11 @@
-[[running-on-kubernetes]]
+[[running-on-kubernetes-standalone]]
 [role="xpack"]
-=== Run {agent} on Kubernetes
+= Run {agent} standalone on Kubernetes
 
 Use {agent} https://www.docker.elastic.co/r/beats/elastic-agent[Docker images] on Kubernetes to
 retrieve cluster metrics.
+
+TIP: Running {ecloud} on Kubernetes? See {eck-ref}/k8s-elastic-agent.html[Run {elastic-agent} on ECK].
 
 ifeval::["{release-state}"=="unreleased"]
 
@@ -12,8 +14,8 @@ A Docker image is not currently available for this version, as version {version}
 endif::[]
 
 
-[float]
-==== Kubernetes deploy manifests
+[discrete]
+== Kubernetes deploy manifests
 
 Deploy {agent} in two different ways at the same time:
 
@@ -44,8 +46,8 @@ This manifest includes the Kubernetes integration to collect Kubernetes metrics,
 System integration to collect system level metrics and logs from nodes, and
 the Pod's log collection using <<kubernetes-provider,dynamic inputs and kubernetes provider>>.
 
-[float]
-==== Settings
+[discrete]
+== Settings
 
 Set the Elasticsearch settings before deploying the manifest:
 
@@ -59,8 +61,8 @@ Set the Elasticsearch settings before deploying the manifest:
   value: "https://somesuperhostiduuid.europe-west1.gcp.cloud.es.io:443"
 ------------------------------------------------
 
-[float]
-===== Running {agent} on master nodes
+[discrete]
+=== Running {agent} on master nodes
 
 Kubernetes master nodes use https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/[taints]
 to limit the workloads that can run on them. The manifest for standalone {agent} defines
@@ -77,8 +79,8 @@ spec:
 ------------------------------------------------
 
 
-[float]
-==== Deploy
+[discrete]
+== Deploy
 To deploy to Kubernetes, run:
 
 ["source", "sh", subs="attributes"]
@@ -98,8 +100,8 @@ elastic-agent-fj2z9             1/1     Running   0          81m
 elastic-agent-hs4pb             1/1     Running   0          81m
 ------------------------------------------------
 
-[float]
-==== Autodiscover targeted Pods
+[discrete]
+== Autodiscover targeted Pods
 
 You can define autodiscover conditions to allow {agent} to automatically
 identify Pods and start collecting from them using predefined integrations. For example, if a

--- a/docs/en/ingest-management/elastic-agent/running-on-kubernetes.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/running-on-kubernetes.asciidoc
@@ -1,6 +1,6 @@
 [[running-on-kubernetes]]
 [role="xpack"]
-=== Run {agent} on Kubernetes
+= Run {agent} on Kubernetes
 
 You can use {agent} https://www.docker.elastic.co/r/beats/elastic-agent[Docker images] on Kubernetes to
 retrieve cluster metrics.
@@ -13,8 +13,8 @@ released, so no Docker image is currently available for this version.
 endif::[]
 
 
-[float]
-==== Kubernetes deploy manifests
+[discrete]
+== Kubernetes deploy manifests
 
 You deploy {agent} in two different ways at the same time:
 
@@ -39,8 +39,8 @@ To download the manifest file, run:
 curl -L -O https://raw.githubusercontent.com/elastic/beats/{branch}/deploy/kubernetes/elastic-agent-kubernetes.yaml
 ------------------------------------------------
 
-[float]
-==== Settings
+[discrete]
+== Settings
 
 By default, {agent} is enrolled to an existing Kibana deployment,
 if present using the specified credentials. FLEET_ENROLLMENT_TOKEN parameter is used to connect Agent to the
@@ -63,8 +63,8 @@ change the following parameters in the manifest file:
   value: "changeme"
 ------------------------------------------------
 
-[float]
-===== Running {agent} on master nodes
+[discrete]
+=== Running {agent} on master nodes
 
 Kubernetes master nodes can use https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/[taints]
 to limit the workloads that can run on them. To run {agent} on master nodes you may need to
@@ -79,8 +79,8 @@ spec:
 ------------------------------------------------
 
 
-[float]
-==== Deploy
+[discrete]
+== Deploy
 
 If planing to deploy `state_*` datasets of Kubernetes package,
 https://github.com/kubernetes/kube-state-metrics#usage[kube-state-metrics] is needed to be already deployed


### PR DESCRIPTION
Backports the following commits to 7.13:
 - Get K8s documentation building (#645)