### PR TITLE
Indicate that Fleet-managed agents do not support http json input

### DIFF
--- a/docs/en/ingest-management/beats-agent-comparison.asciidoc
+++ b/docs/en/ingest-management/beats-agent-comparison.asciidoc
@@ -121,7 +121,7 @@ The following table shows the inputs supported by the {agent} in {version}:
 
 |HTTP JSON
 |{y}
-|{y}
+|{n}
 |{y}
 
 |Kafka


### PR DESCRIPTION
Closes #1207 

Preview: https://observability-docs_1238.docs-preview.app.elstc.co/guide/en/fleet/master/beats-agent-comparison.html

We should backport this to the earliest place where we show support.