### PR TITLE
[Uptime] Remove mistaken heading from guide

### DIFF
--- a/docs/en/observability/troubleshoot-uptime-mapping-issues.asciidoc
+++ b/docs/en/observability/troubleshoot-uptime-mapping-issues.asciidoc
@@ -23,12 +23,10 @@ It is necessary to stop all {heartbeat} instances that are targeting the cluster
 To ensure the mapping is applied to all {heartbeat} data going forward,
 delete all the {heartbeat} indicies that match the pattern the {uptime-app} will use.
 
-=== Step 3: Run the {heartbeat} setup command
-
 There are multiple ways to achieve this.
 You can read about performing this using the {ref}/index-mgmt.html[Index Management UI] or with the {ref}/indices-delete-index.html[Delete index API].
 
-=== Step 4: Perform {heartbeat} setup
+=== Step 3: Perform {heartbeat} setup
 
 The below command will cause {heartbeat} to perform its setup processes.
 
@@ -41,7 +39,7 @@ include::{beats-repo-dir}/tab-widgets/setup-widget.asciidoc[]
 
 This command performs the necessary startup tasks and ensures that your indicies have the appropriate mapping going forward.
 
-=== Step 5: Run {heartbeat} again
+=== Step 4: Run {heartbeat} again
 
 Now, when you run {heartbeat}, your data will be indexed with the appropriate mappings. When
 the {uptime-app} attempts to fetch your data, it should be able to render without issues.


### PR DESCRIPTION
In https://github.com/elastic/observability-docs/pull/1046 we added a troubleshooting page to the Uptime guide. At some point, I added a redundant heading between two sections in the doc, and it doesn't belong there. This fixes the mistake.