### PR TITLE
Add issue to Fleet troubleshooting page for ECE 2.10 / Fleet 7.14 issue

### DIFF
--- a/docs/en/ingest-management/troubleshooting.asciidoc
+++ b/docs/en/ingest-management/troubleshooting.asciidoc
@@ -442,4 +442,6 @@ When an {ece} deployment is set up with APM and {fleet}, even though the deploym
 WARN [transport] transport/tcp.go:52 DNS lookup failure "instance-000000 0000": lookup instance-0000000000 on 169.254.165.225:23: no such host
 ----
 
-This is a known issue with the {stack} pack version 7.14 shipped with {ece} version 2.10. To resolve the problem, link:{ece-ref}/ece-manage-elastic-stack.html[re-upload a fresh copy] of the version 7.14 {stack} pack to overwrite the original one. This issue will also be addressed in later {stack} packs and {ece} versions.
+This is a known issue with the {stack} pack version 7.14 and {ece} version 2.10. With the original {stack} pack version 7.14, if downloaded from the Elastic website before August 10, 2021, Fleet does not work when enabled in a deployment. 
+
+To resolve the problem, link:{ece-ref}/ece-manage-elastic-stack.html[get and re-upload a fresh copy] of the version 7.14 Elastic {stack} pack to overwrite the original one. If you have existing version 7.14 deployments, then restart Fleet/APM after re-uploading the Elastic {stack} pack to enable Fleet. This issue will be addressed in later {stack} packs and {s} versions.

--- a/docs/en/ingest-management/troubleshooting.asciidoc
+++ b/docs/en/ingest-management/troubleshooting.asciidoc
@@ -61,7 +61,6 @@ After running the command:
  .. Follow the documented steps for setting up a self-managed {fleet-server}.
 For more information, refer to <<fleet-server>>.
 
-
 [discrete]
 [[fleet-setup-fails]]
 == The `/api/fleet/setup` endpoint can't reach the package registry
@@ -430,3 +429,17 @@ to `false`, and then save the integration.
 
 // Add Javascript and CSS for tabbed panels
 include::{tab-widgets}/code.asciidoc[]
+
+
+[discrete]
+[[fleet-ece-config]]
+== {fleet} is not working when enabled in an {ece} deployment
+
+When an {ece} deployment is set up with APM and {fleet}, even though the deployment operates as expected {fleet} cannot be configured. Agent log files may contain a message like the following:
+
+[source,sh]
+----
+WARN [transport] transport/tcp.go:52 DNS lookup failure "instance-000000 0000": lookup instance-0000000000 on 169.254.165.225:23: no such host
+----
+
+This is a known issue with the Elastic Stack pack version 7.14 shipped with {ece} version 2.10. To resolve the problem, link:{ece-ref}/ece-manage-elastic-stack.html[re-upload a fresh copy] of the version 7.14 Elastic Stack pack to overwrite the original one. This issue will also be addressed in later Elastic stack packs and {ece} versions.

--- a/docs/en/ingest-management/troubleshooting.asciidoc
+++ b/docs/en/ingest-management/troubleshooting.asciidoc
@@ -442,4 +442,4 @@ When an {ece} deployment is set up with APM and {fleet}, even though the deploym
 WARN [transport] transport/tcp.go:52 DNS lookup failure "instance-000000 0000": lookup instance-0000000000 on 169.254.165.225:23: no such host
 ----
 
-This is a known issue with the Elastic Stack pack version 7.14 shipped with {ece} version 2.10. To resolve the problem, link:{ece-ref}/ece-manage-elastic-stack.html[re-upload a fresh copy] of the version 7.14 Elastic Stack pack to overwrite the original one. This issue will also be addressed in later Elastic stack packs and {ece} versions.
+This is a known issue with the {stack} pack version 7.14 shipped with {ece} version 2.10. To resolve the problem, link:{ece-ref}/ece-manage-elastic-stack.html[re-upload a fresh copy] of the version 7.14 {stack} pack to overwrite the original one. This issue will also be addressed in later {stack} packs and {ece} versions.

--- a/docs/en/ingest-management/troubleshooting.asciidoc
+++ b/docs/en/ingest-management/troubleshooting.asciidoc
@@ -435,7 +435,7 @@ include::{tab-widgets}/code.asciidoc[]
 [[fleet-ece-config]]
 == {fleet} is not working when enabled in an {ece} deployment
 
-When an {ece} deployment is set up with APM and {fleet}, even though the deployment operates as expected {fleet} cannot be configured. Agent log files may contain a message like the following:
+When an {ece} deployment is set up with APM and {fleet}, even though the deployment operates as expected, {fleet} cannot be configured. Agent log files may contain a message like the following:
 
 [source,sh]
 ----


### PR DESCRIPTION
This adds an entry to the 7.14 Fleet [troubleshooting page](https://www.elastic.co/guide/en/fleet/7.14/fleet-troubleshooting.html), since version 7.14 of Fleet is not working with the recently released ECE 2.10. Here's an [issue with the details](https://github.com/elastic/support-known-issues/issues/791). I'm putting similar warnings in the Cloud ECE docs

Please note that the workaround isn't ready yet so we need to wait for that before merging.

I'd really appreciate any help with labels, and I assume there's no backporting since this affects and targets only the 7.14 release.