### PR TITLE
Add 7.14.2  release notes

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-7.14.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-7.14.asciidoc
@@ -39,8 +39,8 @@ Review important information about the {fleet} and {agent} 7.14.2 releases.
 and `xpack.fleet` {kib-pull}111612[#111612]
 
 {agent}::
-* Adds validation for certificate flags to ensure they are absolute paths {agent-pull}#27779[27779]
-* Migrates state on upgrade {agent-pull}#27825[27825]
+* Adds validation for certificate flags to ensure they are absolute paths {agent-pull}27779[#27779]
+* Migrates state on upgrade {agent-pull}27825[#27825]
 
 // end 7.14.2 relnotes
 

--- a/docs/en/ingest-management/release-notes/release-notes-7.14.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-7.14.asciidoc
@@ -39,8 +39,8 @@ Review important information about the {fleet} and {agent} 7.14.2 releases.
 and `xpack.fleet` {kib-pull}111612[#111612]
 
 {agent}::
-* Adds validation for certificate flags to ensure they are absolute paths {agent-pull}27779[27779]
-* Migrates state on upgrade {agent-pull}27825[27825]
+* Adds validation for certificate flags to ensure they are absolute paths {agent-pull}#27779[27779]
+* Migrates state on upgrade {agent-pull}#27825[27825]
 
 // end 7.14.2 relnotes
 

--- a/docs/en/ingest-management/release-notes/release-notes-7.14.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-7.14.asciidoc
@@ -30,92 +30,6 @@ Also see:
 
 Review important information about the {fleet} and {agent} 7.14.2 releases.
 
-//[discrete]
-//[[security-updates-7.14.2]]
-//=== Security updates
-
-//{fleet}::
-//* add info
-
-//{agent}::
-//* add info
-
-//[discrete]
-//[[breaking-changes-7.14.2]]
-//=== Breaking changes
-
-//Breaking changes can prevent your application from optimal operation and
-//performance. Before you upgrade, review the breaking changes, then mitigate the
-//impact to your application.
-
-//[discrete]
-//[[breaking-PR#]]
-//.Short description
-//[%collapsible]
-//====
-//*Details* +
-//<Describe new behavior.> For more information, refer to {kibana-pull}PR[#PR].
-
-//*Impact* +
-//<Describe how users should mitigate the change.> For more information, refer to {fleet-guide}/fleet-server.html[Fleet Server].
-//====
-
-//[discrete]
-//[[known-issues-7.14.2]]
-//=== Known issues
-
-//[[known-issue-issue#]]
-//.Short description
-//[%collapsible]
-//====
-
-//*Details* 
-
-//<Describe known issue.>
-
-//*Impact* +
-
-//<Describe impact or workaround.>
-
-//====
-
-//[discrete]
-//[[deprecations-7.14.2]]
-//=== Deprecations
-
-//The following functionality is deprecated in 7.14.2, and will be removed in
-//8.0.0. Deprecated functionality does not have an immediate impact on your
-//application, but we strongly recommend you make the necessary updates after you
-//upgrade to 7.14.2.
-
-//{fleet}::
-//* add info
-
-//{agent}::
-//* add info
-
-//[discrete]
-//[[new-features-7.14.2]]
-//=== New features
-
-//The 7.14.2 release adds the following new and notable features.
-
-//{fleet}::
-//* add info
-
-//{agent}::
-//* add info
-
-//[discrete]
-//[[enhancements-7.14.2]]
-//=== Enhancements
-
-//{fleet}::
-//* add info
-
-//{agent}::
-//* add info
-
 [discrete]
 [[bug-fixes-7.14.2]]
 === Bug fixes
@@ -124,8 +38,9 @@ Review important information about the {fleet} and {agent} 7.14.2 releases.
 * Fixes config migration from ingestManager to support both `xpack.ingestManager`
 and `xpack.fleet` {kib-pull}111612[#111612]
 
-//{agent}::
-//* add info
+{agent}::
+* Adds validation for certificate flags to ensure they are absolute paths {agent-pull}27779[27779]
+* Migrates state on upgrade {agent-pull}27825[27825]
 
 // end 7.14.2 relnotes
 

--- a/docs/en/ingest-management/release-notes/release-notes-7.14.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-7.14.asciidoc
@@ -12,6 +12,8 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-7.14.2>>
+
 * <<release-notes-7.14.1>>
 
 * <<release-notes-7.14.0>>
@@ -20,6 +22,112 @@ Also see:
 
 * {kibana-ref}/release-notes.html[{kib} release notes]
 * {beats-ref}/release-notes.html[{beats} release notes]
+
+// begin 7.14.2 relnotes
+
+[[release-notes-7.14.2]]
+== {fleet} and {agent} 7.14.2
+
+Review important information about the {fleet} and {agent} 7.14.2 releases.
+
+//[discrete]
+//[[security-updates-7.14.2]]
+//=== Security updates
+
+//{fleet}::
+//* add info
+
+//{agent}::
+//* add info
+
+//[discrete]
+//[[breaking-changes-7.14.2]]
+//=== Breaking changes
+
+//Breaking changes can prevent your application from optimal operation and
+//performance. Before you upgrade, review the breaking changes, then mitigate the
+//impact to your application.
+
+//[discrete]
+//[[breaking-PR#]]
+//.Short description
+//[%collapsible]
+//====
+//*Details* +
+//<Describe new behavior.> For more information, refer to {kibana-pull}PR[#PR].
+
+//*Impact* +
+//<Describe how users should mitigate the change.> For more information, refer to {fleet-guide}/fleet-server.html[Fleet Server].
+//====
+
+//[discrete]
+//[[known-issues-7.14.2]]
+//=== Known issues
+
+//[[known-issue-issue#]]
+//.Short description
+//[%collapsible]
+//====
+
+//*Details* 
+
+//<Describe known issue.>
+
+//*Impact* +
+
+//<Describe impact or workaround.>
+
+//====
+
+//[discrete]
+//[[deprecations-7.14.2]]
+//=== Deprecations
+
+//The following functionality is deprecated in 7.14.2, and will be removed in
+//8.0.0. Deprecated functionality does not have an immediate impact on your
+//application, but we strongly recommend you make the necessary updates after you
+//upgrade to 7.14.2.
+
+//{fleet}::
+//* add info
+
+//{agent}::
+//* add info
+
+//[discrete]
+//[[new-features-7.14.2]]
+//=== New features
+
+//The 7.14.2 release adds the following new and notable features.
+
+//{fleet}::
+//* add info
+
+//{agent}::
+//* add info
+
+//[discrete]
+//[[enhancements-7.14.2]]
+//=== Enhancements
+
+//{fleet}::
+//* add info
+
+//{agent}::
+//* add info
+
+[discrete]
+[[bug-fixes-7.14.2]]
+=== Bug fixes
+
+{fleet}::
+* Fixes config migration from ingestManager to support both `xpack.ingestManager`
+and `xpack.fleet` {kib-pull}111612[#111612]
+
+//{agent}::
+//* add info
+
+// end 7.14.2 relnotes
 
 // begin 7.14.1 relnotes
 


### PR DESCRIPTION
Preview: https://observability-docs_1081.docs-preview.app.elstc.co/guide/en/fleet/7.14/release-notes-7.14.2.html

Adds placeholder file for the release notes.

We are still building the release notes by hand, so I need folks from the Fleet and Elastic Agent teams to identify missing stuff (especially the agent team...I need to know anything from the changelog that you want to highlight).