### PR TITLE
Link Fleet Overview to Fleet API Docs page

### DIFF
--- a/docs/en/ingest-management/overview.asciidoc
+++ b/docs/en/ingest-management/overview.asciidoc
@@ -83,8 +83,9 @@ than doing it yourself by using SSH, Ansible playbooks, or some other tool.
 
 If you prefer infrastructure as code, you may use YAML files and APIs.
 {fleet} has an API-first design. Anything you can do in the UI, you
-can also do using the API. This makes it easy to automate and integrate with
-other systems.
+can also do using the {fleet-guide}/fleet-api-docs.html[`API`].
+This makes it easy to automate and integrate with other systems.
+
 
 [discrete]
 [[agent-self-protection]]


### PR DESCRIPTION
one more contribution towards:
https://github.com/elastic/observability-docs/issues/881

just a quick hyperlink addition.  