### PR TITLE
Adds missing asterisks to a Fleet Server requirement related to wildcard domains

### DIFF
--- a/docs/en/ingest-management/fleet/fleet-server.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-server.asciidoc
@@ -51,7 +51,7 @@ bugfix releases)
 * {ece} 2.9--requires you to self-manage the {fleet-server}.
 * {ece} 2.10 or later--allows you to use a hosted {fleet-server} on {ecloud}.
 ** Requires additional wildcard domains and certificates (which normally only
-cover `*.cname`, not `..cname`). This enables us to provide the URL for
+cover `*.cname`, not `*.*.cname`). This enables us to provide the URL for
 {fleet-server} of `https://.fleet.`
 ** The deployment template must contain an APM & Fleet node.
 


### PR DESCRIPTION
Adds asterisks that were inadvertently gobbled by GitHub in the original issue.

This point needs more details, but it will be added by a follow-up PR tracked in https://github.com/elastic/observability-docs/issues/825.