### PR TITLE
Update deprecation tags for basic auth env vars for agent

### DIFF
--- a/docs/en/ingest-management/elastic-agent/configuration/env/shared-env.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/env/shared-env.asciidoc
@@ -25,11 +25,9 @@ OPTIONAL INFO AND EXAMPLE
 | (int) Set to `1` to enable {fleet} setup.
 Enabling {fleet} is required before {fleet-server} will start.
 When this action is not performed, a user must manually log in to Kibana and visit the Fleet page to enable setup.
+Overrides `FLEET_SETUP` when set.
 
 *Default:* none
-
-NOTE: `FLEET_SETUP` has been deprecated and will be removed in v8.0.0.
-Use `KIBANA_FLEET_SETUP` instead.
 
 // end::kibana-fleet-setup[]
 
@@ -111,6 +109,23 @@ When set to `1`, this automatically forces {fleet} enrollment as well.
 *Default:* none
 
 // end::fleet-server-enable[]
+
+// =============================================================================
+
+// tag::fleet-setup[]
+
+[id="env-{type}-fleet-setup"]
+`FLEET_SETUP`
+
+| (int) Set to `1` to enable {fleet} setup.
+Enabling {fleet} is required before {fleet-server} will start.
+When this action is not performed, a user must manually log in to Kibana and visit the Fleet page to enable setup.
+
+*Default:* none
+
+deprecated:[8.0.0,use `KIBANA_FLEET_SETUP` instead.]
+
+// end::fleet-setup[]
 
 // =============================================================================
 

--- a/docs/en/ingest-management/elastic-agent/configuration/env/shared-env.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/env/shared-env.asciidoc
@@ -57,7 +57,7 @@ Overrides `FLEET_HOST` when set.
 | (string) The basic authentication username used to connect to {kib} and enable {fleet}.
 Overrides `KIBANA_USERNAME` when set.
 
-[deprecated:8.0.0, Behaviour will change in upcoming release.]
+deprecated:[8.0.0,Behaviour will change in upcoming release.]
 
 *Default:* `elastic`
 
@@ -73,7 +73,7 @@ Overrides `KIBANA_USERNAME` when set.
 | (string) The basic authentication password used to connect to {kib} and enable {fleet}.
 Overrides `KIBANA_PASSWORD` when set.
 
-[deprecated:8.0.0, Behaviour will change in upcoming release.]
+deprecated:[8.0.0,Behaviour will change in upcoming release.]
 
 *Default:* `changeme`
 
@@ -138,7 +138,7 @@ Overrides `ELASTICSEARCH_HOST` when set.
 Overrides `ELASTICSEARCH_USERNAME` when set.
 This user needs the privileges required to publish events to {es}.
 
-[deprecated:8.0.0, use `FLEET_SERVER_SERVICE_TOKEN` instead.]
+deprecated:[8.0.0,Use `FLEET_SERVER_SERVICE_TOKEN` instead.]
 
 // To do: link to required privileges
 
@@ -156,7 +156,7 @@ This user needs the privileges required to publish events to {es}.
 | (string) The basic authentication password used to connect to {es}.
 Overrides `ELASTICSEARCH_PASSWORD` when set.
 
-[deprecated:8.0.0, use `FLEET_SERVER_SERVICE_TOKEN` instead.]
+deprecated:[8.0.0,Use `FLEET_SERVER_SERVICE_TOKEN` instead.]
 
 *Default:* `changeme`
 
@@ -423,7 +423,7 @@ Setting this to `true` is not recommended.
 | (string) The basic authentication username used to connect to {es}.
 This user needs the privileges required to publish events to {es}.
 
-[deprecated:8.0.0, Behaviour will change, use `FLEET_SERVER_SERVICE_TOKEN` instead.]
+deprecated:[8.0.0,"Behaviour will change, use `FLEET_SERVER_SERVICE_TOKEN` instead."]
 
 // To do: link to required privileges
 
@@ -456,7 +456,7 @@ This user needs the privileges required to publish events to {es}.
 
 | (string) The basic authentication password used to connect to {es}.
 
-[deprecated:8.0.0, Behaviour will change, use `FLEET_SERVER_SERVICE_TOKEN` instead.]
+deprecated:[8.0.0,"Behaviour will change, use `FLEET_SERVER_SERVICE_TOKEN` instead."]
 
 *Default:* `changeme`
 
@@ -516,7 +516,7 @@ contains your CA's certificate.
 
 | (string) The basic authentication username used to connect to {kib}.
 
-[deprecated:8.0.0, variable will be removed in upcoming release.]
+deprecated:[8.0.0,Variable will be removed in upcoming release.]
 
 *Default:* `elastic`
 
@@ -531,7 +531,7 @@ contains your CA's certificate.
 
 | (string) The basic authentication password used to connect to {kib}.
 
-[deprecated:8.0.0, variable will be removed in upcoming release.]
+deprecated:[8.0.0,Variable will be removed in upcoming release.]
 
 *Default:* `changeme`
 

--- a/docs/en/ingest-management/elastic-agent/configuration/env/shared-env.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/env/shared-env.asciidoc
@@ -57,6 +57,8 @@ Overrides `FLEET_HOST` when set.
 | (string) The basic authentication username used to connect to {kib} and enable {fleet}.
 Overrides `KIBANA_USERNAME` when set.
 
+[deprecated:8.0.0, Behaviour will change in upcoming release.]
+
 *Default:* `elastic`
 
 // end::kibana-fleet-username[]
@@ -70,6 +72,8 @@ Overrides `KIBANA_USERNAME` when set.
 
 | (string) The basic authentication password used to connect to {kib} and enable {fleet}.
 Overrides `KIBANA_PASSWORD` when set.
+
+[deprecated:8.0.0, Behaviour will change in upcoming release.]
 
 *Default:* `changeme`
 
@@ -134,7 +138,7 @@ Overrides `ELASTICSEARCH_HOST` when set.
 Overrides `ELASTICSEARCH_USERNAME` when set.
 This user needs the privileges required to publish events to {es}.
 
-*Deprecated:* use `FLEET_SERVER_SERVICE_TOKEN` instead.
+[deprecated:8.0.0, use `FLEET_SERVER_SERVICE_TOKEN` instead.]
 
 // To do: link to required privileges
 
@@ -152,7 +156,7 @@ This user needs the privileges required to publish events to {es}.
 | (string) The basic authentication password used to connect to {es}.
 Overrides `ELASTICSEARCH_PASSWORD` when set.
 
-*Deprecated:* use `FLEET_SERVER_SERVICE_TOKEN` instead.
+[deprecated:8.0.0, use `FLEET_SERVER_SERVICE_TOKEN` instead.]
 
 *Default:* `changeme`
 
@@ -419,7 +423,7 @@ Setting this to `true` is not recommended.
 | (string) The basic authentication username used to connect to {es}.
 This user needs the privileges required to publish events to {es}.
 
-*Deprecated:* use `FLEET_SERVER_SERVICE_TOKEN` instead.
+[deprecated:8.0.0, Behaviour will change, use `FLEET_SERVER_SERVICE_TOKEN` instead.]
 
 // To do: link to required privileges
 
@@ -452,7 +456,7 @@ This user needs the privileges required to publish events to {es}.
 
 | (string) The basic authentication password used to connect to {es}.
 
-*Deprecated:* use `FLEET_SERVER_SERVICE_TOKEN` instead.
+[deprecated:8.0.0, Behaviour will change, use `FLEET_SERVER_SERVICE_TOKEN` instead.]
 
 *Default:* `changeme`
 
@@ -512,6 +516,8 @@ contains your CA's certificate.
 
 | (string) The basic authentication username used to connect to {kib}.
 
+[deprecated:8.0.0, variable will be removed in upcoming release.]
+
 *Default:* `elastic`
 
 // end::kibana-username[]
@@ -524,6 +530,8 @@ contains your CA's certificate.
 `KIBANA_PASSWORD`
 
 | (string) The basic authentication password used to connect to {kib}.
+
+[deprecated:8.0.0, variable will be removed in upcoming release.]
 
 *Default:* `changeme`
 


### PR DESCRIPTION
Some vars are replaced by service_token, some are removed, some have the behaviour changed