### PR TITLE
Add missing relnotes for 7.13.3 and 7.13.4

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-7.13.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-7.13.asciidoc
@@ -29,9 +29,7 @@ Also see:
 [[release-notes-7.13.4]]
 == {fleet} and {agent} 7.13.4
 
-The 7.13.4 release includes the following bug fixes.
-
-//QUESTION: What do we need to add here?
+There are no bug fixes for {fleet} or {agent} in this release.
 
 [[release-notes-7.13.3]]
 == {fleet} and {agent} 7.13.3

--- a/docs/en/ingest-management/release-notes/release-notes-7.13.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-7.13.asciidoc
@@ -11,6 +11,10 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-7.13.4>>
+
+* <<release-notes-7.13.3>>
+
 * <<release-notes-7.13.2>>
 
 * <<release-notes-7.13.1>>
@@ -21,6 +25,20 @@ Also see:
 
 * {kibana-ref}/release-notes.html[{kib} release notes]
 * {beats-ref}/release-notes.html[{beats} release notes]
+
+[[release-notes-7.13.4]]
+== {fleet} and {agent} 7.13.4
+
+The 7.13.4 release includes the following bug fixes.
+
+//QUESTION: What do we need to add here?
+
+[[release-notes-7.13.3]]
+== {fleet} and {agent} 7.13.3
+
+The 7.13.3 release includes the following bug fixes.
+
+//QUESTION: What do we need to add here?
 
 [[release-notes-7.13.2]]
 == {fleet} and {agent} 7.13.2

--- a/docs/en/ingest-management/release-notes/release-notes-7.13.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-7.13.asciidoc
@@ -34,9 +34,7 @@ There are no bug fixes for {fleet} or {agent} in this release.
 [[release-notes-7.13.3]]
 == {fleet} and {agent} 7.13.3
 
-The 7.13.3 release includes the following bug fixes.
-
-//QUESTION: What do we need to add here?
+There are no bug fixes for {fleet} or {agent} in this release.
 
 [[release-notes-7.13.2]]
 == {fleet} and {agent} 7.13.2


### PR DESCRIPTION
This PR adds a placeholder for 7.13.3 and 7.13.4 release notes that are missing.

We need to fill in details so that the download page has something to link to.