### PR TITLE
[8.0] Delete CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,0 @@
-# GitHub CODEOWNERS definition
-# Automatically add the obs-docs team as a reviewer to all documentaiton PRs
-# For more info, see https://help.github.com/articles/about-codeowners/
-
-/docs/ @elastic/obs-docs


### PR DESCRIPTION
Since we branched 8.0 from main, the CODEOWNERS file that requires obs-docs team reviews in main now also exists in the 8.0 branch. Here’s a look at my email inbox since this started happening: :incoming_envelope: :chart_with_upwards_trend:.

I don't think we need to require code owner reviews in 8.0. What do you think?