### PR TITLE
[Docs] Update cross-document links to Kibana Alerting docs

### DIFF
--- a/docs/en/observability/create-alerts.asciidoc
+++ b/docs/en/observability/create-alerts.asciidoc
@@ -4,7 +4,7 @@
 [IMPORTANT]
 ====
 Make sure to set up alerting in {kib}. For details, see
-{kibana-ref}/alerting-getting-started.html#alerting-setup-prerequisites[Setup and prerequisites].
+{kibana-ref}/alerting-setup.html#alerting-prerequisites[Setup and prerequisites].
 ====
 
 Within the Logs, Metrics, and Uptime apps, alerting enables you to detect

--- a/docs/en/observability/create-alerts.asciidoc
+++ b/docs/en/observability/create-alerts.asciidoc
@@ -4,7 +4,7 @@
 [IMPORTANT]
 ====
 Make sure to set up alerting in {kib}. For details, see
-{kibana-ref}/alerting-setup.html#alerting-prerequisites[Setup and prerequisites].
+{kibana-ref}/alerting-setup.html[Setup and prerequisites].
 ====
 
 Within the Logs, Metrics, and Uptime apps, alerting enables you to detect
@@ -12,8 +12,8 @@ complex *conditions* defined by a *rule*. When a condition is met, the rule
 tracks it as an *alert* and responds by triggering one or more *actions*.
 
 Alerting can be centrally managed from the
-{kibana-ref}/alert-management.html[{kib} Management UI] and provides a
-set of built-in {kibana-ref}/defining-alerts.html[rule types] and
+{kibana-ref}/create-and-manage-rules.html[{kib} Management UI] and provides a
+set of built-in {kibana-ref}/stack-rules.html[rule types] and
 {kibana-ref}/action-types.html[connectors] for you to use.
 
 Extend your rules by connecting them to actions that use built-in *connectors* for email,

--- a/docs/en/observability/create-alerts.asciidoc
+++ b/docs/en/observability/create-alerts.asciidoc
@@ -13,7 +13,7 @@ tracks it as an *alert* and responds by triggering one or more *actions*.
 
 Alerting can be centrally managed from the
 {kibana-ref}/create-and-manage-rules.html[{kib} Management UI] and provides a
-set of built-in {kibana-ref}/stack-rules.html[rule types] and
+set of built-in {kibana-ref}/rule-types.html[rule types] and
 {kibana-ref}/action-types.html[connectors] for you to use.
 
 Extend your rules by connecting them to actions that use built-in *connectors* for email,

--- a/docs/en/observability/observability-ui.asciidoc
+++ b/docs/en/observability/observability-ui.asciidoc
@@ -119,7 +119,7 @@ To help keep you aware of potential issues in your environments, the *Alerts* fe
 provides a snapshot of the alerts occurring within the specified time frame. Displayed are the
 rule types, your specified tags, and the number of instances of each alert within that time frame.
 
-To {kibana-ref}/alert-management.html[create or edit alerts], click *Manage rules*. For more
+To {kibana-ref}/create-and-manage-rules.html[create or edit alerts], click *Manage rules*. For more
 information about specific rules that you can create, see <<create-alerts,Create rules>>.
 
 [role="screenshot"]


### PR DESCRIPTION
Some recent PRs have moved around some of the alerting docs within the Kibana docs, so some of the links need to be updated.

Relevant PRs:
* https://github.com/elastic/kibana/pull/101323
* https://github.com/elastic/kibana/pull/101498
* https://github.com/elastic/kibana/pull/101420