### PR TITLE
[7.14] Add Fleet-related Kibana relnotes (#951)

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-7.14.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-7.14.asciidoc
@@ -101,14 +101,14 @@ malicious users.
 //{agent}::
 //* add info
 
-//[discrete]
-//[[new-features-7.14.0]]
-//=== New features
+[discrete]
+[[new-features-7.14.0]]
+=== New features
 
-//The 7.14.0 release adds the following new and notable features.
+The 7.14.0 release adds the following new and notable features.
 
-//{fleet}::
-//* add info
+{fleet}::
+* Moves integrations to a separate app {kib-pull}99848[#99848]
 
 //{agent}::
 //* add info


### PR DESCRIPTION
Backports the following commits to 7.14:
 - Add Fleet-related Kibana relnotes (#951)