### PR TITLE
Make AWS monitoring tutorial title consistent with other tutorials

### DIFF
--- a/docs/en/observability/monitor-aws.asciidoc
+++ b/docs/en/observability/monitor-aws.asciidoc
@@ -2,7 +2,7 @@
 :aws: AWS
 
 [[monitor-aws]]
-== Monitoring Amazon Web Services ({aws})
+== Monitor Amazon Web Services ({aws})
 
 In this tutorial, you’ll learn how to monitor your {aws} infrastructure using
 Elastic Observability: Logs and Metrics.


### PR DESCRIPTION
Minor change from gerund to a simple verb for consistency. 

![image](https://user-images.githubusercontent.com/14206422/132067533-f24ba6bb-caed-4fca-8f47-b973aaab2ba1.png)
