### PR TITLE
Add placeholder for Fleet/Agent 8.0.0 relnotes

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-8.0.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.0.asciidoc
@@ -1,0 +1,131 @@
+// Use these for links to issue and pulls. 
+:kib-issue: https://github.com/elastic/kibana/issues/
+:kib-pull: https://github.com/elastic/kibana/pull/
+:agent-issue: https://github.com/elastic/beats/issues/
+:agent-pull: https://github.com/elastic/beats/pull/
+:fleet-server-issue: https://github.com/elastic/beats/issues/fleet-server/
+:fleet-server-pull: https://github.com/elastic/beats/pull/fleet-server/
+
+
+[[release-notes]]
+= Release notes
+
+This section summarizes the changes in each release.
+
+//* <<release-notes-8.0.0>>
+
+coming[8.0.0]
+
+Also see:
+
+* {kibana-ref}/release-notes.html[{kib} release notes]
+* {beats-ref}/release-notes.html[{beats} release notes]
+
+// ---------------------
+//TEMPLATE
+//Use the following text as a template. Remember to replace the version info.
+
+// begin 8.0.0 relnotes
+
+//[[release-notes-8.0.0]]
+//== {fleet} and {agent} 8.0.0
+
+//Review important information about the {fleet} and {agent} 8.0.0 releases.
+
+//[discrete]
+//[[security-updates-8.0.0]]
+//=== Security updates
+
+//{fleet}::
+//* add info
+
+//{agent}::
+//* add info
+
+//[discrete]
+//[[breaking-changes-8.0.0]]
+//=== Breaking changes
+
+//Breaking changes can prevent your application from optimal operation and
+//performance. Before you upgrade, review the breaking changes, then mitigate the
+//impact to your application.
+
+//[discrete]
+//[[breaking-PR#]]
+//.Short description
+//[%collapsible]
+//====
+//*Details* +
+//<Describe new behavior.> For more information, refer to {kibana-pull}PR[#PR].
+
+//*Impact* +
+//<Describe how users should mitigate the change.> For more information, refer to {fleet-guide}/fleet-server.html[Fleet Server].
+//====
+
+//[discrete]
+//[[known-issues-8.0.0]]
+//=== Known issues
+
+//[[known-issue-issue#]]
+//.Short description
+//[%collapsible]
+//====
+
+//*Details* 
+
+//<Describe known issue.>
+
+//*Impact* +
+
+//<Describe impact or workaround.>
+
+//====
+
+//[discrete]
+//[[deprecations-8.0.0]]
+//=== Deprecations
+
+//The following functionality is deprecated in 8.0.0, and will be removed in
+//8.0.0. Deprecated functionality does not have an immediate impact on your
+//application, but we strongly recommend you make the necessary updates after you
+//upgrade to 8.0.0.
+
+//{fleet}::
+//* add info
+
+//{agent}::
+//* add info
+
+//[discrete]
+//[[new-features-8.0.0]]
+//=== New features
+
+//The 8.0.0 release adds the following new and notable features.
+
+//{fleet}::
+//* add info
+
+//{agent}::
+//* add info
+
+//[discrete]
+//[[enhancements-8.0.0]]
+//=== Enhancements
+
+//{fleet}::
+//* add info
+
+//{agent}::
+//* add info
+
+//[discrete]
+//[[bug-fixes-8.0.0]]
+//=== Bug fixes
+
+//{fleet}::
+//* add info
+
+//{agent}::
+//* add info
+
+// end 8.0.0 relnotes


### PR DESCRIPTION
Adding a placeholder for 8.0.0 release notes. 

Most of this is boilerplate text that we can change. My main concern is that we replace what's there currently (old release notes from 7.x) with something to indicate the release notes are coming later on.

If the process for generating release notes is not ready by 8.0, we'll need to populate this file with info.

TODO:
- [ ] After merging then backporting to 8.0, update the index.asciidoc file to get this building.