### PR TITLE
[7.x] Add capabilities to beats and agent comparison table (#943)

### DIFF
--- a/docs/en/ingest-management/beats-agent-comparison.asciidoc
+++ b/docs/en/ingest-management/beats-agent-comparison.asciidoc
@@ -6,10 +6,16 @@ Elastic provides two main ways to send data to {es}:
 * *{beats}* are lightweight data shippers that send operational data to
 {es}. Elastic provides separate {beats} for different types of data, such as
 logs, metrics, and uptime. Depending on what data you want to collect, you may
-need to install mutliple shippers on a single host.
+need to install multiple shippers on a single host.
 
 * *{agent}* is a single agent for logs, metrics, security data, and threat
-prevention. {agent} supports central management through {fleet}.
+prevention. The Elastic Agent can be deployed in two different modes:
+
+** *Managed by {fleet}* -- easily deploy services with the {fleet} UI.
+Once installed, the {agent} lifecycle and policy/configuration is managed from a central point.
+
+** *Standalone mode* -- once installed, all configuration is applied to the {agent} manually.
+See <<run-elastic-agent-standalone>> for more information.
 
 The method you use depends on your use case, which features you need, and
 whether you want to centrally manage your agents.
@@ -29,91 +35,111 @@ For {agent}s that are centrally managed by {fleet}, data collection is
 further simplified and defined by integrations. In this model, the decision on
 the inputs is driven by the integration you want to collect data from. The
 complexity of configuration details of various inputs is driven centrally by
-{fleet} and specifically by the integrations. 
+{fleet} and specifically by the integrations.
 
 The following table shows the inputs supported by the {agent} in {version}:
 
 [options,header]
 |===
-|Input |{beats} support |{agent} support
+|Input |Beats |{fleet}-managed {agent} |Standalone {agent}
 
 |AWS CloudWatch
+|{y} (beta)
 |{y} (beta)
 |{y} (beta)
 
 |AWS S3
 |{y}
 |{y}
+|{y}
 
 |Azure Event Hub
+|{y}
 |{y}
 |{y}
 
 |Cloud Foundry
 |{y}
 |{n}
+|{y}
 
 |Container
 |{y}
 |{n}
+|{y}
 
 |Docker
 |{y}
 |{n}
+|{y}
 
 |GCP Pub/Sub
+|{y}
 |{y}
 |{y}
 
 |HTTP Endpoint
 |{y} (beta)
 |{y} (beta)
+|{y} (beta)
 
 |HTTP JSON
+|{y}
 |{y}
 |{y}
 
 |Kafka
 |{y}
 |{n}
+|{y}
 
 |Logfile
+|{y}
 |{y}
 |{y}
 
 |MQTT
 |{y}
 |{n}
+|{y}
 
 |NetFlow
+|{y}
 |{y}
 |{y}
 
 |O365 Mgmt Act API
 |{y} (beta)
 |{y} (beta)
+|{y} (beta)
 
 |Redis
 |{y} (beta)
 |{n}
+|{y} (beta)
 
 |Stdin
 |{y}
 |{n}
+|{y}
 
 |Syslog
+|{y}
 |{y}
 |{y}
 
 |TCP
 |{y}
 |{y}
+|{y}
 
 |UDP
 |{y}
 |{y}
+|{y}
 
 |UNIX
+|{y} (beta)
 |{y} (beta)
 |{y} (beta)
 |===
@@ -133,12 +159,12 @@ NOTE: {endpoint-sec} has a different output matrix.
 
 |{es} Service
 |{y}
-|{y}
+|{y} only to the same cluster where {fleet} runs
 |{y}
 
 |{es}
 |{y}
-|{y}
+|{y} only to the same cluster where {fleet} runs
 |{y}
 
 |{ls}
@@ -166,6 +192,8 @@ NOTE: {endpoint-sec} has a different output matrix.
 |{n}
 |{n}
 |===
+
+Currently, {agent}s managed by {fleet} can only output to the same {es} cluster where {fleet} is running. Support for outputting to remote {es} clusters is under consideration for a future release.
 
 [discrete]
 [[supported-configurations]]
@@ -217,7 +245,7 @@ configuration experience.
 |Processors can be defined at the integration level.
 
 |{filebeat-ref}/configuration-autodiscover.html[Autodiscover]
-|Autodiscover is facilitated through <<dynamic-input-configuration,dynamic inputs>>
+|Autodiscover is facilitated through <<dynamic-input-configuration,dynamic inputs>>. {agent} does not support hints-based autodiscovery.
 
 |{filebeat-ref}/configuring-internal-queue.html[Internal queues]
 |{agent} does not expose the internal memory queues to the end user. You can
@@ -236,6 +264,134 @@ per output type, which enables loadbalancing.
 
 |{filebeat-ref}/regexp-support.html[Regular expressions]
 |Supported
+|===
+
+[discrete]
+[[additional-capabilties-beats-and-agent]]
+== Capabilities comparison
+
+The following table shows a comparison of capabilities supported by {beats} and the {agent} in {version}:
+
+
+[options,header]
+|===
+|Item |{beats} |{fleet}-managed {agent} |Standalone {agent} |Description
+
+|Single agent for all use cases
+|{n}
+|{y}
+|{y}
+|{agent} provides logs, metrics, and more. You'd need to install multiple {beats} for these use cases.
+
+|Install integrations from web UI or API
+|{n}
+|{y}
+|{y}
+|{agent} integrations are installed with a convenient web UI or API, but {beats} modules are installed with a CLI. This installs {es} assets such as index templates and ingest pipelines, and {kib} assets such as dashboards.
+
+|Configure from web UI or API
+|{n}
+|{y}
+|{y} (optional)
+|{fleet}-managed {agent} integrations can be configured in the web UI or API. Standalone {agent} can use the web UI, API, or YAML. {beats} can only be configured via YAML files.
+
+|Central, remote agent policy management
+|{n}
+|{y}
+|{n}
+|{agent} policies can be centrally managed through {fleet}. You have to manage {beats} configuration yourself or with a third-party solution.
+
+|Central, remote agent binary upgrades
+|{n}
+|{y}
+|{n}
+|{agent}s can be remotely upgraded through {fleet}. You have to upgrade {beats} yourself or with a third-party solution.
+
+|Add {kib} and {es} assets for a single integration or module
+|{n}
+|{y}
+|{y}
+|{agent} integrations allow you to add {kib} and {es} assets for a single integration at a time. {beats} installs hundreds of assets for all modules at once.
+
+|Auto-generated {es} API keys
+|{n}
+|{y}
+|{n}
+|{fleet} can automatically generate API keys with limited permissions for each {agent}, which can be individually revoked. Standalone {agent} and {beats} require you to create and manage credentials, and users often share them across hosts.
+
+|Auto-generate minimal {es} permissions
+|{n}
+|{y}
+|{n}
+|{fleet} can automatically give {agent}s minimal output permissions based on the inputs running. With standalone {agent} and {beats}, users often give overly broad permissions because it's more convenient.
+
+|Data streams support
+|{n}
+|{y}
+|{y}
+|{agent}s use <<data-streams,data streams>> with easier index life cycle management and the https://www.elastic.co/blog/an-introduction-to-the-elastic-data-stream-naming-scheme[data stream naming scheme]. {beats} uses a single index with potentially thousands of fields.
+
+|Variables and input conditions
+|{n}
+|{y} (limited)
+|{y}
+|{agent} offers {fleet-guide}/dynamic-input-configuration.html[variables and input conditions] to dynamically adjust based on the local host environment. Users can configure these directly in YAML for standalone {agent} or using the Fleet API for {fleet}-managed {agent}. The Integrations app allows users to enter variables, and we are considering a https://github.com/elastic/kibana/issues/108525[UI to edit conditions]. {beats} only offers static configuration.
+
+|Allow non-superusers to manage assets and agents
+|{y}
+|{n}
+|{y} (it's optional)
+|We require a superuser role to use the {fleet} and Integrations apps and corresponding APIs. We are considering https://github.com/elastic/kibana/issues/108252[changing] this requirement. These apps are optional for standalone {agent}. {beats} offers {filebeat-ref}/feature-roles.html[finer grained] roles.
+
+|Air-gapped network support
+|{y}
+|{n}
+|{y}
+|The Integrations app requires a network connection to the {fleet-guide}/fleet-overview.html#package-registry-intro[Elastic Package Registry]. We are considering an https://github.com/elastic/integrations/issues/1178[on-prem version of EPR]. {fleet}-managed {agent}s require a connection to our artifact repository for agent binary upgrades. These are not required for standalone {agent}s or {beats}.
+
+|Run without root on host
+|{y}
+|{n}
+|{y}
+|{fleet}-managed {agent}s require root permission, in particular for Endpoint Security. Standalone {agent}s and {beats} do not.
+
+|Multiple outputs
+|{y}
+|{n}
+|{y}
+|{fleet}-managed {agent}s only provide a <<elastic-agent-output-configuration,single global output>> to the same {es} cluster where {fleet} is running. We are considering support for https://github.com/elastic/kibana/issues/104980[more outputs].
+
+|Separate monitoring cluster
+|{y}
+|{n}
+|{y}
+|{fleet}-managed {agent}s only provide a single global output to the same {es} cluster where {fleet} is running. We are considering support for https://github.com/elastic/kibana/issues/104980[remote monitoring clusters]. Standalone {agent} and {beats} can send to a remote monitoring cluster.
+
+|Secret management
+|{y}
+|{n}
+|{n}
+|{agent} stores credentials in the agent policy. We are considering adding https://github.com/elastic/integrations/issues/244[keystore support]. {beats} allows users to access credentials in a local https://www.elastic.co/guide/en/beats/filebeat/current/keystore.html[keystore].
+
+|Progressive or canary deployments
+|{y}
+|{n}
+|{y}
+|{fleet} does not have a feature to deploy an {agent} policy update progressively but we are considering https://github.com/elastic/kibana/issues/108267[improved support]. With standalone {agent} and {beats} you can deploy configuration files progressively using third party solutions.
+
+|Multiple configurations per host
+|{y}
+|{n} (uses input conditions instead)
+|{n} (uses input conditions instead)
+|{agent} uses a single {agent} policy for configuration, and uses {fleet-guide}/dynamic-input-configuration.html[variables and input conditions] to adapt on a per-host basis. {beats} supports multiple configuration files per host, enabling third party solutions to deploy files hierarchically or in multiple groups, and enabling finer-grained access control to those files.
+
+|Compatible with version control and infrastructure as code solutions
+|{y}
+|{n} (only via API)
+|{y}
+|{fleet} stores the agent policy in {es}. It does not integrate with external version control or infrastructure as code solutions, but we are considering https://github.com/elastic/kibana/issues/108524[improved support]. However, {beats} and {agent} in standalone mode use a YAML file that is compatible with these solutions.
+
+
 |===
 
 [discrete]
@@ -262,4 +418,3 @@ The *[Elastic Agent] Agent metrics* dashboard shows an aggregated view of agent 
 
 [role="screenshot"]
 image::images/agent-metrics-dashboard.png[Screen capture showing Elastic Agent metrics]
-


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Add capabilities to beats and agent comparison table (#943)