### PR TITLE
Move info from dev guide to Fleet/Agent guide

### DIFF
--- a/docs/en/ingest-management/fleet/fleet-server.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-server.asciidoc
@@ -35,6 +35,19 @@ you can optionally use it for data collection on self-managed clusters. For more
 details, refer to <<fleet-server-scalability>>.
 
 [discrete]
+[[fleet-security-account]]
+== Service account
+
+{fleet-server} uses a service token to communicate with {es}, which contains
+a `fleet-server` service account. Each {fleet-server} can use its own service
+token, and you can share it across multiple servers (not recommended). The
+advantage of using a separate token for each server is that you can invalidate
+each one separately.
+
+You can create a service token by either using the {fleet} UI or the {es} API.
+For more information, refer to <<add-fleet-server>>.
+
+[discrete]
 [[deployment-models]]
 == {fleet-server} deployment models
 

--- a/docs/en/ingest-management/overview.asciidoc
+++ b/docs/en/ingest-management/overview.asciidoc
@@ -38,6 +38,18 @@ It can be started from any available x64 architecture {agent} artifact.
 For more information, refer to <<fleet-server>>.
 
 [discrete]
+[[fleet-communication-layer]]
+== {es} as the communication layer
+
+All communication between the {fleet} UI and {fleet-server} happens through
+{es}. {fleet} writes policies, actions, and any changes to the `fleet-*`
+indices in {es}. Each {fleet-server} monitors the indices, picks up changes, and
+ships it to the {agent}s. To communicate to {fleet} about the status of the
+{agent}s and the policy rollout, the {fleet-server}s write updates to the
+`fleet-*` indices.
+
+
+[discrete]
 [[package-registry-intro]]
 == {package-registry}
 


### PR DESCRIPTION
Removes info from the Fleet Developer Guide in preparation for removing it from the doc build.