### PR TITLE
Update elastic-agent-providers.asciidoc - Fixed typo, replacing `kuberentes` with `kubernetes`

### DIFF
--- a/docs/en/ingest-management/elastic-agent/elastic-agent-providers.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/elastic-agent-providers.asciidoc
@@ -458,12 +458,12 @@ Fox example, if the Kubernetes provider provides the following inventory:
     {
         "id": "2",
         "mapping:": {"namespace": "kube-system", "pod": {"name": "kube-scheduler"}},
-        "processors": {"add_fields": {"kuberentes.namespace": "kube-system", "kubernetes.pod": {"name": "kube-scheduler"}}
+        "processors": {"add_fields": {"kubernetes.namespace": "kube-system", "kubernetes.pod": {"name": "kube-scheduler"}}
     }
 ]
 ----
 
-{agent} automatically prefixes the result with `kuberentes`:
+{agent} automatically prefixes the result with `kubernetes`:
 
 
 [source,json]


### PR DESCRIPTION
Fixed typo, replacing `kuberentes` with `kubernetes`