### PR TITLE
Fleet troubleshooting: update Kibana config file settings

### DIFF
--- a/docs/en/ingest-management/troubleshooting.asciidoc
+++ b/docs/en/ingest-management/troubleshooting.asciidoc
@@ -43,14 +43,12 @@ and specify your user credentials:
 +
 [source,yaml]
 ----
-xpack.fleet.enabled: true <1>
 xpack.encryptedSavedObjects.encryptionKey: "something_at_least_32_characters"
 xpack.security.enabled: true
-elasticsearch.username: "my_username" <2>
+elasticsearch.username: "my_username" <1>
 elasticsearch.password: "my_password"
 ----
-<1> Check that the default setting is `true`.
-<2> Specify a user who is authorized to use {fleet}.
+<1> Specify a user who is authorized to use {fleet}.
 +
 To set up passwords, you can use the documented {es} APIs or the
 `elasticsearch-setup-passwords` command. For example, `./bin/elasticsearch-setup-passwords auto`

--- a/docs/en/ingest-management/troubleshooting.asciidoc
+++ b/docs/en/ingest-management/troubleshooting.asciidoc
@@ -43,14 +43,13 @@ and specify your user credentials:
 +
 [source,yaml]
 ----
-xpack.fleet.enabled: true
-xpack.fleet.agents.tlsCheckDisabled: true <1>
+xpack.fleet.enabled: true <1>
 xpack.encryptedSavedObjects.encryptionKey: "something_at_least_32_characters"
 xpack.security.enabled: true
 elasticsearch.username: "my_username" <2>
 elasticsearch.password: "my_password"
 ----
-<1> Not required if you configure TLS checking.
+<1> Check that the default setting is `true`.
 <2> Specify a user who is authorized to use {fleet}.
 +
 To set up passwords, you can use the documented {es} APIs or the


### PR DESCRIPTION
### Summary

This PR updates the Kibana config file settings called out in the Troubleshooting topic. For 7.13, the `xpack.fleet.agents.tlsCheckDisabled: true` setting was removed.

### Docs preview

https://observability-docs_772.docs-preview.app.elstc.co/guide/en/fleet/master/fleet-troubleshooting.html#fleet-server-not-in-kibana-cloud

### Related issue

Closes https://github.com/elastic/observability-docs/issues/526