### PR TITLE
[7.14] Elastic agent: Add logging content (#808)

### DIFF
--- a/docs/en/ingest-management/elastic-agent/elastic-agent-standalone-logging.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/elastic-agent-standalone-logging.asciidoc
@@ -1,0 +1,126 @@
+[[elastic-agent-standalone-logging-config]]
+[role="xpack"]
+= Configure logging for standalone {agent}s
+
+The Logging section of the `elastic-agent.yml` config file contains settings for configuring the logging output.
+The logging system can write logs to the `syslog`, `file`, `stderr`, `eventlog`, or rotate log files.
+If you do not explicitly configure logging, the `stderr` output is used.
+
+["source","yaml",subs="attributes"]
+----
+agent.logging.level: info
+agent.logging.to_files: true
+agent.logging.files:
+  path: /var/log/elastic-agent
+  name: elastic-agent
+  keepfiles: 7
+  permissions: 0600
+----
+
+[discrete]
+[[elastic-agent-standalone-logging-settings]]
+== Logging configuration settings
+
+You can specify the following settings in the Logging section of the `elastic-agent.yml` config file.
+
+[cols="2*<a"]
+|===
+| *Setting* | *Description*
+| `agent.logging.level` | The minimum log level. 
+
+Possible values: 
+
+* `error`: Logs errors and critical errors.
+
+* `warning`: Logs warnings, errors, and critical errors.
+
+* `info`: Logs informational messages, including the number of events that are published. Also logs any warnings,
+errors, or critical errors.
+
+* `debug`: Logs debug messages, including a detailed printout of all events flushed. Also logs informational messages,
+warnings, errors, and critical errors. When the log level is `debug`, you can specify a list of *selectors* to display
+debug messages for specific components. If no selectors are specified, the `*` selector is used to display debug
+messages for all components.
+
+Default: `info`
+
+| `agent.logging.selectors` | Specify the selector tags that are used by different {agent} components for debugging.
+To debug the output for all components, use `*`. To display debug messages related to event
+publishing, set to `publish`. Multiple selectors can be chained.
+
+Possible values: `[beat]`, `[publish]`, `[service]`
+
+| `agent.logging.to_stderr` | Set to `true` to write all logging output to the `stderr` output—this is equivalent to
+using the `-e` command line option.
+
+Default: `true`
+
+| `agent.logging.to_syslog` | Set to `true` to write all logging output to the `syslog` output.
+
+Default: `false`
+
+| `agent.logging.to_eventlog` | Set to `true` to write all logging output to the Windows `eventlog` output.
+
+Default: `false`
+
+| `agent.logging.metrics.enabled` | Set to `true` for {agent} to periodically log its internal metrics that have changed in the
+last period. For each metric that changed, the delta from the value at the beginning of the period is logged.
+Also, the total values for all non-zero internal metrics get logged on shutdown.
+
+Default: `true`
+
+| `agent.logging.metrics.period` | Specify the period after which to log the internal metrics.
+
+Default: `30s`
+
+| `agent.logging.to_files` | Set to `true` to log to rotating files. Set to `false` to disable logging to files.
+
+Default: `true`
+
+| `agent.logging.files.path` | The directory that log files is written to.
+
+include::{tab-widgets}/logging-widget.asciidoc[]
+
+Logs are numbered log.1, log.2, and so on as they are rotated off the main log.
+
+| `agent.logging.files.name` | The name of the file that logs are written to.
+
+Default: `elastic-agent`
+
+| `agent.logging.files.rotateeverybytes` | The maximum size limit of a log file. If the limit is reached, a new log file is generated.
+
+Default: `10485760` (10MB)
+
+|  `agent.logging.files.keepfiles` | The most recent number of rotated log files to keep on disk. Older files are deleted during log rotation.
+The value must be in the range of `2` to `1024` files.
+
+Default: `7`
+
+| `agent.logging.files.permissions` | The permissions mask to apply when rotating log files. The permissions option
+must be a valid Unix-style file permissions mask expressed in octal notation. In Go, numbers in octal notation must start with 0.
+
+Default: `0600`
+
+| `agent.logging.files.interval` | Enable log file rotation on time intervals in addition to the size-based rotation. Intervals must be at least `1s`.
+Values of `1m`, `1h`, `24h`, `7*24h`, `30*24h`, and `365*24h` are boundary-aligned with minutes, hours, days, weeks, months, and years as
+reported by the local system clock. All other intervals get calculated from the Unix epoch.
+
+Default: `0` (disabled)
+
+| `agent.logging.files.rotateonstartup` | Set to `true` to rotate existing logs on startup rather than to append to the existing file. 
+
+Default: `true`
+
+| `agent.logging.json` | Set to `true` to log messages in JSON format. 
+
+Default: `false`
+
+| `agent.logging.ecs` | Set to `true` to log messages with the minimal required Elastic Common Schema (ECS)
+information. We recommended using this option in combination with `agent.logging.json: true`.
+
+Default: `false`
+
+|===
+
+// Add Javascript and CSS for tabbed panels
+include::{tab-widgets}/code.asciidoc[]

--- a/docs/en/ingest-management/elastic-agent/elastic-agent.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/elastic-agent.asciidoc
@@ -24,6 +24,8 @@ To learn how to install, configure, and run your {agent}s, see:
 * <<unenroll-elastic-agent>>
 * <<elastic-agent-configuration>>
 * <<dynamic-input-configuration>>
+* <<agent-environment-variables>>
+* <<elastic-agent-standalone-logging-config>>
 
 include::install-elastic-agent.asciidoc[leveloffset=+1]
 
@@ -50,5 +52,7 @@ include::elastic-agent-dynamic-inputs.asciidoc[leveloffset=+1]
 include::elastic-agent-capabilities.asciidoc[leveloffset=+1]
 
 include::configuration/env/container-envs.asciidoc[leveloffset=+1]
+
+include::elastic-agent-standalone-logging.asciidoc[leveloffset=+1]
 
 include::redirects.asciidoc[leveloffset=+1]

--- a/docs/en/ingest-management/tab-widgets/logging-widget.asciidoc
+++ b/docs/en/ingest-management/tab-widgets/logging-widget.asciidoc
@@ -1,0 +1,95 @@
+++++
+<div class="tabs" data-tab-group="os">
+  <div role="tablist" aria-label="Logging">
+    <button role="tab"
+            aria-selected="true"
+            aria-controls="mac-tab-logging"
+            id="mac-logging">
+      MacOS
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="linux-tab-logging"
+            id="linux-logging"
+            tabindex="-1">
+      Linux
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="win-tab-logging"
+            id="win-logging"
+            tabindex="-1">
+      Windows
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="deb-tab-logging"
+            id="deb-logging"
+            tabindex="-1">
+      DEB
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="rpm-tab-logging"
+            id="rpm-logging"
+            tabindex="-1">
+      RPM
+    </button>
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="mac-tab-logging"
+       aria-labelledby="mac-logging">
+++++
+
+include::logging.asciidoc[tag=mac]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="linux-tab-logging"
+       aria-labelledby="linux-logging"
+       hidden="">
+++++
+
+include::logging.asciidoc[tag=linux]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="win-tab-logging"
+       aria-labelledby="win-logging"
+       hidden="">
+++++
+
+include::logging.asciidoc[tag=win]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="deb-tab-logging"
+       aria-labelledby="deb-logging"
+       hidden="">
+
+++++
+
+include::logging.asciidoc[tag=deb]
+
+++++
+  </div> 
+  <div tabindex="0"
+       role="tabpanel"
+       id="rpm-tab-logging"
+       aria-labelledby="rpm-logging"
+       hidden="">
+++++
+
+include::logging.asciidoc[tag=rpm]
+
+++++
+  </div>
+</div>
+++++

--- a/docs/en/ingest-management/tab-widgets/logging.asciidoc
+++ b/docs/en/ingest-management/tab-widgets/logging.asciidoc
@@ -1,0 +1,29 @@
+// tag::mac[]
+
+**/Library/Elastic/Agent/data/elastic-agent-*/logs/elastic-agent-json.log**
+
+// end::mac[]
+
+// tag::linux[]
+
+**/opt/Elastic/Agent/data/elastic-agent-*/logs/elastic-agent-json.log**
+
+// end::linux[]
+
+// tag::win[]
+
+**C:\Program Files\Elastic\Agent\data\elastic-agent-*\logs\elastic-agent-json.log**
+
+// end::win[]
+
+// tag::deb[]
+
+**/var/lib/elastic-agent/data/elastic-agent-*/logs/elastic-agent-json.log**
+
+// end::deb[]
+
+// tag::rpm[]
+
+**/var/lib/elastic-agent/data/elastic-agent-*/logs/elastic-agent-json.log**
+
+// end::rpm[]


### PR DESCRIPTION
Backports the following commits to 7.14:
 - Elastic agent: Add logging content (#808)