### PR TITLE
Fix Fleet setting key for registry proxy URL

### DIFF
--- a/docs/en/ingest-management/overview.asciidoc
+++ b/docs/en/ingest-management/overview.asciidoc
@@ -56,7 +56,7 @@ To do so, add the following setting to your `kibana.yml` file:
 
 [source,yaml]
 ----
-xpack.ingestManager.registryProxyUrl: <your-proxy-address>
+xpack.fleet.registryProxyUrl: <your-proxy-address>
 ----
 
 [discrete]


### PR DESCRIPTION
While working on https://github.com/elastic/kibana/pull/113858, I was looking for if we have any documentation around licensing for custom registry URL that needs to be corrected. I did not find any, but came across this which needs to be updated to reflect the `ingestManager` -> `fleet` setting renaming that happened a long time ago.

Could whoever reviews this help me with merging and backporting this to all versions of the docs that contain this? (Looks like >= 7.13)

