### PR TITLE
[7.x][Backport][Synthetics] Docs on secrets and params 

### DIFF
--- a/docs/en/observability/index.asciidoc
+++ b/docs/en/observability/index.asciidoc
@@ -100,6 +100,8 @@ include::synthetics-command-reference.asciidoc[leveloffset=+2]
 
 include::synthetics-visualize.asciidoc[leveloffset=+2]
 
+include::synthetics-params-secrets.asciidoc[leveloffset=+2]
+
 // User experience
 include::user-experience.asciidoc[leveloffset=+1]
 

--- a/docs/en/observability/synthetics-params-secrets.asciidoc
+++ b/docs/en/observability/synthetics-params-secrets.asciidoc
@@ -1,0 +1,132 @@
+[[synthetics-params-secrets]]
+= Working with params and secrets
+
+++++
+<titleabbrev>Working with parameters and secrets</titleabbrev>
+++++
+
+beta[] You may need to use dynamically defined values in your synthetic scripts, which may sometimes be sensitive. 
+For instance, you may want to test a production website with a particular demo account whose password is only known to the team administering heartbeat. 
+Another scenario might be using a different URL when running the tests under Heartbeat and then running them locally using the Synthetics agent.
+Solving these problems is where params come in. Params are variables that you can use within a synthetic suite. 
+They can be defined either in the suites config file, the synthetics agent command line, or in a Heartbeat YAML config file.
+
+You should also note that since synthetics is a full javascript environment, it is also possible to use regular environment variables via
+the standard node `process.env` global object.
+
+[discrete]
+[[synthetics-basic-params]]
+== Parameter Basics
+
+When writing a test suite, parameters can be referenced via the `params` property available within the 
+argument to a `journey`, `before`, `beforeAll`, `after`, or `afterAll` callback function.
+
+[source,js]
+----
+beforeAll(({params}) => {
+  console.log(`Visiting ${params.url}`)
+})
+
+journey("My Journey", ({ page, params }) => {
+    step('launch app', async () => {
+      await page.goto(params.url);<1>
+    });
+});
+----
+<1> Note that in a typescript program you would want to instead use `params.url as string`.
+
+If you try to run the example above you'll notice an error because we haven't specified a value for the `url` parameter.
+Parameter values can be declared by any of the following methods:
+
+* Declaring a default value for the parameter in a configuration file.
+* Passing the `--suite-params` CLI argument. 
+* Specifying the parameter in the heartbeat yaml config using the `params` option.
+
+The values in the configuration file are read first, then merged with either the CLI argument, or the Heartbeat
+option, with the CLI and Heartbeat options taking precedence over the configuration file.
+
+These options are discussed in detail in the sections below.
+
+[discrete]
+[[synthetics-configs]]
+== Using a config file to set params
+
+Use a `synthetics.config.js` or `synthetics.config.ts` file to define variables your tests always need to be defined. 
+This file should be placed in the root of your synthetics project. 
+
+[source,js]
+----
+export default (env) => {
+  let url = "http://localhost:8080";
+  if (env === "production") {
+    url = "https://elastic.github.io/synthetics-demo/"
+  }
+  return {
+    params: {
+      url,
+    },
+  };
+};
+----
+
+Note that we use the `env` variable in the above example, which corresponds to the value of the `NODE_ENV` environment variable
+, or the `environment` parameter in the `browser` monitor definition when using Heartbeat. 
+
+[discrete]
+[[synthetics-cli-params]]
+== Using CLI arguments to set params
+
+To set parameters when running `elastic-synthetics` on the command line, use the `--suite-params` or `-s` arguments to the `elastic-synthetics` program. The provided map is merged over any existing variables defined in the `synthetics.config.{js,ts}` file.
+
+To override the `url` parameter, you would run: `elastic-synthetics . --suite-params '{"url": "http://localhost:8080"}'`
+
+[discrete]
+[[synthetics-hb-params]]
+== Using Heartbeat options to set params
+
+When running via Heartbeat use the `params` option to set additional parameters, passed through the `--suite-params` flag
+mentioned above and have their values merged over any default values. In the example below we run the todos app, overriding the `url`
+parameter.
+
+[source,yaml]
+----
+- name: Todos
+  id: todos
+  type: browser
+  schedule: "@every 3m"
+  tags: todos-app
+  params:
+    url: "https://elastic.github.io/synthetics-demo/"
+  source:
+    zip_url:
+      url: "https://github.com/elastic/synthetics-demo/archive/refs/heads/main.zip"
+      folder: "synthetics-tests"
+----
+
+[[synthetics-secrets-sensitive]]
+== Working with secrets and sensitive values
+
+Your synthetics scripts may require the use of passwords or other sensitive secrets that are not known till runtime. Before we continue, it is 
+important to remember that since synthetics scripts have no limitations, a malicious script author could write a synthetics journey that 
+exfiltrates `params` and other data at runtime. Therefore, it is generally best not to use truly sensitive passwords (e.g. an admin password to test an admin
+panel, or a real credit card) in *any* synthetics tools. Instead, set up limited dummy accounts, or fake credit cards with limited functionality.
+
+Use either environment variables or the Heartbeat keystore to handle any values needing encryption at rest. 
+As an example, the syntax `${URL}` for instance, to reference a variable named `URL` in either the secret store or the environment. For example: 
+
+[source,yaml]
+----
+- name: Todos
+  id: todos
+  type: browser
+  schedule: "@every 3m"
+  tags: todos-app
+  params:
+    url: ${URL}
+  source:
+    zip_url:
+      url: "https://github.com/elastic/synthetics-demo/archive/refs/heads/main.zip"
+      folder: "synthetics-tests"
+----
+
+To setup the heartbeat keystore see the https://www.elastic.co/guide/en/beats/heartbeat/current/keystore.html[Heartbeat keystore documentation]. 


### PR DESCRIPTION
Fixes #805

Adds docs for params and secrets.

Backport of https://github.com/elastic/observability-docs/pull/806