### PR TITLE
[7.x] Hide docs for mamanaged agent on k8s (#799)

### DIFF
--- a/docs/en/ingest-management/elastic-agent/elastic-agent.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/elastic-agent.asciidoc
@@ -16,7 +16,7 @@ To learn how to install, configure, and run your {agent}s, see:
 * <<elastic-agent-installation>>
 * <<uninstall-elastic-agent>>
 * <<run-elastic-agent-standalone>>
-* <<running-on-kubernetes>>
+//* <<running-on-kubernetes>>
 * <<running-on-kubernetes-standalone>>
 * <<upgrade-elastic-agent>>
 * <<start-elastic-agent>>
@@ -31,7 +31,7 @@ include::uninstall-elastic-agent.asciidoc[leveloffset=+1]
 
 include::run-elastic-agent-standalone.asciidoc[leveloffset=+1]
 
-include::running-on-kubernetes.asciidoc[leveloffset=+1]
+//include::running-on-kubernetes.asciidoc[leveloffset=+1]
 
 include::running-on-kubernetes-standalone.asciidoc[leveloffset=+1]
 


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Hide docs for mamanaged agent on k8s (#799)