### PR TITLE
[7.15] docs: fix bad link for 7.16

### DIFF
--- a/docs/en/observability/ingest-splunk.asciidoc
+++ b/docs/en/observability/ingest-splunk.asciidoc
@@ -12,7 +12,7 @@ If you haven't already, you need to install {es} for storing and
 searching your data, and {kib} for visualizing and managing it. For
 more information, see <<add-observability-data,Send data to {es}>>.
 After {es} and {kib} are installed Fleet must be enabled; see the
-https://www.elastic.co/guide/en/fleet/current/fleet-quick-start.html[Fleet quick start].
+{fleet-guide}/fleet-quick-start.html[Fleet quick start].
 
 
 =====
@@ -40,7 +40,7 @@ The options are the same for Apache, AWS Cloudtrail, and Zeek.
 [[splunk-step-one]]
 == Step 1: Add integration
 
-Find the Nginx integration and begin adding it as described in the 
+Find the Nginx integration and begin adding it as described in the
 {fleet-guide}/fleet-quick-start.html#add-nginx-integration[Fleet quick start].
 
 [discrete]
@@ -139,4 +139,3 @@ dependency on any Splunk processing.
 these integrations go through the exact same processing as if {agent}
 had gotten the event from the original source.  So the same level of
 mapping to ECS occurs.
-


### PR DESCRIPTION
The docs PR to upgrade to `7.16` (elastic/docs#2299) is failing due to a broken link in the observability-docs repo:

```
14:29:51 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/observability/7.13/ingest-splunk.html contains broken links to:
14:29:51 INFO:build_docs:   - en/fleet/current/fleet-quick-start.html
14:29:51 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/observability/7.14/ingest-splunk.html contains broken links to:
14:29:51 INFO:build_docs:   - en/fleet/current/fleet-quick-start.html
14:29:51 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/observability/7.15/ingest-splunk.html contains broken links to:
14:29:51 INFO:build_docs:   - en/fleet/current/fleet-quick-start.html
```

This PR needs to be backported to `7.14` and `7.13`.