### PR TITLE
[7.x] Add missing relnotes for 7.13.3 and 7.13.4 (#883)

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-7.13.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-7.13.asciidoc
@@ -11,6 +11,10 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-7.13.4>>
+
+* <<release-notes-7.13.3>>
+
 * <<release-notes-7.13.2>>
 
 * <<release-notes-7.13.1>>
@@ -21,6 +25,16 @@ Also see:
 
 * {kibana-ref}/release-notes.html[{kib} release notes]
 * {beats-ref}/release-notes.html[{beats} release notes]
+
+[[release-notes-7.13.4]]
+== {fleet} and {agent} 7.13.4
+
+There are no bug fixes for {fleet} or {agent} in this release.
+
+[[release-notes-7.13.3]]
+== {fleet} and {agent} 7.13.3
+
+There are no bug fixes for {fleet} or {agent} in this release.
 
 [[release-notes-7.13.2]]
 == {fleet} and {agent} 7.13.2


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Add missing relnotes for 7.13.3 and 7.13.4 (#883)