### PR TITLE
[7.x] Link Fleet Overview to Fleet API Docs page (#903)

### DIFF
--- a/docs/en/ingest-management/overview.asciidoc
+++ b/docs/en/ingest-management/overview.asciidoc
@@ -83,8 +83,9 @@ than doing it yourself by using SSH, Ansible playbooks, or some other tool.
 
 If you prefer infrastructure as code, you may use YAML files and APIs.
 {fleet} has an API-first design. Anything you can do in the UI, you
-can also do using the API. This makes it easy to automate and integrate with
-other systems.
+can also do using the {fleet-guide}/fleet-api-docs.html[`API`].
+This makes it easy to automate and integrate with other systems.
+
 
 [discrete]
 [[agent-self-protection]]


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Link Fleet Overview to Fleet API Docs page (#903)