### PR TITLE
[7.x] Add Fleet and Agent 7.15.1 relnotes (#1158)

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-7.15.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-7.15.asciidoc
@@ -12,12 +12,42 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-7.15.1>>
+
 * <<release-notes-7.15.0>>
 
 Also see:
 
 * {kibana-ref}/release-notes.html[{kib} release notes]
 * {beats-ref}/release-notes.html[{beats} release notes]
+
+// begin 7.15.1 relnotes
+
+[[release-notes-7.15.1]]
+== {fleet} and {agent} 7.15.1
+
+Review important information about the {fleet} and {agent} 7.15.1 releases.
+
+[discrete]
+[[bug-fixes-7.15.1]]
+=== Bug fixes
+
+{fleet}::
+* Fixes policy upgrades for packages with multiple policy templates
+{kib-pull}114011[#114011]
+* Fixes Step 1 in policy editor not loading when agent policy already contains an
+integration that can only be added once (such as Endpoint Security) {kib-pull}113883[#113883]
+* Sets code editor height to solve an overlap in default policy settings
+{kib-pull}113763[#113763]
+* Fixes issue where some variables from `xpack.fleet.agentPolicies` were not
+added to package policies {kib-pull}113204[#113204]
+
+{agent}::
+* Fixes memory leak when {agent} fails to communicate with
+{fleet-server} {agent-pull}27981[#27981]
+
+
+// end 7.15.1 relnotes
 
 // begin 7.15.0 relnotes
 


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Add Fleet and Agent 7.15.1 relnotes (#1158)