### PR TITLE
[7.x] Mention Elastic Agent monitoring in the Fleet docs (#899)

### DIFF
--- a/docs/en/ingest-management/elastic-agent/install-elastic-agent.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/install-elastic-agent.asciidoc
@@ -88,7 +88,13 @@ automatically if the system is rebooted.
 To confirm that {agent} is installed and running, go to the **Agents** tab in
 {fleet}. 
 
-If you run into problems, see <<fleet-troubleshooting>>.
+If you run into problems:
+
+* Check the {agent} logs. If you use the default policy, agent logs and metrics
+are collected automatically unless you change the default settings. For more
+information, refer to <<elastic-agent-logging>>.
+
+* Refer to <<fleet-troubleshooting>>.
 
 [discrete]
 [[installation-layout]]

--- a/docs/en/ingest-management/getting-started-traces.asciidoc
+++ b/docs/en/ingest-management/getting-started-traces.asciidoc
@@ -103,8 +103,13 @@ image::images/kibana-fleet-agents.png[{fleet} showing enrolled agents]
 TIP: If the status hangs at Enrolling, make sure the `elastic-agent` process
 is running.
 
-If you run into problems, see <<fleet-troubleshooting>>.
+If you run into problems:
 
+* Check the {agent} logs. If you use the default policy, agent logs and metrics
+are collected automatically unless you change the default settings. For more
+information, refer to <<elastic-agent-logging>>.
+
+* Refer to <<fleet-troubleshooting>>. 
 
 [discrete]
 [[add-apm-integration]]

--- a/docs/en/ingest-management/getting-started.asciidoc
+++ b/docs/en/ingest-management/getting-started.asciidoc
@@ -95,8 +95,15 @@ image::images/kibana-fleet-agents.png[{fleet} showing enrolled agents]
 TIP: If the status hangs at Enrolling, make sure the `elastic-agent` process
 is running.
 
-If you run into problems, see <<fleet-troubleshooting>>.
+If you run into problems:
+
+* Check the {agent} logs. If you use the default policy, agent logs and metrics
+are collected automatically unless you change the default settings. For more
+information, refer to <<elastic-agent-logging>>.
+
+* Refer to <<fleet-troubleshooting>>. 
 // end::agent-enroll[]
+
 [discrete]
 [[view-data]]
 == Step 3: Monitor host logs and metrics


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Mention Elastic Agent monitoring in the Fleet docs (#899)