### PR TITLE
Add skeleton files for 7.14.1 release notes

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-7.14.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-7.14.asciidoc
@@ -119,6 +119,8 @@ Review important information about the {fleet} and {agent} 7.14.1 releases.
 
 {fleet}::
 * Fixes integrations count in category facet {kibana-pull}107652[#107652]
+* Fixes package info does not exist from older package {kibana-pull}109174[#109174]
+* Fixes {heartbeat} missing from monitoring datasets in the {agent} logs UI {kibana-pull}107989[#107989]
 
 //{agent}::
 //* add info

--- a/docs/en/ingest-management/release-notes/release-notes-7.14.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-7.14.asciidoc
@@ -25,7 +25,7 @@ Also see:
 [[release-notes-7.14.1]]
 == {fleet} and {agent} 7.14.1
 
-Review important information about the {fleet} and {agent} 7.14.x releases.
+Review important information about the {fleet} and {agent} 7.14.1 releases.
 
 //[discrete]
 //[[security-updates-7.14.1]]

--- a/docs/en/ingest-management/release-notes/release-notes-7.14.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-7.14.asciidoc
@@ -122,8 +122,8 @@ Review important information about the {fleet} and {agent} 7.14.1 releases.
 * Fixes package info does not exist from older package {kibana-pull}109174[#109174]
 * Fixes {heartbeat} missing from monitoring datasets in the {agent} logs UI {kibana-pull}107989[#107989]
 
-//{agent}::
-//* add info
+{agent}::
+* Fixes policies not being assigned to {agent}s {agent-pull}27362[#27362] {agent-pull}27297[#27297]
 
 
 // end 7.14.1 relnotes

--- a/docs/en/ingest-management/release-notes/release-notes-7.14.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-7.14.asciidoc
@@ -11,12 +11,122 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-7.14.1>>
+
 * <<release-notes-7.14.0>>
 
 Also see:
 
 * {kibana-ref}/release-notes.html[{kib} release notes]
 * {beats-ref}/release-notes.html[{beats} release notes]
+
+// begin 7.14.1 relnotes
+
+[[release-notes-7.14.1]]
+== {fleet} and {agent} 7.14.1
+
+Review important information about the {fleet} and {agent} 7.14.x releases.
+
+//[discrete]
+//[[security-updates-7.14.1]]
+//=== Security updates
+
+//{fleet}::
+//* add info
+
+//{agent}::
+//* add info
+
+//[discrete]
+//[[breaking-changes-7.14.1]]
+//=== Breaking changes
+
+//Breaking changes can prevent your application from optimal operation and
+//performance. Before you upgrade, review the breaking changes, then mitigate the
+//impact to your application.
+
+//[discrete]
+//[[breaking-PR#]]
+//.Short description
+//[%collapsible]
+//====
+//*Details* +
+//<Describe new behavior.> For more information, refer to {kibana-pull}PR[#PR].
+
+//*Impact* +
+//<Describe how users should mitigate the change.> For more information, refer to {fleet-guide}/fleet-server.html[Fleet Server].
+//====
+
+//[discrete]
+//[[known-issues-7.14.1]]
+//=== Known issues
+
+//[[known-issue-issue#]]
+//.Short description
+//[%collapsible]
+//====
+
+//*Details* 
+
+//<Describe known issue.>
+
+//*Impact* +
+
+//<Describe impact or workaround.>
+
+//====
+
+//[discrete]
+//[[deprecations-7.14.1]]
+//=== Deprecations
+
+//The following functionality is deprecated in 7.14.1, and will be removed in
+//8.0.0. Deprecated functionality does not have an immediate impact on your
+//application, but we strongly recommend you make the necessary updates after you
+//upgrade to 7.14.1.
+
+//{fleet}::
+//* add info
+
+//{agent}::
+//* add info
+
+//[discrete]
+//[[new-features-7.14.1]]
+//=== New features
+
+//The 7.14.1 release adds the following new and notable features.
+
+//{fleet}::
+//* add info
+
+//{agent}::
+//* add info
+
+//[discrete]
+//[[enhancements-7.14.1]]
+//=== Enhancements
+
+//{fleet}::
+//* add info
+
+//{agent}::
+//* add info
+
+[discrete]
+[[bug-fixes-7.14.1]]
+=== Bug fixes
+
+{fleet}::
+* Fixes integrations count in category facet {kibana-pull}107652[#107652]
+
+//{agent}::
+//* add info
+
+
+// end 7.14.1 relnotes
+
+// begin 7.14.0 relnotes
 
 [[release-notes-7.14.0]]
 == {fleet} and {agent} 7.14.0
@@ -192,3 +302,5 @@ The 7.14.0 release adds the following new and notable features.
 
 //{agent}::
 //* add info
+
+// end 7.14.0 relnotes

--- a/docs/en/ingest-management/release-notes/release-notes-7.14.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-7.14.asciidoc
@@ -6,6 +6,7 @@
 :fleet-server-issue: https://github.com/elastic/beats/issues/fleet-server/
 :fleet-server-pull: https://github.com/elastic/beats/pull/fleet-server/
 
+
 [[release-notes]]
 = Release notes
 
@@ -27,92 +28,6 @@ Also see:
 
 Review important information about the {fleet} and {agent} 7.14.1 releases.
 
-//[discrete]
-//[[security-updates-7.14.1]]
-//=== Security updates
-
-//{fleet}::
-//* add info
-
-//{agent}::
-//* add info
-
-//[discrete]
-//[[breaking-changes-7.14.1]]
-//=== Breaking changes
-
-//Breaking changes can prevent your application from optimal operation and
-//performance. Before you upgrade, review the breaking changes, then mitigate the
-//impact to your application.
-
-//[discrete]
-//[[breaking-PR#]]
-//.Short description
-//[%collapsible]
-//====
-//*Details* +
-//<Describe new behavior.> For more information, refer to {kibana-pull}PR[#PR].
-
-//*Impact* +
-//<Describe how users should mitigate the change.> For more information, refer to {fleet-guide}/fleet-server.html[Fleet Server].
-//====
-
-//[discrete]
-//[[known-issues-7.14.1]]
-//=== Known issues
-
-//[[known-issue-issue#]]
-//.Short description
-//[%collapsible]
-//====
-
-//*Details* 
-
-//<Describe known issue.>
-
-//*Impact* +
-
-//<Describe impact or workaround.>
-
-//====
-
-//[discrete]
-//[[deprecations-7.14.1]]
-//=== Deprecations
-
-//The following functionality is deprecated in 7.14.1, and will be removed in
-//8.0.0. Deprecated functionality does not have an immediate impact on your
-//application, but we strongly recommend you make the necessary updates after you
-//upgrade to 7.14.1.
-
-//{fleet}::
-//* add info
-
-//{agent}::
-//* add info
-
-//[discrete]
-//[[new-features-7.14.1]]
-//=== New features
-
-//The 7.14.1 release adds the following new and notable features.
-
-//{fleet}::
-//* add info
-
-//{agent}::
-//* add info
-
-//[discrete]
-//[[enhancements-7.14.1]]
-//=== Enhancements
-
-//{fleet}::
-//* add info
-
-//{agent}::
-//* add info
-
 [discrete]
 [[bug-fixes-7.14.1]]
 === Bug fixes
@@ -125,7 +40,6 @@ Review important information about the {fleet} and {agent} 7.14.1 releases.
 {agent}::
 * Fixes policies not being assigned to {agent}s {agent-pull}27362[#27362] {agent-pull}27297[#27297]
 
-
 // end 7.14.1 relnotes
 
 // begin 7.14.0 relnotes
@@ -133,37 +47,7 @@ Review important information about the {fleet} and {agent} 7.14.1 releases.
 [[release-notes-7.14.0]]
 == {fleet} and {agent} 7.14.0
 
-Review important information about the {fleet} and {agent} 7.14.x releases.
-
-//[discrete]
-//[[security-updates-7.14.0]]
-//=== Security updates
-
-//{fleet}::
-//* add info
-
-//{agent}::
-//* add info
-
-//[discrete]
-//[[breaking-changes-7.14.0]]
-//=== Breaking changes
-
-//Breaking changes can prevent your application from optimal operation and
-//performance. Before you upgrade, review the breaking changes, then mitigate the
-//impact to your application.
-
-//[discrete]
-//[[breaking-PR#]]
-//.Short description
-//[%collapsible]
-//====
-//*Details* +
-//<Describe new behavior.> For more information, refer to {kibana-pull}PR[#PR].
-
-//*Impact* +
-//<Describe how users should mitigate the change.> For more information, refer to {fleet-guide}/fleet-server.html[Fleet Server].
-//====
+Review important information about the {fleet} and {agent} 7.14.0 releases.
 
 [discrete]
 [[known-issues-7.14.0]]
@@ -258,21 +142,6 @@ POST .fleet-enrollment-api-keys/_delete_by_query?q=policy-elastic-agent-on-cloud
 
 ====
 
-//[discrete]
-//[[deprecations-7.14.0]]
-//=== Deprecations
-
-//The following functionality is deprecated in 7.14.0, and will be removed in
-//8.0.0. Deprecated functionality does not have an immediate impact on your
-//application, but we strongly recommend you make the necessary updates after you
-//upgrade to 7.14.0.
-
-//{fleet}::
-//* add info
-
-//{agent}::
-//* add info
-
 [discrete]
 [[new-features-7.14.0]]
 === New features
@@ -282,11 +151,97 @@ The 7.14.0 release adds the following new and notable features.
 {fleet}::
 * Moves integrations to a separate app {kib-pull}99848[#99848]
 
+// end 7.14.0 relnotes
+
+// ---------------------
+//TEMPLATE
+//Use the following text as a template. Remember to replace the version info.
+
+// begin 7.14.x relnotes
+
+//[[release-notes-7.14.x]]
+//== {fleet} and {agent} 7.14.x
+
+//Review important information about the {fleet} and {agent} 7.14.x releases.
+
+//[discrete]
+//[[security-updates-7.14.x]]
+//=== Security updates
+
+//{fleet}::
+//* add info
+
 //{agent}::
 //* add info
 
 //[discrete]
-//[[enhancements-7.14.0]]
+//[[breaking-changes-7.14.x]]
+//=== Breaking changes
+
+//Breaking changes can prevent your application from optimal operation and
+//performance. Before you upgrade, review the breaking changes, then mitigate the
+//impact to your application.
+
+//[discrete]
+//[[breaking-PR#]]
+//.Short description
+//[%collapsible]
+//====
+//*Details* +
+//<Describe new behavior.> For more information, refer to {kibana-pull}PR[#PR].
+
+//*Impact* +
+//<Describe how users should mitigate the change.> For more information, refer to {fleet-guide}/fleet-server.html[Fleet Server].
+//====
+
+//[discrete]
+//[[known-issues-7.14.x]]
+//=== Known issues
+
+//[[known-issue-issue#]]
+//.Short description
+//[%collapsible]
+//====
+
+//*Details* 
+
+//<Describe known issue.>
+
+//*Impact* +
+
+//<Describe impact or workaround.>
+
+//====
+
+//[discrete]
+//[[deprecations-7.14.x]]
+//=== Deprecations
+
+//The following functionality is deprecated in 7.14.x, and will be removed in
+//8.0.0. Deprecated functionality does not have an immediate impact on your
+//application, but we strongly recommend you make the necessary updates after you
+//upgrade to 7.14.x.
+
+//{fleet}::
+//* add info
+
+//{agent}::
+//* add info
+
+//[discrete]
+//[[new-features-7.14.x]]
+//=== New features
+
+//The 7.14.x release adds the following new and notable features.
+
+//{fleet}::
+//* add info
+
+//{agent}::
+//* add info
+
+//[discrete]
+//[[enhancements-7.14.x]]
 //=== Enhancements
 
 //{fleet}::
@@ -296,13 +251,13 @@ The 7.14.0 release adds the following new and notable features.
 //* add info
 
 //[discrete]
-//[[bug-fixes-7.14.0]]
+//[[bug-fixes-7.14.x]]
 //=== Bug fixes
 
 //{fleet}::
-//* add info 
+//* add info
 
 //{agent}::
 //* add info
 
-// end 7.14.0 relnotes
+// end 7.14.x relnotes


### PR DESCRIPTION
Preview link: https://observability-docs_1010.docs-preview.app.elstc.co/guide/en/fleet/master/release-notes-7.14.1.html 

@andresrc I know the new changelog process is not ready, but we still need some kind of release notes for Fleet and Elastic Agent in 7.14.1. So I've created this placeholder where we can add stuff.

For  Elastic Agent, should I pull changes from the [changelog](https://github.com/elastic/beats/blob/master/x-pack/elastic-agent/CHANGELOG.next.asciidoc)? It looks like developers are still updating CHANGELOG.next.asciidoc, but no one has created a versioned changelog since 7.9. If someone can tell me what to add for 7.14.x, I'll include any relevant info here.

I'll leave the placeholder text in 7.14.0 in case we want to add anything to that section.