### PR TITLE
[7.x] [Docs] Update cross-document links to Kibana Alerting docs (#779)

### DIFF
--- a/docs/en/observability/create-alerts.asciidoc
+++ b/docs/en/observability/create-alerts.asciidoc
@@ -4,7 +4,7 @@
 [IMPORTANT]
 ====
 Make sure to set up alerting in {kib}. For details, see
-{kibana-ref}/alerting-getting-started.html#alerting-setup-prerequisites[Setup and prerequisites].
+{kibana-ref}/alerting-setup.html[Setup and prerequisites].
 ====
 
 Within the Logs, Metrics, and Uptime apps, alerting enables you to detect
@@ -12,8 +12,8 @@ complex *conditions* defined by a *rule*. When a condition is met, the rule
 tracks it as an *alert* and responds by triggering one or more *actions*.
 
 Alerting can be centrally managed from the
-{kibana-ref}/alert-management.html[{kib} Management UI] and provides a
-set of built-in {kibana-ref}/defining-alerts.html[rule types] and
+{kibana-ref}/create-and-manage-rules.html[{kib} Management UI] and provides a
+set of built-in {kibana-ref}/rule-types.html[rule types] and
 {kibana-ref}/action-types.html[connectors] for you to use.
 
 Extend your rules by connecting them to actions that use built-in *connectors* for email,

--- a/docs/en/observability/observability-ui.asciidoc
+++ b/docs/en/observability/observability-ui.asciidoc
@@ -119,7 +119,7 @@ To help keep you aware of potential issues in your environments, the *Alerts* fe
 provides a snapshot of the alerts occurring within the specified time frame. Displayed are the
 rule types, your specified tags, and the number of instances of each alert within that time frame.
 
-To {kibana-ref}/alert-management.html[create or edit alerts], click *Manage rules*. For more
+To {kibana-ref}/create-and-manage-rules.html[create or edit alerts], click *Manage rules*. For more
 information about specific rules that you can create, see <<create-alerts,Create rules>>.
 
 [role="screenshot"]


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [Docs] Update cross-document links to Kibana Alerting docs (#779)