### PR TITLE
[7.14] Add info about --insecure flag to agent install docs (#902)

### DIFF
--- a/docs/en/ingest-management/elastic-agent/install-elastic-agent.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/install-elastic-agent.asciidoc
@@ -80,6 +80,11 @@ systemd, so use the `enroll` command instead of `install`.
 include::{tab-widgets}/install-widget.asciidoc[]
 --
 +
+TIP: If you see an "x509: certificate signed by unknown authority" error, you
+might be trying to enroll in a {fleet-server} that uses self-signed certs. To
+fix this problem in a non-production environment, pass the `--insecure` flag.
+For more information, refer to the <<agent-enrollment-certs,troubleshooting guide>>.
++
 Refer to <<installation-layout>> for the location of installed {agent} files.
 
 Because {agent} is installed as an auto-starting service, it will restart

--- a/docs/en/ingest-management/getting-started-traces.asciidoc
+++ b/docs/en/ingest-management/getting-started-traces.asciidoc
@@ -87,6 +87,11 @@ in the selected policy, and starts the service. For example:
 ./elastic-agent install -f --url=https://10.0.2.2:8220 \
 --enrollment-token=blJqaUdua0JqYXA0bmNscVVjUkE6ZGh4WWNRSHRRek9aSS1paEs2cHdFQQ==
 ----
++
+TIP: If you see an "x509: certificate signed by unknown authority" error, you
+might be trying to enroll in a {fleet-server} that uses self-signed certs. To
+fix this problem in a non-production environment, pass the `--insecure` flag.
+For more information, refer to the <<agent-enrollment-certs,troubleshooting guide>>.
 
 * Because {agent} is installed as an auto-starting service, it will restart
 automatically if the system is rebooted. 

--- a/docs/en/ingest-management/getting-started.asciidoc
+++ b/docs/en/ingest-management/getting-started.asciidoc
@@ -80,6 +80,11 @@ in the selected policy, and starts the service. For example:
 --enrollment-token=blJqaUdua0JqYXA0bmNscVVjUkE6ZGh4WWNRSHRRek9aSS1paEs2cHdFQQ==
 ----
 +
+TIP: If you see an "x509: certificate signed by unknown authority" error, you
+might be trying to enroll in a {fleet-server} that uses self-signed certs. To
+fix this problem in a non-production environment, pass the `--insecure` flag.
+For more information, refer to the <<agent-enrollment-certs,troubleshooting guide>>.
+
 * Because {agent} is installed as an auto-starting service, it will restart
 automatically if the system is rebooted. 
 

--- a/docs/en/ingest-management/tab-widgets/install.asciidoc
+++ b/docs/en/ingest-management/tab-widgets/install.asciidoc
@@ -34,7 +34,7 @@ sudo systemctl enable elastic-agent <2>
 sudo systemctl start elastic-agent
 ----
 <1> `fleet_server_url` is the host and IP where {fleet-server} is running, and
-`enrollment_token` is the enrollment token acquired from {fleet}. 
+`enrollment_token` is the enrollment token acquired from {fleet}.
 <2> The RPM package includes a service unit for Linux systems with systemd. On
 these systems, you can manage {agent} by using the usual systemd commands. If
 you don't have systemd, run `sudo service elastic-agent start`.
@@ -51,7 +51,7 @@ cd elastic-agent-{version}-darwin-x86_64
 sudo ./elastic-agent install -f --url=<fleet_server_url> --enrollment-token=<enrollment_token> <1> <2>
 ----
 <1> `fleet_server_url` is the host and IP where {fleet-server} is running, and
-`enrollment_token` is the enrollment token acquired from {fleet}. 
+`enrollment_token` is the enrollment token acquired from {fleet}.
 <2> Omit `-f` to run an interactive installation.
 
 // end::mac[]
@@ -66,7 +66,7 @@ cd elastic-agent-{version}-linux-x86_64
 sudo ./elastic-agent install -f --url=<fleet_server_url> --enrollment-token=<enrollment_token> <1> <2> <3>
 ----
 <1> `fleet_server_url` is the host and IP where {fleet-server} is running, and
-`enrollment_token` is the enrollment token acquired from {fleet}. 
+`enrollment_token` is the enrollment token acquired from {fleet}.
 <2> This command requires a system and service manager like systemd.
 <3> Omit `-f` to run an interactive installation.
 
@@ -84,7 +84,7 @@ and run:
 .\elastic-agent.exe install -f --url=<fleet_server_url> --enrollment-token=<enrollment_token> <1> <2>
 ----
 <1> `fleet_server_url` is the host and IP where {fleet-server} is running, and
-`enrollment_token` is the enrollment token acquired from {fleet}. 
+`enrollment_token` is the enrollment token acquired from {fleet}.
 <2> Omit `-f` to run an interactive installation.
 
 // end::win[]

--- a/docs/en/ingest-management/troubleshooting.asciidoc
+++ b/docs/en/ingest-management/troubleshooting.asciidoc
@@ -79,6 +79,41 @@ One of the requests to the {fleet} API will most likely have returned an error. 
 message doesn't give you enough information to fix the problem, please contact us in the {forum}[discuss forum].
 
 [discrete]
+[[agent-enrollment-certs]]
+== {agent} enrollment fails on the host with `x509: certificate signed by unknown authority` message
+
+To ensure that communication with {fleet-server} is encrypted,
+{fleet-server} requires {agent}s to present a signed certificate. In a
+self-managed cluster, if you don't specify certificates when you set up
+{fleet-server}, self-signed certificates are generated automatically.
+
+If you attempt to enroll an {agent} in a {fleet-server} with a self-signed
+certificate, you will encounter the following error:
+
+[source,sh]
+----
+Error: fail to enroll: fail to execute request to fleet-server: x509: certificate signed by unknown authority
+Error: enroll command failed with exit code: 1
+----
+
+To fix this problem, pass the `--insecure` flag along with the `enroll` or
+`install` command. For example:
+
+[source,sh]
+----
+sudo ./elastic-agent install -f --url=https://<fleet-server-ip>:8220 --enrollment-token=<token> --insecure
+----
+
+Traffic between {agent}s and {fleet-server} over HTTPS will be encrypted; you're
+simply acknowledging that you understand that the certificate chain cannot be
+verified.
+
+Allowing {fleet-server} to generate self-signed certificates is useful to get
+things running for development, but not recommended in a production environment.
+
+For more information, refer to <<secure-connections>>.
+
+[discrete]
 [[agent-enrollment-timeout]]
 == {agent} enrollment fails on the host with `Client.Timeout exceeded` message
 
@@ -197,7 +232,7 @@ elastic-agent enroll -f --fleet-server-es=https://<es-url>:443 --fleet-server-se
 ----
 Note: Port `443` is commonly used in {ecloud}. However, with self-managed deployments, your {es} may run on port `9200` or something entirely different.
 
-For information on where to find agent logs, see our <<where-are-the-agent-logs,FAQ>>.
+For information on where to find agent logs, refer to our <<where-are-the-agent-logs,FAQ>>.
 
 [discrete]
 [[agent-healthy-but-no-data-in-es]]
@@ -311,7 +346,7 @@ agent you want to unenroll.
 You may see this error message for a number of different reasons. A common reason is when attempting production-like usage and the ca.crt file passed in cannot be found.  To verify if this is the problem, bootstrap {fleet-server} without passing a ca.crt file. This implies you would test any subsequent
 {agent} installs temporarily with {fleet-sever}'s own self-signed cert.
 
-Tip: Ensure to pass in the full path to the ca.crt file. A relative path is not viable.
+TIP: Ensure to pass in the full path to the ca.crt file. A relative path is not viable.
 
 You will know if your {fleet-server} is set up with its testing oriented self-signed certificate usage,
 when you see the following error during {agent} installs:
@@ -329,6 +364,8 @@ command:
 ----
 sudo ./elastic-agent install -f --url=https://<fleet-server-ip>:8220 --enrollment-token=<token> --insecure
 ----
+
+For more information, refer to <<agent-enrollment-certs>>.
 
 [discrete]
 [[endpoint-not-uninstalled-with-agent]]


### PR DESCRIPTION
Backports the following commits to 7.14:
 - Add info about --insecure flag to agent install docs (#902)