### PR TITLE
Change agent pprof default to false

### DIFF
--- a/docs/en/ingest-management/elastic-agent/configuration/elastic-agent-monitoring.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/elastic-agent-monitoring.asciidoc
@@ -21,7 +21,7 @@ agent.monitoring:
   logs: true
   # enables metrics monitoring
   metrics: true
-  # exposes /debug/pprof/ endpoints for agent and beats
+  # exposes /debug/pprof/ endpoints for Elastic Agent and Beats
   # enable these endpoints if the monitoring endpoint is set to localhost
   pprof: false
   # specifies output to be used
@@ -37,8 +37,8 @@ To enable monitoring, set `agent.monitoring.enabled` to `true`. Also set the
 collected. If neither setting is specified, monitoring is turned off. Set
 `use_output` to specify the output to which monitoring events are sent.
 
-The `agent.monitoring.pprof` option controls whether the {agent} and {beats} exposes the
+The `agent.monitoring.pprof` option controls whether the {agent} and {beats} expose the
 `/debug/pprof/` endpoints with the monitoring endpoints. It is set to `false`
 by default. Data produced by these endpoints can be useful for debugging but present a
-security risk. It is reccomended that this option remains `false` if the monitoring endpoint
+security risk. It is recommended that this option remains `false` if the monitoring endpoint
 is accessible over a network.

--- a/docs/en/ingest-management/elastic-agent/configuration/elastic-agent-monitoring.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/elastic-agent-monitoring.asciidoc
@@ -21,9 +21,9 @@ agent.monitoring:
   logs: true
   # enables metrics monitoring
   metrics: true
-  # exposes /debug/pprof/ endpoints
+  # exposes /debug/pprof/ endpoints for agent and beats
   # enable these endpoints if the monitoring endpoint is set to localhost
-  pprof: true
+  pprof: false
   # specifies output to be used
   use_output: monitoring
 ----
@@ -37,7 +37,8 @@ To enable monitoring, set `agent.monitoring.enabled` to `true`. Also set the
 collected. If neither setting is specified, monitoring is turned off. Set
 `use_output` to specify the output to which monitoring events are sent.
 
-The `agent.monitoring.pprof` option controls whether the {agent} exposes the
-`/debug/pprof/` endpoints with the monitoring endpoints. It is set to `true`
-by default. If the monitoring endpoint is accessible over a network (not recommended),
-set this option to `false` to disable the `/debug/pprof/` endpoints.
+The `agent.monitoring.pprof` option controls whether the {agent} and {beats} exposes the
+`/debug/pprof/` endpoints with the monitoring endpoints. It is set to `false`
+by default. Data produced by these endpoints can be useful for debugging but present a
+security risk. It is reccomended that this option remains `false` if the monitoring endpoint
+is accessible over a network.


### PR DESCRIPTION
As discussed in https://github.com/elastic/beats/issues/29108 we will be changing the default `agent.monitoring.pprof` option to false.

Behaviour of the option has also slightly changed to also apply to beats that the agent runs: https://github.com/elastic/beats/pull/29155