### PR TITLE
Update troubleshooting page to remove my "Elastic Elastic Stack" references

### DIFF
--- a/docs/en/ingest-management/troubleshooting.asciidoc
+++ b/docs/en/ingest-management/troubleshooting.asciidoc
@@ -444,4 +444,4 @@ WARN [transport] transport/tcp.go:52 DNS lookup failure "instance-000000 0000": 
 
 This is a known issue with the {stack} pack version 7.14 and {ece} version 2.10. With the original {stack} pack version 7.14, if downloaded from the Elastic website before August 10, 2021, Fleet does not work when enabled in a deployment. 
 
-To resolve the problem, link:{ece-ref}/ece-manage-elastic-stack.html[get and re-upload a fresh copy] of the version 7.14 Elastic {stack} pack to overwrite the original one. If you have existing version 7.14 deployments, then restart Fleet/APM after re-uploading the Elastic {stack} pack to enable Fleet. This issue will be addressed in later {stack} packs and {s} versions.
+To resolve the problem, link:{ece-ref}/ece-manage-elastic-stack.html[get and re-upload a fresh copy] of the version 7.14 {stack} pack to overwrite the original one. If you have existing version 7.14 deployments, then restart Fleet/APM after re-uploading the {stack} pack to enable Fleet. This issue will be addressed in later stack packs and {s} versions.


### PR DESCRIPTION
Sorry for the churn! This is a small update to #968 to fix my "Elastic Elastic Stack" references on the troubleshooting page (I didn't realize that `{stack}` resolves to `Elastic Stack`).