### PR TITLE
[7.x] Remove SDH reference in documentation (#976)

### DIFF
--- a/docs/en/ingest-management/troubleshooting.asciidoc
+++ b/docs/en/ingest-management/troubleshooting.asciidoc
@@ -157,7 +157,7 @@ token when you run the `elastic-agent enroll` command.
 [[general-fleet-server-triage]]
 == Many {fleet-server} problems can be triaged and fixed with the below tips
 
-IMPORTANT: When logging an SDH or sending a support forum communication, this section
+IMPORTANT: When creating an issue or sending a support forum communication, this section
 can help you identify what is required.
 
 {fleet-server} allows {agent} to connect to {es}, which is the same as the connection


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Remove SDH reference in documentation (#976)