### PR TITLE
[Uptime] Add troubleshooting page for Uptime guide

### DIFF
--- a/docs/en/observability/index.asciidoc
+++ b/docs/en/observability/index.asciidoc
@@ -87,7 +87,7 @@ include::inspect-uptime-duration-anomalies.asciidoc[leveloffset=+2]
 
 include::configure-uptime-settings.asciidoc[leveloffset=+2]
 
-include::troubleshoot-uptime.asciidoc[leveloffset=+2]
+include::troubleshoot-uptime-mapping-issues.asciidoc[leveloffset=+2]
 
 // Synthetic monitoring
 :playwright-url:      https://playwright.dev/

--- a/docs/en/observability/index.asciidoc
+++ b/docs/en/observability/index.asciidoc
@@ -87,6 +87,8 @@ include::inspect-uptime-duration-anomalies.asciidoc[leveloffset=+2]
 
 include::configure-uptime-settings.asciidoc[leveloffset=+2]
 
+include::troubleshoot-uptime.asciidoc[leveloffset=+2]
+
 // Synthetic monitoring
 :playwright-url:      https://playwright.dev/
 :playwright-api-docs: https://playwright.dev/docs/api/class-playwright

--- a/docs/en/observability/troubleshoot-uptime-mapping-issues.asciidoc
+++ b/docs/en/observability/troubleshoot-uptime-mapping-issues.asciidoc
@@ -14,17 +14,21 @@ through an intermediary such as {ls} without the `setup` command being run.
 To fix this problem, you typically need to remove your {heartbeat} indices and create
 new ones with the appropriate mappings installed. To achieve this, follow the steps below.
 
-=== Step 1: Delete your {heartbeat} indices
+=== Step 1: Stop your {heartbeat} instances
+
+It is necessary to stop all {heartbeat} instances that are targeting the cluster, so they will not write to or re-create indices prematurely.
+
+=== Step 2: Delete your {heartbeat} indices
 
 To ensure the mapping is applied to all {heartbeat} data going forward,
 delete all the {heartbeat} indicies that match the pattern the {uptime-app} will use.
 
-=== Step 2: Run the {heartbeat} setup command
+=== Step 3: Run the {heartbeat} setup command
 
 There are multiple ways to achieve this.
 You can read about performing this using the {ref}/index-mgmt.html[Index Management UI] or with the {ref}/indices-delete-index.html[Delete index API].
 
-=== Step 3: Perform {heartbeat} setup
+=== Step 4: Perform {heartbeat} setup
 
 The below command will cause {heartbeat} to perform its setup processes.
 
@@ -37,7 +41,7 @@ include::{beats-repo-dir}/tab-widgets/setup-widget.asciidoc[]
 
 This command performs the necessary startup tasks and ensures that your indicies have the appropriate mapping going forward.
 
-=== Step 3: Run {heartbeat} again
+=== Step 5: Run {heartbeat} again
 
 Now, when you run {heartbeat}, your data will be indexed with the appropriate mappings. When
 the {uptime-app} attempts to fetch your data, it should be able to render without issues.

--- a/docs/en/observability/troubleshoot-uptime-mapping-issues.asciidoc
+++ b/docs/en/observability/troubleshoot-uptime-mapping-issues.asciidoc
@@ -1,4 +1,7 @@
 [[troubleshoot-uptime-mapping-issues]]
+
+:beatname_lc: heartbeat
+
 = Troubleshoot mapping issues
 
 == Mapping issues
@@ -30,10 +33,9 @@ The below command will cause {heartbeat} to perform its setup processes.
 NOTE: For more information on how to use this command, you can reference the
 {heartbeat-ref}/heartbeat-installation-configuration.html[Heartbeat quickstart guide].
 
-["source","sh"]
-----
-./heartbeat setup -e 
-----
+--
+include::{beats-repo-dir}/tab-widgets/setup-widget.asciidoc[]
+--
 
 This command performs the necessary startup tasks and ensures that your indicies have the appropriate mapping going forward.
 
@@ -41,3 +43,5 @@ This command performs the necessary startup tasks and ensures that your indicies
 
 Now, when you run {heartbeat}, your data will be indexed with the appropriate mappings. When
 the {uptime-app} attempts to fetch your data, it should be able to render without issues.
+
+:!beatname_lc:

--- a/docs/en/observability/troubleshoot-uptime-mapping-issues.asciidoc
+++ b/docs/en/observability/troubleshoot-uptime-mapping-issues.asciidoc
@@ -1,5 +1,5 @@
-[[troubleshoot-uptime]]
-= Uptime troubleshooting
+[[troubleshoot-uptime-mapping-issues]]
+= Troubleshoot mapping issues
 
 == Mapping issues
 

--- a/docs/en/observability/troubleshoot-uptime-mapping-issues.asciidoc
+++ b/docs/en/observability/troubleshoot-uptime-mapping-issues.asciidoc
@@ -19,8 +19,6 @@ new ones with the appropriate mappings installed. To achieve this, follow the st
 To ensure the mapping is applied to all {heartbeat} data going forward,
 delete all the {heartbeat} indicies that match the pattern the {uptime-app} will use.
 
-
-
 === Step 2: Run the {heartbeat} setup command
 
 There are multiple ways to achieve this.

--- a/docs/en/observability/troubleshoot-uptime.asciidoc
+++ b/docs/en/observability/troubleshoot-uptime.asciidoc
@@ -11,7 +11,7 @@ through an intermediary such as {ls} without the `setup` command being run.
 To fix this problem, you typically need to remove your Heartbeat indices, and create
 new ones, with the appropriate mappings installed. To achieve this, follow the steps below.
 
-=== Step 1: Delete your Heartbeat indices
+=== Step 1: Delete your {heartbeat} indices
 
 Because we need to ensure the mapping is appropriately applied to all {heartbeat} data going forward,
 we must delete all {heartbeat} indicies that match the pattern the {uptime-app} will use.

--- a/docs/en/observability/troubleshoot-uptime.asciidoc
+++ b/docs/en/observability/troubleshoot-uptime.asciidoc
@@ -4,7 +4,7 @@
 == Mapping issues
 
 There are situations in which {heartbeat} data can be indexed without the correct mappings applied.
-These situations cannot occur with the {elastic-agent} configured via fleet, only with standalone {heartbeat}.
+These situations cannot occur with the {elastic-agent} configured via {fleet}, only with standalone {heartbeat}.
 This can occur when the underlying `heartbeat-VERSION` ILM alias is deleted manually or when {heartbeat} writes data
 through an intermediary such as {ls} without the `setup` command being run.
 

--- a/docs/en/observability/troubleshoot-uptime.asciidoc
+++ b/docs/en/observability/troubleshoot-uptime.asciidoc
@@ -35,8 +35,7 @@ NOTE: For more information on how to use this command, you can reference the
 ./heartbeat setup -e 
 ----
 
-This will perform the necessary startup tasks and ensure that your indices will have the appropriate
-mapping going forward.
+This command performs the necessary startup tasks and ensures that your indicies have the appropriate mapping going forward.
 
 === Step 3: Run {heartbeat} again
 

--- a/docs/en/observability/troubleshoot-uptime.asciidoc
+++ b/docs/en/observability/troubleshoot-uptime.asciidoc
@@ -1,0 +1,33 @@
+[[troubleshoot-uptime]]
+= Uptime troubleshooting
+
+== Mapping issues
+
+It is possible for Heartbeat to create an index without the appropriate mappings.
+When this happens, the {uptime-app} will be unable to get the data it requires; in this
+state, the UI cannot function.
+
+To fix this problem, you typically need to remove your Heartbeat indices, and create
+new ones, with the appropriate mappings installed. To achieve this, follow the steps below.
+
+=== Step 1: Delete your Heartbeat indices
+
+["source","sh"]
+----
+curl -u {USERNAME}:{PASSWORD} -X DELETE {INDEX_URL}
+----
+
+=== Step 2: Run the Heartbeat setup command
+
+["source","sh"]
+----
+./heartbeat setup -e 
+----
+
+This will perform the necessary startup tasks and ensure that your indices will have the appropriate
+mapping going forward.
+
+=== Step 3: Run Heartbeat again
+
+Now when you run heartbeat, your data will be indexed with the appropriate mappings. When
+the {uptime-app} attempts to fetch the data, it should be able to render without issues.

--- a/docs/en/observability/troubleshoot-uptime.asciidoc
+++ b/docs/en/observability/troubleshoot-uptime.asciidoc
@@ -18,7 +18,7 @@ delete all the {heartbeat} indicies that match the pattern the {uptime-app} will
 
 
 
-=== Step 2: Run the Heartbeat setup command
+=== Step 2: Run the {heartbeat} setup command
 
 There are multiple ways to achieve this.
 You can read about performing this using the {ref}/index-mgmt.html[Index Management UI] or with the {ref}/indices-delete-index.html[Delete index API].

--- a/docs/en/observability/troubleshoot-uptime.asciidoc
+++ b/docs/en/observability/troubleshoot-uptime.asciidoc
@@ -21,7 +21,7 @@ we must delete all {heartbeat} indicies that match the pattern the {uptime-app} 
 === Step 2: Run the Heartbeat setup command
 
 There are multiple ways to achieve this.
-You can read about how to perform this using the {ref}/index-mgmt.html[Index Management UI], or with the {ref}/indices-delete-index.html[Delete index API].
+You can read about performing this using the {ref}/index-mgmt.html[Index Management UI] or with the {ref}/indices-delete-index.html[Delete index API].
 
 === Step 3: Perform {heartbeat} setup
 

--- a/docs/en/observability/troubleshoot-uptime.asciidoc
+++ b/docs/en/observability/troubleshoot-uptime.asciidoc
@@ -8,8 +8,8 @@ These situations cannot occur with the {elastic-agent} configured via {fleet}, o
 This can occur when the underlying `heartbeat-VERSION` ILM alias is deleted manually or when {heartbeat} writes data
 through an intermediary such as {ls} without the `setup` command being run.
 
-To fix this problem, you typically need to remove your Heartbeat indices, and create
-new ones, with the appropriate mappings installed. To achieve this, follow the steps below.
+To fix this problem, you typically need to remove your {heartbeat} indices and create
+new ones with the appropriate mappings installed. To achieve this, follow the steps below.
 
 === Step 1: Delete your {heartbeat} indices
 

--- a/docs/en/observability/troubleshoot-uptime.asciidoc
+++ b/docs/en/observability/troubleshoot-uptime.asciidoc
@@ -3,21 +3,32 @@
 
 == Mapping issues
 
-It is possible for Heartbeat to create an index without the appropriate mappings.
-When this happens, the {uptime-app} will be unable to get the data it requires; in this
-state, the UI cannot function.
+There are situations in which {heartbeat} data can be indexed without the correct mappings applied.
+These situations cannot occur with the {elastic-agent} configured via fleet, only with standalone {heartbeat}.
+This can occur when the underlying `heartbeat-VERSION` ILM alias is deleted manually or when {heartbeat} writes data
+through an intermediary such as {ls} without the `setup` command being run.
 
 To fix this problem, you typically need to remove your Heartbeat indices, and create
 new ones, with the appropriate mappings installed. To achieve this, follow the steps below.
 
 === Step 1: Delete your Heartbeat indices
 
-["source","sh"]
-----
-curl -u {USERNAME}:{PASSWORD} -X DELETE {INDEX_URL}
-----
+Because we need to ensure the mapping is appropriately applied to all {heartbeat} data going forward,
+we must delete all {heartbeat} indicies that match the pattern the {uptime-app} will use.
+
+
 
 === Step 2: Run the Heartbeat setup command
+
+There are multiple ways to achieve this.
+You can read about how to perform this using the {ref}/index-mgmt.html[Index Management UI], or with the {ref}/indices-delete-index.html[Delete index API].
+
+=== Step 3: Perform {heartbeat} setup
+
+The below command will cause {heartbeat} to perform its setup processes.
+
+NOTE: For more information on how to use this command, you can reference the
+{heartbeat-ref}/heartbeat-installation-configuration.html[Heartbeat quickstart guide].
 
 ["source","sh"]
 ----
@@ -29,5 +40,5 @@ mapping going forward.
 
 === Step 3: Run Heartbeat again
 
-Now when you run heartbeat, your data will be indexed with the appropriate mappings. When
-the {uptime-app} attempts to fetch the data, it should be able to render without issues.
+Now, when you run {heartbeat}, your data will be indexed with the appropriate mappings. When
+the {uptime-app} attempts to fetch your data, it should be able to render without issues.

--- a/docs/en/observability/troubleshoot-uptime.asciidoc
+++ b/docs/en/observability/troubleshoot-uptime.asciidoc
@@ -38,7 +38,7 @@ NOTE: For more information on how to use this command, you can reference the
 This will perform the necessary startup tasks and ensure that your indices will have the appropriate
 mapping going forward.
 
-=== Step 3: Run Heartbeat again
+=== Step 3: Run {heartbeat} again
 
 Now, when you run {heartbeat}, your data will be indexed with the appropriate mappings. When
 the {uptime-app} attempts to fetch your data, it should be able to render without issues.

--- a/docs/en/observability/troubleshoot-uptime.asciidoc
+++ b/docs/en/observability/troubleshoot-uptime.asciidoc
@@ -13,8 +13,8 @@ new ones with the appropriate mappings installed. To achieve this, follow the st
 
 === Step 1: Delete your {heartbeat} indices
 
-Because we need to ensure the mapping is appropriately applied to all {heartbeat} data going forward,
-we must delete all {heartbeat} indicies that match the pattern the {uptime-app} will use.
+To ensure the mapping is applied to all {heartbeat} data going forward,
+delete all the {heartbeat} indicies that match the pattern the {uptime-app} will use.
 
 
 


### PR DESCRIPTION
Resolves https://github.com/elastic/observability-docs/issues/1018.

The goal of this PR is to introduce a troubleshooting page we can link to from the Uptime app in certain cases. Today, the only issue we have is this mapping problem.

Our goal is to link to this docs page from the Uptime UI when this issue occurs.