### PR TITLE
[7.14] Add known issue about problem with agents enrolled through a proxy (#961)

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-7.14.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-7.14.asciidoc
@@ -86,6 +86,25 @@ malicious users.
 
 ====
 
+[[known-issue-27114]]
+
+.{agent} fails to start correctly when enrolled in {fleet} through a proxy
+[%collapsible]
+====
+
+*Details*
+
+When you attempt to enroll an {agent} in {fleet} and specify the `proxy-url`
+flag, the status of the agent hangs at `Updating` in {fleet}, and the
+{agent} fails to start correctly. 
+
+*Impact* +
+
+Do not enroll {agent}s through a proxy until this issue is fixed.
+{agent-issue}27114[#27114] {agent-issue}27187[#27187]
+
+====
+
 //[discrete]
 //[[deprecations-7.14.0]]
 //=== Deprecations


### PR DESCRIPTION
Backports the following commits to 7.14:
 - Add known issue about problem with agents enrolled through a proxy (#961)