### PR TITLE
Update fleet-settings.asciidoc with caveat for Fleet URL

### DIFF
--- a/docs/en/ingest-management/fleet/fleet-settings.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-settings.asciidoc
@@ -25,7 +25,7 @@ is required. On self-managed clusters, you must specify one or more URLs.
 On {ecloud}, this field is populated automatically. If you are using
 Azure Private Link, GCP Private Service Connect, or AWS PrivateLink
 and enrolling the {agent} with a private link URL,
-ensure that this setting is configured. Otherwise, Elastic Agent will
+ensure that this setting is configured. Otherwise, {agent} will
 reset to use a default address instead of the private link URL.
 
 NOTE: If a URL is specified without a port, {kib} sets the port to `80` (http)

--- a/docs/en/ingest-management/fleet/fleet-settings.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-settings.asciidoc
@@ -20,8 +20,13 @@ Configure {fleet} settings to apply global settings to all {agent}s enrolled in
 *{fleet-server} hosts*
 
 | The URLs your {agent}s will use to connect to a {fleet-server}. This setting
-is required. On self-managed clusters, you must specify one or more URLs. On
-{ecloud}, this field is populated automatically.
+is required. On self-managed clusters, you must specify one or more URLs.
+
+On {ecloud}, this field is populated automatically. If you are using
+Azure Private Link, GCP Private Service Connect, or AWS PrivateLink
+and enrolling the Elastic Agent with a private link URL, you need to
+ensure that this setting is configured. Otherwise, Elastic Agent will
+reset to use a default address instead of the private link URL.
 
 NOTE: If a URL is specified without a port, {kib} sets the port to `80` (http)
 or `443` (https).

--- a/docs/en/ingest-management/fleet/fleet-settings.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-settings.asciidoc
@@ -24,7 +24,7 @@ is required. On self-managed clusters, you must specify one or more URLs.
 
 On {ecloud}, this field is populated automatically. If you are using
 Azure Private Link, GCP Private Service Connect, or AWS PrivateLink
-and enrolling the Elastic Agent with a private link URL, you need to
+and enrolling the {agent} with a private link URL,
 ensure that this setting is configured. Otherwise, Elastic Agent will
 reset to use a default address instead of the private link URL.
 


### PR DESCRIPTION
Customers using the AWS, GCP, or Azure private link services need to make sure that the `Fleet Server hosts` field is populated. This warning has been added to the Cloud docs via [this PR](https://github.com/elastic/cloud/pull/93165), but it's worth calling out in the Fleet Server docs as well. 

Rel: https://github.com/elastic/sdh-cloud/issues/30443
Rel: https://github.com/elastic/cloud/pull/93165
