### PR TITLE
Clarify breaking changes for 7.13

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-7.13.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-7.13.asciidoc
@@ -33,7 +33,7 @@ impact to your application.
 
 [discrete]
 [[breaking-97206]]
-.Remove Elastic Agent routes and related services from {kib}
+.Remove Elastic Agent routes and related services from {kib} and implement them in {fleet-server}
 [%collapsible]
 ====
 *Details* +

--- a/docs/en/ingest-management/release-notes/release-notes-7.13.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-7.13.asciidoc
@@ -33,7 +33,7 @@ impact to your application.
 
 [discrete]
 [[breaking-97206]]
-.Remove Elastic Agent routes and related services
+.Remove Elastic Agent routes and related services from {kib}
 [%collapsible]
 ====
 *Details* +


### PR DESCRIPTION
The breaking change about removing agent routes needs to be qualified so it's clear in the title that we're talking about Kibana.