### PR TITLE
[7.x] Logs app: Add index pattern content (#725)

### DIFF
--- a/docs/en/observability/configure-logs-sources.asciidoc
+++ b/docs/en/observability/configure-logs-sources.asciidoc
@@ -23,7 +23,17 @@ default configuration settings.
 
 | *Name* | Name of the source configuration. 
 
-| *Indices* | Index pattern or patterns in the {es} indices to read log data from.
+| *Index pattern* | {kib} index patterns or index name patterns in the {es} indices
+to read log data from.
+
+Each log source now integrates with {kib} index patterns which support creating and
+querying {kibana-ref}/managing-index-patterns.html[runtime fields]. You can continue
+to use log sources configured to use an index name pattern, such as `filebeat-*`,
+instead of a {kib} index pattern. However, some features like those depending on
+runtime fields may not be available.
+
+Instead of entering an index pattern name,
+click *Use {kib} index patterns* and select the `filebeat-*` log index pattern.
 
 | *Fields* | Configuring fields input has been deprecated. You should adjust your indexing using the
 <<logs-app-fields,Logs app fields>>, which use the {ecs-ref}/index.html[Elastic Common Schema (ECS) specification].


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Logs app: Add index pattern content (#725)