### PR TITLE
Clarify licensing requirements for bulk agent upgrades

### DIFF
--- a/docs/en/ingest-management/fleet/upgrade-elastic-agent.asciidoc
+++ b/docs/en/ingest-management/fleet/upgrade-elastic-agent.asciidoc
@@ -38,6 +38,11 @@ the {kib} version is lower than the agent version.
 +
 [role="screenshot"]
 image::images/fleet-agents.png[Upgrade menu for bulk upgrade in {fleet}]
++
+Unable to select multiple agents? Confirm that your subscription level supports
+selective agent binary updates in {fleet}. See
+{subscriptions}[{stack} subscriptions] for more information about available
+features.
 
 TIP: Want to upgrade a standalone agent instead? See <<upgrade-standalone>>.
 


### PR DESCRIPTION
Closes https://github.com/elastic/observability-docs/issues/1191.

@jen-huang Can you please confirm that "selective agent binary updates" is the feature that covers bulk selection?  I'm not very keen on the phrasing used there, but I want to make sure we mention it in the docs.

Note that we don't document specific subscription levels in the docs because we point to the subscriptions page as a single source of truth about licensing requirements. (We've been told over and over again not to mention specific license levels in the docs.)