### PR TITLE
[7.16] Indicate that Fleet-managed agents do not support http json input (#1238)

### DIFF
--- a/docs/en/ingest-management/beats-agent-comparison.asciidoc
+++ b/docs/en/ingest-management/beats-agent-comparison.asciidoc
@@ -122,7 +122,7 @@ The following table shows the inputs supported by the {agent} in {version}:
 
 |HTTP JSON
 |{y}
-|{y}
+|{n}
 |{y}
 
 |Kafka


### PR DESCRIPTION
Backports the following commits to 7.16:
 - Indicate that Fleet-managed agents do not support http json input (#1238)