### PR TITLE
[7.14] docs: fix links to PHP agent documentation (#992)

### DIFF
--- a/docs/en/ingest-management/index.asciidoc
+++ b/docs/en/ingest-management/index.asciidoc
@@ -16,7 +16,9 @@ include::{docs-root}/shared/attributes.asciidoc[]
 :y: image:images/green-check.svg[yes]
 :n: image:images/red-x.svg[no]
 
+:apm-ios-ref-v:         https://www.elastic.co/guide/en/apm/agent/swift/{apm-ios-branch}
 :apm-py-ref-v:         https://www.elastic.co/guide/en/apm/agent/python/{apm-py-branch}
+:apm-php-ref-v:         https://www.elastic.co/guide/en/apm/agent/php/{apm-php-branch}
 :apm-node-ref-v:       https://www.elastic.co/guide/en/apm/agent/nodejs/{apm-node-branch}
 :apm-rum-ref-v:        https://www.elastic.co/guide/en/apm/agent/rum-js/{apm-rum-branch}
 :apm-ruby-ref-v:       https://www.elastic.co/guide/en/apm/agent/ruby/{apm-ruby-branch}


### PR DESCRIPTION
Backports the following commits to 7.14:
 - docs: fix links to PHP agent documentation (#992)