### PR TITLE
[7.16] docs: update APM links (#1181)

### DIFF
--- a/docs/en/observability/apm.asciidoc
+++ b/docs/en/observability/apm.asciidoc
@@ -29,4 +29,4 @@ ifeval::["{is-current-version}"=="false"]
 image::images/apm-app-landing.png[APM app in Kibana]
 endif::[]
 
-To learn more, see {apm-overview-ref-v}[APM Overview].
+To learn more, see {apm-guide-ref}/index.html[APM Overview].

--- a/docs/en/observability/ingest-traces.asciidoc
+++ b/docs/en/observability/ingest-traces.asciidoc
@@ -5,8 +5,6 @@
 <titleabbrev>Ingest traces</titleabbrev>
 ++++
 
-experimental::[]
-
 This guide describes how to:
 
 * Collect Application Performance Monitoring (APM) data
@@ -18,9 +16,6 @@ For feedback and questions, please contact us in the {forum}[discuss forum].
 [discrete]
 [[fleet-prereqs-traces]]
 == Prerequisites
-
-* The APM integration is experimental and has a number of known limitations.
-Please read the list of {apm-server-ref-v}/apm-integration.html[known limitations].
 
 * You need {es} for storing and searching your data, and {kib} for visualizing and
 managing it. You can use our
@@ -146,7 +141,7 @@ TIP: You can edit your APM integration settings if you need to change the APM Se
 or secret token to match your APM agents.
 
 --
-include::{apm-repo-dir}/tab-widgets/install-agents-widget.asciidoc[]
+include::{apm-repo-dir}/legacy/tab-widgets/install-agents-widget.asciidoc[]
 --
 
 [discrete]
@@ -159,7 +154,7 @@ You should see application performance monitoring data flowing into the {stack}!
 NOTE: The built-in `apm_user` role is not compatible with the APM integration
 as it only provides read access to `apm-*` indices.
 For a list of indices users need access to, refer to
-{apm-server-ref-v}/apm-integration-data-streams.html[APM data streams]
+{apm-guide-ref}/apm-data-streams.html[APM data streams]
 
 [role="screenshot"]
 image::images/kibana-apm-sample-data.png[APM app with data]

--- a/docs/en/observability/instrument-apps.asciidoc
+++ b/docs/en/observability/instrument-apps.asciidoc
@@ -20,11 +20,11 @@ visualizing and managing it, and APM Server. For more information, see <<spin-up
 == Step 1: Install APM agents
 
 :leveloffset: -1
-include::{apm-repo-dir}/guide/install-and-run.asciidoc[tag=apm-agent]
+include::{apm-repo-dir}/apm-quick-start.asciidoc[tag=apm-agent]
 :leveloffset: +1
 
 --
-include::{apm-repo-dir}/tab-widgets/install-agents-widget.asciidoc[]
+include::{apm-repo-dir}/legacy/tab-widgets/install-agents-widget.asciidoc[]
 --
 
 [discrete]
@@ -39,14 +39,14 @@ Luckily, there are many different ways to tweak and tune the Elastic ecosystem t
 *Configure APM Agents*
 
 --
-include::{apm-repo-dir}/tab-widgets/configure-agent-widget.asciidoc[]
+include::{apm-repo-dir}/legacy/tab-widgets/configure-agent-widget.asciidoc[]
 --
 
 [[configure-elastic-cloud]]
 *Configure APM Server*
 
 --
-include::{apm-repo-dir}/tab-widgets/configure-server-widget.asciidoc[]
+include::{apm-repo-dir}/legacy/tab-widgets/configure-server-widget.asciidoc[]
 --
 
 [discrete]

--- a/docs/en/observability/monitor-k8s/monitor-k8s-application-performance.asciidoc
+++ b/docs/en/observability/monitor-k8s/monitor-k8s-application-performance.asciidoc
@@ -34,13 +34,13 @@ Useful when all pods in a node should share a single APM Server instance.
 * Deploy APM Server as a sidecar -- For environments that should not share an APM Server,
 like when directing traces from multiple applications to separate {es} clusters.
 
-* {apm-server-ref-v}/installing.html[Download and install APM Server] -- The classic, non-Kubernetes option.
+* {apm-guide-ref}/apm-quick-start.html[Download and install APM Server] -- The classic, non-Kubernetes option.
 ====
 
 [discrete]
 === Step 2: Save your secret token
 
-A {apm-server-ref-v}/secret-token.html[secret token] is used to secure communication between APM agents
+A {apm-guide-ref}/input-apm.html[secret token] is used to secure communication between APM agents
 and APM Server. On the {ecloud} deployment page, select *APM* and copy your APM Server secret token.
 To avoid exposing the secret token, you can store it in a Kubernetes secret. For example:
 
@@ -51,7 +51,7 @@ kubectl create secret generic apm-secret --from-literal=ELASTIC_APM_SECRET_TOKEN
 <1> Create the secret in the same namespace that you'll be deploying your applications in.
 
 If you're managing APM Server yourself,
-see {apm-server-ref-v}/secret-token.html[secret token] for instructions on how to set up your secret token.
+see {apm-guide-ref}/input-apm.html[secret token] for instructions on how to set up your secret token.
 
 If you are using ECK to set up APM Server, the operator automatically generates an `{APM-server-name}-apm-token` secret for you.
 

--- a/docs/en/shared/configure-apm-server/content.asciidoc
+++ b/docs/en/shared/configure-apm-server/content.asciidoc
@@ -10,10 +10,6 @@ Full details are available in the {cloud}/ec-manage-apm-settings.html[APM user s
 // tag::self-managed[]
 
 If you've installed APM Server yourself, you can edit the `apm-server.yml` configuration file to make changes.
-More information is available in {apm-server-ref-v}/configuring-howto-apm-server.html[configuring APM Server].
-
-Don't forget to also read about
-{apm-server-ref-v}/securing-apm-server.html[securing APM Server], and
-{apm-server-ref-v}/monitoring.html[monitoring APM Server].
+More information is available in {apm-guide-ref}/input-apm.html[configuring APM Server].
 
 // end::self-managed[]

--- a/docs/en/shared/spin-up-the-stack/content.asciidoc
+++ b/docs/en/shared/spin-up-the-stack/content.asciidoc
@@ -10,6 +10,6 @@ version of {es}, {kib}, and APM Server.
 
 . {stack-gs}/get-started-elastic-stack.html#install-elasticsearch[Install {es}]
 . {stack-gs}/get-started-elastic-stack.html#install-kibana[Install Kibana]
-. {apm-server-ref-v}/installing.html[Install APM server]
+. {apm-guide-ref}/apm-quick-start.html[Install APM server]
 
 // end::self-managed[]


### PR DESCRIPTION
Backports the following commits to 7.16:
 - docs: update APM links (#1181)