### PR TITLE
Make more clear in the example that conditions accumulate

### DIFF
--- a/docs/en/observability/metrics-threshold-alert.asciidoc
+++ b/docs/en/observability/metrics-threshold-alert.asciidoc
@@ -30,8 +30,7 @@ Conditions for each rule can be applied to specific metrics that you select. You
 the metric, and by including a warning threshold value, you can be alerted on multiple threshold values based on severity scores.
 To help you determine which thresholds are meaningful to you, the preview charts provide a visualization.
 
-In this example, the conditions state that you will receive a critical alert for any any hosts that have a CPU usage of 120% or above
-and a warning alert if CPU usage is 100% or above. You will also receive a critical alert if memory usage is 20% or above.
+In this example, the conditions state that you will receive a critical alert for any any hosts that have a CPU usage of 120% or above and a warning alert if CPU usage is 100% or above. Note that you will receive a critical alert only if memory usage is 20% or above, as per the second condition.
 
 [role="screenshot"]
 image::images/metrics-alert.png[Inventory alert]

--- a/docs/en/observability/metrics-threshold-alert.asciidoc
+++ b/docs/en/observability/metrics-threshold-alert.asciidoc
@@ -30,7 +30,7 @@ Conditions for each rule can be applied to specific metrics that you select. You
 the metric, and by including a warning threshold value, you can be alerted on multiple threshold values based on severity scores.
 To help you determine which thresholds are meaningful to you, the preview charts provide a visualization.
 
-In this example, the conditions state that you will receive a critical alert for any any hosts that have a CPU usage of 120% or above and a warning alert if CPU usage is 100% or above. Note that you will receive a critical alert only if memory usage is 20% or above, as per the second condition.
+In this example, the conditions state that you will receive a critical alert for hosts with a CPU usage of 120% or above and a warning alert if CPU usage is 100% or above. Note that you will receive a critical alert only if memory usage is 20% or above, as per the second condition.
 
 [role="screenshot"]
 image::images/metrics-alert.png[Inventory alert]


### PR DESCRIPTION
The [example](https://www.elastic.co/guide/en/observability/7.13/metrics-threshold-alert.html#metrics-conditions) documentation page for the metrics threshold is a bit unclear on the fact that the conditions are combined. This small change tries to make it more explicit that both conditions need to be met in order for the alert to be triggered.

@elastic/obs-docs 