### PR TITLE
Add pointer to docs about kibana.yml settings

### DIFF
--- a/docs/en/ingest-management/fleet/fleet-settings.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-settings.asciidoc
@@ -3,8 +3,13 @@
 
 beta[]
 
-Configure {fleet} settings in {kib} to apply global settings to all {agent}s
-enrolled in {fleet}:
+NOTE: The settings described here are configurable through the {fleet} UI. There
+are additional settings available in the `kibana.yml` that control {fleet}
+behavior. For more information, refer to
+{kibana-ref}/fleet-settings-kb.html[{fleet} settings in {kib}].
+
+Configure {fleet} settings to apply global settings to all {agent}s enrolled in
+{fleet}:
 
 . In {kib}, open the main menu, then click *Management > {fleet}*.
 

--- a/docs/en/ingest-management/fleet/fleet-settings.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-settings.asciidoc
@@ -3,10 +3,9 @@
 
 beta[]
 
-NOTE: The settings described here are configurable through the {fleet} UI. There
-are additional settings available in the `kibana.yml` that control {fleet}
-behavior. For more information, refer to
-{kibana-ref}/fleet-settings-kb.html[{fleet} settings in {kib}].
+NOTE: The settings described here are configurable through the {fleet} UI. Refer to
+{kibana-ref}/fleet-settings-kb.html[{fleet} settings in {kib}] for a list of
+settings that you can configure in the `kibana.yml` configuration file.
 
 Configure {fleet} settings to apply global settings to all {agent}s enrolled in
 {fleet}:


### PR DESCRIPTION
Closes elastic/observability-docs#758.

This PR assumes that we will continue to provide Fleet kibana.yml settings along with the other config settings in the Kibana Guide.

If we decide to provide kibana.yml settings in the Fleet User guide, we should pull in the topic from the Kibana docs so that it appears in both places.

@jen-huang Let me know which approach you prefer (a link as shown in this PR, or an include that pulls in the Fleet settings). Pulling settings in from Kibana would add another dependency to the doc build. I think we will always have some problems with fragmentation until we move to a doc system where documentation no longer lives in separate silos.