### PR TITLE
[7.15] Show username setting in Fleet quick start prereqs (#1139)

### DIFF
--- a/docs/en/ingest-management/tab-widgets/prereq.asciidoc
+++ b/docs/en/ingest-management/tab-widgets/prereq.asciidoc
@@ -51,7 +51,10 @@ kibana.yml example:
 
 [source,yaml]
 ----
+elasticsearch.username: "kibana_system" <1>
 xpack.security.enabled: true
 xpack.encryptedSavedObjects.encryptionKey: "something_at_least_32_characters"
 ----
+<1> The password should be stored in the {kib} keystore as described in the
+{ref}/security-minimal-setup.html[{es} security documentation].
 // end::self-managed[]


### PR DESCRIPTION
Backports the following commits to 7.15:
 - Show username setting in Fleet quick start prereqs (#1139)