### PR TITLE
Add capabilities to beats and agent comparison table

### DIFF
--- a/docs/en/ingest-management/beats-agent-comparison.asciidoc
+++ b/docs/en/ingest-management/beats-agent-comparison.asciidoc
@@ -133,7 +133,7 @@ NOTE: {endpoint-sec} has a different output matrix.
 
 |{es} Service
 |{y}
-|{y} only to the same cluster where Fleet runs
+|{y} only to the same cluster where {fleet} runs
 |{y}
 
 |{es}

--- a/docs/en/ingest-management/beats-agent-comparison.asciidoc
+++ b/docs/en/ingest-management/beats-agent-comparison.asciidoc
@@ -167,7 +167,7 @@ NOTE: {endpoint-sec} has a different output matrix.
 |{n}
 |===
 
-Support for outputing to remote {es} clusters in {fleet}-managed agents is under consideration for a future release.
+Currently, {agent}s managed by Fleet can only output to the same {es} cluster where {fleet} is running. Support for outputting to remote {es} clusters is under consideration for a future release.
 
 [discrete]
 [[supported-configurations]]

--- a/docs/en/ingest-management/beats-agent-comparison.asciidoc
+++ b/docs/en/ingest-management/beats-agent-comparison.asciidoc
@@ -244,7 +244,7 @@ per output type, which enables loadbalancing.
 [[additional-capabilties-beats-and-agent]]
 == Additional capabilities
 
-The following table shows the additional capabilties supported by Beats and the {agent} in {version}:
+The following table shows the additional capabilities supported by {beats} and the {agent} in {version}:
 
 
 [options,header]

--- a/docs/en/ingest-management/beats-agent-comparison.asciidoc
+++ b/docs/en/ingest-management/beats-agent-comparison.asciidoc
@@ -133,12 +133,12 @@ NOTE: {endpoint-sec} has a different output matrix.
 
 |{es} Service
 |{y}
-|{y}
+|{y} only to the same cluster where Fleet runs
 |{y}
 
 |{es}
 |{y}
-|{y}
+|{y} only to the same cluster where Fleet runs
 |{y}
 
 |{ls}
@@ -166,6 +166,8 @@ NOTE: {endpoint-sec} has a different output matrix.
 |{n}
 |{n}
 |===
+
+Support for outputing to remote {es} clusters in {fleet}-managed agents is under consideration for a future release.
 
 [discrete]
 [[supported-configurations]]
@@ -217,7 +219,7 @@ configuration experience.
 |Processors can be defined at the integration level.
 
 |{filebeat-ref}/configuration-autodiscover.html[Autodiscover]
-|Autodiscover is facilitated through <<dynamic-input-configuration,dynamic inputs>>
+|Autodiscover is facilitated through <<dynamic-input-configuration,dynamic inputs>>. Elastic Agent does not support hints-based autodiscovery.
 
 |{filebeat-ref}/configuring-internal-queue.html[Internal queues]
 |{agent} does not expose the internal memory queues to the end user. You can
@@ -237,6 +239,106 @@ per output type, which enables loadbalancing.
 |{filebeat-ref}/regexp-support.html[Regular expressions]
 |Supported
 |===
+
+[discrete]
+[[additional-capabilties-beats-and-agent]]
+== Additional capabilities
+
+The following table shows the additional capabilties supported by Beats and the {agent} in {version}:
+
+
+[options,header]
+|===
+|Item |Beats |{fleet}-managed {agent} |Standalone {agent}
+
+|Single agent for all use cases
+|{n}
+|{y}
+|{y}
+
+|Install integrations from Kibana UI or API
+|{n}
+|{y}
+|{y}
+
+|Configure from integrations UI
+|{n}
+|{y}
+|{y} (optional)
+
+|Central, remote agent policy management
+|{n}
+|{y}
+|{n}
+
+|Central, remote agent binary upgrades
+|{n}
+|{y}
+|{n}
+
+|Choose which module or integration assets to add
+|{n}
+|{y}
+|{y}
+
+|Auto-generated ES API keys
+|{n}
+|{y}
+|{n}
+
+|Auto-generate minimal ES privileges on the edge
+|{n}
+|{y}
+|{y} (when using Integrations UI)
+
+|Data streams support
+|{n}
+|{y}
+|{y}
+
+|Variables and input conditions
+|{n}
+|{y}
+|{y}
+
+|Requires superuser role
+|{n}
+|{y}
+|{n} (required to use integrations UI)
+
+|Air-gapped network support
+|{y}
+|{n}
+|{y}
+
+|Run without root on host
+|{y}
+|{n}
+|{y}
+
+|Mulitple outputs
+|{y}
+|{n}
+|{y}
+
+|Separate monitoring cluster 
+|{y}
+|{n}
+|{y}
+
+|Keystore for secrets
+|{y}
+|{n}
+|{n}
+
+|Cloned machine images or virtual desktops
+|{y}
+|{n}
+|{n}
+
+|===
+
+Also, both Beats and {agent} standalone work well with version control, IaaC, and change management processes because the configuration is a simple text file. {fleet} only supports these processes through its REST API.
 
 [discrete]
 [[agent-monitoring-support]]

--- a/docs/en/ingest-management/beats-agent-comparison.asciidoc
+++ b/docs/en/ingest-management/beats-agent-comparison.asciidoc
@@ -138,7 +138,7 @@ NOTE: {endpoint-sec} has a different output matrix.
 
 |{es}
 |{y}
-|{y} only to the same cluster where Fleet runs
+|{y} only to the same cluster where {fleet} runs
 |{y}
 
 |{ls}

--- a/docs/en/ingest-management/beats-agent-comparison.asciidoc
+++ b/docs/en/ingest-management/beats-agent-comparison.asciidoc
@@ -338,7 +338,7 @@ The following table shows the additional capabilties supported by Beats and the 
 
 |===
 
-Also, both Beats and {agent} standalone work well with version control, IaaC, and change management processes because the configuration is a simple text file. {fleet} only supports these processes through its REST API.
+Also, both {beats} and {agent} standalone work well with version control, IaaC, and change management processes because the configuration is a simple text file. {fleet} only supports these processes through its REST API.
 
 [discrete]
 [[agent-monitoring-support]]
@@ -364,4 +364,3 @@ The *[Elastic Agent] Agent metrics* dashboard shows an aggregated view of agent 
 
 [role="screenshot"]
 image::images/agent-metrics-dashboard.png[Screen capture showing Elastic Agent metrics]
-

--- a/docs/en/ingest-management/beats-agent-comparison.asciidoc
+++ b/docs/en/ingest-management/beats-agent-comparison.asciidoc
@@ -249,7 +249,7 @@ The following table shows the additional capabilities supported by {beats} and t
 
 [options,header]
 |===
-|Item |Beats |{fleet}-managed {agent} |Standalone {agent}
+|Item |{beats} |{fleet}-managed {agent} |Standalone {agent}
 
 |Single agent for all use cases
 |{n}

--- a/docs/en/ingest-management/beats-agent-comparison.asciidoc
+++ b/docs/en/ingest-management/beats-agent-comparison.asciidoc
@@ -219,7 +219,7 @@ configuration experience.
 |Processors can be defined at the integration level.
 
 |{filebeat-ref}/configuration-autodiscover.html[Autodiscover]
-|Autodiscover is facilitated through <<dynamic-input-configuration,dynamic inputs>>. Elastic Agent does not support hints-based autodiscovery.
+|Autodiscover is facilitated through <<dynamic-input-configuration,dynamic inputs>>. {agent} does not support hints-based autodiscovery.
 
 |{filebeat-ref}/configuring-internal-queue.html[Internal queues]
 |{agent} does not expose the internal memory queues to the end user. You can

--- a/docs/en/ingest-management/beats-agent-comparison.asciidoc
+++ b/docs/en/ingest-management/beats-agent-comparison.asciidoc
@@ -261,7 +261,7 @@ The following table shows the additional capabilities supported by {beats} and t
 |{y}
 |{y}
 
-|Configure from integrations UI
+|Configure from Integrations UI
 |{n}
 |{y}
 |{y} (optional)

--- a/docs/en/ingest-management/beats-agent-comparison.asciidoc
+++ b/docs/en/ingest-management/beats-agent-comparison.asciidoc
@@ -255,7 +255,7 @@ The following table shows a comparison of capabilities supported by {beats} and 
 |{n}
 |{y}
 |{y}
-|{agent} provides logs, metrics and more. You'd need to install multiple {beats} for these use cases.
+|{agent} provides logs, metrics, and more. You'd need to install multiple {beats} for these use cases.
 
 |Install integrations from web UI or API
 |{n}
@@ -267,7 +267,7 @@ The following table shows a comparison of capabilities supported by {beats} and 
 |{n}
 |{y}
 |{y} (optional)
-|{fleet}-managed {agent} integrations can be configured in the web UI or API. Standalone {agent} can use the web UI, API, or YAML. {beats} can only be configured via YAML file.
+|{fleet}-managed {agent} integrations can be configured in the web UI or API. Standalone {agent} can use the web UI, API, or YAML. {beats} can only be configured via YAML files.
 
 |Central, remote agent policy management
 |{n}
@@ -291,7 +291,7 @@ The following table shows a comparison of capabilities supported by {beats} and 
 |{n}
 |{y}
 |{n}
-|{fleet} can automatically generate API keys with limited permissions for each {agent}, which can be individually revoked. Standalone {agent} and {beats} requires you to create and manage credentials, and users often share them across hosts.
+|{fleet} can automatically generate API keys with limited permissions for each {agent}, which can be individually revoked. Standalone {agent} and {beats} require you to create and manage credentials, and users often share them across hosts.
 
 |Auto-generate minimal {es} permissions
 |{n}
@@ -309,7 +309,7 @@ The following table shows a comparison of capabilities supported by {beats} and 
 |{n}
 |{y} (limited)
 |{y}
-|{agent} offers {fleet-guide}/dynamic-input-configuration.html[variables and input conditions] to dynamically adjust based on the local host environment. Users can configure these directly in YAML for standalone {agent} or using the Fleet API for {fleet}-managed {agent}. The Integrations app allows users to enter variables and we are considering a https://github.com/elastic/kibana/issues/108525[UI to edit conditions]. {beats} only offers static configuration.
+|{agent} offers {fleet-guide}/dynamic-input-configuration.html[variables and input conditions] to dynamically adjust based on the local host environment. Users can configure these directly in YAML for standalone {agent} or using the Fleet API for {fleet}-managed {agent}. The Integrations app allows users to enter variables, and we are considering a https://github.com/elastic/kibana/issues/108525[UI to edit conditions]. {beats} only offers static configuration.
 
 |Allow non-superusers to manage assets and agents
 |{y}

--- a/docs/en/ingest-management/beats-agent-comparison.asciidoc
+++ b/docs/en/ingest-management/beats-agent-comparison.asciidoc
@@ -321,7 +321,7 @@ The following table shows the additional capabilities supported by {beats} and t
 |{y}
 |{n}
 |{y}
-|The Integrations app requires a network connection to the https://www.elastic.co/guide/en/fleet/current/fleet-overview.html#package-registry-intro[Elastic Package Registry]. We are considering an https://github.com/elastic/integrations/issues/1178[offline version]. This is not required for standalone {agent}s or {beats}. 
+|The Integrations app requires a network connection to the https://www.elastic.co/guide/en/fleet/current/fleet-overview.html#package-registry-intro[Elastic Package Registry]. We are considering an https://github.com/elastic/integrations/issues/1178[on-prem version of EPR]. {fleet}-managed {agent}s require a connection to our artifact repository for agent binary upgrades. These are not required for standalone {agent}s or {beats}. 
 
 |Run without root on host
 |{y}

--- a/docs/en/ingest-management/beats-agent-comparison.asciidoc
+++ b/docs/en/ingest-management/beats-agent-comparison.asciidoc
@@ -335,11 +335,11 @@ The following table shows a comparison of capabilities supported by {beats} and 
 |{y}
 |{fleet}-managed {agent}s require root permission, in particular for Endpoint Security. Standalone {agent}s and {beats} do not.
 
-|Mulitple outputs
+|Multiple outputs
 |{y}
 |{n}
 |{y}
-|{fleet}-managed {agent}s only provide a single global output to the same {es} cluster where {fleet} is running. We are considering support for https://github.com/elastic/kibana/issues/104980[more outputs].
+|{fleet}-managed {agent}s only provide a <<elastic-agent-output-configuration,single global output>> to the same {es} cluster where {fleet} is running. We are considering support for https://github.com/elastic/kibana/issues/104980[more outputs].
 
 |Separate monitoring cluster
 |{y}

--- a/docs/en/ingest-management/beats-agent-comparison.asciidoc
+++ b/docs/en/ingest-management/beats-agent-comparison.asciidoc
@@ -301,10 +301,10 @@ The following table shows the additional capabilities supported by {beats} and t
 |{y}
 |{y}
 
-|Requires superuser role
+|Requires superuser role to add integrations and agent polices
 |{n}
-|{y}
-|{n} (required to use Integrations UI)
+|{y} 
+|{n} (it's optional to use the Integrations UI)
 
 |Air-gapped network support
 |{y}

--- a/docs/en/ingest-management/beats-agent-comparison.asciidoc
+++ b/docs/en/ingest-management/beats-agent-comparison.asciidoc
@@ -304,7 +304,7 @@ The following table shows the additional capabilities supported by {beats} and t
 |Requires superuser role
 |{n}
 |{y}
-|{n} (required to use integrations UI)
+|{n} (required to use Integrations UI)
 
 |Air-gapped network support
 |{y}

--- a/docs/en/ingest-management/beats-agent-comparison.asciidoc
+++ b/docs/en/ingest-management/beats-agent-comparison.asciidoc
@@ -309,7 +309,7 @@ The following table shows the additional capabilities supported by {beats} and t
 |{n}
 |{y} (limited)
 |{y}
-|{agent} offers https://www.elastic.co/guide/en/fleet/current/dynamic-input-configuration.html[variables and input conditions] to dynamically adjust based on the local host environment. The Integrations app allows users to enter variables and we are considering a https://github.com/elastic/obs-dc-team/issues/567[UI to edit conditions]. {beats} only offers static configuration.
+|{agent} offers https://www.elastic.co/guide/en/fleet/current/dynamic-input-configuration.html[variables and input conditions] to dynamically adjust based on the local host environment. The Integrations app allows users to enter variables and we are considering a https://github.com/elastic/kibana/issues/108525[UI to edit conditions]. {beats} only offers static configuration.
 
 |Allow non-superusers to manage assets and agents
 |{y}
@@ -363,7 +363,7 @@ The following table shows the additional capabilities supported by {beats} and t
 |{y}
 |{n} (only via API)
 |{y}
-|{fleet} offers support for externally managed policies through it's REST API and we are considering https://github.com/elastic/observability-dev/issues/1627[improved support]. Both {agent} standalone and {beats} offer a simple text file configuration, so you can more easily implement these processes in third party solutions.
+|{fleet} offers support for externally managed policies through it's REST API and we are considering https://github.com/elastic/kibana/issues/108524[improved support]. Both {agent} standalone and {beats} offer a simple text file configuration, so you can more easily implement these processes in third party solutions.
 
 |Multiple configurations
 |{y}

--- a/docs/en/ingest-management/beats-agent-comparison.asciidoc
+++ b/docs/en/ingest-management/beats-agent-comparison.asciidoc
@@ -29,7 +29,7 @@ For {agent}s that are centrally managed by {fleet}, data collection is
 further simplified and defined by integrations. In this model, the decision on
 the inputs is driven by the integration you want to collect data from. The
 complexity of configuration details of various inputs is driven centrally by
-{fleet} and specifically by the integrations. 
+{fleet} and specifically by the integrations.
 
 The following table shows the inputs supported by the {agent} in {version}:
 
@@ -242,9 +242,9 @@ per output type, which enables loadbalancing.
 
 [discrete]
 [[additional-capabilties-beats-and-agent]]
-== Additional capabilities
+== Capabilities comparison
 
-The following table shows the additional capabilities supported by {beats} and the {agent} in {version}:
+The following table shows a comparison of capabilities supported by {beats} and the {agent} in {version}:
 
 
 [options,header]
@@ -255,37 +255,37 @@ The following table shows the additional capabilities supported by {beats} and t
 |{n}
 |{y}
 |{y}
-|{agent} provides logs, metrics and more. You'd need to install mulitple {beats} for these use cases.
+|{agent} provides logs, metrics and more. You'd need to install multiple {beats} for these use cases.
 
 |Install integrations from web UI or API
 |{n}
 |{y}
 |{y}
-|{agent} integrations are installed in a convenient web UI or API, but {beat}s modules are installed in a CLI. These installs ES assets such as index templates and ingest pipelines, and Kibana assets such as dashboards.
+|{agent} integrations are installed in a convenient web UI or API, but {beats} modules are installed in a CLI. This installs {es} assets such as index templates and ingest pipelines, and {kib} assets such as dashboards.
 
 |Configure from web UI or API
 |{n}
 |{y}
 |{y} (optional)
-|{fleet}-managed {agent} integrations can be configured in the web UI or API. Standalone {agent} can use the web UI, API or YAML. {beats} can only configured via YAML file.
+|{fleet}-managed {agent} integrations can be configured in the web UI or API. Standalone {agent} can use the web UI, API, or YAML. {beats} can only be configured via YAML file.
 
 |Central, remote agent policy management
 |{n}
 |{y}
 |{n}
-|{agent} policies can be centrally managed thorugh {fleet}. You have to manage {beats} configuration yourself or with a third party solution.
+|{agent} policies can be centrally managed through {fleet}. You have to manage {beats} configuration yourself or with a third-party solution.
 
 |Central, remote agent binary upgrades
 |{n}
 |{y}
 |{n}
-|{agent}s can be remotely upgraded through {fleet}. You have to upgrade {beats} yourself or with a third party solution.
+|{agent}s can be remotely upgraded through {fleet}. You have to upgrade {beats} yourself or with a third-party solution.
 
-|Add {kibana} and {es} assets for a single integration or module
+|Add {kib} and {es} assets for a single integration or module
 |{n}
 |{y}
 |{y}
-|{agent} integrations allow you to add {kibana} and {es} assets for a single integration at a time. {beats} installs hundreds of assets for all modules at once.
+|{agent} integrations allow you to add {kib} and {es} assets for a single integration at a time. {beats} installs hundreds of assets for all modules at once.
 
 |Auto-generated {es} API keys
 |{n}
@@ -297,31 +297,31 @@ The following table shows the additional capabilities supported by {beats} and t
 |{n}
 |{y}
 |{n}
-|{fleet} can automatically give {agent}s minimal output permissions based on the inputs running. With standalone {agent} and {beats}, users often give overly broad permissions because its more convenient.
+|{fleet} can automatically give {agent}s minimal output permissions based on the inputs running. With standalone {agent} and {beats}, users often give overly broad permissions because it's more convenient.
 
 |Data streams support
 |{n}
 |{y}
 |{y}
-|{agent}s use https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html[data streams] with easier index life cycle management and the https://www.elastic.co/blog/an-introduction-to-the-elastic-data-stream-naming-scheme[data stream naming scheme]. {beats} uses a single index with potentially thousands of fields.
+|{agent}s use {ref}/data-streams.html[data streams] with easier index life cycle management and the https://www.elastic.co/blog/an-introduction-to-the-elastic-data-stream-naming-scheme[data stream naming scheme]. {beats} uses a single index with potentially thousands of fields.
 
 |Variables and input conditions
 |{n}
 |{y} (limited)
 |{y}
-|{agent} offers https://www.elastic.co/guide/en/fleet/current/dynamic-input-configuration.html[variables and input conditions] to dynamically adjust based on the local host environment. Users can configure these directly in YAML for standalone {agent} or using the Fleet API for {fleet}-managed {agent}. The Integrations app allows users to enter variables and we are considering a https://github.com/elastic/kibana/issues/108525[UI to edit conditions]. {beats} only offers static configuration.
+|{agent} offers {fleet-guide}/dynamic-input-configuration.html[variables and input conditions] to dynamically adjust based on the local host environment. Users can configure these directly in YAML for standalone {agent} or using the Fleet API for {fleet}-managed {agent}. The Integrations app allows users to enter variables and we are considering a https://github.com/elastic/kibana/issues/108525[UI to edit conditions]. {beats} only offers static configuration.
 
 |Allow non-superusers to manage assets and agents
 |{y}
 |{n}
 |{y} (it's optional)
-|We require a superuser role to use the {fleet} and Integrations apps and cooresponding APIs. We are considering https://github.com/elastic/kibana/issues/108252[changing] this requirement. These apps are optional for standalone {agent}. {beats} offers https://www.elastic.co/guide/en/beats/filebeat/current/feature-roles.html[finer grained] roles.
+|We require a superuser role to use the {fleet} and Integrations apps and corresponding APIs. We are considering https://github.com/elastic/kibana/issues/108252[changing] this requirement. These apps are optional for standalone {agent}. {beats} offers {filebeat-ref}/feature-roles.html[finer grained] roles.
 
 |Air-gapped network support
 |{y}
 |{n}
 |{y}
-|The Integrations app requires a network connection to the https://www.elastic.co/guide/en/fleet/current/fleet-overview.html#package-registry-intro[Elastic Package Registry]. We are considering an https://github.com/elastic/integrations/issues/1178[on-prem version of EPR]. {fleet}-managed {agent}s require a connection to our artifact repository for agent binary upgrades. These are not required for standalone {agent}s or {beats}. 
+|The Integrations app requires a network connection to the {fleet-guide}/fleet-overview.html#package-registry-intro[Elastic Package Registry]. We are considering an https://github.com/elastic/integrations/issues/1178[on-prem version of EPR]. {fleet}-managed {agent}s require a connection to our artifact repository for agent binary upgrades. These are not required for standalone {agent}s or {beats}.
 
 |Run without root on host
 |{y}
@@ -333,25 +333,19 @@ The following table shows the additional capabilities supported by {beats} and t
 |{y}
 |{n}
 |{y}
-|{fleet}-managed {agent}s only provide a single global output to the same {es} cluster where {fleet} is running. We are considering support for https://github.com/elastic/kibana/issues/104980[more outputs]. Standalone {agent} and {beats} can send to mulitple outputs.
+|{fleet}-managed {agent}s only provide a single global output to the same {es} cluster where {fleet} is running. We are considering support for https://github.com/elastic/kibana/issues/104980[more outputs].
 
-|Separate monitoring cluster 
+|Separate monitoring cluster
 |{y}
 |{n}
 |{y}
 |{fleet}-managed {agent}s only provide a single global output to the same {es} cluster where {fleet} is running. We are considering support for https://github.com/elastic/kibana/issues/104980[remote monitoring clusters]. Standalone {agent} and {beats} can send to a remote monitoring cluster.
 
-|Keystore for secrets
+|Secret management
 |{y}
 |{n}
 |{n}
-|{agent} stores credentials in the agent policy. We are considering adding https://github.com/elastic/integrations/issues/244[keystore support]. {beats} allows users to access credentials in a local https://www.elastic.co/guide/en/beats/filebeat/current/keystore.html[keystore]. 
-
-|Cloned machine images or virtual desktops
-|{y}
-|{n}
-|{n}
-|{agent} may not work well with cloned images because it may lead to duplicate IDs, and we are considering a https://github.com/elastic/beats/issues/22281[solution]. {beats} do not have unique IDs.
+|{agent} stores credentials in the agent policy. We are considering adding https://github.com/elastic/integrations/issues/244[keystore support]. {beats} allows users to access credentials in a local https://www.elastic.co/guide/en/beats/filebeat/current/keystore.html[keystore].
 
 |Progressive or canary deployments
 |{y}
@@ -359,17 +353,18 @@ The following table shows the additional capabilities supported by {beats} and t
 |{y}
 |{fleet} does not have a feature to deploy an {agent} policy update progressively but we are considering https://github.com/elastic/kibana/issues/108267[improved support]. With standalone {agent} and {beats} you can deploy configuration files progressively using third party solutions.
 
-|Version control, change management, rollback, and infrastructure as code
-|{y}
-|{n} (only via API)
-|{y}
-|{fleet} offers support for externally managed policies through it's REST API and we are considering https://github.com/elastic/kibana/issues/108524[improved support]. Both standalone {agent} and {beats} offer a simple text file configuration, so you can more easily implement these processes in third party solutions.
-
 |Multiple configurations per host
 |{y}
 |{n} (uses input conditions instead)
 |{n} (uses input conditions instead)
-|{agent} uses a single {agent} policy for configuration, and uses https://www.elastic.co/guide/en/fleet/current/dynamic-input-configuration.html[variables and input conditions] to adapt on a per-host basis. {beats} supports multiple configuration files per host, enabling third party solutions to deploy files hierarchically or in multiple groups, and enabling finer-grained access control to those files.
+|{agent} uses a single {agent} policy for configuration, and uses {fleet-guide}/dynamic-input-configuration.html[variables and input conditions] to adapt on a per-host basis. {beats} supports multiple configuration files per host, enabling third party solutions to deploy files hierarchically or in multiple groups, and enabling finer-grained access control to those files.
+
+|Compatible with version control and infrastructure as code solutions
+|{y}
+|{n} (only via API)
+|{y}
+|{fleet} stores the agent policy in {es}. It does not integrate with external version control or infrastructure as code solutions, but we are considering https://github.com/elastic/kibana/issues/108524[improved support]. However, {beats} and {agent} in standalone mode use a YAML file that is compatible with these solutions.
+
 
 |===
 

--- a/docs/en/ingest-management/beats-agent-comparison.asciidoc
+++ b/docs/en/ingest-management/beats-agent-comparison.asciidoc
@@ -167,7 +167,7 @@ NOTE: {endpoint-sec} has a different output matrix.
 |{n}
 |===
 
-Currently, {agent}s managed by Fleet can only output to the same {es} cluster where {fleet} is running. Support for outputting to remote {es} clusters is under consideration for a future release.
+Currently, {agent}s managed by {fleet} can only output to the same {es} cluster where {fleet} is running. Support for outputting to remote {es} clusters is under consideration for a future release.
 
 [discrete]
 [[supported-configurations]]
@@ -249,96 +249,123 @@ The following table shows the additional capabilities supported by {beats} and t
 
 [options,header]
 |===
-|Item |{beats} |{fleet}-managed {agent} |Standalone {agent}
+|Item |{beats} |{fleet}-managed {agent} |Standalone {agent} |Description
 
 |Single agent for all use cases
 |{n}
 |{y}
 |{y}
+|{agent} provides logs, metrics and more. You'd need to install mulitple {beats} for these use cases.
 
-|Install integrations from Kibana UI or API
+|Install integrations from web UI or API
 |{n}
 |{y}
 |{y}
+|{agent} integrations are installed in a convenient web UI or API, but {beat}s modules are installed in a CLI. These installs ES assets such as index templates and ingest pipelines, and Kibana assets such as dashboards.
 
-|Configure from Integrations UI
+|Configure from web UI or API
 |{n}
 |{y}
 |{y} (optional)
+|{agent} integrations can be configured in the web UI or API. Standalone {agent} can use the web UI, API or YAML. {beats} can only configured via YAML file.
 
 |Central, remote agent policy management
 |{n}
 |{y}
 |{n}
+|{agent} policies can be centrally managed thorugh {fleet}. You have to manage {beats} configuration yourself or with a third party solution.
 
 |Central, remote agent binary upgrades
 |{n}
 |{y}
 |{n}
+|{agent}s can be remotely upgraded through {fleet}. You have to upgrade {beats} yourself or with a third party solution.
 
 |Choose which module or integration assets to add
 |{n}
 |{y}
 |{y}
+|Integrations allow you to choose which assets to add. {beats} installs hundreds of assets for all modules at once.
 
 |Auto-generated {es} API keys
 |{n}
 |{y}
 |{n}
+|{fleet} can automatically generate API keys with limited permissions for each {agent}, which can be individually revoked. {beats} requires you to create and manage credentials, and users often share them across hosts.
 
-|Auto-generate minimal {es} privileges on the edge
+|Auto-generate minimal {es} permissions
 |{n}
 |{y}
-|{y} (when using Integrations UI)
+|{n}
+|{fleet} can automatically give {agent}s minimal output permissions based on the inputs running. With {beats}, users often give broad permissions due to convenience.
 
 |Data streams support
 |{n}
 |{y}
 |{y}
+|{agent}s use https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html[data streams] with easier index life cycle management and the https://www.elastic.co/blog/an-introduction-to-the-elastic-data-stream-naming-scheme[data stream naming scheme]. {beats} uses a single index with potentially thousands of fields.
 
 |Variables and input conditions
 |{n}
+|{y} (limited)
 |{y}
-|{y}
+|{agent} offers https://www.elastic.co/guide/en/fleet/current/dynamic-input-configuration.html[variables and input conditions] to dynamically adjust based on the local host environment. The Integrations app allows users to enter variables and we are considering a https://github.com/elastic/obs-dc-team/issues/567[UI to edit conditions]. {beats} only offers static configuration.
 
 |Requires superuser role to add integrations and agent polices
 |{n}
-|{y} 
-|{n} (it's optional to use the Integrations UI)
+|{y}
+|{n} (it's optional)
+|{fleet}-managed {agent}s require a superuser role for the {fleet} and Integrations apps. We are considering https://github.com/elastic/kibana/issues/108252[changing] this requirement. These apps are optional for standalone agents. {beats} offers https://www.elastic.co/guide/en/beats/filebeat/current/feature-roles.html[finer grained] roles.
 
 |Air-gapped network support
 |{y}
 |{n}
 |{y}
+|The Integrations app requires a network connection to the https://www.elastic.co/guide/en/fleet/current/fleet-overview.html#package-registry-intro[Elastic Package Registry]. We are considering an https://github.com/elastic/integrations/issues/1178[offline version]. This is not required for standalone {agent}s or {beats}. 
 
 |Run without root on host
 |{y}
 |{n}
 |{y}
+|{fleet}-managed {agent}s require root permission, in particular for Endpoint Security. Standalone {agent}s and {beats} do not.
 
 |Mulitple outputs
 |{y}
 |{n}
 |{y}
+|{fleet} only supports output to {es} where {fleet} is running so it can generate API keys. We are considering support for https://github.com/elastic/kibana/issues/104980[more outputs]. Standalone {agent} and {beats} can send to mulitple outputs.
 
 |Separate monitoring cluster 
 |{y}
 |{n}
 |{y}
+|{fleet} only supports output to {es} where {fleet} is running so it can generate API keys. We are considering support for https://github.com/elastic/kibana/issues/104980[remote monitoring clusters]. Standalone {agent} and {beats} can send to a remote monitoring cluster.
 
 |Keystore for secrets
 |{y}
 |{n}
 |{n}
+|{agent} stores credentials in the agent policy. We are considering adding https://github.com/elastic/integrations/issues/244[keystore support]. {beats} allows users to access credentials in a local https://www.elastic.co/guide/en/beats/filebeat/current/keystore.html[keystore]. 
 
 |Cloned machine images or virtual desktops
 |{y}
 |{n}
 |{n}
+|{agent} may not work well with cloned images because it may lead to duplicate IDs, and we are considering a https://github.com/elastic/beats/issues/22281[solution]. {beats} do not have unique IDs.
+
+|Progressive or canary deployments
+|{y}
+|{n}
+|{y}
+|{fleet} does not have a feature to deploy a policy update progressively but we are considering https://github.com/elastic/kibana/issues/108267[improved support]. With standalone {agent} and {beats} you can deploy configuration files progressively using third party solutions.
+
+|Version control, change management, rollback, and infrastructure as code
+|{y}
+|{n} (only via API)
+|{y}
+|{fleet} offers support for externally managed policies through it's REST API and we are considering https://github.com/elastic/observability-dev/issues/1627[improved support]. Both {agent} standalone and {beats} offer a simple text file configuration, so you can more easily implement these processes in third party solutions.
 
 |===
-
-Also, both {beats} and {agent} standalone work well with version control, IaaC, and change management processes because the configuration is a simple text file. {fleet} only supports these processes through its REST API.
 
 [discrete]
 [[agent-monitoring-support]]

--- a/docs/en/ingest-management/beats-agent-comparison.asciidoc
+++ b/docs/en/ingest-management/beats-agent-comparison.asciidoc
@@ -6,10 +6,10 @@ Elastic provides two main ways to send data to {es}:
 * *{beats}* are lightweight data shippers that send operational data to
 {es}. Elastic provides separate {beats} for different types of data, such as
 logs, metrics, and uptime. Depending on what data you want to collect, you may
-need to install mutliple shippers on a single host.
+need to install multiple shippers on a single host.
 
 * *{agent}* is a single agent for logs, metrics, security data, and threat
-prevention. The Elastic Agent can be deployed in two differing modes:
+prevention. The Elastic Agent can be deployed in two different modes:
 
 ** *Managed by {fleet}* -- easily deploy services with the {fleet} UI.
 Once installed, the {agent} lifecycle and policy/configuration is managed from a central point.

--- a/docs/en/ingest-management/beats-agent-comparison.asciidoc
+++ b/docs/en/ingest-management/beats-agent-comparison.asciidoc
@@ -41,85 +41,105 @@ The following table shows the inputs supported by the {agent} in {version}:
 
 [options,header]
 |===
-|Input |{beats} support |{agent} support
+|Input |Beats |{fleet}-managed {agent} |Standalone {agent}
 
 |AWS CloudWatch
+|{y} (beta)
 |{y} (beta)
 |{y} (beta)
 
 |AWS S3
 |{y}
 |{y}
+|{y}
 
 |Azure Event Hub
+|{y}
 |{y}
 |{y}
 
 |Cloud Foundry
 |{y}
 |{n}
+|{y}
 
 |Container
 |{y}
 |{n}
+|{y}
 
 |Docker
 |{y}
 |{n}
+|{y}
 
 |GCP Pub/Sub
+|{y}
 |{y}
 |{y}
 
 |HTTP Endpoint
 |{y} (beta)
 |{y} (beta)
+|{y} (beta)
 
 |HTTP JSON
+|{y}
 |{y}
 |{y}
 
 |Kafka
 |{y}
 |{n}
+|{y}
 
 |Logfile
+|{y}
 |{y}
 |{y}
 
 |MQTT
 |{y}
 |{n}
+|{y}
 
 |NetFlow
+|{y}
 |{y}
 |{y}
 
 |O365 Mgmt Act API
 |{y} (beta)
 |{y} (beta)
+|{y} (beta)
 
 |Redis
 |{y} (beta)
 |{n}
+|{y} (beta)
 
 |Stdin
 |{y}
 |{n}
+|{y}
 
 |Syslog
+|{y}
 |{y}
 |{y}
 
 |TCP
 |{y}
 |{y}
+|{y}
 
 |UDP
 |{y}
 |{y}
+|{y}
 
 |UNIX
+|{y} (beta)
 |{y} (beta)
 |{y} (beta)
 |===

--- a/docs/en/ingest-management/beats-agent-comparison.asciidoc
+++ b/docs/en/ingest-management/beats-agent-comparison.asciidoc
@@ -311,11 +311,11 @@ The following table shows the additional capabilities supported by {beats} and t
 |{y}
 |{agent} offers https://www.elastic.co/guide/en/fleet/current/dynamic-input-configuration.html[variables and input conditions] to dynamically adjust based on the local host environment. The Integrations app allows users to enter variables and we are considering a https://github.com/elastic/obs-dc-team/issues/567[UI to edit conditions]. {beats} only offers static configuration.
 
-|Requires superuser role to add integrations and agent polices
-|{n}
+|Allow non-superusers to manage assets and agents
 |{y}
-|{n} (it's optional)
-|{fleet}-managed {agent}s require a superuser role for the {fleet} and Integrations apps. We are considering https://github.com/elastic/kibana/issues/108252[changing] this requirement. These apps are optional for standalone agents. {beats} offers https://www.elastic.co/guide/en/beats/filebeat/current/feature-roles.html[finer grained] roles.
+|{n}
+|{y} (it's optional)
+|{fleet}-managed {agent}s require a superuser role to use {fleet} and Integrations. We are considering https://github.com/elastic/kibana/issues/108252[changing] this requirement. These apps are optional for standalone agents. {beats} offers https://www.elastic.co/guide/en/beats/filebeat/current/feature-roles.html[finer grained] roles.
 
 |Air-gapped network support
 |{y}
@@ -364,6 +364,12 @@ The following table shows the additional capabilities supported by {beats} and t
 |{n} (only via API)
 |{y}
 |{fleet} offers support for externally managed policies through it's REST API and we are considering https://github.com/elastic/observability-dev/issues/1627[improved support]. Both {agent} standalone and {beats} offer a simple text file configuration, so you can more easily implement these processes in third party solutions.
+
+|Multiple configurations
+|{y}
+|{n}
+|{n}
+|{agent} uses a single agent policy for configuration, and uses https://www.elastic.co/guide/en/fleet/current/dynamic-input-configuration.html[variables and input conditions] to adapt to each host's local environment. {beats} offers support for mulitple configuration files, which offers more flexibility in assigning agent's to multiple groups and controlling access in third party solutions.
 
 |===
 

--- a/docs/en/ingest-management/beats-agent-comparison.asciidoc
+++ b/docs/en/ingest-management/beats-agent-comparison.asciidoc
@@ -267,7 +267,7 @@ The following table shows the additional capabilities supported by {beats} and t
 |{n}
 |{y}
 |{y} (optional)
-|{agent} integrations can be configured in the web UI or API. Standalone {agent} can use the web UI, API or YAML. {beats} can only configured via YAML file.
+|{fleet}-managed {agent} integrations can be configured in the web UI or API. Standalone {agent} can use the web UI, API or YAML. {beats} can only configured via YAML file.
 
 |Central, remote agent policy management
 |{n}
@@ -281,23 +281,23 @@ The following table shows the additional capabilities supported by {beats} and t
 |{n}
 |{agent}s can be remotely upgraded through {fleet}. You have to upgrade {beats} yourself or with a third party solution.
 
-|Choose which module or integration assets to add
+|Add {kibana} and {es} assets for a single integration or module
 |{n}
 |{y}
 |{y}
-|Integrations allow you to choose which assets to add. {beats} installs hundreds of assets for all modules at once.
+|{agent} integrations allow you to add {kibana} and {es} assets for a single integration at a time. {beats} installs hundreds of assets for all modules at once.
 
 |Auto-generated {es} API keys
 |{n}
 |{y}
 |{n}
-|{fleet} can automatically generate API keys with limited permissions for each {agent}, which can be individually revoked. {beats} requires you to create and manage credentials, and users often share them across hosts.
+|{fleet} can automatically generate API keys with limited permissions for each {agent}, which can be individually revoked. Standalone {agent} and {beats} requires you to create and manage credentials, and users often share them across hosts.
 
 |Auto-generate minimal {es} permissions
 |{n}
 |{y}
 |{n}
-|{fleet} can automatically give {agent}s minimal output permissions based on the inputs running. With {beats}, users often give broad permissions due to convenience.
+|{fleet} can automatically give {agent}s minimal output permissions based on the inputs running. With standalone {agent} and {beats}, users often give overly broad permissions because its more convenient.
 
 |Data streams support
 |{n}
@@ -309,13 +309,13 @@ The following table shows the additional capabilities supported by {beats} and t
 |{n}
 |{y} (limited)
 |{y}
-|{agent} offers https://www.elastic.co/guide/en/fleet/current/dynamic-input-configuration.html[variables and input conditions] to dynamically adjust based on the local host environment. The Integrations app allows users to enter variables and we are considering a https://github.com/elastic/kibana/issues/108525[UI to edit conditions]. {beats} only offers static configuration.
+|{agent} offers https://www.elastic.co/guide/en/fleet/current/dynamic-input-configuration.html[variables and input conditions] to dynamically adjust based on the local host environment. Users can configure these directly in YAML for standalone {agent} or using the Fleet API for {fleet}-managed {agent}. The Integrations app allows users to enter variables and we are considering a https://github.com/elastic/kibana/issues/108525[UI to edit conditions]. {beats} only offers static configuration.
 
 |Allow non-superusers to manage assets and agents
 |{y}
 |{n}
 |{y} (it's optional)
-|{fleet}-managed {agent}s require a superuser role to use {fleet} and Integrations. We are considering https://github.com/elastic/kibana/issues/108252[changing] this requirement. These apps are optional for standalone agents. {beats} offers https://www.elastic.co/guide/en/beats/filebeat/current/feature-roles.html[finer grained] roles.
+|We require a superuser role to use the {fleet} and Integrations apps and cooresponding APIs. We are considering https://github.com/elastic/kibana/issues/108252[changing] this requirement. These apps are optional for standalone {agent}. {beats} offers https://www.elastic.co/guide/en/beats/filebeat/current/feature-roles.html[finer grained] roles.
 
 |Air-gapped network support
 |{y}
@@ -333,13 +333,13 @@ The following table shows the additional capabilities supported by {beats} and t
 |{y}
 |{n}
 |{y}
-|{fleet} only supports output to {es} where {fleet} is running so it can generate API keys. We are considering support for https://github.com/elastic/kibana/issues/104980[more outputs]. Standalone {agent} and {beats} can send to mulitple outputs.
+|{fleet}-managed {agent}s only provide a single global output to the same {es} cluster where {fleet} is running. We are considering support for https://github.com/elastic/kibana/issues/104980[more outputs]. Standalone {agent} and {beats} can send to mulitple outputs.
 
 |Separate monitoring cluster 
 |{y}
 |{n}
 |{y}
-|{fleet} only supports output to {es} where {fleet} is running so it can generate API keys. We are considering support for https://github.com/elastic/kibana/issues/104980[remote monitoring clusters]. Standalone {agent} and {beats} can send to a remote monitoring cluster.
+|{fleet}-managed {agent}s only provide a single global output to the same {es} cluster where {fleet} is running. We are considering support for https://github.com/elastic/kibana/issues/104980[remote monitoring clusters]. Standalone {agent} and {beats} can send to a remote monitoring cluster.
 
 |Keystore for secrets
 |{y}
@@ -357,19 +357,19 @@ The following table shows the additional capabilities supported by {beats} and t
 |{y}
 |{n}
 |{y}
-|{fleet} does not have a feature to deploy a policy update progressively but we are considering https://github.com/elastic/kibana/issues/108267[improved support]. With standalone {agent} and {beats} you can deploy configuration files progressively using third party solutions.
+|{fleet} does not have a feature to deploy an {agent} policy update progressively but we are considering https://github.com/elastic/kibana/issues/108267[improved support]. With standalone {agent} and {beats} you can deploy configuration files progressively using third party solutions.
 
 |Version control, change management, rollback, and infrastructure as code
 |{y}
 |{n} (only via API)
 |{y}
-|{fleet} offers support for externally managed policies through it's REST API and we are considering https://github.com/elastic/kibana/issues/108524[improved support]. Both {agent} standalone and {beats} offer a simple text file configuration, so you can more easily implement these processes in third party solutions.
+|{fleet} offers support for externally managed policies through it's REST API and we are considering https://github.com/elastic/kibana/issues/108524[improved support]. Both standalone {agent} and {beats} offer a simple text file configuration, so you can more easily implement these processes in third party solutions.
 
-|Multiple configurations
+|Multiple configurations per host
 |{y}
-|{n}
-|{n}
-|{agent} uses a single agent policy for configuration, and uses https://www.elastic.co/guide/en/fleet/current/dynamic-input-configuration.html[variables and input conditions] to adapt to each host's local environment. {beats} offers support for mulitple configuration files, which offers more flexibility in assigning agent's to multiple groups and controlling access in third party solutions.
+|{n} (uses input conditions instead)
+|{n} (uses input conditions instead)
+|{agent} uses a single {agent} policy for configuration, and uses https://www.elastic.co/guide/en/fleet/current/dynamic-input-configuration.html[variables and input conditions] to adapt on a per-host basis. {beats} supports multiple configuration files per host, enabling third party solutions to deploy files hierarchically or in multiple groups, and enabling finer-grained access control to those files.
 
 |===
 

--- a/docs/en/ingest-management/beats-agent-comparison.asciidoc
+++ b/docs/en/ingest-management/beats-agent-comparison.asciidoc
@@ -281,7 +281,7 @@ The following table shows the additional capabilities supported by {beats} and t
 |{y}
 |{y}
 
-|Auto-generated ES API keys
+|Auto-generated {es} API keys
 |{n}
 |{y}
 |{n}

--- a/docs/en/ingest-management/beats-agent-comparison.asciidoc
+++ b/docs/en/ingest-management/beats-agent-comparison.asciidoc
@@ -286,7 +286,7 @@ The following table shows the additional capabilities supported by {beats} and t
 |{y}
 |{n}
 
-|Auto-generate minimal ES privileges on the edge
+|Auto-generate minimal {es} privileges on the edge
 |{n}
 |{y}
 |{y} (when using Integrations UI)

--- a/docs/en/ingest-management/beats-agent-comparison.asciidoc
+++ b/docs/en/ingest-management/beats-agent-comparison.asciidoc
@@ -29,7 +29,7 @@ For {agent}s that are centrally managed by {fleet}, data collection is
 further simplified and defined by integrations. In this model, the decision on
 the inputs is driven by the integration you want to collect data from. The
 complexity of configuration details of various inputs is driven centrally by
-{fleet} and specifically by the integrations.
+{fleet} and specifically by the integrations. 
 
 The following table shows the inputs supported by the {agent} in {version}:
 
@@ -241,114 +241,135 @@ per output type, which enables loadbalancing.
 |===
 
 [discrete]
-[[capabilties-comparison-beats-agent]]
-== Capabilities comparison
+[[additional-capabilties-beats-and-agent]]
+== Additional capabilities
 
 The following table shows the additional capabilities supported by {beats} and the {agent} in {version}:
 
+
 [options,header]
 |===
-|Item |{beats} |Standalone {agent} |Description
+|Item |{beats} |{fleet}-managed {agent} |Standalone {agent} |Description
 
 |Single agent for all use cases
 |{n}
 |{y}
-|{agent} provides logs, metrics and more. You'd need to install multiple {beats} for these use cases.
+|{y}
+|{agent} provides logs, metrics and more. You'd need to install mulitple {beats} for these use cases.
 
 |Install integrations from web UI or API
 |{n}
 |{y}
-|{agent} integrations are installed in a convenient web UI or API, but {beats} modules are installed in a CLI. This installs ES assets such as index templates and ingest pipelines, and Kibana assets such as dashboards.
+|{y}
+|{agent} integrations are installed in a convenient web UI or API, but {beat}s modules are installed in a CLI. These installs ES assets such as index templates and ingest pipelines, and Kibana assets such as dashboards.
 
 |Configure from web UI or API
 |{n}
 |{y}
-|{fleet}-managed {agent} integrations can be configured in the web UI or API. {beats} can only configured via YAML file.
+|{y} (optional)
+|{fleet}-managed {agent} integrations can be configured in the web UI or API. Standalone {agent} can use the web UI, API or YAML. {beats} can only configured via YAML file.
 
 |Central, remote agent policy management
 |{n}
 |{y}
+|{n}
 |{agent} policies can be centrally managed thorugh {fleet}. You have to manage {beats} configuration yourself or with a third party solution.
 
 |Central, remote agent binary upgrades
 |{n}
 |{y}
+|{n}
 |{agent}s can be remotely upgraded through {fleet}. You have to upgrade {beats} yourself or with a third party solution.
 
-|Add {kib} and {es} assets for a single integration or module
+|Add {kibana} and {es} assets for a single integration or module
 |{n}
 |{y}
-|{agent} integrations allow you to add {kib} and {es} assets for a single integration at a time. {beats} installs hundreds of assets for all modules at once.
+|{y}
+|{agent} integrations allow you to add {kibana} and {es} assets for a single integration at a time. {beats} installs hundreds of assets for all modules at once.
 
 |Auto-generated {es} API keys
 |{n}
 |{y}
-|{fleet} can automatically generate API keys with limited permissions for each {agent}, which can be individually revoked. {beats} requires you to create and manage credentials, and users often share them across hosts.
+|{n}
+|{fleet} can automatically generate API keys with limited permissions for each {agent}, which can be individually revoked. Standalone {agent} and {beats} requires you to create and manage credentials, and users often share them across hosts.
 
 |Auto-generate minimal {es} permissions
 |{n}
 |{y}
-|{fleet} can automatically give {agent}s minimal output permissions based on the inputs running. With {beats}, users often give overly broad permissions because its more convenient.
+|{n}
+|{fleet} can automatically give {agent}s minimal output permissions based on the inputs running. With standalone {agent} and {beats}, users often give overly broad permissions because its more convenient.
 
 |Data streams support
 |{n}
 |{y}
-|{agent}s use {ref}/data-streams.html[data streams] with easier index life cycle management and the https://www.elastic.co/blog/an-introduction-to-the-elastic-data-stream-naming-scheme[data stream naming scheme]. {beats} uses a single index with potentially thousands of fields.
+|{y}
+|{agent}s use https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html[data streams] with easier index life cycle management and the https://www.elastic.co/blog/an-introduction-to-the-elastic-data-stream-naming-scheme[data stream naming scheme]. {beats} uses a single index with potentially thousands of fields.
 
 |Variables and input conditions
 |{n}
 |{y} (limited)
-|{agent} offers {fleet-guide}/dynamic-input-configuration.html[variables and input conditions] to dynamically adjust based on the local host environment. Users can configure these directly in YAML for standalone {agent} or using the Fleet API for {fleet}-managed {agent}. The Integrations app allows users to enter variables and we are considering a https://github.com/elastic/kibana/issues/108525[UI to edit conditions]. {beats} only offers static configuration.
+|{y}
+|{agent} offers https://www.elastic.co/guide/en/fleet/current/dynamic-input-configuration.html[variables and input conditions] to dynamically adjust based on the local host environment. Users can configure these directly in YAML for standalone {agent} or using the Fleet API for {fleet}-managed {agent}. The Integrations app allows users to enter variables and we are considering a https://github.com/elastic/kibana/issues/108525[UI to edit conditions]. {beats} only offers static configuration.
 
 |Allow non-superusers to manage assets and agents
 |{y}
 |{n}
-|We require a superuser role to use the {fleet} and Integrations apps and cooresponding APIs. We are considering https://github.com/elastic/kibana/issues/108252[changing] this requirement. These apps are optional for standalone {agent}. {beats} offers {filebeat-ref}/feature-roles.html[finer grained] roles.
+|{y} (it's optional)
+|We require a superuser role to use the {fleet} and Integrations apps and cooresponding APIs. We are considering https://github.com/elastic/kibana/issues/108252[changing] this requirement. These apps are optional for standalone {agent}. {beats} offers https://www.elastic.co/guide/en/beats/filebeat/current/feature-roles.html[finer grained] roles.
 
 |Air-gapped network support
 |{y}
 |{n}
-|The Integrations app requires a network connection to the {fleet-guide}/fleet-overview.html#package-registry-intro[Elastic Package Registry]. We are considering an https://github.com/elastic/integrations/issues/1178[on-prem version of EPR]. {fleet}-managed {agent}s require a connection to our artifact repository for agent binary upgrades. These are not required for standalone {agent}s or {beats}.
+|{y}
+|The Integrations app requires a network connection to the https://www.elastic.co/guide/en/fleet/current/fleet-overview.html#package-registry-intro[Elastic Package Registry]. We are considering an https://github.com/elastic/integrations/issues/1178[on-prem version of EPR]. {fleet}-managed {agent}s require a connection to our artifact repository for agent binary upgrades. These are not required for standalone {agent}s or {beats}. 
 
 |Run without root on host
 |{y}
 |{n}
+|{y}
 |{fleet}-managed {agent}s require root permission, in particular for Endpoint Security. Standalone {agent}s and {beats} do not.
 
 |Mulitple outputs
 |{y}
 |{n}
+|{y}
 |{fleet}-managed {agent}s only provide a single global output to the same {es} cluster where {fleet} is running. We are considering support for https://github.com/elastic/kibana/issues/104980[more outputs]. Standalone {agent} and {beats} can send to mulitple outputs.
 
-|Separate monitoring cluster
+|Separate monitoring cluster 
 |{y}
 |{n}
+|{y}
 |{fleet}-managed {agent}s only provide a single global output to the same {es} cluster where {fleet} is running. We are considering support for https://github.com/elastic/kibana/issues/104980[remote monitoring clusters]. Standalone {agent} and {beats} can send to a remote monitoring cluster.
 
 |Keystore for secrets
 |{y}
 |{n}
-|{agent} stores credentials in the agent policy. We are considering adding https://github.com/elastic/integrations/issues/244[keystore support]. {beats} allows users to access credentials in a local {filebeat-ref}/keystore.html[keystore].
+|{n}
+|{agent} stores credentials in the agent policy. We are considering adding https://github.com/elastic/integrations/issues/244[keystore support]. {beats} allows users to access credentials in a local https://www.elastic.co/guide/en/beats/filebeat/current/keystore.html[keystore]. 
 
 |Cloned machine images or virtual desktops
 |{y}
+|{n}
 |{n}
 |{agent} may not work well with cloned images because it may lead to duplicate IDs, and we are considering a https://github.com/elastic/beats/issues/22281[solution]. {beats} do not have unique IDs.
 
 |Progressive or canary deployments
 |{y}
 |{n}
+|{y}
 |{fleet} does not have a feature to deploy an {agent} policy update progressively but we are considering https://github.com/elastic/kibana/issues/108267[improved support]. With standalone {agent} and {beats} you can deploy configuration files progressively using third party solutions.
 
 |Version control, change management, rollback, and infrastructure as code
 |{y}
 |{n} (only via API)
+|{y}
 |{fleet} offers support for externally managed policies through it's REST API and we are considering https://github.com/elastic/kibana/issues/108524[improved support]. Both standalone {agent} and {beats} offer a simple text file configuration, so you can more easily implement these processes in third party solutions.
 
 |Multiple configurations per host
 |{y}
 |{n} (uses input conditions instead)
-|{agent} uses a single {agent} policy for configuration, and uses {fleet-guide}/dynamic-input-configuration.html[variables and input conditions] to adapt on a per-host basis. {beats} supports multiple configuration files per host, enabling third party solutions to deploy files hierarchically or in multiple groups, and enabling finer-grained access control to those files.
+|{n} (uses input conditions instead)
+|{agent} uses a single {agent} policy for configuration, and uses https://www.elastic.co/guide/en/fleet/current/dynamic-input-configuration.html[variables and input conditions] to adapt on a per-host basis. {beats} supports multiple configuration files per host, enabling third party solutions to deploy files hierarchically or in multiple groups, and enabling finer-grained access control to those files.
 
 |===
 

--- a/docs/en/ingest-management/beats-agent-comparison.asciidoc
+++ b/docs/en/ingest-management/beats-agent-comparison.asciidoc
@@ -29,7 +29,7 @@ For {agent}s that are centrally managed by {fleet}, data collection is
 further simplified and defined by integrations. In this model, the decision on
 the inputs is driven by the integration you want to collect data from. The
 complexity of configuration details of various inputs is driven centrally by
-{fleet} and specifically by the integrations. 
+{fleet} and specifically by the integrations.
 
 The following table shows the inputs supported by the {agent} in {version}:
 
@@ -241,135 +241,114 @@ per output type, which enables loadbalancing.
 |===
 
 [discrete]
-[[additional-capabilties-beats-and-agent]]
-== Additional capabilities
+[[capabilties-comparison-beats-agent]]
+== Capabilities comparison
 
 The following table shows the additional capabilities supported by {beats} and the {agent} in {version}:
 
-
 [options,header]
 |===
-|Item |{beats} |{fleet}-managed {agent} |Standalone {agent} |Description
+|Item |{beats} |Standalone {agent} |Description
 
 |Single agent for all use cases
 |{n}
 |{y}
-|{y}
-|{agent} provides logs, metrics and more. You'd need to install mulitple {beats} for these use cases.
+|{agent} provides logs, metrics and more. You'd need to install multiple {beats} for these use cases.
 
 |Install integrations from web UI or API
 |{n}
 |{y}
-|{y}
-|{agent} integrations are installed in a convenient web UI or API, but {beat}s modules are installed in a CLI. These installs ES assets such as index templates and ingest pipelines, and Kibana assets such as dashboards.
+|{agent} integrations are installed in a convenient web UI or API, but {beats} modules are installed in a CLI. This installs ES assets such as index templates and ingest pipelines, and Kibana assets such as dashboards.
 
 |Configure from web UI or API
 |{n}
 |{y}
-|{y} (optional)
-|{fleet}-managed {agent} integrations can be configured in the web UI or API. Standalone {agent} can use the web UI, API or YAML. {beats} can only configured via YAML file.
+|{fleet}-managed {agent} integrations can be configured in the web UI or API. {beats} can only configured via YAML file.
 
 |Central, remote agent policy management
 |{n}
 |{y}
-|{n}
 |{agent} policies can be centrally managed thorugh {fleet}. You have to manage {beats} configuration yourself or with a third party solution.
 
 |Central, remote agent binary upgrades
 |{n}
 |{y}
-|{n}
 |{agent}s can be remotely upgraded through {fleet}. You have to upgrade {beats} yourself or with a third party solution.
 
-|Add {kibana} and {es} assets for a single integration or module
+|Add {kib} and {es} assets for a single integration or module
 |{n}
 |{y}
-|{y}
-|{agent} integrations allow you to add {kibana} and {es} assets for a single integration at a time. {beats} installs hundreds of assets for all modules at once.
+|{agent} integrations allow you to add {kib} and {es} assets for a single integration at a time. {beats} installs hundreds of assets for all modules at once.
 
 |Auto-generated {es} API keys
 |{n}
 |{y}
-|{n}
-|{fleet} can automatically generate API keys with limited permissions for each {agent}, which can be individually revoked. Standalone {agent} and {beats} requires you to create and manage credentials, and users often share them across hosts.
+|{fleet} can automatically generate API keys with limited permissions for each {agent}, which can be individually revoked. {beats} requires you to create and manage credentials, and users often share them across hosts.
 
 |Auto-generate minimal {es} permissions
 |{n}
 |{y}
-|{n}
-|{fleet} can automatically give {agent}s minimal output permissions based on the inputs running. With standalone {agent} and {beats}, users often give overly broad permissions because its more convenient.
+|{fleet} can automatically give {agent}s minimal output permissions based on the inputs running. With {beats}, users often give overly broad permissions because its more convenient.
 
 |Data streams support
 |{n}
 |{y}
-|{y}
-|{agent}s use https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html[data streams] with easier index life cycle management and the https://www.elastic.co/blog/an-introduction-to-the-elastic-data-stream-naming-scheme[data stream naming scheme]. {beats} uses a single index with potentially thousands of fields.
+|{agent}s use {ref}/data-streams.html[data streams] with easier index life cycle management and the https://www.elastic.co/blog/an-introduction-to-the-elastic-data-stream-naming-scheme[data stream naming scheme]. {beats} uses a single index with potentially thousands of fields.
 
 |Variables and input conditions
 |{n}
 |{y} (limited)
-|{y}
-|{agent} offers https://www.elastic.co/guide/en/fleet/current/dynamic-input-configuration.html[variables and input conditions] to dynamically adjust based on the local host environment. Users can configure these directly in YAML for standalone {agent} or using the Fleet API for {fleet}-managed {agent}. The Integrations app allows users to enter variables and we are considering a https://github.com/elastic/kibana/issues/108525[UI to edit conditions]. {beats} only offers static configuration.
+|{agent} offers {fleet-guide}/dynamic-input-configuration.html[variables and input conditions] to dynamically adjust based on the local host environment. Users can configure these directly in YAML for standalone {agent} or using the Fleet API for {fleet}-managed {agent}. The Integrations app allows users to enter variables and we are considering a https://github.com/elastic/kibana/issues/108525[UI to edit conditions]. {beats} only offers static configuration.
 
 |Allow non-superusers to manage assets and agents
 |{y}
 |{n}
-|{y} (it's optional)
-|We require a superuser role to use the {fleet} and Integrations apps and cooresponding APIs. We are considering https://github.com/elastic/kibana/issues/108252[changing] this requirement. These apps are optional for standalone {agent}. {beats} offers https://www.elastic.co/guide/en/beats/filebeat/current/feature-roles.html[finer grained] roles.
+|We require a superuser role to use the {fleet} and Integrations apps and cooresponding APIs. We are considering https://github.com/elastic/kibana/issues/108252[changing] this requirement. These apps are optional for standalone {agent}. {beats} offers {filebeat-ref}/feature-roles.html[finer grained] roles.
 
 |Air-gapped network support
 |{y}
 |{n}
-|{y}
-|The Integrations app requires a network connection to the https://www.elastic.co/guide/en/fleet/current/fleet-overview.html#package-registry-intro[Elastic Package Registry]. We are considering an https://github.com/elastic/integrations/issues/1178[on-prem version of EPR]. {fleet}-managed {agent}s require a connection to our artifact repository for agent binary upgrades. These are not required for standalone {agent}s or {beats}. 
+|The Integrations app requires a network connection to the {fleet-guide}/fleet-overview.html#package-registry-intro[Elastic Package Registry]. We are considering an https://github.com/elastic/integrations/issues/1178[on-prem version of EPR]. {fleet}-managed {agent}s require a connection to our artifact repository for agent binary upgrades. These are not required for standalone {agent}s or {beats}.
 
 |Run without root on host
 |{y}
 |{n}
-|{y}
 |{fleet}-managed {agent}s require root permission, in particular for Endpoint Security. Standalone {agent}s and {beats} do not.
 
 |Mulitple outputs
 |{y}
 |{n}
-|{y}
 |{fleet}-managed {agent}s only provide a single global output to the same {es} cluster where {fleet} is running. We are considering support for https://github.com/elastic/kibana/issues/104980[more outputs]. Standalone {agent} and {beats} can send to mulitple outputs.
 
-|Separate monitoring cluster 
+|Separate monitoring cluster
 |{y}
 |{n}
-|{y}
 |{fleet}-managed {agent}s only provide a single global output to the same {es} cluster where {fleet} is running. We are considering support for https://github.com/elastic/kibana/issues/104980[remote monitoring clusters]. Standalone {agent} and {beats} can send to a remote monitoring cluster.
 
 |Keystore for secrets
 |{y}
 |{n}
-|{n}
-|{agent} stores credentials in the agent policy. We are considering adding https://github.com/elastic/integrations/issues/244[keystore support]. {beats} allows users to access credentials in a local https://www.elastic.co/guide/en/beats/filebeat/current/keystore.html[keystore]. 
+|{agent} stores credentials in the agent policy. We are considering adding https://github.com/elastic/integrations/issues/244[keystore support]. {beats} allows users to access credentials in a local {filebeat-ref}/keystore.html[keystore].
 
 |Cloned machine images or virtual desktops
 |{y}
-|{n}
 |{n}
 |{agent} may not work well with cloned images because it may lead to duplicate IDs, and we are considering a https://github.com/elastic/beats/issues/22281[solution]. {beats} do not have unique IDs.
 
 |Progressive or canary deployments
 |{y}
 |{n}
-|{y}
 |{fleet} does not have a feature to deploy an {agent} policy update progressively but we are considering https://github.com/elastic/kibana/issues/108267[improved support]. With standalone {agent} and {beats} you can deploy configuration files progressively using third party solutions.
 
 |Version control, change management, rollback, and infrastructure as code
 |{y}
 |{n} (only via API)
-|{y}
 |{fleet} offers support for externally managed policies through it's REST API and we are considering https://github.com/elastic/kibana/issues/108524[improved support]. Both standalone {agent} and {beats} offer a simple text file configuration, so you can more easily implement these processes in third party solutions.
 
 |Multiple configurations per host
 |{y}
 |{n} (uses input conditions instead)
-|{n} (uses input conditions instead)
-|{agent} uses a single {agent} policy for configuration, and uses https://www.elastic.co/guide/en/fleet/current/dynamic-input-configuration.html[variables and input conditions] to adapt on a per-host basis. {beats} supports multiple configuration files per host, enabling third party solutions to deploy files hierarchically or in multiple groups, and enabling finer-grained access control to those files.
+|{agent} uses a single {agent} policy for configuration, and uses {fleet-guide}/dynamic-input-configuration.html[variables and input conditions] to adapt on a per-host basis. {beats} supports multiple configuration files per host, enabling third party solutions to deploy files hierarchically or in multiple groups, and enabling finer-grained access control to those files.
 
 |===
 

--- a/docs/en/ingest-management/beats-agent-comparison.asciidoc
+++ b/docs/en/ingest-management/beats-agent-comparison.asciidoc
@@ -9,7 +9,13 @@ logs, metrics, and uptime. Depending on what data you want to collect, you may
 need to install mutliple shippers on a single host.
 
 * *{agent}* is a single agent for logs, metrics, security data, and threat
-prevention. {agent} supports central management through {fleet}.
+prevention. The Elastic Agent can be deployed in two differing modes:
+
+** *Managed by {fleet}* -- easily deploy services with the {fleet} UI.
+Once installed, the {agent} lifecycle and policy/configuration is managed from a central point.
+
+** *Standalone mode* -- once installed, all configuration is applied to the {agent} manually.
+See <<run-elastic-agent-standalone>> for more information.
 
 The method you use depends on your use case, which features you need, and
 whether you want to centrally manage your agents.
@@ -261,7 +267,7 @@ The following table shows a comparison of capabilities supported by {beats} and 
 |{n}
 |{y}
 |{y}
-|{agent} integrations are installed in a convenient web UI or API, but {beats} modules are installed in a CLI. This installs {es} assets such as index templates and ingest pipelines, and {kib} assets such as dashboards.
+|{agent} integrations are installed with a convenient web UI or API, but {beats} modules are installed with a CLI. This installs {es} assets such as index templates and ingest pipelines, and {kib} assets such as dashboards.
 
 |Configure from web UI or API
 |{n}
@@ -303,7 +309,7 @@ The following table shows a comparison of capabilities supported by {beats} and 
 |{n}
 |{y}
 |{y}
-|{agent}s use {ref}/data-streams.html[data streams] with easier index life cycle management and the https://www.elastic.co/blog/an-introduction-to-the-elastic-data-stream-naming-scheme[data stream naming scheme]. {beats} uses a single index with potentially thousands of fields.
+|{agent}s use <<data-streams,data streams>> with easier index life cycle management and the https://www.elastic.co/blog/an-introduction-to-the-elastic-data-stream-naming-scheme[data stream naming scheme]. {beats} uses a single index with potentially thousands of fields.
 
 |Variables and input conditions
 |{n}


### PR DESCRIPTION
Add capabilities to beats and agent comparison table to highlight benefits of Elastic Agent and Fleet, and capabilities that only Beats supports

CC @nimarezainia 