### PR TITLE
[7.14] Rename Fleet User Guide (#1115)

### DIFF
--- a/docs/en/ingest-management/index.asciidoc
+++ b/docs/en/ingest-management/index.asciidoc
@@ -26,9 +26,10 @@ include::{docs-root}/shared/attributes.asciidoc[]
 :apm-go-ref-v:         https://www.elastic.co/guide/en/apm/agent/go/{apm-go-branch}
 :apm-dotnet-ref-v:     https://www.elastic.co/guide/en/apm/agent/dotnet/{apm-dotnet-branch}
 
+//TODO: Remove release-state override before merging
 :release-state: released
 
-= Fleet User Guide
+= Fleet and Elastic Agent Guide
 
 include::overview.asciidoc[leveloffset=+1]
 


### PR DESCRIPTION
Backports the following commits to 7.14:
 - Rename Fleet User Guide (#1115)