### PR TITLE
Add stack compatibility info to Fleet Server docs

### DIFF
--- a/docs/en/ingest-management/fleet/fleet-server.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-server.asciidoc
@@ -48,13 +48,12 @@ a self-managed cluster).
 bugfix releases)
 ** {kib} should be on the same minor version as {es}.
 
-* {ece} 2.10 or later
-** Requires additional wildcard domains and certificates (which normally only
-cover *.cname, not ..cname). This enables us to provide the URL for
-{fleet-server} of `https://.fleet.`
-** The deployment template must contain a slider for APM & Fleet.
-
-//QUESTION: Should this say 2.9? 2.10 is not available yet. 
+//TODO: Uncomment this section when ECE 2.10 is available
+//* {ece} 2.10 or later
+//** Requires additional wildcard domains and certificates (which normally only
+//cover *.cname, not ..cname). This enables us to provide the URL for
+//{fleet-server} of `https://.fleet.`
+//** The deployment template must contain a slider for APM & Fleet.
 
 [discrete]
 [[add-fleet-server]]

--- a/docs/en/ingest-management/fleet/fleet-server.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-server.asciidoc
@@ -38,7 +38,7 @@ details, refer to <<fleet-server-deployment>>.
 
 [discrete]
 [[fleet-server-compatibility]]
-== Compatibility
+== Compatibility and prerequisites
 
 {fleet-server} is compatible with the following Elastic products:
 
@@ -49,6 +49,10 @@ bugfix releases)
 ** {kib} should be on the same minor version as {es}.
 
 * {ece} 2.10 or later
+** Requires additional wildcard domains and certificates (which normally only
+cover *.cname, not ..cname). This enables us to provide the URL for
+{fleet-server} of `https://.fleet.`
+** The deployment template must contain a slider for APM & Fleet.
 
 //QUESTION: Should this say 2.9? 2.10 is not available yet. 
 

--- a/docs/en/ingest-management/fleet/fleet-server.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-server.asciidoc
@@ -42,14 +42,15 @@ details, refer to <<fleet-server-deployment>>.
 
 {fleet-server} is compatible with the following Elastic products:
 
-* {stack} 7.13 or later (our {ess-product}[hosted {ess}] on {ecloud} or
+* {stack} 7.13 or later ({ess-product}[hosted {ess}] on {ecloud}, or
 a self-managed cluster).
+** For version compatibility: {es} >= {fleet-server} >= {agent} (except for
+bugfix releases)
+** {kib} should be on the same minor version as {es}.
 
 * {ece} 2.10 or later
 
-//TODO: Confirm that ECE version shown here is correct ^^.
-
-{fleet-server} is supported on x64 architectures only.
+//QUESTION: Should this say 2.9? 2.10 is not available yet. 
 
 [discrete]
 [[add-fleet-server]]


### PR DESCRIPTION
Closes #643 and https://github.com/elastic/observability-docs/issues/640

This info was dumped into a meta issue awhile back ago. Need confirmation that the details are correct.