### PR TITLE
Add discrete markers to prepare for chunk level increase

### DIFF
--- a/docs/en/observability/analyze-monitors.asciidoc
+++ b/docs/en/observability/analyze-monitors.asciidoc
@@ -6,6 +6,7 @@ to view more details and analyze further.
 
 The monitor detail screen displays several panels of information.
 
+[discrete]
 [[uptime-status-panel]] 
 == Status panel
 
@@ -25,6 +26,7 @@ the selected time period.
 To display a map with each location as a pinpoint, you can toggle the availability view from list
 view to map view.
 
+[discrete]
 [[uptime-monitor-duration]] 
 == Monitor duration 
 
@@ -38,6 +40,7 @@ Included on this chart is the anomaly detection ({ml}) integration. For more inf
 [role="screenshot"]
 image::images/monitor-duration-chart.png[Monitor duration chart]
 
+[discrete]
 [[uptime-pings-chart]] 
 == Pings over time 
 
@@ -47,6 +50,7 @@ Hover over the charts to display crosshairs with specific numeric data.
 [role="screenshot"]
 image::images/pings-over-time.png[Pings over time chart]
 
+[discrete]
 [[uptime-history-panel]]
 == Check history
 

--- a/docs/en/observability/categorize-logs.asciidoc
+++ b/docs/en/observability/categorize-logs.asciidoc
@@ -10,7 +10,7 @@ your log events quickly. Instead of manually identifying similar logs, the logs
 categorization view lists log events that have been grouped based on their 
 messages and formats so that you can take action quicker.
 
-
+[discrete]
 [[create-log-categories]]
 == Create log categories
 
@@ -32,7 +32,7 @@ image::images/log-create-categorization-job.jpg[Configure log categorization job
    minutes for the {ml} robots to collect the necessary data. After the job 
    processed the data, you can view the results.
 
-
+[discrete]
 [[analyze-log-categories]]
 == Analyze log categories
 

--- a/docs/en/observability/configure-logs-sources.asciidoc
+++ b/docs/en/observability/configure-logs-sources.asciidoc
@@ -12,6 +12,7 @@ If your logs have custom index patterns, use non-default field settings, or cont
 parsed fields that you want to expose as individual columns, you can override the
 default configuration settings.
 
+[discrete]
 [[edit-config-settings]]
 == Edit configuration settings
 
@@ -44,6 +45,7 @@ click *Use {kib} index patterns* and select the `filebeat-*` log index pattern.
 +
 . When you have completed your changes, click *Apply*.
 
+[discrete]
 [[customize-stream-page]]
 == Customize Stream page
 

--- a/docs/en/observability/configure-metrics-sources.asciidoc
+++ b/docs/en/observability/configure-metrics-sources.asciidoc
@@ -6,6 +6,7 @@ By default, the {kibana-ref}/infrastructure-ui-settings-kb.html[configuration se
 to query the data. The configuration also defines field settings for things like timestamps
 and container names.
 
+[discrete]
 [[metrics-config-settings]]
 == Override configuration settings
 

--- a/docs/en/observability/configure-uptime-settings.asciidoc
+++ b/docs/en/observability/configure-uptime-settings.asciidoc
@@ -17,6 +17,7 @@ To modify items on this page, you must have the {kibana-ref}/kibana-privileges.h
 privilege granted to your role.
 =====
 
+[discrete]
 [[configure-uptime-indices]]
 == Configure indices
 
@@ -31,6 +32,7 @@ data outside of this pattern.
 [role="screenshot"]
 image::images/heartbeat-indices.png[Heartbeat indices]
 
+[discrete]
 [[configure-uptime-alert-connectors]]
 == Configure connectors
 
@@ -47,6 +49,7 @@ For more information about each connector, see {kibana-ref}/action-types.html[ac
 [role="screenshot"]
 image::images/alert-connector.png[Rule connector]
 
+[discrete]
 [[configure-cert-thresholds]]
 == Configure certificate thresholds
 

--- a/docs/en/observability/infrastructure-threshold-alert.asciidoc
+++ b/docs/en/observability/infrastructure-threshold-alert.asciidoc
@@ -19,6 +19,7 @@ populate the rule. You can use the Inventory first to view which nodes in your i
 like to be notified about and then quickly create a rule in just a few clicks.
 ==============================================
 
+[discrete]
 [[inventory-conditions]]
 == Inventory conditions
 
@@ -40,6 +41,7 @@ hour, day, week, or month.
 [role="screenshot"]
 image::images/alert-preview.png[Preview rules]
 
+[discrete]
 [[action-types-infrastructure]]
 == Action types
 
@@ -54,11 +56,12 @@ threshold condition: `Alert`, `Warning`, or `Recovered` (a value that was once a
 [role="screenshot"]
 image::images/run-when-selection.png[Configure when an alert is triggered]
 
+[discrete]
 == Action variables
 
 This section details the variables that infrastructure threshold rules will send to your actions.
 
-[float]
+[discrete]
 === Basic variables
 
 [role="screenshot"]
@@ -76,8 +79,7 @@ that was queried, and `ERROR` indicates an error when querying the data.
 it includes the detected value of the monitored metric and a description of the threshold.
 - `context.timestamp`: The timestamp of when the rule was detected.
 
-
-[float]
+[discrete]
 === Advanced variables
 
 [role="screenshot"]
@@ -98,6 +100,7 @@ one condition (accessible with `.condition0`). Using just `{{context.[Variable N
 - `context.value.threshold[X]`: This variable resolves to the threshold values of conditions 0, 1, 2, and so on.
 - `context.value.metric[X]`: This variable resolves to the monitored metric of conditions 0, 1, 2, and so on.
 
+[discrete]
 [[infra-alert-settings]]
 == Settings
 

--- a/docs/en/observability/ingest-logs.asciidoc
+++ b/docs/en/observability/ingest-logs.asciidoc
@@ -24,6 +24,7 @@ collects log events, and forwards them to {es}. To ease the collection and parsi
 log formats for common applications such as Apache, MySQL, and Kafka, a number of
 {filebeat-ref}/filebeat-modules.html[modules] are available.
 
+[discrete]
 [[install-filebeat]]
 == Step 1: Install {beatname_uc}
 
@@ -33,6 +34,7 @@ To download and install {beatname_uc}, use the commands that work with your syst
 
 include::{beats-repo-dir}/tab-widgets/install-widget.asciidoc[]
 
+[discrete]
 [[other-filebeat-installations]]
 === Other installation options
 
@@ -43,6 +45,7 @@ include::{beats-repo-dir}/tab-widgets/install-widget.asciidoc[]
 * {filebeat-ref}/setup-repositories.html[APT or YUM]
 * https://www.elastic.co/downloads/beats/filebeat[Download page]
 
+[discrete]
 [[logs-connect-to-stack]]
 == Step 2: Connect to {es} and {kib}
 
@@ -63,6 +66,7 @@ but that requires additional configuration and setup.
 
 =====
 
+[discrete]
 [[enable-logs-modules]]
 == Step 3: Enable and configure modules
 
@@ -119,6 +123,7 @@ For more information about configuring {beatname_uc}, also see:
 * {filebeat-ref}/filebeat-reference-yml.html[`filebeat.reference.yml`]: This reference
 configuration file shows all non-deprecated options. You’ll find it in the same location as `filebeat.yml`.
 
+[discrete]
 [[set-filebeat-assets]]
 == Step 4: Set up assets
 {beatname_uc} comes with predefined assets for parsing, indexing, and
@@ -152,6 +157,7 @@ environment. If you're using a different output, such as {ls}, see:
 * {filebeat-ref}/load-ingest-pipelines.html[Load ingest pipelines]
 =====
 
+[discrete]
 [[start-filebeat]]
 == Step 5: Start {beatname_uc}
 
@@ -169,6 +175,7 @@ include::{beats-repo-dir}/tab-widgets/start-widget.asciidoc[]
 
 {beatname_uc} should begin streaming events to {es}.
 
+[discrete]
 [[view-logs-kibana]]
 == Step 6: Confirm logs are streaming
 

--- a/docs/en/observability/ingest-metrics.asciidoc
+++ b/docs/en/observability/ingest-metrics.asciidoc
@@ -28,6 +28,7 @@ integration defines the basic logic for collecting data from specific services, 
 Redis or MySQL. A module consists of metricsets that fetch and structure the data. To learn more, see
 {metricbeat-ref}/how-metricbeat-works.html[How {metricbeat} works].
 
+[discrete]
 [[install-metricbeat]]
 == Step 1: Install {metricbeat}
 
@@ -37,6 +38,7 @@ To download and install {metricbeat}, use the commands that work with your syste
 
 include::{beats-repo-dir}/tab-widgets/install-widget.asciidoc[]
 
+[discrete]
 === Other installation options
 
 * {metricbeat-ref}/running-on-kubernetes.html[Kubernetes]
@@ -45,6 +47,7 @@ include::{beats-repo-dir}/tab-widgets/install-widget.asciidoc[]
 * {metricbeat-ref}/setup-repositories.html[APT or YUM]
 * https://www.elastic.co/downloads/beats/{beatname_lc}[Download page]
 
+[discrete]
 [[metrics-connect-to-stack]]
 == Step 2: Connect to {es} and {kib}
 
@@ -57,6 +60,7 @@ include::{beats-repo-dir}/tab-widgets/set-connection-widget.asciidoc[]
 
 To learn more about required roles and privileges, see {metricbeat-ref}/feature-roles.html[Grant users access to secured resources].
 
+[discrete]
 [[enable-metrics-modules]]
 == Step 3: Enable and configure modules
 
@@ -96,6 +100,7 @@ For more information about configuring {beatname_uc}, also see:
 * {metricbeat-ref}/metricbeat-reference-yml.html[`metricbeat.reference.yml`]:
 This reference configuration file shows all non-deprecated options. You’ll find it in the same location as `metricbeat.yml`.
 
+[discrete]
 [[set-metricbeat-assets]]
 == Step 4: Set up assets
 
@@ -120,6 +125,7 @@ If you’re using a different output, such as Logstash, see
 {metricbeat-ref}/metricbeat-template.html#load-template-manually[Load the index template manually]
 and {metricbeat-ref}/load-kibana-dashboards.html[Load Kibana dashboards].
 
+[discrete]
 [[start-metricbeat]]
 == Step 5: Start {beatname_uc}
 
@@ -135,6 +141,7 @@ include::{beats-repo-dir}/tab-widgets/start-widget.asciidoc[]
 :requires-sudo!:
 // end::start-step[]
 
+[discrete]
 [[view-metrics-kibana]]
 == Step 6: Confirm metrics are ingested
 

--- a/docs/en/observability/ingest-uptime.asciidoc
+++ b/docs/en/observability/ingest-uptime.asciidoc
@@ -21,6 +21,7 @@ verify that you’re meeting your service level agreements for service uptime.
 You typically install {heartbeat} as part of a monitoring service that runs on a separate machine
 and possibly even outside of the network where the services that you want to monitor are running.
 
+[discrete]
 [[deployment-considerations]]
 == Deployment considerations
 
@@ -56,6 +57,7 @@ copy of the service and its counterpart across the country. Set up two monitors 
 the local service, and one for the remote service. In the event of a data center failure, it will be
 immediately apparent if the service has a connectivity issue to the outside world, or if the failure is only internal.
 
+[discrete]
 [[install-heartbeat]]
 == Step 1: Install {beatname_uc}
 
@@ -66,6 +68,7 @@ To download and install {beatname_uc}, use the commands that work with your syst
 
 include::{beats-repo-dir}/tab-widgets/install-widget.asciidoc[]
 
+[discrete]
 [[other-heartbeat-installations]]
 === Other installation options
 
@@ -73,6 +76,7 @@ include::{beats-repo-dir}/tab-widgets/install-widget.asciidoc[]
 * {heartbeat-ref}/setup-repositories.html[APT or YUM]
 * https://www.elastic.co/downloads/beats/heartbeat[Download page]
 
+[discrete]
 [[uptime-connect-to-stack]]
 == Step 2: Connect to {es} and {kib}
 
@@ -93,6 +97,7 @@ but that requires additional configuration and setup.
 
 To learn more about required roles and privileges, see {heartbeat-ref}/feature-roles.html[Grant users access to secured resources].
 
+[discrete]
 [[heartbeat-configuration]]
 == Step 3: Configure {beatname_uc} monitors
 
@@ -142,6 +147,7 @@ For more information about configuring {beatname_uc}, also see:
 * {heartbeat-ref}/heartbeat-reference-yml.html[`heartbeat.reference.yml`]: This
 reference configuration file shows all non-deprecated options. You’ll find it in the same location as `heartbeat.yml`.
 
+[discrete]
 [[configure-heartbeat-location]]
 == Step 4: Configure {beatname_uc} location
 
@@ -183,6 +189,7 @@ is installed, and run {beatname_uc} in the foreground with the following options
 `-c` flag to specify the path to the config file.
 =====
 
+[discrete]
 [[set-heartbeat-assets]]
 == Step 5: Set up assets
 
@@ -212,6 +219,7 @@ environment. If you're using a different output, such as {ls}, see
 {heartbeat-ref}/heartbeat-template.html#load-template-manually[Load the index template manually].
 =====
 
+[discrete]
 [[start-heartbeat]]
 == Step 6: Start {beatname_uc}
 
@@ -229,6 +237,7 @@ include::{beats-repo-dir}/tab-widgets/start-widget.asciidoc[]
 
 {beatname_uc} is now ready to check the status of your services and send events to your defined output.
 
+[discrete]
 [[view-uptime-kibana]]
 == Step 7: View your data in {kib}
 

--- a/docs/en/observability/inspect-log-anomalies.asciidoc
+++ b/docs/en/observability/inspect-log-anomalies.asciidoc
@@ -19,6 +19,7 @@ This may lead to an investigation of IP addresses from incoming requests.
 
 You can also view log anomalies directly in the {kibana-ref}/xpack-ml-anomalies.html[Machine Learning app].
 
+[discrete]
 [[enable-anomaly-detection]]
 == Enable log rate analysis and anomaly detection
 
@@ -30,6 +31,7 @@ Create a machine learning job to detect anomalous log entry rates automatically.
 4. Click *Create ML job*.
 5. You're now ready to explore your log partitions.
 
+[discrete]
 [[anomalies-chart]]
 == Anomalies chart
 

--- a/docs/en/observability/inspect-metric-anomalies.asciidoc
+++ b/docs/en/observability/inspect-metric-anomalies.asciidoc
@@ -9,6 +9,7 @@ You can model system memory usage, along with inbound and outbound network
 traffic across hosts or pods. You can detect unusual increases in memory usage
 and unusually high inbound or outbound traffic across hosts or pods.
 
+[discrete]
 [[ml-jobs-hosts]]
 == Enable {ml} jobs for hosts or Kubernetes pods
 
@@ -71,6 +72,7 @@ update the rules in the {ml-docs}/ml-gs-results.html[Anomaly Explorer], select
 If you want to apply the changes to existing results, clone and rerun the job.
 =====
 
+[discrete]
 [[history-chart]]
 == History chart
 

--- a/docs/en/observability/inspect-uptime-duration-anomalies.asciidoc
+++ b/docs/en/observability/inspect-uptime-duration-anomalies.asciidoc
@@ -5,6 +5,7 @@ Each monitor location is modelled, and when a monitor runs
 for an unusual amount of time, at a particular time, an anomaly is recorded and highlighted
 on the *Monitor duration* chart.
 
+[discrete]
 [[uptime-anomaly-detection]]
 == Enable uptime duration anomaly detection
 

--- a/docs/en/observability/instrument-apps.asciidoc
+++ b/docs/en/observability/instrument-apps.asciidoc
@@ -11,6 +11,7 @@ If you haven’t already, you need to install {es} for storing and searching you
 visualizing and managing it, and APM Server. For more information, see <<add-observability-data,Send data to {es}>>.
 =====
 
+[discrete]
 [[install-apm-agents]]
 == Step 1: Install APM agents
 
@@ -22,6 +23,7 @@ include::{apm-repo-dir}/guide/install-and-run.asciidoc[tag=apm-agent]
 include::{apm-repo-dir}/tab-widgets/install-agents-widget.asciidoc[]
 --
 
+[discrete]
 [[configuring-apm]]
 == Step 2: Configure APM
 
@@ -43,6 +45,7 @@ include::{apm-repo-dir}/tab-widgets/configure-agent-widget.asciidoc[]
 include::{apm-repo-dir}/tab-widgets/configure-server-widget.asciidoc[]
 --
 
+[discrete]
 [[view-apm-data]]
 == Step 3: View your data in {kib}
 

--- a/docs/en/observability/logs-threshold-alert.asciidoc
+++ b/docs/en/observability/logs-threshold-alert.asciidoc
@@ -7,6 +7,7 @@
 [role="screenshot"]
 image::images/log-threshold-alert.png[Log threshold alert configuration]
 
+[discrete]
 [[fields-comparators-logs]]
 == Fields and comparators
 
@@ -63,6 +64,7 @@ due to the host not reporting logs for the duration of the query.
 [role="screenshot"]
 image::images/log-threshold-alert-group-by.png[Log threshold rule group by]
 
+[discrete]
 [[chart-previews]]
 == Chart previews
 
@@ -75,6 +77,7 @@ image::images/log-threshold-alert-chart-previews.png[Log threshold chart preview
 
 The shaded area denotes the threshold that has been selected.
 
+[discrete]
 [[ratio-alerts]]
 == Ratio rules
 
@@ -93,6 +96,7 @@ As it is not possible to divide by 0, when the document count of query A or quer
 ratio. In this scenario, no alert is triggered.
 =====
 
+[discrete]
 [[action-types-logs]]
 == Action types
 
@@ -249,6 +253,7 @@ image::images/log-threshold-alert-es-query-grouped.png[Log threshold grouped Ela
 <1> Taken from the *Log indices* setting
 <2> Taken from the *Timestamp* setting
 
+[discrete]
 [[settings]]
 == Settings
 

--- a/docs/en/observability/metrics-app-fields.asciidoc
+++ b/docs/en/observability/metrics-app-fields.asciidoc
@@ -14,6 +14,7 @@ which is the metricset name.
 To determine each metric's optimal time interval, all charts use `metricset.period`.
 If `metricset.period` is not available, then it falls back to 1 minute intervals.
 
+[discrete]
 [[base-fields]]
 == Base fields
 
@@ -51,6 +52,7 @@ ECS field: True
 +
 example: `Hello World`
 
+[discrete]
 [[host-fields]]
 == Hosts fields
 
@@ -80,6 +82,7 @@ required: True
 +
 ECS field: True
 
+[discrete]
 [[docker-fields]]
 == Docker container fields
 
@@ -117,6 +120,7 @@ required: True
 +
 ECS field: False
 
+[discrete]
 [[kubernetes-fields]]
 == Kubernetes pod fields
 
@@ -156,6 +160,7 @@ required: True
 +
 ECS field: False
 
+[discrete]
 [[aws-ec2-fields]]
 == AWS EC2 instance fields
 
@@ -193,6 +198,7 @@ required: True
 +
 ECS field: False
 
+[discrete]
 [[aws-s3-fields]]
 == AWS S3 bucket fields
 
@@ -208,6 +214,7 @@ required: True
 +
 ECS field: False
 
+[discrete]
 [[aws-sqs-fields]]
 == AWS SQS queue fields
 
@@ -223,6 +230,7 @@ required: True
 +
 ECS field: False
 
+[discrete]
 [[aws-rds-fields]]
 == AWS RDS database fields
 
@@ -248,6 +256,7 @@ required: True
 +
 ECS field: False
 
+[discrete]
 [[group-inventory-fields]]
 == Additional grouping fields
 

--- a/docs/en/observability/metrics-threshold-alert.asciidoc
+++ b/docs/en/observability/metrics-threshold-alert.asciidoc
@@ -23,6 +23,7 @@ click *Actions > Create alert*. The condition and filter sections of the thresho
 are automatically populated.
 =====
 
+[discrete]
 [[metrics-conditions]]
 == Metric conditions
 
@@ -42,6 +43,7 @@ The *Filters* control the scope of the rule, and the *Create alert per* creates 
 unique value of the `field` added. For example, create a rule per host, or per every mount point of each host. You
 can also add multiple fields.
 
+[discrete]
 [[action-types-metrics]]
 == Action types
 
@@ -56,11 +58,12 @@ threshold condition: `Alert`, `Warning`, or `Recovered` (a value that was once a
 [role="screenshot"]
 image::images/run-when-selection.png[Configure when an rule is triggered]
 
+[discrete]
 == Action variables
 
 This section details the variables that metrics threshold rules will send to your actions.
 
-[float]
+[discrete]
 === Basic variables
 
 [role="screenshot"]
@@ -79,7 +82,7 @@ time period that the rule queried, and `ERROR` indicates an error when querying 
 conditions, it includes the **detected value** of the monitored **metric**, and a description of the **threshold**.
 - `context.timestamp`: This variable resolves to the timestamp of when the rule was evaluated.
 
-[float]
+[discrete]
 === Advanced variables
 
 [role="screenshot"]
@@ -100,6 +103,7 @@ to a blank line or `[object Object]` depending on the action type.
 - `context.value.threshold[X]`: This variable resolves to the threshold values of conditions 0, 1, 2, and so on.
 - `context.value.metric[X]`: This variable resolves to the monitored metric of conditions 0, 1, 2, and so on.
 
+[discrete]
 [[metrics-alert-settings]]
 == Settings
 

--- a/docs/en/observability/monitor-aws-services.asciidoc
+++ b/docs/en/observability/monitor-aws-services.asciidoc
@@ -17,6 +17,7 @@ you can install {metricbeat} on any machine that can make the API requests and e
 Additional AWS charges for GetMetricData API requests are generated using this module.
 =====
 
+[discrete]
 [[monitor-ec2-instances]]
 == Monitor EC2 instances
 
@@ -37,6 +38,7 @@ view filters based on the following predefined metrics or you can add <<custom-m
 
 |===
 
+[discrete]
 [[monitor-s3-buckets]]
 == Monitor S3 buckets
 
@@ -57,6 +59,7 @@ view filters based on the following predefined metrics or you can add <<custom-m
 
 |===
 
+[discrete]
 [[monitor-sqs-queues]]
 == Monitor SQS queues
 
@@ -77,6 +80,7 @@ view filters based on the following predefined metrics or you can add <<custom-m
 
 |===
 
+[discrete]
 [[monitor-rds-databases]]
 == Monitor RDS databases
 

--- a/docs/en/observability/monitor-servers.asciidoc
+++ b/docs/en/observability/monitor-servers.asciidoc
@@ -33,6 +33,7 @@ This metric relies on the same indices as the logs.
 For information about which required fields the {metrics-app} uses to display host metrics, see the
 <<metrics-app-fields,Metrics field reference>>.
 
+[discrete]
 [[enhanced-host-details]]
 == Host details
 

--- a/docs/en/observability/monitor-status-alert.asciidoc
+++ b/docs/en/observability/monitor-status-alert.asciidoc
@@ -13,6 +13,7 @@ based on errors and outages.
 If you already have a query in the overview page search bar, it's populated here.
 ===============================
 
+[discrete]
 [[status-alert-conditions]]
 == Conditions
 
@@ -42,6 +43,7 @@ image::images/monitor-status-alert.png[Monitor status rule]
 The final step when creating a rule is to select one or more actions to take when
 the alert is triggered.
 
+[discrete]
 [[action-types-status]]
 == Action types
 
@@ -54,6 +56,7 @@ You can configure action types on the <<configure-uptime-alert-connectors,Settin
 [role="screenshot"]
 image::images/uptime-alert-connectors.png[Uptime rule connectors]
 
+[discrete]
 [[action-variables-status]]
 == Action variables
 

--- a/docs/en/observability/synthetics-params-secrets.asciidoc
+++ b/docs/en/observability/synthetics-params-secrets.asciidoc
@@ -103,6 +103,7 @@ parameter.
       folder: "synthetics-tests"
 ----
 
+[discrete]
 [[synthetics-secrets-sensitive]]
 == Working with secrets and sensitive values
 

--- a/docs/en/observability/synthetics-quickstart-fleet.asciidoc
+++ b/docs/en/observability/synthetics-quickstart-fleet.asciidoc
@@ -34,10 +34,11 @@ To add an {agent} to {fleet}, you'll need an enrollment token and the URL of you
 
 You may need to set additional environment variables. See the {fleet-guide}/agent-environment-variables.html[{agent} environment variables guide] for more information. See {fleet-guide}/elastic-agent-container.html[Run {agent} in a container] for more information on running {agent} with Docker.
 
+[discrete]
 [[synthetics-quickstart-fleet-configure-policy]]
-== Configure an Elastic Synthetics integration policy beta[]
+== Configure an Elastic Synthetics integration policy
 
-Elastic Synthetics tests can be configured through {fleet} using the Elastic Synthetics integration. To learn more, see {fleet-guide}/fleet-quick-start.html#add-synthetics-integration[Elastic Synthetics].
+beta[] Elastic Synthetics tests can be configured through {fleet} using the Elastic Synthetics integration. To learn more, see {fleet-guide}/fleet-quick-start.html#add-synthetics-integration[Elastic Synthetics].
 
 [role="screenshot"]
 image::images/synthetics-integration.png[Synthetics integration]
@@ -71,6 +72,7 @@ If a test does fail (shown as `down` in the app), you'll be able to view the ste
 any errors, and a stack trace.
 See <<synthetics-visualize>> for more information.
 
+[discrete]
 [[synthetics-quickstart-fleet-security]]
 == Note on Sandboxing and Security
 

--- a/docs/en/observability/synthetics-visualize.asciidoc
+++ b/docs/en/observability/synthetics-visualize.asciidoc
@@ -11,6 +11,7 @@ your other Uptime monitors.
 [role="screenshot"]
 image::images/synthetic-app-overview.png[Synthetics app overview]
 
+[discrete]
 [[analyze-synthetic-journeys]]
 == Analyze synthetic journeys
 
@@ -26,6 +27,7 @@ For any failed checks, the error and the failed step are displayed.
 [role="screenshot"]
 image::images/synthetics_overview.png[Synthetics overview page]
 
+[discrete]
 [[review-synthetic-checks]]
 == Review synthetic checks
 
@@ -52,6 +54,7 @@ You can expand the table row for each step to view the following additional info
 
 Select *View performance breakdown* to view the waterfall chart for the synthetic check.
 
+[discrete]
 [[synthetic-waterfall]]
 == Waterfall chart
 
@@ -115,6 +118,7 @@ to view its content in a new tab.
 You can also navigate between steps and checks at the top of the page to view the
 corresponding waterfall charts.
 
+[discrete]
 [[synthetic-filtering]]
 === Filter network requests
 
@@ -127,6 +131,7 @@ image::images/waterfall-filter.png[Waterfall filter]
 You can filter by XHR, HTML, JS, CSS, Font, and Media, to highlight the waterfall chart's matching
 results. To remove even more noise from the chart, you can select only the matching requests to view and group.
 
+[discrete]
 [[synthetics-alerting]]
 == Alerts
 

--- a/docs/en/observability/tail-logs.asciidoc
+++ b/docs/en/observability/tail-logs.asciidoc
@@ -26,6 +26,7 @@ ifeval::["{is-current-version}"=="true"]
 ++++
 endif::[]
 
+[discrete]
 [[filter-logs]]
 == Filter logs
 
@@ -38,6 +39,7 @@ histogram, located to the right, highlights the number of discovered terms and w
 This helps you quickly jump between potential areas of interest in large amounts of logs, or from a high level,
 view when a large number of events occurred.
 
+[discrete]
 [[inspect-log-event]]
 == Inspect log event details
 
@@ -49,6 +51,7 @@ the workflow of monitoring logs, the icons next to each field value enable you t
 [role="screenshot"]
 image::images/log-event-details.png[Log event details]
 
+[discrete]
 [[view-contextual-logs]]
 == View contextual logs
 
@@ -64,6 +67,7 @@ preserved and helps you find the root cause as soon as possible.
 [role="screenshot"]
 image::images/contextual-logs.png[Contextual log event]
 
+[discrete]
 [[uptime-apm-integration]]
 == Integrate with Uptime and APM
 

--- a/docs/en/observability/troubleshoot-uptime-mapping-issues.asciidoc
+++ b/docs/en/observability/troubleshoot-uptime-mapping-issues.asciidoc
@@ -4,6 +4,7 @@
 
 = Troubleshoot mapping issues
 
+[discrete]
 == Mapping issues
 
 There are situations in which {heartbeat} data can be indexed without the correct mappings applied.
@@ -15,10 +16,12 @@ When running {elastic-agent} in standalone mode this can happen if manually setu
 To fix this problem, you typically need to remove your {heartbeat} indices and datastreams. 
 Then you must create new ones with the appropriate mappings installed. To achieve this, follow the steps below.
 
+[discrete]
 === Stop your {heartbeat}/{elastic-agent} instances
 
 It is necessary to stop all {heartbeat}/{elastic-agent} instances that are targeting the cluster, so they will not write to or re-create indices prematurely.
 
+[discrete]
 === Delete your {heartbeat} indices / {elastic-agent} datastreams
 
 To ensure the mapping is applied to all {heartbeat} data going forward,
@@ -29,6 +32,7 @@ You can read about performing this using the {ref}/index-mgmt.html[Index Managem
 
 If using {elastic-agent} you will want to fix any issues with custom datastream mappings. We encourage the use of fleet to eliminate this issue.
 
+[discrete]
 === If using {heartbeat}, perform {heartbeat} setup
 
 The below command will cause {heartbeat} to perform its setup processes and recreate the index template properly.
@@ -42,6 +46,7 @@ include::{beats-repo-dir}/tab-widgets/setup-widget.asciidoc[]
 
 This command performs the necessary startup tasks and ensures that your indicies have the appropriate mapping going forward.
 
+[discrete]
 === Step 5: Run {heartbeat}/{elastic-agent} again
 
 Now, when you run {heartbeat}/{elastic-agent}, your data will be indexed with the appropriate mappings. When

--- a/docs/en/observability/uptime-duration-anomaly-alert.asciidoc
+++ b/docs/en/observability/uptime-duration-anomaly-alert.asciidoc
@@ -9,6 +9,7 @@ highlighted on the <<inspect-uptime-duration-anomalies,Monitor duration>> chart.
 . To access this page, go to *Observability > Uptime*.
 . On the *Monitors* page, select on a monitor, and then click *Enable anomaly detection*.
 
+[discrete]
 [[duration-alert-conditions]]
 == Conditions
 
@@ -33,6 +34,7 @@ red and the low scored values are indicated in blue.
 [role="screenshot"]
 image::images/response-durations-alert.png[Uptime response duration rule]
 
+[discrete]
 [[action-types-duration]]
 == Action types
 
@@ -45,6 +47,7 @@ You can configure action types on the <<configure-uptime-alert-connectors,Settin
 [role="screenshot"]
 image::images/alert-action-types.png[Uptime rule connectors]
 
+[discrete]
 [[action-variables-duration]]
 == Action variables
 

--- a/docs/en/observability/uptime-tls-alert.asciidoc
+++ b/docs/en/observability/uptime-tls-alert.asciidoc
@@ -9,6 +9,7 @@ within a specified threshold, or when it exceeds an age limit.
 . At the top of the page, click *Alerts and rules > Create rule*.
 . Select *TLS rule*.
 
+[discrete]
 [[tls-alert-conditions]]
 == Conditions
 
@@ -35,7 +36,7 @@ alert status changes.
 [role="screenshot"]
 image::images/tls-alert.png[Monitor status rule]
 
-
+[discrete]
 [[action-types-certs]]
 == Action types
 
@@ -48,6 +49,7 @@ You can configure action types on the <<configure-uptime-alert-connectors,Settin
 [role="screenshot"]
 image::images/alert-action-types.png[Uptime rule connectors]
 
+[discrete]
 [[action-variables-certs]]
 == Action variables
 

--- a/docs/en/observability/view-infrastructure-metrics.asciidoc
+++ b/docs/en/observability/view-infrastructure-metrics.asciidoc
@@ -16,6 +16,7 @@ Without leaving the *Inventory* page, you can view enhanced metrics relating to 
 running in your infrastructure. On the waffle map, select the host to display the host metrics
 overlay. For more information, see <<enhanced-host-details,*Host details*>>.
 
+[discrete]
 [[filter-resources]]
 == Filter related resources
 
@@ -36,6 +37,7 @@ For example, enter `host.hostname : "host1"`` to see only the information for `h
 
 To examine the metrics for a specific time, use the time filter to select the date and time.
 
+[discrete]
 [[custom-metrics]]
 == Add custom metrics
 
@@ -50,6 +52,7 @@ image::images/add-custom-metric.png[Add custom metrics]
 You can also group your resources by custom fields. Select your resource, and then click
 *Group by > Custom field*.
 
+[discrete]
 [[analyze-resource-metrics]]
 == Analyze resource metrics
 
@@ -60,6 +63,7 @@ click on the pod displayed in the high-level view, and then select *Kubernetes P
 [role="screenshot"]
 image::images/pod-metrics.png[Kubernetes pod metrics]
 
+[discrete]
 [[apm-uptime-integration]]
 == Integrate with Logs, Uptime, and APM
 

--- a/docs/en/observability/view-monitor-status.asciidoc
+++ b/docs/en/observability/view-monitor-status.asciidoc
@@ -12,6 +12,7 @@ To access this page, go to *Observability > Uptime > Monitors*.
 Each endpoint, URL, and service represents a _monitor_.
 =====
 
+[discrete]
 [[filter-monitors]]
 == Filter monitors
 
@@ -22,6 +23,7 @@ monitor ID, and other attributes.
 [role="screenshot"]
 image::images/uptime-filter-bar.png[Uptime filter bar]
 
+[discrete]
 [[monitor-availability]]
 == Monitor availability
 
@@ -57,6 +59,7 @@ when it occurred, the date and time of any recent test runs, and it's URL.
 [role="screenshot"]
 image::images/monitors-list.png[Monitors list]
 
+[discrete]
 [[observability-integrations]]
 == Integrate with Logs, Metrics, and APM
 
@@ -70,6 +73,7 @@ metrics, or APM data relating to that monitor. You can choose:
 * Show APM data in the {kibana-ref}/traces.html[{apm-app}].
 * Show host, pod, or container metrics in the <<analyze-metrics,{metrics-app}>>.
 
+[discrete]
 [[view-certificate-status]]
 == View TLS certificate status
 


### PR DESCRIPTION
### Summary

This PR adds missing `[discrete]` markers. These updates are to prepare for increasing the chunk level to `2` within the Observability guide.

### Docs preview

https://observability-docs_1134.docs-preview.app.elstc.co/guide/en/observability/master/index.html

### Related PR

https://github.com/elastic/docs/pull/2242



