### PR TITLE
[7.14] Remove beta admonitions from Fleet and Elastic Agent docs (#871)

### DIFF
--- a/docs/en/ingest-management/agent-policies.asciidoc
+++ b/docs/en/ingest-management/agent-policies.asciidoc
@@ -6,8 +6,6 @@
 <titleabbrev>Policies</titleabbrev>
 ++++
 
-beta[]
-
 A {policy} is a collection of inputs and settings that defines the data to be collected
 by an {agent}. Each {agent} can only be enrolled in a single {policy}.
 

--- a/docs/en/ingest-management/commands.asciidoc
+++ b/docs/en/ingest-management/commands.asciidoc
@@ -4,8 +4,6 @@
 [role="xpack"]
 = Command reference
 
-beta[]
-
 {agent} provides commands for running {agent}, managing {fleet-server}, and
 doing common tasks:
 

--- a/docs/en/ingest-management/elastic-agent/elastic-agent-configuration.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/elastic-agent-configuration.asciidoc
@@ -2,8 +2,6 @@
 [role="xpack"]
 = Policy settings
 
-beta[]
-
 The policy settings for {fleet}-managed agents are specified through the UI.
 You do not set them explicitly in a configuration file.
 

--- a/docs/en/ingest-management/elastic-agent/elastic-agent.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/elastic-agent.asciidoc
@@ -3,8 +3,6 @@
 
 = {agent}s
 
-beta[]
-
 // tag::agent-install-intro[]
 {agent} is a single, unified agent that you can deploy to hosts or containers to
 collect data and send it to the {stack}. Behind the scenes, {agent} runs the

--- a/docs/en/ingest-management/elastic-agent/install-elastic-agent.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/install-elastic-agent.asciidoc
@@ -2,8 +2,6 @@
 [role="xpack"]
 = Install {agent}s
 
-beta[]
-
 To collect and ship data to the {stack}, install an {agent} on each host you
 want to monitor. These steps assume that you're running a fresh installation. If
 {agent} is already running on your system and you want to upgrade to a new

--- a/docs/en/ingest-management/elastic-agent/run-elastic-agent-standalone.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/run-elastic-agent-standalone.asciidoc
@@ -2,8 +2,6 @@
 [role="xpack"]
 = Run {agent} standalone (advanced users)
 
-beta[]
-
 Instead of using {fleet} to manage your {agent}s, you can run agents standalone.
 With standalone mode, you manually configure and manage the agents locally on
 the systems where they are installed. 

--- a/docs/en/ingest-management/elastic-agent/uninstall-elastic-agent.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/uninstall-elastic-agent.asciidoc
@@ -2,8 +2,6 @@
 [role="xpack"]
 = Uninstall {agent}
 
-beta[]
-
 [discrete]
 == Uninstall on macOS, Linux, and Windows
 

--- a/docs/en/ingest-management/faq.asciidoc
+++ b/docs/en/ingest-management/faq.asciidoc
@@ -2,8 +2,6 @@
 [role="xpack"]
 = Frequently asked questions
 
-beta[]
-
 We have collected the most frequently asked questions here. If your question
 isn't answered here, contact us in the {forum}[discuss forum]. Your feedback
 is very valuable to us.

--- a/docs/en/ingest-management/fleet/fleet-limitations.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-limitations.asciidoc
@@ -2,8 +2,6 @@
 [role="xpack"]
 = Limitations of this release
 
-beta[]
-
 {fleet} is currently only available to users with the
 {ref}/built-in-roles.html[superuser role]. This role is necessary to create
 indices, install integration assets, and update {agent} policies. In order

--- a/docs/en/ingest-management/fleet/fleet-server.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-server.asciidoc
@@ -1,8 +1,6 @@
 [[fleet-server]]
 = {fleet-server}
 
-beta[]
-
 {fleet-server} is a component of the {stack} used to centrally manage {agent}s.
 It's launched as part of an {agent} on a host intended to act as a server.
 One {fleet-server} process can support many {agent} connections,

--- a/docs/en/ingest-management/fleet/fleet-settings.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-settings.asciidoc
@@ -1,8 +1,6 @@
 [[fleet-settings]]
 = {fleet} settings
 
-beta[]
-
 NOTE: The settings described here are configurable through the {fleet} UI. Refer to
 {kibana-ref}/fleet-settings-kb.html[{fleet} settings in {kib}] for a list of
 settings that you can configure in the `kibana.yml` configuration file.

--- a/docs/en/ingest-management/getting-started.asciidoc
+++ b/docs/en/ingest-management/getting-started.asciidoc
@@ -2,8 +2,6 @@
 [role="xpack"]
 = Quick start: Get logs, metrics, and uptime data into the {stack}
 
-beta[]
-
 This guide describes how to:
 
 * Set up {fleet}

--- a/docs/en/ingest-management/overview.asciidoc
+++ b/docs/en/ingest-management/overview.asciidoc
@@ -2,8 +2,6 @@
 [role="xpack"]
 = {fleet} and {agent} overview
 
-beta[]
-
 [discrete]
 [[elastic-agent]]
 == {agent}

--- a/docs/en/ingest-management/troubleshooting.asciidoc
+++ b/docs/en/ingest-management/troubleshooting.asciidoc
@@ -2,8 +2,6 @@
 [role="xpack"]
 = Troubleshoot common problems
 
-beta[]
-
 We have collected the most common known problems and listed them here. If your problem
 is not described here, please review the open issues in the following GitHub repositories:
 


### PR DESCRIPTION
Backports the following commits to 7.14:
 - Remove beta admonitions from Fleet and Elastic Agent docs (#871)