### PR TITLE
[7.15] Link to Integrations documentation from overview (#1076)

### DIFF
--- a/docs/en/ingest-management/overview.asciidoc
+++ b/docs/en/ingest-management/overview.asciidoc
@@ -65,7 +65,8 @@ xpack.ingestManager.registryProxyUrl: <your-proxy-address>
 
 {kib} provides a web-based UI for configuring integrations with your
 data sources. This includes popular services and platforms like Nginx or AWS,
-as well as many generic input types like log files.
+as well as many generic input types like log files. For a list of
+available integrations, refer to {integrations-docs}[Elastic Integrations].
 
 The {agent} policy allows you to use any number of integrations for
 data sources. You can apply the {agent} policy to multiple agents,


### PR DESCRIPTION
Backports the following commits to 7.15:
 - Link to Integrations documentation from overview (#1076)