### PR TITLE
Add Endpoint security and Osquery to beats/agent comparison

### DIFF
--- a/docs/en/ingest-management/beats-agent-comparison.asciidoc
+++ b/docs/en/ingest-management/beats-agent-comparison.asciidoc
@@ -73,6 +73,11 @@ The following table shows the inputs supported by the {agent} in {version}:
 |{n}
 |{y}
 
+|Endpoint security
+|{n}
+|{n}
+|{y}
+
 |GCP Pub/Sub
 |{y}
 |{y}
@@ -110,6 +115,11 @@ The following table shows the inputs supported by the {agent} in {version}:
 
 |O365 Mgmt Act API
 |{y} (beta)
+|{y} (beta)
+|{y} (beta)
+
+|Osquery 
+|{n}
 |{y} (beta)
 |{y} (beta)
 

--- a/docs/en/ingest-management/beats-agent-comparison.asciidoc
+++ b/docs/en/ingest-management/beats-agent-comparison.asciidoc
@@ -75,8 +75,8 @@ The following table shows the inputs supported by the {agent} in {version}:
 
 |Endpoint security
 |{n}
-|{n}
 |{y}
+|{n}
 
 |GCP Pub/Sub
 |{y}
@@ -121,7 +121,7 @@ The following table shows the inputs supported by the {agent} in {version}:
 |Osquery 
 |{n}
 |{y} (beta)
-|{y} (beta)
+|{n}
 
 |Redis
 |{y} (beta)


### PR DESCRIPTION
I noticed that we are missing Endpoint security and Osquery in the beats/agent comparison docs https://www.elastic.co/guide/en/fleet/current/beats-agent-comparison.html.  These are key advantages and reasons to adopt Elastic Agent so we should include them in the comparison.

CC @melissaburpo @caitlinbetz 