### PR TITLE
[7.13] Fix Fleet setting key for custom registry URL (#1114)

### DIFF
--- a/docs/en/ingest-management/overview.asciidoc
+++ b/docs/en/ingest-management/overview.asciidoc
@@ -58,7 +58,7 @@ To do so, add the following setting to your `kibana.yml` file:
 
 [source,yaml]
 ----
-xpack.ingestManager.registryProxyUrl: <your-proxy-address>
+xpack.fleet.registryProxyUrl: <your-proxy-address>
 ----
 
 [discrete]


### PR DESCRIPTION
Backports the following commits to 7.13:
 - Fix Fleet setting key for custom registry URL (#1114)