### PR TITLE
[backport] Update deprecation tags for basic auth env vars for agent (#1434)

### DIFF
--- a/docs/en/ingest-management/elastic-agent/configuration/env/shared-env.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/env/shared-env.asciidoc
@@ -25,11 +25,9 @@ OPTIONAL INFO AND EXAMPLE
 | (int) Set to `1` to enable {fleet} setup.
 Enabling {fleet} is required before {fleet-server} will start.
 When this action is not performed, a user must manually log in to Kibana and visit the Fleet page to enable setup.
+Overrides `FLEET_SETUP` when set.
 
 *Default:* none
-
-NOTE: `FLEET_SETUP` has been deprecated and will be removed in v8.0.0.
-Use `KIBANA_FLEET_SETUP` instead.
 
 // end::kibana-fleet-setup[]
 
@@ -57,6 +55,8 @@ Overrides `FLEET_HOST` when set.
 | (string) The basic authentication username used to connect to {kib} and enable {fleet}.
 Overrides `KIBANA_USERNAME` when set.
 
+deprecated:[8.0.0,Behaviour will change in upcoming release.]
+
 *Default:* `elastic`
 
 // end::kibana-fleet-username[]
@@ -70,6 +70,8 @@ Overrides `KIBANA_USERNAME` when set.
 
 | (string) The basic authentication password used to connect to {kib} and enable {fleet}.
 Overrides `KIBANA_PASSWORD` when set.
+
+deprecated:[8.0.0,Behaviour will change in upcoming release.]
 
 *Default:* `changeme`
 
@@ -110,6 +112,23 @@ When set to `1`, this automatically forces {fleet} enrollment as well.
 
 // =============================================================================
 
+// tag::fleet-setup[]
+
+[id="env-{type}-fleet-setup"]
+`FLEET_SETUP`
+
+| (int) Set to `1` to enable {fleet} setup.
+Enabling {fleet} is required before {fleet-server} will start.
+When this action is not performed, a user must manually log in to Kibana and visit the Fleet page to enable setup.
+
+*Default:* none
+
+deprecated:[8.0.0,use `KIBANA_FLEET_SETUP` instead.]
+
+// end::fleet-setup[]
+
+// =============================================================================
+
 // tag::fleet-server-elasticsearch-host[]
 |
 [id="env-{type}-fleet-server-elasticsearch-host"]
@@ -134,6 +153,8 @@ Overrides `ELASTICSEARCH_HOST` when set.
 Overrides `ELASTICSEARCH_USERNAME` when set.
 This user needs the privileges required to publish events to {es}.
 
+deprecated:[8.0.0,Use `FLEET_SERVER_SERVICE_TOKEN` instead.]
+
 // To do: link to required privileges
 
 *Default:* `elastic`
@@ -149,6 +170,8 @@ This user needs the privileges required to publish events to {es}.
 
 | (string) The basic authentication password used to connect to {es}.
 Overrides `ELASTICSEARCH_PASSWORD` when set.
+
+deprecated:[8.0.0,Use `FLEET_SERVER_SERVICE_TOKEN` instead.]
 
 *Default:* `changeme`
 
@@ -415,6 +438,8 @@ Setting this to `true` is not recommended.
 | (string) The basic authentication username used to connect to {es}.
 This user needs the privileges required to publish events to {es}.
 
+deprecated:[8.0.0,"Behaviour will change, use `FLEET_SERVER_SERVICE_TOKEN` instead."]
+
 // To do: link to required privileges
 
 *Default:* `elastic`
@@ -445,6 +470,8 @@ This user needs the privileges required to publish events to {es}.
 `ELASTICSEARCH_PASSWORD`
 
 | (string) The basic authentication password used to connect to {es}.
+
+deprecated:[8.0.0,"Behaviour will change, use `FLEET_SERVER_SERVICE_TOKEN` instead."]
 
 *Default:* `changeme`
 
@@ -504,6 +531,8 @@ contains your CA's certificate.
 
 | (string) The basic authentication username used to connect to {kib}.
 
+deprecated:[8.0.0,Variable will be removed in upcoming release.]
+
 *Default:* `elastic`
 
 // end::kibana-username[]
@@ -516,6 +545,8 @@ contains your CA's certificate.
 `KIBANA_PASSWORD`
 
 | (string) The basic authentication password used to connect to {kib}.
+
+deprecated:[8.0.0,Variable will be removed in upcoming release.]
 
 *Default:* `changeme`
 


### PR DESCRIPTION
* Update deprecation tags for basic auth env vars for agent

* Fix syntax

* Add FLEET_SETUP env var with deprecation warning