### PR TITLE
[Fleet] Fix workaround for missing Fleet server policies for cloud

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-7.14.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-7.14.asciidoc
@@ -140,7 +140,7 @@ POST .fleet-enrollment-api-keys/_delete_by_query?q=policy-elastic-agent-on-cloud
 
 . Go to **Management > {fleet}** to force reloading of the object.
 
-. On Cloud you could have to restart APM and Fleet server instances.
+. On {ecloud} you might need to restart the APM and {fleet-server} instances.
 
 // end::fleet-server-input-missing-fix[]
 

--- a/docs/en/ingest-management/release-notes/release-notes-7.14.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-7.14.asciidoc
@@ -129,14 +129,18 @@ To fix this problem:
 
 .. In {kib}, open the main menu, then go to **Management > Dev Tools > Console**.
 
-.. In the Console, send the following request:
+.. In the Console, send the following requests:
 +
 [source,console]
 ----
 POST .kibana/_delete_by_query?q=ingest-agent-policies.is_default_fleet_server:true
+DELETE .kibana/_doc/ingest-agent-policies:policy-elastic-agent-on-cloud
+POST .fleet-enrollment-api-keys/_delete_by_query?q=policy-elastic-agent-on-cloud
 ----
 
 . Go to **Management > {fleet}** to force reloading of the object.
+
+. On Cloud you could have to restart APM and Fleet server instances.
 
 // end::fleet-server-input-missing-fix[]
 


### PR DESCRIPTION
## Description

The workaround I provided for #938 is not totally accurate as it's not working in cloud where pre configured policies have different ids and properties.

That PR update the instructions so it's working in cloud too.