### PR TITLE
Fix example command to show one module instead of multiple

### DIFF
--- a/docs/en/observability/ingest-logs.asciidoc
+++ b/docs/en/observability/ingest-logs.asciidoc
@@ -5,7 +5,7 @@
 :beatname_lc: filebeat
 :beatname_pkg: {beatname_lc}
 :beatname_url: {beats-ref-root}/{beatname_lc}/{branch}
-:modulename: system nginx mysql
+:modulename: nginx
 :has_modules_command:
 :release-state: released
 
@@ -86,14 +86,13 @@ Can’t find a module for your file type? Skip this section and
 {filebeat-ref}/configuration-filebeat-options.html[configure the input manually].
 
 . From the installation directory, enable one or more modules. For example, the
-following command enables the `system`, `nginx`, and `mysql` module
-configs:
+following command enables the +{modulename}+ module config:
 +
 --
 include::{beats-repo-dir}/tab-widgets/enable-modules-widget.asciidoc[]
 --
 
-. In the module configs under `modules.d`, change the module settings to match
+. In the module config under `modules.d`, change the module settings to match
 your environment.
 +
 For example, log locations are set based on the OS. If your logs aren't in

--- a/docs/en/observability/ingest-metrics.asciidoc
+++ b/docs/en/observability/ingest-metrics.asciidoc
@@ -5,7 +5,7 @@
 :beatname_lc: metricbeat
 :beatname_pkg: {beatname_lc}
 :beatname_url: {beats-ref-root}/{beatname_lc}/{branch}
-:modulename: apache mysql
+:modulename: nginx
 :has_modules_command:
 
 [[ingest-metrics]]
@@ -77,7 +77,7 @@ include::{beats-repo-dir}/tab-widgets/list-modules-widget.asciidoc[]
 . From the installation directory, enable one or more modules. If you accept the default configuration without enabling additional
 modules, {beatname_uc} collects system metrics only.
 +
-The following command enables the `apache` and `mysql` configs in the `modules.d` directory:
+The following command enables the +{modulename}+ config in the `modules.d` directory:
 +
 --
 include::{beats-repo-dir}/tab-widgets/enable-modules-widget.asciidoc[]
@@ -87,7 +87,7 @@ See the {metricbeat-ref}/command-line-options.html#modules-command[modules comma
 to learn more about this command. If you are using a Docker image,
 see {metricbeat-ref}/running-on-docker.html[Run Metricbeat on Docker].
 
-. In the module configs under `modules.d`, change the module settings to match your environment.
+. In the module config under `modules.d`, change the module settings to match your environment.
 See {metricbeat-ref}/configuration-metricbeat.html#module-config-options[Standard config options]
 for more about available settings.
 


### PR DESCRIPTION
This change is related to https://github.com/elastic/beats/pull/29569.

I need to use {modulename} to set the yml name in `start.asciidoc`, so it has to be a single value rather than a list. Plus it matches the example, so it works here, too.