### PR TITLE
[7.13] Add stack compatibility info to Fleet Server docs (#731)

### DIFF
--- a/docs/en/ingest-management/fleet/fleet-server.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-server.asciidoc
@@ -38,18 +38,22 @@ details, refer to <<fleet-server-deployment>>.
 
 [discrete]
 [[fleet-server-compatibility]]
-== Compatibility
+== Compatibility and prerequisites
 
 {fleet-server} is compatible with the following Elastic products:
 
-* {stack} 7.13 or later (our {ess-product}[hosted {ess}] on {ecloud} or
+* {stack} 7.13 or later ({ess-product}[hosted {ess}] on {ecloud}, or
 a self-managed cluster).
+** For version compatibility: {es} >= {fleet-server} >= {agent} (except for
+bugfix releases)
+** {kib} should be on the same minor version as {es}.
 
-* {ece} 2.10 or later
-
-//TODO: Confirm that ECE version shown here is correct ^^.
-
-{fleet-server} is supported on x64 architectures only.
+//TODO: Uncomment this section when ECE 2.10 is available
+//* {ece} 2.10 or later
+//** Requires additional wildcard domains and certificates (which normally only
+//cover *.cname, not ..cname). This enables us to provide the URL for
+//{fleet-server} of `https://.fleet.`
+//** The deployment template must contain a slider for APM & Fleet.
 
 [discrete]
 [[add-fleet-server]]


### PR DESCRIPTION
Backports the following commits to 7.13:
 - Add stack compatibility info to Fleet Server docs (#731)