### PR TITLE
Fix link to air gapped registry docs

### DIFF
--- a/docs/en/observability/whats-new.asciidoc
+++ b/docs/en/observability/whats-new.asciidoc
@@ -62,8 +62,7 @@ news for you. EPR is now available as a Docker image that you can run and host i
 It will enable {kib} to understand all available integrations and provide you with the out-of-box assets and
 documentation for all the desired {integrations}.
 
-This EPR Docker image is an experimental standalone server that will grow and evolve further in the future. To learn more,
-see {fleet-guide}/air-gapped.html[Air-gapped environments].
+This EPR Docker image is an experimental standalone server that will grow and evolve further in the future.
 
 [discrete]
 == Upgrade integration policies

--- a/docs/en/observability/whats-new.asciidoc
+++ b/docs/en/observability/whats-new.asciidoc
@@ -63,7 +63,7 @@ It will enable {kib} to understand all available integrations and provide you wi
 documentation for all the desired {integrations}.
 
 This EPR Docker image is an experimental standalone server that will grow and evolve further in the future. To learn more,
-see https://www.elastic.co/guide/en/integrations-developer/current/air-gapped.html[Air-gapped environments].
+see {fleet-guide}/air-gapped.html[Air-gapped environments].
 
 [discrete]
 == Upgrade integration policies


### PR DESCRIPTION
Points to the new location for the docs about using integrations in an air-gapped environ.