### PR TITLE
Add note about avoid using leaderelection in large clusters

### DIFF
--- a/docs/en/ingest-management/elastic-agent/running-on-kubernetes-managed-by-fleet.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/running-on-kubernetes-managed-by-fleet.asciidoc
@@ -150,3 +150,13 @@ elastic-agent-olpsd   1/1     Running   0          12m
 
 {agent}s should be enrolled to Fleet and users should be able to deploy the Kubernetes package accordingly.
 This can be confirmed in {kib} under Fleet  / Agents section.
+
+
+[discrete]
+== Deploying {agent} to collect cluster-level metrics in large clusters
+
+The size and the number of nodes in a Kubernetes cluster can be fairly large at times,
+and in such cases the Pod that will be collecting cluster level metrics might face performance
+issues due to resources limitations. In this case users might consider to avoid using the
+leader election strategy and instead run a dedicated, standalone {agent} instance using
+a Deployment in addition to the DaemonSet.

--- a/docs/en/ingest-management/elastic-agent/running-on-kubernetes-standalone.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/running-on-kubernetes-standalone.asciidoc
@@ -161,3 +161,13 @@ the following configuration should be added as an extra input in the Daemonset m
 
 See <<kubernetes-provider,dynamic inputs and kubernetes provider>> for more information
 about shaping dynamic inputs for autodiscovery.
+
+
+[discrete]
+== Deploying {agent} to collect cluster-level metrics in large clusters
+
+The size and the number of nodes in a Kubernetes cluster can be fairly large at times,
+and in such cases the Pod that will be collecting cluster level metrics might face performance
+issues due to resources limitations. In this case users might consider to avoid using the
+leader election strategy and instead run a dedicated, standalone {agent} instance using
+a Deployment in addition to the DaemonSet.


### PR DESCRIPTION
This PR adds a note about avoid using leaderelection in large clusters and instead consider using a Deployment in addition to the Daemonset so as to specify different resources according to the cluster's needs.

We have a similar note for Beats too: https://www.elastic.co/guide/en/beats/metricbeat/7.13/running-on-kubernetes.html#_deploying_metricbeat_to_collect_cluster_level_metrics_in_large_clusters