### PR TITLE
[7.13] Add .gitignore to 7.x (#676)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+.gradle
+.local-*
+build
+.DS_Store
+.project
+.classpath
+.settings
+bin
+
+/html_docs
+html_docs
+.vscode


### PR DESCRIPTION
Backports the following commits to 7.13:
 - Add .gitignore to 7.x (#676)