### PR TITLE
[7.14] Add Endpoint security and Osquery to beats/agent comparison (#1058)

### DIFF
--- a/docs/en/ingest-management/beats-agent-comparison.asciidoc
+++ b/docs/en/ingest-management/beats-agent-comparison.asciidoc
@@ -73,6 +73,11 @@ The following table shows the inputs supported by the {agent} in {version}:
 |{n}
 |{y}
 
+|Endpoint security
+|{n}
+|{y}
+|{n}
+
 |GCP Pub/Sub
 |{y}
 |{y}
@@ -112,6 +117,11 @@ The following table shows the inputs supported by the {agent} in {version}:
 |{y} (beta)
 |{y} (beta)
 |{y} (beta)
+
+|Osquery 
+|{n}
+|{y} (beta)
+|{n}
 
 |Redis
 |{y} (beta)


### PR DESCRIPTION
Backports the following commits to 7.14:
 - Add Endpoint security and Osquery to beats/agent comparison (#1058)