### PR TITLE
[7.x] Rename Fleet User Guide (#1115)

### DIFF
--- a/docs/en/ingest-management/index.asciidoc
+++ b/docs/en/ingest-management/index.asciidoc
@@ -26,9 +26,10 @@ include::{docs-root}/shared/attributes.asciidoc[]
 :apm-go-ref-v:         https://www.elastic.co/guide/en/apm/agent/go/{apm-go-branch}
 :apm-dotnet-ref-v:     https://www.elastic.co/guide/en/apm/agent/dotnet/{apm-dotnet-branch}
 
+//TODO: Remove release-state override before merging
 :release-state: released
 
-= Fleet User Guide
+= Fleet and Elastic Agent Guide
 
 include::overview.asciidoc[leveloffset=+1]
 

--- a/docs/en/integrations/air-gapped.asciidoc
+++ b/docs/en/integrations/air-gapped.asciidoc
@@ -20,7 +20,7 @@ can orchestrate to use a proxy server:
 xpack.ingestManager.registryProxyUrl: your-nat-gateway.corp.net
 ----
 
-For more information, see the {fleet-guide}/fleet-overview.html#package-registry-intro[Fleet User Guide].
+For more information, see the {fleet-guide}/fleet-overview.html#package-registry-intro[Fleet and Elastic Agent Guide].
 
 [discrete]
 [[air-gapped-diy-epr]]


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Rename Fleet User Guide (#1115)