### PR TITLE
[7.x] Update Fleet Server docs with link to related ECE info (#1020)

### DIFF
--- a/docs/en/ingest-management/fleet/fleet-server.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-server.asciidoc
@@ -48,10 +48,16 @@ bugfix releases)
 
 * {ece} 2.9--requires you to self-manage the {fleet-server}.
 * {ece} 2.10 or later--allows you to use a hosted {fleet-server} on {ecloud}.
++
+--
 ** Requires additional wildcard domains and certificates (which normally only
 cover `*.cname`, not `*.*.cname`). This enables us to provide the URL for
-{fleet-server} of `https://.fleet.`
+{fleet-server} of `https://.fleet.`.
 ** The deployment template must contain an APM & Fleet node.
+--
++
+For more information about hosting {fleet-server} on {ece}, refer to
+{ece-ref}/ece-manage-apm-and-fleet.html[Manage your APM & {fleet-server}].
 
 [discrete]
 [[add-fleet-server]]
@@ -66,9 +72,6 @@ include::{tab-widgets}/add-fleet-server/widget.asciidoc[]
 
 Now you're ready to add {agent}s to your host systems. To learn how, see
 <<add-agent-to-fleet>>.
-
-//TODO: Describe other installation options (like using the enroll
-// command rather than installing as service) and point to that info.
 
 [discrete]
 [[fleet-server-deployment]]


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Update Fleet Server docs with link to related ECE info (#1020)