### PR TITLE
Add Fleet and Agent release notes for 7.13.2

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-7.13.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-7.13.asciidoc
@@ -11,6 +11,8 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-7.13.2>>
+
 * <<release-notes-7.13.1>>
 
 * <<release-notes-7.13.0>>
@@ -19,6 +21,19 @@ Also see:
 
 * {kibana-ref}/release-notes.html[{kib} release notes]
 * {beats-ref}/release-notes.html[{beats} release notes]
+
+[[release-notes-7.13.2]]
+== {fleet} and {agent} 7.13.2
+
+The 7.13.2 release includes the following bug fixes.
+
+[discrete]
+[[bug-fixes-7.13.2]]
+=== Bug fixes
+
+{fleet}::
+* Fixes the double install button on the Integrations page {kibana-pull}101511[#101511]
+* Fixes an issue where integration packages were accidentally upgraded when they were added to an agent policy {kibana-pull}101542[#101542]
 
 [[release-notes-7.13.1]]
 == {fleet} and {agent} 7.13.1


### PR DESCRIPTION
Copies over release notes from Kibana so that they appear in the Fleet User Guide.

Do we need to add anything else? Anything for Elastic Agent?