### PR TITLE
small placeholder file and link to git repo api docs

### DIFF
--- a/docs/en/ingest-management/fleet/fleet-api-docs.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-api-docs.asciidoc
@@ -1,5 +1,5 @@
 [[fleet-api-docs]]
-= {Fleet API Docs}
+= {{fleet} API Docs}
 
 {fleet} is fully supported by an API layer.  Anything you can do in the UI, can be
 done using the API.  Indeed, the UI consumes the API and proves out its usage!

--- a/docs/en/ingest-management/fleet/fleet-api-docs.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-api-docs.asciidoc
@@ -5,6 +5,5 @@
 through the {fleet} UI are also available through the API. In fact, the UI
 consumes the API.
 
-Please see the {kib} repo
-https://github.com/elastic/kibana/blob/master/x-pack/plugins/fleet/common/openapi/README.md[{fleet} API Documentation file]
-for more details.
+Please refer to the
+https://github.com/elastic/kibana/blob/master/x-pack/plugins/fleet/common/openapi/README.md[{fleet} OpenAPI file] in the {kib} repo for more details.

--- a/docs/en/ingest-management/fleet/fleet-api-docs.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-api-docs.asciidoc
@@ -1,5 +1,5 @@
 [[fleet-api-docs]]
-= {{fleet} API Docs}
+= {fleet} APIs
 
 {fleet} is fully supported by an API layer.  Anything you can do in the UI, can be
 done using the API.  Indeed, the UI consumes the API and proves out its usage!

--- a/docs/en/ingest-management/fleet/fleet-api-docs.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-api-docs.asciidoc
@@ -7,6 +7,3 @@ done using the API.  Indeed, the UI consumes the API and proves out its usage!
 Please see the {kib} repo
 https://github.com/elastic/kibana/blob/master/x-pack/plugins/fleet/common/openapi/README.md[{fleet} API Documentation file]
 for more details.
-
-//needed to render tab widgets
-include::{tab-widgets}/code.asciidoc[]

--- a/docs/en/ingest-management/fleet/fleet-api-docs.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-api-docs.asciidoc
@@ -1,8 +1,9 @@
 [[fleet-api-docs]]
 = {fleet} APIs
 
-{fleet} is fully supported by an API layer.  Anything you can do in the UI, can be
-done using the API.  Indeed, the UI consumes the API and proves out its usage!
+{fleet} is fully supported by an API layer. Any actions you can perform
+through the {fleet} UI are also available through the API. In fact, the UI
+consumes the API.
 
 Please see the {kib} repo
 https://github.com/elastic/kibana/blob/master/x-pack/plugins/fleet/common/openapi/README.md[{fleet} API Documentation file]

--- a/docs/en/ingest-management/fleet/fleet-api-docs.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-api-docs.asciidoc
@@ -1,0 +1,12 @@
+[[fleet-api-docs]]
+= {Fleet API Docs}
+
+{fleet} is fully supported by an API layer.  Anything you can do in the UI, can be
+done using the API.  Indeed, the UI consumes the API and proves out its usage!
+
+Please see the {kib} repo
+https://github.com/elastic/kibana/blob/master/x-pack/plugins/fleet/common/openapi/README.md[{fleet} API Documentation file]
+for more details.
+
+//needed to render tab widgets
+include::{tab-widgets}/code.asciidoc[]

--- a/docs/en/ingest-management/fleet/fleet-api-docs.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-api-docs.asciidoc
@@ -6,4 +6,4 @@ through the {fleet} UI are also available through the API. In fact, the UI
 consumes the API.
 
 Please refer to the
-https://github.com/elastic/kibana/blob/master/x-pack/plugins/fleet/common/openapi/README.md[{fleet} OpenAPI file] in the {kib} repo for more details.
+https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/fleet/common/openapi/README.md[{fleet} OpenAPI file] in the {kib} repo for more details.

--- a/docs/en/ingest-management/fleet/fleet-api-docs.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-api-docs.asciidoc
@@ -2,8 +2,7 @@
 = {fleet} APIs
 
 {fleet} is fully supported by an API layer. Any actions you can perform
-through the {fleet} UI are also available through the API. In fact, the UI
-consumes the API.
+through the {fleet} UI are also available through the API.
 
 Please refer to the
 https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/fleet/common/openapi/README.md[{fleet} OpenAPI file] in the {kib} repo for more details.

--- a/docs/en/ingest-management/index.asciidoc
+++ b/docs/en/ingest-management/index.asciidoc
@@ -58,3 +58,4 @@ include::faq.asciidoc[leveloffset=+1]
 
 include::release-notes/release-notes-7.13.asciidoc[leveloffset=+1]
 
+include::fleet/fleet-api-docs.asciidoc[leveloffset=+1]


### PR DESCRIPTION
Hello, this is a first part of support to fix / implement the Fleet API Docs per:
https://github.com/elastic/observability-docs/issues/881

I'm not 100% sure if I have all the bits in place to instantiate a new file and have it show up in the right hand side widget.  But I'll try it out.

2 subsequent prs (one to elasticsearch and one more to observability-docs) will follow to point to this new 'api docs' home page location.  we can change whats on the page anytime, but it seemed prudent to have it in place for google searchability and linking from other projects, etc.