### PR TITLE
[7.x] small placeholder file and link to git repo api docs (#882)

### DIFF
--- a/docs/en/ingest-management/fleet/fleet-api-docs.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-api-docs.asciidoc
@@ -1,0 +1,8 @@
+[[fleet-api-docs]]
+= {fleet} APIs
+
+{fleet} is fully supported by an API layer. Any actions you can perform
+through the {fleet} UI are also available through the API.
+
+Please refer to the
+https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/fleet/common/openapi/README.md[{fleet} OpenAPI file] in the {kib} repo for more details.

--- a/docs/en/ingest-management/index.asciidoc
+++ b/docs/en/ingest-management/index.asciidoc
@@ -58,3 +58,4 @@ include::faq.asciidoc[leveloffset=+1]
 
 include::release-notes/release-notes-7.13.asciidoc[leveloffset=+1]
 
+include::fleet/fleet-api-docs.asciidoc[leveloffset=+1]


### PR DESCRIPTION
Backports the following commits to 7.x:
 - small placeholder file and link to git repo api docs (#882)