### PR TITLE
[DOCS] Adds missing link in What's New

### DIFF
--- a/docs/en/observability/whats-new.asciidoc
+++ b/docs/en/observability/whats-new.asciidoc
@@ -99,7 +99,7 @@ you to visualize how these attributes are distributed compared to what is expect
 cause of your performance problems. 
 
 Correlations give you the flexibility of exploring your data your way, which means you can set a different threshold value for your slow transactions
-or even specify what attributes you want to run the analysis on, right from the UI. For more information, see our Correlations docs.
+or even specify what attributes you want to run the analysis on, right from the UI. For more information, see our {kibana-ref}/correlations.html[Correlations docs].
 
 [discrete]
 == Improved waterfall experience in Synthetics


### PR DESCRIPTION
This PR adds a missing link in https://www.elastic.co/guide/en/observability/7.12/whats-new.html#_correlations_in_apm

In particular, it adds a link to https://www.elastic.co/guide/en/kibana/7.12/correlations.html