### PR TITLE
[7.17] FIx links on "Fleet and Elastic Agent overview" (#1402)

### DIFF
--- a/docs/en/ingest-management/overview.asciidoc
+++ b/docs/en/ingest-management/overview.asciidoc
@@ -21,7 +21,7 @@ For more information, refer to <<elastic-agent-installation>>.
 [[unified-integrations]]
 == {integrations}
 
-Our [integrations](https://www.elastic.co/integrations/) provide an easy way to connect Elastic to external services and systems, and quickly get insights or take action.
+Our https://www.elastic.co/integrations/[integrations] provide an easy way to connect Elastic to external services and systems, and quickly get insights or take action.
 They can collect new sources of data, and they often ship
 with out-of-the-box assets like dashboards, visualizations, and pipelines to
 extract structured fields out of logs and events. This makes it easier to get insights
@@ -35,7 +35,7 @@ integrations.
 [role="screenshot"]
 image::images/integrations.png[Integrations page]
 
-See our [list of integrations](https://www.elastic.co/integrations/data-integrations) to learn more about them.
+See our https://www.elastic.co/integrations/data-integrations[list of integrations] to learn more about them.
 
 [discrete]
 [[configuring-integrations]]


### PR DESCRIPTION
Backports the following commits to 7.17:
 - FIx links on "Fleet and Elastic Agent overview" (#1402)