### PR TITLE
[7.14] Update elastic-agent Url docker official repo (#1099)

### DIFF
--- a/docs/en/ingest-management/elastic-agent/elastic-agent-container.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/elastic-agent-container.asciidoc
@@ -22,7 +22,7 @@ Run the `docker pull` command against the Elastic Docker registry:
 
 [source,terminal]
 ----
-docker pull docker.elastic.co/r/beats/elastic-agent:{version}
+docker pull docker.elastic.co/beats/elastic-agent:{version}
 ----
 
 [discrete]


### PR DESCRIPTION
Backports the following commits to 7.14:
 - Update elastic-agent Url docker official repo (#1099)