### PR TITLE
Update fleet-settings.asciidoc with caveat for Fleet URL, take2

### DIFF
--- a/docs/en/ingest-management/fleet/fleet-settings.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-settings.asciidoc
@@ -20,8 +20,13 @@ Configure {fleet} settings to apply global settings to all {agent}s enrolled in
 *{fleet-server} hosts*
 
 | The URLs your {agent}s will use to connect to a {fleet-server}. This setting
-is required. On self-managed clusters, you must specify one or more URLs. On
-{ecloud}, this field is populated automatically.
+is required. On self-managed clusters, you must specify one or more URLs.
+
+On {ecloud}, this field is populated automatically. If you are using
+Azure Private Link, GCP Private Service Connect, or AWS PrivateLink
+and enrolling the {agent} with a private link URL,
+ensure that this setting is configured. Otherwise, {agent} will
+reset to use a default address instead of the private link URL.
 
 NOTE: If a URL is specified without a port, {kib} sets the port to `80` (http)
 or `443` (https).


### PR DESCRIPTION
This is a re-do of #1355 since I'm unsure/nervous about rebasing in this repo. :-)

Customers using the AWS, GCP, or Azure private link services need to make sure that the Fleet Server hosts field is populated. This warning has been added to the Cloud docs via this PR, but it's worth calling out in the Fleet Server docs as well.

Rel: elastic/sdh-cloud#30443
Rel: elastic/cloud#93165