### PR TITLE
[7.x] Add ECE 2.10 requirements for Fleet Server (#778)

### DIFF
--- a/docs/en/ingest-management/fleet/fleet-server.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-server.asciidoc
@@ -48,12 +48,12 @@ a self-managed cluster).
 bugfix releases)
 ** {kib} should be on the same minor version as {es}.
 
-//TODO: Uncomment this section when ECE 2.10 is available
-//* {ece} 2.10 or later
-//** Requires additional wildcard domains and certificates (which normally only
-//cover *.cname, not ..cname). This enables us to provide the URL for
-//{fleet-server} of `https://.fleet.`
-//** The deployment template must contain a slider for APM & Fleet.
+* {ece} 2.9--requires you to self-manage the {fleet-server}.
+* {ece} 2.10 or later--allows you to use a hosted {fleet-server} on {ecloud}.
+** Requires additional wildcard domains and certificates (which normally only
+cover `*.cname`, not `..cname`). This enables us to provide the URL for
+{fleet-server} of `https://.fleet.`
+** The deployment template must contain an APM & Fleet node.
 
 [discrete]
 [[add-fleet-server]]


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Add ECE 2.10 requirements for Fleet Server (#778)