### PR TITLE
Updating limitations for 7.13

### DIFF
--- a/docs/en/ingest-management/fleet/fleet-limitations.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-limitations.asciidoc
@@ -17,6 +17,7 @@ This feature has additional limitations at the current time:
 *   No output to {ls}, Kafka, or other remote clusters
 *   No proxy support for Fleet Server
 *   Requires internet access for {kib} to download integration packages from the Elastic Package Registry
+*   {agent} requires internet access to perform binary upgrades from Fleet
 *   Limited support in the Fleet app for advanced {beats} settings like multiline, processors, and so
 on
 *   On {ecloud}, there's a limit to the number of enrolled {agent}s that a

--- a/docs/en/ingest-management/fleet/fleet-limitations.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-limitations.asciidoc
@@ -15,10 +15,10 @@ This feature has additional limitations at the current time:
 
 *   Support for a limited number of integrations (more coming soon)
 *   No output to {ls}, Kafka, or other remote clusters
-*   No proxy support for Fleet Server
+*   No proxy support for {fleet-server}
 *   Requires internet access for {kib} to download integration packages from the Elastic Package Registry
 *   {agent} requires internet access to perform binary upgrades from Fleet
-*   Limited support in the Fleet app for advanced {beats} settings like multiline, processors, and so
+*   Limited support in the {fleet} app for advanced {beats} settings like multiline, processors, and so
 on
 *   On {ecloud}, there's a limit to the number of enrolled {agent}s that a
 single {kib} instance can handle:

--- a/docs/en/ingest-management/fleet/fleet-limitations.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-limitations.asciidoc
@@ -14,11 +14,10 @@ a network connection is not available or not needed.
 This feature has additional limitations at the current time:
 
 *   Support for a limited number of integrations (more coming soon)
-*   Support for only {filebeat}, {metricbeat}, and Endpoint Security
 *   No output to {ls}, Kafka, or other remote clusters
-*   No proxy support in {agent}
-*   Requires internet access for {kib} to download integration packages
-*   No support for advanced {beats} settings like multiline, processors, and so
+*   No proxy support for Fleet Server
+*   Requires internet access for {kib} to download integration packages from the Elastic Package Registry
+*   Limited support in the Fleet app for advanced {beats} settings like multiline, processors, and so
 on
 *   On {ecloud}, there's a limit to the number of enrolled {agent}s that a
 single {kib} instance can handle:
@@ -31,5 +30,5 @@ single {kib} instance can handle:
 |1gb| 2000
 |===
 
-Beta releases are not officially supported, but we encourage you to
+Beta releases are not supported at a production level, but we encourage you to
 report issues in our {forum}[discuss forum].


### PR DESCRIPTION
Providing feature updates here. This still doesn't have updated limits on the number of agents, but tracking that here https://github.com/elastic/fleet-server/issues/134