### PR TITLE
Clean up release notes and add items from Kibana

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-7.13.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-7.13.asciidoc
@@ -13,27 +13,15 @@ Review important information about the {fleet} and {agent} 7.13.x releases.
 
 // Add link to changelogs for Beats/Agent and Kibana.
 
-[discrete]
-[[security-updates-7.13.0]]
-=== Security updates
+//[discrete]
+//[[security-updates-7.13.0]]
+//=== Security updates
 
-{fleet}::
-* add info
+//{fleet}::
+//* add info
 
-{agent}::
-* add info
-
-[discrete]
-[[known-issues-7.13.0]]
-=== Known issues
-
-{fleet}::
-* The `fleet_enroll` role and user are no longer needed for central management
-of {agent}s in {kib}. If the role and user were set up in a previous release,
-remove them now to avoid them being orphaned in the cluster. {kib-pull}98745[#98745]
-
-{agent}::
-* add info
+//{agent}::
+//* add info
 
 [discrete]
 [[breaking-changes-7.13.0]]
@@ -43,55 +31,96 @@ Breaking changes can prevent your application from optimal operation and
 performance. Before you upgrade, review the breaking changes, then mitigate the
 impact to your application.
 
-{fleet}::
-* add info
+[discrete]
+[[breaking-97206]]
+.Remove Elastic Agent routes and related services
+[%collapsible]
+====
+*Details* +
+Elastic Agents now use the Fleet Server to enroll agents, get agent policies, collect status information, and more. For more information, refer to {kibana-pull}97206[#97206].
 
-{agent}::
-* add info
+*Impact* +
+To run and manage Elastic Agents, use the Fleet Server instead of {kib}. For more information, refer to {fleet-guide}/fleet-server.html[Fleet Server].
+====
+      
+[discrete]
+[[breaking-95789]]
+.Invalidate API keys for existing agents
+[%collapsible]
+====
+*Details* +
+The existing agents in {kib} are not migrated as part of the migration to Fleet. For more information, refer to {kibana-pull}95789[#95789].
+
+*Impact* +
+The existing agent API keys are invalidated and display as `Inactive` on the *Agents* page.
+====
 
 [discrete]
-[[deprecations-7.13.0]]
-=== Deprecations
+[[known-issues-7.13.0]]
+=== Known issue
 
-The following functionality is deprecated in 7.13.0, and will be removed in
-8.0.0. Deprecated functionality does not have an immediate impact on your
-application, but we strongly recommend you make the necessary updates after you
-upgrade to 7.13.0.
+*Details* 
 
-{fleet}::
-* add info
+The `fleet_enroll` role and user are no longer needed for central management
+of {agent}s in {kib}.
 
-{agent}::
-* add info
+*Impact* +
+If the role and user were set up in a previous release, remove them now to avoid
+them being orphaned in the cluster. {kib-pull}98745[#98745]
 
-[discrete]
-[[new-features-7.13.0]]
-=== New features
+//[discrete]
+//[[deprecations-7.13.0]]
+//=== Deprecations
 
-The 7.13.0 release adds the following new and notable features.
+//The following functionality is deprecated in 7.13.0, and will be removed in
+//8.0.0. Deprecated functionality does not have an immediate impact on your
+//application, but we strongly recommend you make the necessary updates after you
+//upgrade to 7.13.0.
 
-{fleet}::
-* add info
+//{fleet}::
+//* add info
 
-{agent}::
-* add info
+//{agent}::
+//* add info
+
+//[discrete]
+//[[new-features-7.13.0]]
+//=== New features
+
+//The 7.13.0 release adds the following new and notable features.
+
+//{fleet}::
+//* add info
+
+//{agent}::
+//* add info
 
 [discrete]
 [[enhancements-7.13.0]]
 === Enhancements
 
 {fleet}::
-* add info
+* Hide Fleet Server policies in standalone agent instructions {kibana-pull}98787[#98787]
+* Adds troubleshooting link to setup instructions {kibana-pull}98531[#98531]
+* Adds ability to specify which integration variables should be configurable {kibana-pull}97163[#97163]
+* Configure Fleet packages and integrations through endpoint {kibana-pull}94509[#94509]
+* Adds submitOnBlur functionality to QueryStringInput {kibana-pull}93819[#93819]
 
-{agent}::
-* add info
+//{agent}::
+//* add info
 
 [discrete]
 [[bug-fixes-7.13.0]]
 === Bug fixes
 
 {fleet}::
-* add info
+* Correctly parse falsy YAML fields in agent policy integrations {kibana-pull}95966[#95966]
+* Match telemetry key names to UI agent states {kibana-pull}95567[#95567]
+* Ignore inactive agents when removing a policy {kibana-pull}94311[#94311]
+* Correctly track install status of an integration {kibana-pull}93464[#93464]
+* Fix default integration name when adding 10+ names {kibana-pull}93278[#93278]
+* Prevent duplicate enrollment token names {kibana-pull}92735[#92735]
+* Set all keyword and text fields for `index.query.default_field` index template setting {kibana-pull}91791[#91791]
 
-{agent}::
-* add info
+//{agent}::
+//* add info


### PR DESCRIPTION
Preview is [here](https://observability-docs_702.docs-preview.app.elstc.co/guide/en/fleet/master/release-notes-7.13.0.html).

Summary of changes:

- Moved the breaking changes section to match order in Kibana docs.
- Commented out sections that do not yet have content: Security updates, Deprecations, New features, sub-sections for Elastic Agent.
- Added Fleet-related info copied from the Kibana release notes. Duplicating through copy/paste for now (not ideal, but we can figure out a better long-term solution for GA).

We need to add items for Elastic Agent because they are currently missing, but it's vital that we get this merged before the release goes live.
