### PR TITLE
[monitor-gcp] create Pub/Sub subscription in both GCP tutorials

### DIFF
--- a/docs/en/observability/gcp-dataflow.asciidoc
+++ b/docs/en/observability/gcp-dataflow.asciidoc
@@ -67,23 +67,6 @@ topic and subscription from your Google Cloud Console where you can send your
 logs from Google Operations Suite.
 include::gcp-topic.asciidoc[]
 
-. Now go to the *Pub/Sub* page to add a subscription to the topic you just
-created. Use the search bar to find the page:
-+
-image::monitor-gcp-pub-sub.png[GCP Pub/Sub]
-+
-To add a subscription to the `monitor-gcp-audit` topic click
-*Create subscription*:
-+
-image::monitor-gcp-pub-sub-create-subscription.png[Create GCP Pub/Sub Subscription]
-+
-Set `monitor-gcp-audit-sub` as the *Subscription ID* and leave the
-*Delivery type* as pull:
-+
-image::monitor-gcp-pub-sub-subscription-id.png[GCP Pub/Sub Subscription ID]
-+
-Finally, scroll down and click *Create*.
-
 [discrete]
 ==== Step 3: Configure the Google Dataflow template
 

--- a/docs/en/observability/gcp-topic.asciidoc
+++ b/docs/en/observability/gcp-topic.asciidoc
@@ -17,3 +17,22 @@ Finally, under *Choose logs to include in sink*, add
 Click *create sink*.  It will look something like the following:
 +
 image::monitor-gcp-create-sink.png[Create logs routing sink]
+
+. Now go to the *Pub/Sub* page to add a subscription to the topic you just
+created. Use the search bar to find the page:
++
+image::monitor-gcp-pub-sub.png[GCP Pub/Sub]
++
+To add a subscription to the `monitor-gcp-audit` topic click
+*Create subscription*:
++
+image::monitor-gcp-pub-sub-create-subscription.png[Create GCP Pub/Sub Subscription]
++
+Set `monitor-gcp-audit-sub` as the *Subscription ID* and leave the
+*Delivery type* as pull:
++
+image::monitor-gcp-pub-sub-subscription-id.png[GCP Pub/Sub Subscription ID]
++
+Finally, scroll down and click *Create*.
+
+

--- a/docs/en/observability/monitor-gcp.asciidoc
+++ b/docs/en/observability/monitor-gcp.asciidoc
@@ -235,8 +235,7 @@ include::gcp-topic.asciidoc[]
 <2> Enables the `audit` fileset.
 <3> Collects data within the `elastic-education` project-id.
 <4> Collects logs from the `monitor-gcp-audit` topic.
-<5> Google Cloud Pub/Sub topic subscription name. If the subscription does not
-exist it will be created.
+<5> Google Cloud Pub/Sub topic subscription name.
 <6> The GCP credential file that you generated earlier. (Don't forget to create
 the file if it does not exist and to use the correct full path).
 


### PR DESCRIPTION
I just realized that the steps for creating the GCP Pub/Sub subscription should be used in both **Monitor Google Cloud Platform** and **GCP Dataflow templates** tutorials. I'm sending this PR to amend this. 