### PR TITLE
Update ci-cd-observability.asciidoc

### DIFF
--- a/docs/en/observability/ci-cd-observability.asciidoc
+++ b/docs/en/observability/ci-cd-observability.asciidoc
@@ -267,7 +267,7 @@ For example, you can add the following snippet to your pom.xml file:
       <extension>
           <groupId>io.opentelemetry.contrib</groupId>
           <artifactId>opentelemetry-maven-extension</artifactId>
-          <version>1.7.0-alpha</version>
+          <version>1.9.0-alpha</version>
       </extension>
     </extensions>
   </build>

--- a/docs/en/observability/ci-cd-observability.asciidoc
+++ b/docs/en/observability/ci-cd-observability.asciidoc
@@ -281,6 +281,7 @@ passing the configuration details as environment variables:
 ----
 export OTEL_EXPORTER_OTLP_ENDPOINT="https://elastic-apm-server.example.com:8200"
 export OTEL_EXPORTER_OTLP_HEADERS="Authorization=Bearer an_apm_secret_token"
+export OTEL_TRACES_EXPORTER="otlp"
 
 mvn verify
 ----
@@ -292,6 +293,7 @@ command line argument “-Dmaven.ext.class.path=...”
 ----
 export OTEL_EXPORTER_OTLP_ENDPOINT="https://elastic-apm-server.example.com:8200"
 export OTEL_EXPORTER_OTLP_HEADERS="Authorization=Bearer an_apm_secret_token"
+export OTEL_TRACES_EXPORTER="otlp"
 
 mvn -Dmaven.ext.class.path=path/to/opentelemetry-maven-extension.jar verify
 ----
@@ -384,6 +386,9 @@ To invoke shell scripts that use otel-cli for tracing:
 [source,bash]
 ----
 export OTEL_EXPORTER_OTLP_ENDPOINT="elastic-apm-server.example.com:8200"
+export OTEL_EXPORTER_OTLP_HEADERS="Authorization=Bearer an_apm_secret_token"
+export OTEL_TRACES_EXPORTER="otlp"
+
 make login build push
 ----
 


### PR DESCRIPTION
Document `export OTEL_TRACES_EXPORTER="otlp"` that will be needed with the otel maven extension 1.10-alpha