### PR TITLE
Add header to legacy observability docs

### DIFF
--- a/docs/en/logs/page_header.html
+++ b/docs/en/logs/page_header.html
@@ -1,0 +1,2 @@
+A newer version is available. For the latest information, see the
+<a href="https://www.elastic.co/guide/en/observability/current/monitor-logs.html">current release documentation</a>.

--- a/docs/en/metrics/page_header.html
+++ b/docs/en/metrics/page_header.html
@@ -1,0 +1,2 @@
+A newer version is available. For the latest information, see the
+<a href="https://www.elastic.co/guide/en/observability/current/analyze-metrics.html">current release documentation</a>.

--- a/docs/en/uptime/page_header.html
+++ b/docs/en/uptime/page_header.html
@@ -1,0 +1,2 @@
+A newer version is available. For the latest information, see the
+<a href="https://www.elastic.co/guide/en/observability/current/monitor-uptime.html">current release documentation</a>.


### PR DESCRIPTION
Closes https://github.com/elastic/observability-docs/issues/793

7.9 versions of our old docs are not flagged as outdated. These files add a header to the page that redirects users to the current version of the observability docs.

Previews of the header are here:

https://observability-docs_1264.docs-preview.app.elstc.co/guide/en/uptime/7.9/index.html
https://observability-docs_1264.docs-preview.app.elstc.co/guide/en/logs/guide/current/index.html
https://observability-docs_1264.docs-preview.app.elstc.co/guide/en/metrics/guide/current/index.html