### PR TITLE
[7.x] Update elastic-agent Url docker official repo (#1099)

### DIFF
--- a/docs/en/ingest-management/elastic-agent/elastic-agent-container.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/elastic-agent-container.asciidoc
@@ -24,14 +24,14 @@ Run the `docker pull` command against the Elastic Docker registry:
 
 [source,terminal]
 ----
-docker pull docker.elastic.co/r/beats/elastic-agent:{version}
+docker pull docker.elastic.co/beats/elastic-agent:{version}
 ----
 
 If want to run synthetics tests, run the `docker pull` command to fetch the *elastic-agent-complete* image:
 
 [source,terminal]
 ----
-docker pull docker.elastic.co/r/beats/elastic-agent-complete:{version}
+docker pull docker.elastic.co/beats/elastic-agent-complete:{version}
 ----
 
 [discrete]


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Update elastic-agent Url docker official repo (#1099)