### PR TITLE
[7.14] docs: update apm ds naming scheme (#946)

### DIFF
--- a/docs/en/ingest-management/data-streams.asciidoc
+++ b/docs/en/ingest-management/data-streams.asciidoc
@@ -34,8 +34,6 @@ A generic `type` describing the data, such as `logs`, `metrics`, `traces`, or `s
 The `dataset` is defined by the integration and describes the ingested data and its structure for each index.
 For example, you might have a dataset for process metrics with a field describing whether the process is running or not,
 and another dataset for disk I/O metrics with a field describing the number of bytes read.
-+
-For APM data, the `dataset` is the instrumented service's `service.name`.
 
 `namespace`::
 A user-configurable arbitrary grouping, such as an environment (`dev`, `prod`, or `qa`),
@@ -59,12 +57,12 @@ For example, if you've set up the Nginx integration with a namespace of `prod`,
 logs-nginx.access-prod
 --
 
-Alternatively, if you use the APM integration with a namespace of `dev`, and a `service.name` of `frontend`,
+Alternatively, if you use the APM integration with a namespace of `dev`,
 {agent} stores data in the following data stream:
 
 [source,text]
 --
-traces-apm.frontend-dev
+traces-apm-dev
 --
 
 All data streams, and the pre-built dashboards that they ship with,


### PR DESCRIPTION
Backports the following commits to 7.14:
 - docs: update apm ds naming scheme (#946)