### PR TITLE
[7.x] example for resetting a package to bring back the dashboard assets (#898)

### DIFF
--- a/docs/en/ingest-management/faq.asciidoc
+++ b/docs/en/ingest-management/faq.asciidoc
@@ -207,7 +207,6 @@ same way as other integrations. Try it out! For more information, see the
 //REVIEWERS: Unsure here whether we want to say Elastic Endpoint or Elastic
 //Security. ^^
 
-
 [discrete]
 [[how-are-agent-kibana-communications-secured]]
 == How are communications secured between {agent} and {kib}?
@@ -227,3 +226,25 @@ and port for your setup. If you run everything locally, the address is
 you can copy the {es} endpoint URL from the overview page of your deployment.
 If you're not running in {ecloud}, make sure the {kib} and {es} HTTPS ports
 are both accessible; by default these are `5601` and `9200` respectively.
+
+[discrete]
+[[how-do-i-reinstall-a-missing-dashboard-asset]]
+== If I delete an integration dashboard asset from {kib}, how do I get it back?
+
+To reinstall the assets for a specific integration, you can use the {fleet} API using the package name and version.
+To reinstall package assets, execute the following call with the `force` parameter in the body:
+
+[source,console]
+----
+POST /api/fleet/epm/packages/[package name]-[package version]
+{ "force": true }
+----
+
+So, for example, to reinstall the system v1.0.0 package, POST:
+[source,console]
+----
+POST /api/fleet/epm/packages/system-1.0.0
+{ "force": true }
+----
+
+The package version is shown in the Integrations view in {kib}.


### PR DESCRIPTION
Backports the following commits to 7.x:
 - example for resetting a package to bring back the dashboard assets (#898)