### PR TITLE
Add .gitignore to 7.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+.gradle
+.local-*
+build
+.DS_Store
+.project
+.classpath
+.settings
+bin
+
+/html_docs
+html_docs
+.vscode


### PR DESCRIPTION
The obs-docs `.gitignore` file only exists in master. I think it'd be useful to add this file to other production branches so the `html_docs` directory isn't always getting in the way.