### PR TITLE
Add ECE 2.10 requirements for Fleet Server

### DIFF
--- a/docs/en/ingest-management/fleet/fleet-server.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-server.asciidoc
@@ -48,11 +48,12 @@ a self-managed cluster).
 bugfix releases)
 ** {kib} should be on the same minor version as {es}.
 
-* {ece} 2.10 or later
+* {ece} 2.9--requires you to self-manage the {fleet-server}.
+* {ece} 2.10 or later--allows you to use a hosted {fleet-server} on {ecloud}.
 ** Requires additional wildcard domains and certificates (which normally only
-cover *.cname, not ..cname). This enables us to provide the URL for
+cover `*.cname`, not `..cname`). This enables us to provide the URL for
 {fleet-server} of `https://.fleet.`
-** The deployment template must contain a slider for APM & Fleet.
+** The deployment template must contain an APM & Fleet node.
 
 [discrete]
 [[add-fleet-server]]

--- a/docs/en/ingest-management/fleet/fleet-server.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-server.asciidoc
@@ -48,12 +48,11 @@ a self-managed cluster).
 bugfix releases)
 ** {kib} should be on the same minor version as {es}.
 
-//TODO: Uncomment this section when ECE 2.10 is available
-//* {ece} 2.10 or later
-//** Requires additional wildcard domains and certificates (which normally only
-//cover *.cname, not ..cname). This enables us to provide the URL for
-//{fleet-server} of `https://.fleet.`
-//** The deployment template must contain a slider for APM & Fleet.
+* {ece} 2.10 or later
+** Requires additional wildcard domains and certificates (which normally only
+cover *.cname, not ..cname). This enables us to provide the URL for
+{fleet-server} of `https://.fleet.`
+** The deployment template must contain a slider for APM & Fleet.
 
 [discrete]
 [[add-fleet-server]]


### PR DESCRIPTION
Adds ECE 2.10 prereq for using Fleet Server. When the 2.10 is live and the docs are available, we can add links to the documentation about wildcard domains and certificates