### PR TITLE
Add agent.monitoring.pprof doc

### DIFF
--- a/docs/en/ingest-management/elastic-agent/configuration/elastic-agent-monitoring.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/elastic-agent-monitoring.asciidoc
@@ -22,7 +22,7 @@ agent.monitoring:
   # enables metrics monitoring
   metrics: true
   # exposes /debug/pprof/ endpoints
-  # recommended that these endpoints are only enabled if the monitoring endpoint is set to localhost
+  # enable these endpoints if the monitoring endpoint is set to localhost
   pprof: true
   # specifies output to be used
   use_output: monitoring
@@ -39,5 +39,5 @@ collected. If neither setting is specified, monitoring is turned off. Set
 
 The `agent.monitoring.pprof` option controls whether the {agent} exposes the
 `/debug/pprof/` endpoints with the monitoring endpoints. It is set to `true`
-by default. It is recommended that these endpoints are disabled on the agent
-if the monitoring endpoint is accessible over a network (not recommended).
+by default. If the monitoring endpoint is accessible over a network (not recommended),
+set this option to `false` to disable the `/debug/pprof/` endpoints.

--- a/docs/en/ingest-management/elastic-agent/configuration/elastic-agent-monitoring.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/elastic-agent-monitoring.asciidoc
@@ -21,6 +21,9 @@ agent.monitoring:
   logs: true
   # enables metrics monitoring
   metrics: true
+  # exposes /debug/pprof/ endpoints
+  # recommended that these endpoints are only enabled if the monitoring endpoint is set to localhost
+  pprof: true
   # specifies output to be used
   use_output: monitoring
 ----
@@ -33,3 +36,8 @@ To enable monitoring, set `agent.monitoring.enabled` to `true`. Also set the
 `logs` and `metrics` settings to control whether logs, metrics, or both are
 collected. If neither setting is specified, monitoring is turned off. Set
 `use_output` to specify the output to which monitoring events are sent.
+
+The `agent.monitoring.pprof` option controls whether the {agent} exposes the
+`/debug/pprof/` endpoints with the monitoring endpoints. It is set to `true`
+by default. It is recommended that these endpoints are disabled on the agent
+if the monitoring endpoint is accessible over a network (not recommended).


### PR DESCRIPTION
Add some explanation for the agent.monitoring.pprof option, and when to
disable it, in the stand-alone documentation.