### PR TITLE
[7.x] Remove review comments and add missing support statement (#932)

### DIFF
--- a/docs/en/ingest-management/beats-agent-comparison.asciidoc
+++ b/docs/en/ingest-management/beats-agent-comparison.asciidoc
@@ -1,22 +1,12 @@
 [[beats-agent-comparison]]
 = {beats} and {agent} capabilities
 
-//QUESTION: I think we need a short intro here for new users who don't know
-//about Beats, but might need to consider using it if the service they want to
-//monitor is not yet covered by agent. Is this good enough?
-
 Elastic provides two main ways to send data to {es}:
 
 * *{beats}* are lightweight data shippers that send operational data to
 {es}. Elastic provides separate {beats} for different types of data, such as
 logs, metrics, and uptime. Depending on what data you want to collect, you may
 need to install mutliple shippers on a single host.
-
-//QUESTION: Should I list the Beats by name here? Or maybe describe capabilities:
-//audit data, log files, cloud data, availability, systems journals, metrics,
-//network traffic, and Windows event logs." when written out, it's clear that
-//beats have more functionality right now. That's true, but is that what we
-//want to convey?
 
 * *{agent}* is a single agent for logs, metrics, security data, and threat
 prevention. {agent} supports central management through {fleet}.
@@ -125,7 +115,7 @@ The following table shows the inputs supported by the {agent} in {version}:
 
 |UNIX
 |{y} (beta)
-|NEED INFO HERE
+|{y} (beta)
 |===
 
 [discrete]
@@ -136,8 +126,6 @@ The following table shows the outputs supported by the {agent} in {version}:
 
 
 NOTE: {endpoint-sec} has a different output matrix.
-
-//QUESTION: Is the endpoint matrix available somewhere so that I can point to it?
 
 [options,header]
 |===
@@ -182,11 +170,6 @@ NOTE: {endpoint-sec} has a different output matrix.
 [discrete]
 [[supported-configurations]]
 == Supported configurations
-
-//QUESTION: I've removed the verbs and gerunds from the config description
-//because they made the info harder to scan. I think the verb/gerund is
-//implied by the section title here and not required. Plus the link to the Beats
-//docs removes ambiguities.
 
 [options,header]
 |===


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Remove review comments and add missing support statement (#932)