### PR TITLE
[8.0] Add tip about ECK to Fleet-managed Agent section (#1150)

### DIFF
--- a/docs/en/ingest-management/elastic-agent/running-on-kubernetes-managed-by-fleet.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/running-on-kubernetes-managed-by-fleet.asciidoc
@@ -4,6 +4,8 @@
 Use {agent} https://www.docker.elastic.co/r/beats/elastic-agent[Docker images] on Kubernetes to
 retrieve cluster metrics.
 
+TIP: Running {ecloud} on Kubernetes? Refer to {eck-ref}/k8s-elastic-agent-fleet.html[Run {elastic-agent} on ECK].
+
 ifeval::["{release-state}"=="unreleased"]
 
 However, version {version} of {agent} has not yet been


### PR DESCRIPTION
Backports the following commits to 8.0:
 - Add tip about ECK to Fleet-managed Agent section (#1150)