### PR TITLE
[7.x] Docs for --fleet-server-es-insecure (#1159)

### DIFF
--- a/docs/en/ingest-management/commands.asciidoc
+++ b/docs/en/ingest-management/commands.asciidoc
@@ -91,6 +91,7 @@ elastic-agent enroll --fleet-server-es <string>
                      [--force]
                      [--help]
                      [--url <string>] <2>
+                     [--fleet-server-es-insecure ] <3>
                      [global-flags]
 ----
 <1> If no `fleet-server-cert*` flags are specified, {agent} auto-generates a
@@ -100,6 +101,7 @@ the `--insecure` flag.
 <2> Required when enrolling in a {fleet-server} with custom certificates. The
 URL must match the DNS name used to generate the certificate specified by
 `--fleet-server-cert`.
+<3> Required when using self-signed certificate on {es} side. 
 
 For more information about custom certificates, refer to <<secure-connections>>.
 
@@ -132,6 +134,18 @@ specified {es} URL.
 
 `--fleet-server-es-ca <string>`::
 Path to certificate authority to use to communicate with {es}.
+
+`--fleet-server-es-insecure`::
+Allows fleet server to connect to {es} in the following situations:
++
+--
+* When connecting to an HTTP server.
+* When connecting to an HTTPs server and the certificate chain cannot be
+verified. The content is encrypted, but the certificate is not verified.
+* When using self-signed certificates.
+--
++
+When this flag is used the certificate verification is disabled.
 
 `--fleet-server-host <string>`::
 {fleet-server} HTTP binding host (overrides the policy).
@@ -381,6 +395,7 @@ elastic-agent install --fleet-server-es <string>
                       [--force]
                       [--help]
                       [--url <string>] <2>
+                      [--fleet-server-es-insecure ] <3>
                       [global-flags]
 ----
 <1> If no `fleet-server-cert*` flags are specified, {agent} auto-generates a
@@ -390,6 +405,7 @@ the `--insecure` flag.
 <2> Required when enrolling in a {fleet-server} with custom certificates. The
 URL must match the DNS name used to generate the certificate specified by
 `--fleet-server-cert`.
+<3> Required when using self-signed certificate on {es} side. 
 
 For more information about custom certificates, refer to <<secure-connections>>.
 

--- a/docs/en/ingest-management/troubleshooting/troubleshooting.asciidoc
+++ b/docs/en/ingest-management/troubleshooting/troubleshooting.asciidoc
@@ -123,6 +123,19 @@ things running for development, but not recommended in a production environment.
 For more information, refer to <<secure-connections>>.
 
 [discrete]
+[[es-enrollment-certs]]
+== {agent} enrollment fails on the host with `x509: cannot validate certificate for x.x.x.x because it doesn't contain any IP SANs` message
+
+To ensure that communication with {es} is encrypted,
+{fleet-server} requires {es} to present a signed certificate. 
+
+This error occurs when you use self-signed certificates with {es} using IP as a Common Name (CN). 
+With IP as a CN, {fleet-server} looks into subject alternative names (SANs), which is empty. To work
+around this situation, use the `--fleet-server-es-insecure` flag to disable certificate verification.
+
+You will also need to set `ssl.verification_mode: none` in the Output settings in {fleet} and {integrations} UI.
+
+[discrete]
 [[agent-enrollment-timeout]]
 == {agent} enrollment fails on the host with `Client.Timeout exceeded` message
 


### PR DESCRIPTION
Backport for https://github.com/elastic/observability-docs/pull/1159