### PR TITLE
Update air-gapped.asciidoc

### DIFF
--- a/docs/en/integrations/air-gapped.asciidoc
+++ b/docs/en/integrations/air-gapped.asciidoc
@@ -17,7 +17,7 @@ can orchestrate to use a proxy server:
 
 [source,yaml]
 ----
-xpack.ingestManager.registryProxyUrl: your-nat-gateway.corp.net
+xpack.fleet.registryProxyUrl: your-nat-gateway.corp.net
 ----
 
 For more information, see the {fleet-guide}/fleet-overview.html#package-registry-intro[Fleet and Elastic Agent Guide].


### PR DESCRIPTION
Changing to fleet since ingestManager is the old name.

CC @akshay-saraswat 