### PR TITLE
[mergify] in order to automate the backport and notifications

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,93 @@
+pull_request_rules:
+  - name: ask to resolve conflict
+    conditions:
+      - -merged
+      - -closed
+      - conflict
+    actions:
+        comment:
+          message: |
+            This pull request is now in conflicts. Could you fix it @{{author}}? 🙏
+            To fixup this pull request, you can check out it locally. See documentation: https://help.github.com/articles/checking-out-pull-requests-locally/
+            ```
+            git fetch upstream
+            git checkout -b {{head}} upstream/{{head}}
+            git merge upstream/{{base}}
+            git push upstream {{head}}
+            ```
+  - name: backport patches to 8.0 branch
+    conditions:
+      - merged
+      - base=master
+      - label=v8.0.0
+    actions:
+      backport:
+        assignees:
+          - "{{ author }}"
+        branches:
+          - "8.0"
+        title: "[{{ destination_branch }}] {{ title }} (backport #{{ number }})"
+        labels:
+          - backport
+  - name: backport patches to 7.16 branch
+    conditions:
+      - merged
+      - base=master
+      - label=v7.16.0
+    actions:
+      backport:
+        assignees:
+          - "{{ author }}"
+        branches:
+          - "7.16"
+        title: "[{{ destination_branch }}] {{ title }} (backport #{{ number }})"
+        labels:
+          - backport
+  - name: backport patches to 7.15 branch
+    conditions:
+      - merged
+      - base=master
+      - label=v7.15.0
+    actions:
+      backport:
+        assignees:
+          - "{{ author }}"
+        branches:
+          - "7.15"
+        title: "[{{ destination_branch }}] {{ title }} (backport #{{ number }})"
+        labels:
+          - backport
+  - name: notify the backport policy
+    conditions:
+      - -label~=(^v\d|backport-skip)
+      - base=master
+    actions:
+      comment:
+        message: |
+          This pull request does not have a backport label. Could you fix it @{{author}}? 🙏
+          To fixup this pull request, you need to add the backport labels for the needed
+          branches, such as:
+          * `v7./d./d` is the label to automatically backport to the `7./d` branch. `/d` is the digit
+          **NOTE**: `backport-skip` has been added to this pull request.
+      label:
+        add:
+          - backport-skip
+  - name: remove backport-skip label
+    conditions:
+      - label~=^v\d
+    actions:
+      label:
+        remove:
+          - backport-skip
+  - name: notify the backport has not been merged yet
+    conditions:
+      - -merged
+      - -closed
+      - author=mergify[bot]
+      - "#check-success>0"
+      - schedule=Mon-Mon 06:00-10:00[Europe/Paris]
+      - "#assignee>=1"
+    actions:
+      comment:
+        message: |
+          This pull request has not been merged yet. Could you please review and merge it @{{ assignee | join(', @') }}? 🙏

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -7,7 +7,7 @@ pull_request_rules:
     actions:
         comment:
           message: |
-            This pull request is now in conflicts. Could you fix it @{{author}}? 🙏
+            This pull request is now in conflict. Could you fix it @{{author}}? 🙏
             To fixup this pull request, you can check out it locally. See documentation: https://help.github.com/articles/checking-out-pull-requests-locally/
             ```
             git fetch upstream

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -18,7 +18,7 @@ pull_request_rules:
   - name: backport patches to 8.0 branch
     conditions:
       - merged
-      - base=master
+      - base=main
       - label=v8.0.0
     actions:
       backport:
@@ -32,7 +32,7 @@ pull_request_rules:
   - name: backport patches to 7.16 branch
     conditions:
       - merged
-      - base=master
+      - base=main
       - label=v7.16.0
     actions:
       backport:
@@ -46,7 +46,7 @@ pull_request_rules:
   - name: backport patches to 7.15 branch
     conditions:
       - merged
-      - base=master
+      - base=main
       - label=v7.15.0
     actions:
       backport:
@@ -60,7 +60,7 @@ pull_request_rules:
   - name: notify the backport policy
     conditions:
       - -label~=(^v\d|backport-skip)
-      - base=master
+      - base=main
     actions:
       comment:
         message: |

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -19,7 +19,7 @@ pull_request_rules:
     conditions:
       - merged
       - base=main
-      - label=v8.0.0
+      - label=backport-8.0
     actions:
       backport:
         assignees:
@@ -33,7 +33,7 @@ pull_request_rules:
     conditions:
       - merged
       - base=main
-      - label=v7.16.0
+      - label=backport-7.16
     actions:
       backport:
         assignees:
@@ -47,7 +47,7 @@ pull_request_rules:
     conditions:
       - merged
       - base=main
-      - label=v7.15.0
+      - label=backport-7.15
     actions:
       backport:
         assignees:
@@ -59,7 +59,7 @@ pull_request_rules:
           - backport
   - name: notify the backport policy
     conditions:
-      - -label~=(^v\d|backport-skip)
+      - -label~=^backport
       - base=main
     actions:
       comment:
@@ -67,14 +67,16 @@ pull_request_rules:
           This pull request does not have a backport label. Could you fix it @{{author}}? 🙏
           To fixup this pull request, you need to add the backport labels for the needed
           branches, such as:
-          * `v7./d./d` is the label to automatically backport to the `7./d` branch. `/d` is the digit
+          * `backport-/d./d` is the label to automatically backport to the `/d./d` branch. `/d` is the digit
           **NOTE**: `backport-skip` has been added to this pull request.
       label:
         add:
           - backport-skip
   - name: remove backport-skip label
     conditions:
-      - label~=^v\d
+      - label~=^backport-\d
+      - -merged
+      - -closed
     actions:
       label:
         remove:


### PR DESCRIPTION
### What

This is just a proposal to use mergify in order to:

* create the backports automatically
* notify when a backport has a conflict to be resolved.
* notify in the original PR when there is no v\d* labels or backport-skip labels.
* notify when backports are not merged but have been reviewed, this happens once a week.

**NOTE**:

This is a complementary service, so contributors can decide to opt-in and use the labels to automate the backports or use any other kind of process to do the backports


### Why

This is a SaaS that works out of the box with public repositories. So it can simplify your backport.

It's stateless, so it does not track if a particular PR should have been backported, it backports any PR only if:

1) It was merged and tagged with the labels -> https://docs.mergify.io/actions/backport/ and see the `.mergify.yml` file.
2) An explicit GitHub comment was added -> https://docs.mergify.io/commands/#backport

### How does it work?

- Tag, aka add a GitHub label, your PR with `v7.16` or `v7.15` or `backport-skip`
- Then merge your original PR (Pull Request).
- Automatically `mergify` will create the backports and assign the author of the original Pull Request to the new backported PRs.
- If there are any conflicts then, those will be shown in the Description of the backported Pull Request in addition to the `conflicts` github Label. You can resolve those conflicts using the GitHub UI, checking out the PR locally, or as you normally do, if the latter, please close the backported Pull Request.
- By default, the `backport-skip` GitHub label is added in all the new Pull Requests, this helps with the automation. As soon as, the `v7.x` or a similar GitHub label is added the `backport-skip` label is removed.

### What's required?

0) [x] Agree if you'd like to move forward.
1) [ ] Enable mergify (need to ask infra to enable this service)
2) [ ] Agree with the `backport-skip` label since it's required to explicitly comment in the original PR when no backport tags have been added.
3) [ ] Agree with the `v-` or `backport-` labels since product teams use `backport-` mostly.
4) [ ] When a new release branch is created, then it's required to edit `.mergify.yml` to add the new branch backport entry 

### Further details

This particular service has been enabled for different projects:
- https://github.com/elastic/apm-server
- https://github.com/elastic/beats
- https://github.com/elastic/security-docs/

It does allow to auto-merge backported PRs if their GitHub checks passed and some other automations.

