### PR TITLE
[7.x] Add details for logging.metrics.enabled (#853)

### DIFF
--- a/docs/en/ingest-management/elastic-agent/elastic-agent-configuration.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/elastic-agent-configuration.asciidoc
@@ -8,7 +8,7 @@ You do not set them explicitly in a configuration file.
 For standalone agents, you need to configure settings in the `elastic-agent.yml`
 file. Prior to installation, edit the file located in the extracted {agent}
 package. After installation, edit the file located in the directory
-described in <<installation-layout>>. 
+described in <<installation-layout>>.
 
 TIP: To get started quickly, you can use {fleet} to generate a standalone
 configuration. For more information, see <<run-elastic-agent-standalone>>.

--- a/docs/en/ingest-management/elastic-agent/elastic-agent-standalone-logging.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/elastic-agent-standalone-logging.asciidoc
@@ -26,9 +26,9 @@ You can specify the following settings in the Logging section of the `elastic-ag
 [cols="2*<a"]
 |===
 | *Setting* | *Description*
-| `agent.logging.level` | The minimum log level. 
+| `agent.logging.level` | The minimum log level.
 
-Possible values: 
+Possible values:
 
 * `error`: Logs errors and critical errors.
 
@@ -65,11 +65,13 @@ Default: `false`
 
 | `agent.logging.metrics.enabled` | Set to `true` for {agent} to periodically log its internal metrics that have changed in the
 last period. For each metric that changed, the delta from the value at the beginning of the period is logged.
-Also, the total values for all non-zero internal metrics get logged on shutdown.
+Also, the total values for all non-zero internal metrics get logged on shutdown. If set to `false`, no metrics for the agent or
+any of the {beats} running under it are logged.
 
 Default: `true`
 
-| `agent.logging.metrics.period` | Specify the period after which to log the internal metrics.
+| `agent.logging.metrics.period` | Specify the period after which to log the internal metrics. This setting is not passed to
+any {beats} running under the {agent}.
 
 Default: `30s`
 
@@ -107,11 +109,11 @@ reported by the local system clock. All other intervals get calculated from the 
 
 Default: `0` (disabled)
 
-| `agent.logging.files.rotateonstartup` | Set to `true` to rotate existing logs on startup rather than to append to the existing file. 
+| `agent.logging.files.rotateonstartup` | Set to `true` to rotate existing logs on startup rather than to append to the existing file.
 
 Default: `true`
 
-| `agent.logging.json` | Set to `true` to log messages in JSON format. 
+| `agent.logging.json` | Set to `true` to log messages in JSON format.
 
 Default: `false`
 


### PR DESCRIPTION
Backport the following commit to 7.x:
- Add details for logging.metrics.enabled (#853) 