### PR TITLE
Add docs for elastic-agent diagnostics collect

### DIFF
--- a/docs/en/ingest-management/commands.asciidoc
+++ b/docs/en/ingest-management/commands.asciidoc
@@ -31,11 +31,11 @@ run these commands.
 
 Gather diagnostics information from the {agent} and applications it's running.
 
-If no options are specified, this command will display version numbers and application meta-data.
+If no options are specified, this command displays version numbers and application metadata.
 
-If the `collect` option is specified, it will produce an archive with this meta-data, configuration information, the policy, as well as any local logs.
+If `collect` is specified, it produces an archive containing application metadata, configuration information, the policy, and any local logs.
 
-Note that the archive *will not redact credentials*, they may appear in plain text in the configuration or policy files inside the archive.
+Note that *credentials are not redacted* in the archive; they may appear in plain text in the configuration or policy files inside the archive.
 
 [discrete]
 === Synopsis
@@ -53,12 +53,12 @@ elastic-agent diagnostics collect [--output <string>]
 === Options
 
 `--output <string>`::
-Output format. Specify `human`, `json`, or `yaml`. The default is `human`.
-If using the `collect` option, specify `yaml`, or `json`. The default in this case is `yaml`.
+Output format. If using `collect`, specify `json` or `yaml` (the default).
+Otherwise specify `json`, `yaml`, or `human` (the default).
 
 `--file`::
 Output archive name for the `collect` option.
-Defaults to "elastic-agent-diagnostics-<timestamp>.zip" where the timestamp is the current time in UTC.
+Defaults to `elastic-agent-diagnostics-<timestamp>.zip` where the timestamp is the current time in UTC.
 
 `--help`::
 Show help for the `diagnostics` command.


### PR DESCRIPTION
Add documentation for the elastic-agent diagnostics collect subvommand.
This command produces an archive that can be used to help debug issued
with the elastic-agent.