### PR TITLE
[7.x] Add link to Fleet settings topic (#713)

### DIFF
--- a/docs/en/ingest-management/tab-widgets/add-fleet-server/content.asciidoc
+++ b/docs/en/ingest-management/tab-widgets/add-fleet-server/content.asciidoc
@@ -27,8 +27,6 @@ automatically when you run {fleet} for the first time.
 
 To add {fleet-server}:
 
-//TODO: Mention API for adding the token.
-
 . Log in to {kib} and go to *Management > {fleet}*. The first time you visit
 this page, it might take a minute to load.
 
@@ -39,6 +37,8 @@ install {fleet-server}.
 
 . In the *{es} hosts* field, specify the {es} URLs where {agent}s will send data.
 For example, `https://192.0.2.0:9200`.
++
+For more information about these settings, see <<fleet-settings>>.
 
 . Save and apply the settings.
 


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Add link to Fleet settings topic (#713)