### PR TITLE
[7.x] Adds 7.13.1 Elastic Agent and Fleet release notes (#744)

### DIFF
--- a/docs/en/ingest-management/index.asciidoc
+++ b/docs/en/ingest-management/index.asciidoc
@@ -52,5 +52,5 @@ include::troubleshooting.asciidoc[leveloffset=+1]
 
 include::faq.asciidoc[leveloffset=+1]
 
-include::release-notes.asciidoc[leveloffset=+1]
+include::release-notes/release-notes-7.13.asciidoc[leveloffset=+1]
 

--- a/docs/en/ingest-management/release-notes.asciidoc
+++ b/docs/en/ingest-management/release-notes.asciidoc
@@ -1,8 +1,0 @@
-[[release-notes]]
-= Release notes
-
-This section summarizes the changes in each release.
-
-* <<release-notes-7.13.0>>
-
-include::release-notes/release-notes-7.13.asciidoc[]

--- a/docs/en/ingest-management/release-notes/release-notes-7.13.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-7.13.asciidoc
@@ -3,15 +3,43 @@
 :kib-pull: https://github.com/elastic/kibana/pull/
 :agent-issue: https://github.com/elastic/beats/issues/
 :agent-pull: https://github.com/elastic/beats/pull/
+:fleet-server-issue: https://github.com/elastic/beats/issues/fleet-server/
+:fleet-server-pull: https://github.com/elastic/beats/pull/fleet-server/
 
-//QUESTION: Any other repos that are needed here? ^^
+[[release-notes]]
+= Release notes
+
+This section summarizes the changes in each release.
+
+* <<release-notes-7.13.1>>
+
+* <<release-notes-7.13.0>>
+
+Also see:
+
+* {kibana-ref}/release-notes.html[{kib} release notes]
+* {beats-ref}/release-notes.html[{beats} release notes]
+
+[[release-notes-7.13.1]]
+== {fleet} and {agent} 7.13.1
+
+The 7.13.1 release includes the following bug fixes.
+
+[discrete]
+[[bug-fixes-7.13.1]]
+=== Bug fixes
+
+{fleet}::
+* Add missing install button for integrations that aren't installed yet {kibana-pull}100370[#100370]
+
+{agent}::
+* Fix unenroll of {agent}s when connected to a self-managed {fleet-server} {fleet-server-pull}381[#381]
+
 
 [[release-notes-7.13.0]]
 == {fleet} and {agent} 7.13.0
 
 Review important information about the {fleet} and {agent} 7.13.x releases.
-
-// Add link to changelogs for Beats/Agent and Kibana.
 
 //[discrete]
 //[[security-updates-7.13.0]]


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Adds 7.13.1 Elastic Agent and Fleet release notes (#744)