### PR TITLE
mark logging.ecs and logging.json as deprecated

### DIFF
--- a/docs/en/ingest-management/elastic-agent/configuration/elastic-agent-standalone-logging.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/elastic-agent-standalone-logging.asciidoc
@@ -119,9 +119,14 @@ Default: `0` (disabled)
 
 Default: `true`
 
+deprecated::[7.16.0]
+
 | `agent.logging.json` | Set to `true` to log messages in JSON format.
 
+
 Default: `false`
+
+deprecated::[7.16.0]
 
 | `agent.logging.ecs` | Set to `true` to log messages with the minimal required Elastic Common Schema (ECS)
 information. We recommended using this option in combination with `agent.logging.json: true`.

--- a/docs/en/ingest-management/elastic-agent/configuration/elastic-agent-standalone-logging.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/elastic-agent-standalone-logging.asciidoc
@@ -119,10 +119,7 @@ Default: `0` (disabled)
 
 Default: `true`
 
-deprecated::[7.16.0]
-
 | `agent.logging.json` | Set to `true` to log messages in JSON format.
-
 
 Default: `false`
 
@@ -132,5 +129,7 @@ deprecated::[7.16.0]
 information. We recommended using this option in combination with `agent.logging.json: true`.
 
 Default: `false`
+
+deprecated::[7.16.0]
 
 |===


### PR DESCRIPTION
Mark `logging.ecs` and `logging.json` as deprecated in 7.16 as both settings will be disables (defaulted to true) in the 8.x releases as part of the Elastic Stack shipping ECS logs.