### PR TITLE
Rename Fleet User Guide

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -22,7 +22,7 @@ pipeline {
       when { changeRequest() }
       steps {
         deleteDir()
-        githubPrComment(message: "A documentation preview will be available soon:</br><ul><li>📚 [HTML diff](https://observability-docs_${CHANGE_ID}.docs-preview.app.elstc.co/diff)</li><li>📘 [Fleet User Guide](https://observability-docs_${CHANGE_ID}.docs-preview.app.elstc.co/guide/en/fleet/master/index.html)</li><li>📙 [Observability Guide](https://observability-docs_${CHANGE_ID}.docs-preview.app.elstc.co/guide/en/observability/master/index.html)</li></ui>")
+        githubPrComment(message: "A documentation preview will be available soon:</br><ul><li>📚 [HTML diff](https://observability-docs_${CHANGE_ID}.docs-preview.app.elstc.co/diff)</li><li>📘 [Fleet and Elastic Agent Guide](https://observability-docs_${CHANGE_ID}.docs-preview.app.elstc.co/guide/en/fleet/master/index.html)</li><li>📙 [Observability Guide](https://observability-docs_${CHANGE_ID}.docs-preview.app.elstc.co/guide/en/observability/master/index.html)</li></ui>")
       }
     }
   }

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Within this repo, the `/docs/en/` directory is structured as follows:
 | Directory             | Description |
 | --------------------- | ----------- |
 | __observability__     | Contains the source files for the [Observability Guide](https://www.elastic.co/guide/en/observability/master/index.html), which includes content for APM, Logs, Metrics, Synthetics, User experience, and Uptime.|
-| __ingest-management__ | Contains the source files for the [Fleet User Guide](https://www.elastic.co/guide/en/ingest-management/master/index.html).|
+| __ingest-management__ | Contains the source files for the [Fleet and Elastic Agent Guide](https://www.elastic.co/guide/en/ingest-management/master/index.html).|
 | __shared__ | Contains the source files for shared Observability content.|
 | __templates__ | Contains content templates.|
 

--- a/docs/en/ingest-management/index.asciidoc
+++ b/docs/en/ingest-management/index.asciidoc
@@ -26,9 +26,10 @@ include::{docs-root}/shared/attributes.asciidoc[]
 :apm-go-ref-v:         https://www.elastic.co/guide/en/apm/agent/go/{apm-go-branch}
 :apm-dotnet-ref-v:     https://www.elastic.co/guide/en/apm/agent/dotnet/{apm-dotnet-branch}
 
+//TODO: Remove release-state override before merging
 :release-state: released
 
-= Fleet User Guide
+= Fleet and Elastic Agent Guide
 
 include::overview.asciidoc[leveloffset=+1]
 

--- a/docs/en/integrations/air-gapped.asciidoc
+++ b/docs/en/integrations/air-gapped.asciidoc
@@ -20,7 +20,7 @@ can orchestrate to use a proxy server:
 xpack.ingestManager.registryProxyUrl: your-nat-gateway.corp.net
 ----
 
-For more information, see the {fleet-guide}/fleet-overview.html#package-registry-intro[Fleet User Guide].
+For more information, see the {fleet-guide}/fleet-overview.html#package-registry-intro[Fleet and Elastic Agent Guide].
 
 [discrete]
 [[air-gapped-diy-epr]]


### PR DESCRIPTION
Changes the name of the Fleet User Guide as described in elastic/observability-docs#1104.

Related to https://github.com/elastic/docs/pull/2238 and https://github.com/elastic/observability-docs/issues/1104