### PR TITLE
Add 7.15 release notes

### DIFF
--- a/docs/en/ingest-management/index.asciidoc
+++ b/docs/en/ingest-management/index.asciidoc
@@ -62,7 +62,7 @@ include::troubleshooting.asciidoc[leveloffset=+1]
 
 include::faq.asciidoc[leveloffset=+1]
 
-include::release-notes/release-notes-7.14.asciidoc[leveloffset=+1]
+include::release-notes/release-notes-7.15.asciidoc[leveloffset=+1]
 
 include::fleet/fleet-api-docs.asciidoc[leveloffset=+1]
 

--- a/docs/en/ingest-management/release-notes/release-notes-7.15.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-7.15.asciidoc
@@ -1,0 +1,237 @@
+// Use these for links to issue and pulls. 
+:kib-issue: https://github.com/elastic/kibana/issues/
+:kib-pull: https://github.com/elastic/kibana/pull/
+:agent-issue: https://github.com/elastic/beats/issues/
+:agent-pull: https://github.com/elastic/beats/pull/
+:fleet-server-issue: https://github.com/elastic/beats/issues/fleet-server/
+:fleet-server-pull: https://github.com/elastic/beats/pull/fleet-server/
+
+
+[[release-notes]]
+= Release notes
+
+This section summarizes the changes in each release.
+
+* <<release-notes-7.15.0>>
+
+Also see:
+
+* {kibana-ref}/release-notes.html[{kib} release notes]
+* {beats-ref}/release-notes.html[{beats} release notes]
+
+// begin 7.15.0 relnotes
+
+[[release-notes-7.15.0]]
+== {fleet} and {agent} 7.15.0
+
+Review important information about the {fleet} and {agent} 7.15.0 releases.
+
+//[discrete]
+//[[security-updates-7.15.0]]
+//=== Security updates
+
+//{fleet}::
+//* add info
+
+//{agent}::
+//* add info
+
+//[discrete]
+//[[breaking-changes-7.15.0]]
+//=== Breaking changes
+
+//Breaking changes can prevent your application from optimal operation and
+//performance. Before you upgrade, review the breaking changes, then mitigate the
+//impact to your application.
+
+//[discrete]
+//[[breaking-PR#]]
+//.Short description
+//[%collapsible]
+//====
+//*Details* +
+//<Describe new behavior.> For more information, refer to {kibana-pull}PR[#PR].
+
+//*Impact* +
+//<Describe how users should mitigate the change.> For more information, refer to {fleet-guide}/fleet-server.html[Fleet Server].
+//====
+
+[discrete]
+[[known-issues-7.15.0]]
+=== Known issues
+
+.Upgrade {agent}s to use Osquery Manager integration
+[%collapsible]
+====
+*Details* +
+You must upgrade your {agent}s to the latest version to use the Osquery Manager
+integration.
+
+*Impact* +
+To upgrade, refer to <<upgrade-elastic-agent>>.
+====
+
+//[discrete]
+//[[deprecations-7.15.0]]
+//=== Deprecations
+
+//The following functionality is deprecated in 7.15.0, and will be removed in
+//8.0.0. Deprecated functionality does not have an immediate impact on your
+//application, but we strongly recommend you make the necessary updates after you
+//upgrade to 7.15.0.
+
+//{fleet}::
+//* add info
+
+//{agent}::
+//* add info
+
+//[discrete]
+//[[new-features-7.15.0]]
+//=== New features
+
+//The 7.15.0 release adds the following new and notable features.
+
+//{fleet}::
+//* add info
+
+//{agent}::
+//* add info
+
+[discrete]
+[[enhancements-7.15.0]]
+=== Enhancements
+
+{fleet}::
+* Updates Package Policy UI to support upgrading package policies
+{kib-pull}107171[#107171]
+* Removes subseconds from `event.ingested` {kib-pull}104044[#104044]
+* Adds package policy upgrade API {kib-pull}103017[#103017]
+
+//{agent}::
+//* add info
+
+[discrete]
+[[bug-fixes-7.15.0]]
+=== Bug fixes
+
+{fleet}::
+* Fixes Fleet settings and HostInput error handling {kib-pull}109418[#109418]
+* Fixes Agent policy search to support simple text filters
+{kib-pull}107306[#107306]
+
+//{agent}::
+//* add info
+
+// end 7.15.x relnotes
+
+
+
+// ---------------------
+//TEMPLATE
+//Use the following text as a template. Remember to replace the version info.
+
+// begin 7.15.x relnotes
+
+//[[release-notes-7.15.x]]
+//== {fleet} and {agent} 7.15.x
+
+//Review important information about the {fleet} and {agent} 7.15.x releases.
+
+//[discrete]
+//[[security-updates-7.15.x]]
+//=== Security updates
+
+//{fleet}::
+//* add info
+
+//{agent}::
+//* add info
+
+//[discrete]
+//[[breaking-changes-7.15.x]]
+//=== Breaking changes
+
+//Breaking changes can prevent your application from optimal operation and
+//performance. Before you upgrade, review the breaking changes, then mitigate the
+//impact to your application.
+
+//[discrete]
+//[[breaking-PR#]]
+//.Short description
+//[%collapsible]
+//====
+//*Details* +
+//<Describe new behavior.> For more information, refer to {kibana-pull}PR[#PR].
+
+//*Impact* +
+//<Describe how users should mitigate the change.> For more information, refer to {fleet-guide}/fleet-server.html[Fleet Server].
+//====
+
+//[discrete]
+//[[known-issues-7.15.x]]
+//=== Known issues
+
+//[[known-issue-issue#]]
+//.Short description
+//[%collapsible]
+//====
+
+//*Details* 
+
+//<Describe known issue.>
+
+//*Impact* +
+
+//<Describe impact or workaround.>
+
+//====
+
+//[discrete]
+//[[deprecations-7.15.x]]
+//=== Deprecations
+
+//The following functionality is deprecated in 7.15.x, and will be removed in
+//8.0.0. Deprecated functionality does not have an immediate impact on your
+//application, but we strongly recommend you make the necessary updates after you
+//upgrade to 7.15.x.
+
+//{fleet}::
+//* add info
+
+//{agent}::
+//* add info
+
+//[discrete]
+//[[new-features-7.15.x]]
+//=== New features
+
+//The 7.15.x release adds the following new and notable features.
+
+//{fleet}::
+//* add info
+
+//{agent}::
+//* add info
+
+//[discrete]
+//[[enhancements-7.15.x]]
+//=== Enhancements
+
+//{fleet}::
+//* add info
+
+//{agent}::
+//* add info
+
+//[discrete]
+//[[bug-fixes-7.15.x]]
+//=== Bug fixes
+
+//{fleet}::
+//* add info
+
+//{agent}::
+//* add info
+
+// end 7.15.x relnotes

--- a/docs/en/ingest-management/release-notes/release-notes-7.15.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-7.15.asciidoc
@@ -26,36 +26,6 @@ Also see:
 
 Review important information about the {fleet} and {agent} 7.15.0 releases.
 
-//[discrete]
-//[[security-updates-7.15.0]]
-//=== Security updates
-
-//{fleet}::
-//* add info
-
-//{agent}::
-//* add info
-
-//[discrete]
-//[[breaking-changes-7.15.0]]
-//=== Breaking changes
-
-//Breaking changes can prevent your application from optimal operation and
-//performance. Before you upgrade, review the breaking changes, then mitigate the
-//impact to your application.
-
-//[discrete]
-//[[breaking-PR#]]
-//.Short description
-//[%collapsible]
-//====
-//*Details* +
-//<Describe new behavior.> For more information, refer to {kibana-pull}PR[#PR].
-
-//*Impact* +
-//<Describe how users should mitigate the change.> For more information, refer to {fleet-guide}/fleet-server.html[Fleet Server].
-//====
-
 [discrete]
 [[known-issues-7.15.0]]
 === Known issues
@@ -71,33 +41,6 @@ integration.
 To upgrade, refer to <<upgrade-elastic-agent>>.
 ====
 
-//[discrete]
-//[[deprecations-7.15.0]]
-//=== Deprecations
-
-//The following functionality is deprecated in 7.15.0, and will be removed in
-//8.0.0. Deprecated functionality does not have an immediate impact on your
-//application, but we strongly recommend you make the necessary updates after you
-//upgrade to 7.15.0.
-
-//{fleet}::
-//* add info
-
-//{agent}::
-//* add info
-
-//[discrete]
-//[[new-features-7.15.0]]
-//=== New features
-
-//The 7.15.0 release adds the following new and notable features.
-
-//{fleet}::
-//* add info
-
-//{agent}::
-//* add info
-
 [discrete]
 [[enhancements-7.15.0]]
 === Enhancements
@@ -108,9 +51,6 @@ To upgrade, refer to <<upgrade-elastic-agent>>.
 {kib-pull}107171[#107171]
 * Removes subseconds from `event.ingested` {kib-pull}104044[#104044]
 
-//{agent}::
-//* add info
-
 [discrete]
 [[bug-fixes-7.15.0]]
 === Bug fixes
@@ -120,8 +60,9 @@ To upgrade, refer to <<upgrade-elastic-agent>>.
 * Fixes Agent policy search to support simple text filters
 {kib-pull}107306[#107306]
 
-//{agent}::
-//* add info
+{agent}::
+* Adds validation for certificate flags to ensure they are absolute paths {agent-pull}27779[#27779]
+* Migrates state on upgrade {agent-pull}27825[#27825]
 
 // end 7.15.x relnotes
 

--- a/docs/en/ingest-management/release-notes/release-notes-7.15.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-7.15.asciidoc
@@ -103,10 +103,10 @@ To upgrade, refer to <<upgrade-elastic-agent>>.
 === Enhancements
 
 {fleet}::
+* Adds package policy upgrade API {kib-pull}103017[#103017]
 * Updates Package Policy UI to support upgrading package policies
 {kib-pull}107171[#107171]
 * Removes subseconds from `event.ingested` {kib-pull}104044[#104044]
-* Adds package policy upgrade API {kib-pull}103017[#103017]
 
 //{agent}::
 //* add info


### PR DESCRIPTION
Link to preview: https://observability-docs_1080.docs-preview.app.elstc.co/guide/en/fleet/master/release-notes-7.15.0.html

Adds placeholder file for the release notes. 

We are still building the release notes by hand, so I need folks from the Fleet and Elastic Agent teams to identify missing stuff (especially the agent team...I need to know anything from the changelog that you want to highlight).