### PR TITLE
Add 7.16 release notes for Elastic Agent and Fleet

### DIFF
--- a/docs/en/ingest-management/index.asciidoc
+++ b/docs/en/ingest-management/index.asciidoc
@@ -134,4 +134,4 @@ include::troubleshooting/troubleshooting.asciidoc[leveloffset=+2]
 
 include::troubleshooting/faq.asciidoc[leveloffset=+2]
 
-include::release-notes/release-notes-7.15.asciidoc[leveloffset=+1]
+include::release-notes/release-notes-7.16.asciidoc[leveloffset=+1]

--- a/docs/en/ingest-management/release-notes/release-notes-7.16.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-7.16.asciidoc
@@ -26,44 +26,6 @@ Also see:
 
 Review important information about the {fleet} and {agent} 7.16.0 releases.
 
-//[discrete]
-//[[breaking-changes-7.16.0]]
-//=== Breaking changes
-
-//Breaking changes can prevent your application from optimal operation and
-//performance. Before you upgrade, review the breaking changes, then mitigate the
-//impact to your application.
-
-//[discrete]
-//[[breaking-PR#]]
-//.Short description
-//[%collapsible]
-//====
-//*Details* +
-//<Describe new behavior.> For more information, refer to {kibana-pull}PR[#PR].
-
-//*Impact* +
-//<Describe how users should mitigate the change.> For more information, refer to {fleet-guide}/fleet-server.html[Fleet Server].
-//====
-
-//[discrete]
-//[[known-issues-7.16.0]]
-//=== Known issues
-
-//[[known-issue-issue#]]
-//.Short description
-//[%collapsible]
-//====
-
-//*Details* 
-
-//<Describe known issue.>
-
-//*Impact* +
-
-//<Describe impact or workaround.>
-
-//====
 
 [discrete]
 [[enhancements-7.16.0]]

--- a/docs/en/ingest-management/release-notes/release-notes-7.16.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-7.16.asciidoc
@@ -56,8 +56,6 @@ Fleet::
 * Improves default settings for {fleet} component templates {kib-pull}114101[#114101]
 * Report `installing` status while package install is in progress {kib-pull}111875[#111875]
 
-//{agent}::
-//* add info
 
 // end 7.16.0 relnotes
 

--- a/docs/en/ingest-management/release-notes/release-notes-7.16.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-7.16.asciidoc
@@ -77,6 +77,7 @@ Fleet::
 * Allow packages to specify index privileges {kib-pull}112397[#112397]
 * Allow Integrations browse page to filter on descriptions {kib-pull}111649[#111649]
 * Support automatic upgrades of package policies when updating integrations {kib-pull}108269[#108269]
+* Allow preconfiguration of alternative {es} outputs {kib-pull}111002[#111002]
 
 {agent}::
 * Adds `diagnostics` command to {agent} {agent-pull}28265[#28265] {agent-pull}28461[#28461]

--- a/docs/en/ingest-management/release-notes/release-notes-7.16.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-7.16.asciidoc
@@ -1,0 +1,208 @@
+// Use these for links to issue and pulls. 
+:kib-issue: https://github.com/elastic/kibana/issues/
+:kib-pull: https://github.com/elastic/kibana/pull/
+:agent-issue: https://github.com/elastic/beats/issues/
+:agent-pull: https://github.com/elastic/beats/pull/
+:fleet-server-issue: https://github.com/elastic/beats/issues/fleet-server/
+:fleet-server-pull: https://github.com/elastic/beats/pull/fleet-server/
+
+
+[[release-notes]]
+= Release notes
+
+This section summarizes the changes in each release.
+
+* <<release-notes-7.16.0>>
+
+Also see:
+
+* {kibana-ref}/release-notes.html[{kib} release notes]
+* {beats-ref}/release-notes.html[{beats} release notes]
+
+// begin 7.16.0 relnotes
+
+[[release-notes-7.16.0]]
+== {fleet} and {agent} 7.16.0
+
+Review important information about the {fleet} and {agent} 7.16.0 releases.
+
+//[discrete]
+//[[breaking-changes-7.16.0]]
+//=== Breaking changes
+
+//Breaking changes can prevent your application from optimal operation and
+//performance. Before you upgrade, review the breaking changes, then mitigate the
+//impact to your application.
+
+//[discrete]
+//[[breaking-PR#]]
+//.Short description
+//[%collapsible]
+//====
+//*Details* +
+//<Describe new behavior.> For more information, refer to {kibana-pull}PR[#PR].
+
+//*Impact* +
+//<Describe how users should mitigate the change.> For more information, refer to {fleet-guide}/fleet-server.html[Fleet Server].
+//====
+
+//[discrete]
+//[[known-issues-7.16.0]]
+//=== Known issues
+
+//[[known-issue-issue#]]
+//.Short description
+//[%collapsible]
+//====
+
+//*Details* 
+
+//<Describe known issue.>
+
+//*Impact* +
+
+//<Describe impact or workaround.>
+
+//====
+
+[discrete]
+[[enhancements-7.16.0]]
+=== Enhancements
+
+Fleet::
+* Adds prompt for users to add an agent if they add an integration to an agent policy with no agents {kib-pull}114830[#114830]
+* Allow users with read access to view Integrations app {kib-pull}113925[#113925]
+* Removes enterprise license requirement for custom registry URL {kib-pull}113858[#113858]
+* Adds "Keep Policies up to Date" functionality for integrations {kib-pull}112702[#112702]
+* Allow packages to specify index privileges {kib-pull}112397[#112397]
+* Allow Integrations browse page to filter on descriptions {kib-pull}111649[#111649]
+* Support automatic upgrades of package policies when updating integrations {kib-pull}108269[#108269]
+
+{agent}::
+* Adds `diagnostics` command to {agent} {agent-pull}28265[#28265] {agent-pull}28461[#28461]
+* Enables `/debug/pprof/` endpoints for all {beats} that the {agent} starts {agent-pull}28983[#28983]
+
+[discrete]
+[[bug-fixes-7.16.0]]
+=== Bug fixes
+
+Fleet::
+* Link to the installed version of an integration from global search {kib-pull}115736[#115736]
+* Fixes agent count in update modal {kib-pull}114622[#114622]
+* Shows security requirements page when {es} security is not enabled {kib-pull}114583[#114583]
+* Improves default settings for {fleet} component templates {kib-pull}114101[#114101]
+* Report `installing` status while package install is in progress {kib-pull}111875[#111875]
+
+//{agent}::
+//* add info
+
+// end 7.16.0 relnotes
+
+// ---------------------
+//TEMPLATE
+//Use the following text as a template. Remember to replace the version info.
+
+// begin 7.16.x relnotes
+
+//[[release-notes-7.16.x]]
+//== {fleet} and {agent} 7.16.x
+
+//Review important information about the {fleet} and {agent} 7.16.x releases.
+
+//[discrete]
+//[[security-updates-7.16.x]]
+//=== Security updates
+
+//{fleet}::
+//* add info
+
+//{agent}::
+//* add info
+
+//[discrete]
+//[[breaking-changes-7.16.x]]
+//=== Breaking changes
+
+//Breaking changes can prevent your application from optimal operation and
+//performance. Before you upgrade, review the breaking changes, then mitigate the
+//impact to your application.
+
+//[discrete]
+//[[breaking-PR#]]
+//.Short description
+//[%collapsible]
+//====
+//*Details* +
+//<Describe new behavior.> For more information, refer to {kibana-pull}PR[#PR].
+
+//*Impact* +
+//<Describe how users should mitigate the change.> For more information, refer to {fleet-guide}/fleet-server.html[Fleet Server].
+//====
+
+//[discrete]
+//[[known-issues-7.16.x]]
+//=== Known issues
+
+//[[known-issue-issue#]]
+//.Short description
+//[%collapsible]
+//====
+
+//*Details* 
+
+//<Describe known issue.>
+
+//*Impact* +
+
+//<Describe impact or workaround.>
+
+//====
+
+//[discrete]
+//[[deprecations-7.16.x]]
+//=== Deprecations
+
+//The following functionality is deprecated in 7.16.x, and will be removed in
+//8.0.0. Deprecated functionality does not have an immediate impact on your
+//application, but we strongly recommend you make the necessary updates after you
+//upgrade to 7.16.x.
+
+//{fleet}::
+//* add info
+
+//{agent}::
+//* add info
+
+//[discrete]
+//[[new-features-7.16.x]]
+//=== New features
+
+//The 7.16.x release adds the following new and notable features.
+
+//{fleet}::
+//* add info
+
+//{agent}::
+//* add info
+
+//[discrete]
+//[[enhancements-7.16.x]]
+//=== Enhancements
+
+//{fleet}::
+//* add info
+
+//{agent}::
+//* add info
+
+//[discrete]
+//[[bug-fixes-7.16.x]]
+//=== Bug fixes
+
+//{fleet}::
+//* add info
+
+//{agent}::
+//* add info
+
+// end 7.16.x relnotes


### PR DESCRIPTION
Adds release notes to the Elastic Agent and Fleet Guide.

Preview link: https://observability-docs_1319.docs-preview.app.elstc.co/guide/en/fleet/master/release-notes-7.16.0.html 

Reviewers: Please respond to these questions:

- [x] Do we have any breaking changes or known issues that we want to document in 7.16?
- [x] The following PRs seem like internals (stuff users don't need to know). Please confirm whether we want to document these changes in the release notes:
https://github.com/elastic/beats/pull/28165
https://github.com/elastic/beats/pull/28260
- [x] This seems like internals (stuff users might want to know), but I’m not sure how to describe this for users. Do we want to document this in the release notes? What is the user impact of this PR?
https://github.com/elastic/beats/pull/28096

NOTE: The diff includes a template for the next update. You can ignore everything after after:
```
// ---------------------
//TEMPLATE
```

Closes #1319 