### PR TITLE
Remove air-gapped topic from the integrations dev guide

### DIFF
--- a/docs/en/integrations/air-gapped.asciidoc
+++ b/docs/en/integrations/air-gapped.asciidoc
@@ -1,5 +1,0 @@
-[[air-gapped]]
-= Air-gapped environments
-
-You can find the documentation about {fleet} and the {package-registry} in
-air-gapped environments in {fleet-guide}/air-gapped.html.

--- a/docs/en/integrations/index.asciidoc
+++ b/docs/en/integrations/index.asciidoc
@@ -39,8 +39,6 @@ include::elastic-package.asciidoc[leveloffset=+1]
 
 include::package-spec.asciidoc[leveloffset=+1]
 
-include::air-gapped.asciidoc[leveloffset=+1]
-
 // include::integration-example.asciidoc[leveloffset=+1]
 
 // == Community integrations


### PR DESCRIPTION
Closes #1305

The build will break until all links are cleaned up.

Links that need to be cleaned up:

- [x] 18:58:20 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/elastic-stack/7.15/observability-highlights.html contains broken links to:
18:58:20 INFO:build_docs:   - en/integrations-developer/current/air-gapped.html
PR: https://github.com/elastic/observability-docs/pull/1362
- [x] 18:58:20 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/observability/7.15/whats-new.html contains broken links to:
18:58:20 INFO:build_docs:   - en/integrations-developer/current/air-gapped.html
PR: https://github.com/elastic/observability-docs/pull/1362
- [x] 18:58:20 INFO:build_docs:  Kibana [7.16]: src/core/public/doc_links/doc_links_service.ts contains broken links to:
18:58:20 INFO:build_docs:   - en/integrations-developer/current/air-gapped.html
- [x] 18:58:20 INFO:build_docs:  Kibana [8.0]: src/core/public/doc_links/doc_links_service.ts contains broken links to:
18:58:20 INFO:build_docs:   - en/integrations-developer/current/air-gapped.html
- [x] 18:58:20 INFO:build_docs:  Kibana [master]: src/core/public/doc_links/doc_links_service.ts contains broken links to:
18:58:20 INFO:build_docs:   - en/integrations-developer/master/air-gapped.html
PR: https://github.com/elastic/kibana/pull/121236