### PR TITLE
Add note about removing system extension during uninstall

### DIFF
--- a/docs/en/ingest-management/elastic-agent/uninstall-elastic-agent.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/uninstall-elastic-agent.asciidoc
@@ -51,10 +51,10 @@ files are installed? See <<installation-layout>>.
 installed for endpoint protection. The directory structure is similar to {agent},
 for example, `/Library/Elastic/Endpoint/*`.
 +
-//TODO: Add to docs when this is confirmed.
-//NOTE: When you remove the Elastic Endpoint integration from a macOS host, the
-//Endpoint System Extension is left on disk intentionally. If you want to remove
-//the extension, refer to the documentation for your operating sytem.
+NOTE: When you remove the Elastic Endpoint integration from a macOS host
+(10.13, 10.14, or 10.15), the Endpoint System Extension is left on disk
+intentionally. If you want to remove the extension, refer to the documentation
+for your operating sytem.
 
 // Add Javascript and CSS for tabbed panels
 include::{tab-widgets}/code.asciidoc[]

--- a/docs/en/ingest-management/elastic-agent/uninstall-elastic-agent.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/uninstall-elastic-agent.asciidoc
@@ -51,7 +51,7 @@ files are installed? See <<installation-layout>>.
 installed for endpoint protection. The directory structure is similar to {agent},
 for example, `/Library/Elastic/Endpoint/*`.
 +
-NOTE: When you remove the Elastic Endpoint integration from a macOS host
+NOTE: When you remove the {elastic-endpoint} integration from a macOS host
 (10.13, 10.14, or 10.15), the Endpoint System Extension is left on disk
 intentionally. If you want to remove the extension, refer to the documentation
 for your operating sytem.


### PR DESCRIPTION
@EricDavisX  It sounds like this note would be useful to macOS users, so I've added it back in.

Do we want to say where the extension lives? 