### PR TITLE
Add docs about debugging standalone Elastic Agents

### DIFF
--- a/docs/en/ingest-management/commands.asciidoc
+++ b/docs/en/ingest-management/commands.asciidoc
@@ -696,7 +696,23 @@ elastic-agent status [--output <string>]
 === Options
 
 `--output <string>`::
-Output the status information in either `human`, `json`, or `yaml`. (default `human`)
+Output the status information in either `human` (the default), `json`, or
+`yaml`. When the output is `json` or `yaml`, the command returns status codes:
++
+--
+|===
+|Code |Status
+
+|0    |`STARTING`    
+|1    |`CONFIGURING`
+|2    |`HEALTHY`
+|3    |`DEGRADED`
+|4    |`FAILED`
+|5    |`STOPPING`
+|6    |`UPGRADING`
+|7    |`ROLLBACK`
+|===
+--
 
 `--help`::
 Show help for the `status` command.

--- a/docs/en/ingest-management/elastic-agent/debug-standalone-elastic-agent.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/debug-standalone-elastic-agent.asciidoc
@@ -84,10 +84,6 @@ agent.logging.files:
 
 For other log settings, refer to <<elastic-agent-standalone-logging-config>>.
 
-//REVIEWERS: Should we also talk about exposing the agent monitoring endpoint
-//here? Sounds like that could be risky. We could point to the topic and
-//let users decides.
-
 [discrete]
 [[inspect-configuration]]
 == Inspect the {agent} configuration

--- a/docs/en/ingest-management/elastic-agent/debug-standalone-elastic-agent.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/debug-standalone-elastic-agent.asciidoc
@@ -1,0 +1,96 @@
+[[debug-standalone-agents]]
+= Debug standalone {agent}s
+
+When you run standalone {agent}s, you are responsible for monitoring the status
+of your deployed {agent}s. You cannot view the status or logs in {fleet}.
+
+Use the following tips to help identify potential issues.
+
+Also refer to <<fleet-troubleshooting>> for guidance on specific problems.
+
+NOTE: You might need to log in as a root user (or Administrator on Windows) to
+run these commands.
+
+[discrete]
+== Check the status of the running {agent}
+
+To check the status of the running {agent} daemon and other processes managed by
+{agent}, run the `status` command. For example:
+
+[source,shell]
+----
+elastic-agent status
+----
+
+Returns something like: 
+
+[source,yaml]
+----
+Status: HEALTHY
+Message: (no message)
+Applications:
+  * metricbeat  (HEALTHY)
+                Running
+  * filebeat    (STOPPING)
+                (no message)
+----
+
+By default, this command returns the status in human-readable format. Use the
+`--output` flag to change it to `json` or `yaml`.
+
+For more information about this command, refer to
+<<elastic-agent-status-command>>.
+
+//REVIEWERS: Looks like JSON and YAML return status codes instead of healthy,
+//stopping, etc. Where can I find the mapping of status code to status?
+
+[discrete]
+[[inspect-standalone-agent-logs]]
+== Inspect {agent} and related logs
+
+If the {agent} status is unhealthy, or behaving unexpectedly, inspect the logs
+of the running {agent}. The log location varies by platform. Refer to
+<<installation-layout>> for the correct location.
+
+//REVIEWERS: Can we add more guidance here about how to explore logs, what to
+//look for, etc.
+
+[discrete]
+[[increase-log-level]]
+== Increase the log level of the running {agent}
+
+The log level of the running agent is set to `info` by default. At this level,
+{agent} will log informational messages, including the number of events that are
+published. It also logs any warnings, errors, or critical errors.
+
+To increase the log level, set it to `debug` in the `elastic-agent.yml` file.
+
+The `debug` setting configures {agent} to log debug messages, including a
+detailed printout of all flushed events, plus all the information collected at
+other log levels.
+
+Set other options if you want write logs to a file. For example:
+
+[source,yaml]
+----
+agent.logging.level: debug
+agent.logging.to_files: true
+agent.logging.files:
+  path: /var/log/elastic-agent
+  name: elastic-agent
+  keepfiles: 7
+  permissions: 0600
+----
+
+For other log settings, refer to <<elastic-agent-standalone-logging-config>>.
+
+//REVIEWERS: Should we also talk about exposing the agent monitoring endpoint
+//here? Sounds like that could be risky. We chould point to the topic and
+//let users decides.
+
+//REVIEWERS: Do we want to cover the diagnostics command here? Not sure there
+//is much info here that's helpful to end users.
+
+//What about the inspect command? I think it could be useful to inspect the
+//config, but only if we are mentioning it during a longer procedure that
+//involves troubleshooting config problems.

--- a/docs/en/ingest-management/elastic-agent/debug-standalone-elastic-agent.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/debug-standalone-elastic-agent.asciidoc
@@ -85,12 +85,119 @@ agent.logging.files:
 For other log settings, refer to <<elastic-agent-standalone-logging-config>>.
 
 //REVIEWERS: Should we also talk about exposing the agent monitoring endpoint
-//here? Sounds like that could be risky. We chould point to the topic and
+//here? Sounds like that could be risky. We could point to the topic and
 //let users decides.
 
-//REVIEWERS: Do we want to cover the diagnostics command here? Not sure there
-//is much info here that's helpful to end users.
+[discrete]
+[[inspect-configuration]]
+== Inspect the {agent} configuration
 
-//What about the inspect command? I think it could be useful to inspect the
-//config, but only if we are mentioning it during a longer procedure that
-//involves troubleshooting config problems.
+To inspect the {agent} configuration, run the `inspect` command. For example:
+
+[source,shell]
+----
+elastic-agent inspect
+----
+
+Use the `--output` flag to inspect the configuration passed to other processes,
+such as {filebeat}. For example:
+
+[source,shell]
+----
+elastic-agent inspect output --output default --program filebeat
+----
+
+Returns something like:
+
+["source","yaml",subs="attributes"]
+----
+[default] filebeat:
+filebeat:
+  inputs:
+  - exclude_files:
+    - .gz$
+    id: logfile-system.auth-default-system
+    index: logs-system.auth-default
+    meta:
+      package:
+        name: system
+        version: {version}
+    multiline:
+      match: after
+      pattern: ^\s
+    name: system-1
+    paths:
+    - /var/log/auth.log*
+    - /var/log/secure*
+    processors:
+    - add_locale: null
+    - add_fields:
+        fields:
+          dataset: system.auth
+          namespace: default
+          type: logs
+        target: data_stream
+    - add_fields:
+        fields:
+          dataset: system.auth
+        target: event
+    - add_fields:
+        fields:
+          id: 3c4a8f14-561a-449f-8935-7485cd494bac
+          snapshot: false
+          version: {version}
+        target: elastic_agent
+    - add_fields:
+        fields:
+          id: 3c4a8f14-561a-449f-8935-7485cd494bac
+        target: agent
+    revision: 1
+    type: log
+  - exclude_files:
+    - .gz$
+    id: logfile-system.syslog-default-system
+    index: logs-system.syslog-default
+    meta:
+      package:
+        name: system
+        version: 1.6.4
+    multiline:
+      match: after
+      pattern: ^\s
+    name: system-1
+    paths:
+    - /var/log/messages*
+    - /var/log/syslog*
+    processors:
+    - add_locale: null
+    - add_fields:
+        fields:
+          dataset: system.syslog
+          namespace: default
+          type: logs
+        target: data_stream
+    - add_fields:
+        fields:
+          dataset: system.syslog
+        target: event
+    - add_fields:
+        fields:
+          id: 3c4a8f14-561a-449f-8935-7485cd494bac
+          snapshot: false
+          version: {version}
+        target: elastic_agent
+    - add_fields:
+        fields:
+          id: 3c4a8f14-561a-449f-8935-7485cd494bac
+        target: agent
+    revision: 1
+    type: log
+output:
+  elasticsearch:
+    api_key: your:apikey
+    hosts:
+    - https://5d87573b66ed4d7f6cd1d2d3f1e30bc5.us-central1.gcp.foundit.no:443
+----
+
+For more information about this command, refer to
+<<elastic-agent-inspect-command>>.

--- a/docs/en/ingest-management/elastic-agent/debug-standalone-elastic-agent.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/debug-standalone-elastic-agent.asciidoc
@@ -41,19 +41,22 @@ By default, this command returns the status in human-readable format. Use the
 For more information about this command, refer to
 <<elastic-agent-status-command>>.
 
-//REVIEWERS: Looks like JSON and YAML return status codes instead of healthy,
-//stopping, etc. Where can I find the mapping of status code to status?
-
 [discrete]
 [[inspect-standalone-agent-logs]]
 == Inspect {agent} and related logs
 
 If the {agent} status is unhealthy, or behaving unexpectedly, inspect the logs
-of the running {agent}. The log location varies by platform. Refer to
-<<installation-layout>> for the correct location.
+of the running {agent}.
 
-//REVIEWERS: Can we add more guidance here about how to explore logs, what to
-//look for, etc.
+The log location varies by platform. {agent} logs are in the folders described
+in <<installation-layout>>. {beats} and {fleet-server} logs are in folders named
+for the output (for example, `default`). Elastic Endpoint logs are in the
+installation directory.
+
+Start by investigating any errors you see in the {agent} and related logs. Also
+look for repeated lines that might indicate problems like connection issues. If
+the {agent} and related logs look clean, check the host operating system logs
+for out of memory (OOM) errors related to the {agent} or any of its processes.
 
 [discrete]
 [[increase-log-level]]
@@ -83,6 +86,119 @@ agent.logging.files:
 ----
 
 For other log settings, refer to <<elastic-agent-standalone-logging-config>>.
+
+[discrete]
+[[expose-debug-endpoint]]
+== Expose /debug/pprof/ endpoints with the monitoring endpoint
+
+Profiling data produced by the `/debug/pprof/` endpoints can be useful for
+debugging, but presents a security risk. Do not expose these endpoints if the
+monitoring endpoint is accessible over a network. (By default, the monitoring
+endpoint is bound to a local unix socket or Windows npipe and not accessible
+over a network.)
+
+To expose the `/debug/pprof/` endpoints, set `agent.monitoring.pprof: true` in
+the `elastic-agent.yml` file. For more information about monitoring settings,
+refer to <<elastic-agent-monitoring-configuration>>.
+
+After exposing the endpoints, you can access the http handler bound to a socket
+for {beats} or the {agent}. For example:
+
+[source,shell]
+----
+sudo curl --unix-socket /Library/Elastic/Agent/data/tmp/default/filebeat/filebeat.sock http://socket/ | json_pp
+----
+
+Returns something like:
+
+[source,json]
+----
+{
+   "beat" : "filebeat",
+   "binary_arch" : "amd64",
+   "build_commit" : "93708bd74e909e57ed5d9bea3cf2065f4cc43af3",
+   "build_time" : "2022-01-28T09:53:29.000Z",
+   "elastic_licensed" : true,
+   "ephemeral_id" : "421e2525-9360-41db-9395-b9e627fbbe6e",
+   "gid" : "0",
+   "hostname" : "My-MacBook-Pro.local",
+   "name" : "My-MacBook-Pro.local",
+   "uid" : "0",
+   "username" : "root",
+   "uuid" : "fc0cc98b-b6d8-4eef-abf5-2d5f26adc7e8",
+   "version" : "7.17.0"
+}
+----
+
+Likewise, the following request:
+
+[source,shell]
+----
+sudo curl --unix-socket /Library/Elastic/Agent/data/tmp/elastic-agent.sock http://socket/stats | json_pp
+----
+
+Returns something like:
+
+[source,shell]
+----
+{
+   "beat" : {
+      "cpu" : {
+         "system" : {
+            "ticks" : 16272,
+            "time" : {
+               "ms" : 16273
+            }
+         },
+         "total" : {
+            "ticks" : 42981,
+            "time" : {
+               "ms" : 42982
+            },
+            "value" : 42981
+         },
+         "user" : {
+            "ticks" : 26709,
+            "time" : {
+               "ms" : 26709
+            }
+         }
+      },
+      "info" : {
+         "ephemeral_id" : "ea8fec0d-f7dd-4577-85d7-a2c38583c9c6",
+         "uptime" : {
+            "ms" : 5885653
+         },
+         "version" : "7.17.0"
+      },
+      "memstats" : {
+         "gc_next" : 13027776,
+         "memory_alloc" : 7771632,
+         "memory_sys" : 39666696,
+         "memory_total" : 757970208,
+         "rss" : 58990592
+      },
+      "runtime" : {
+         "goroutines" : 101
+      }
+   },
+   "system" : {
+      "cpu" : {
+         "cores" : 12
+      },
+      "load" : {
+         "1" : 4.8892,
+         "15" : 2.6748,
+         "5" : 3.0537,
+         "norm" : {
+            "1" : 0.4074,
+            "15" : 0.2229,
+            "5" : 0.2545
+         }
+      }
+   }
+}
+----
 
 [discrete]
 [[inspect-configuration]]

--- a/docs/en/ingest-management/index.asciidoc
+++ b/docs/en/ingest-management/index.asciidoc
@@ -122,6 +122,8 @@ include::elastic-agent/configuration/create-standalone-agent-policy.asciidoc[lev
 
 include::elastic-agent/grant-access-to-elasticsearch.asciidoc[leveloffset=+2]
 
+include::elastic-agent/debug-standalone-elastic-agent.asciidoc[leveloffset=+2]
+
 include::elastic-agent/configuration/inputs/input-configuration.asciidoc[leveloffset=+2]
 
 include::elastic-agent/elastic-agent-dynamic-inputs.asciidoc[leveloffset=+3]

--- a/docs/en/ingest-management/troubleshooting/troubleshooting.asciidoc
+++ b/docs/en/ingest-management/troubleshooting/troubleshooting.asciidoc
@@ -19,6 +19,8 @@ is not described here, please review the open issues in the following GitHub rep
 Have a question? Read our <<fleet-faq,FAQ>>, or contact us in the
 {forum}[discuss forum]. Your feedback is valuable to us.
 
+Running {agent} standalone? Also refer to <<debug-standalone-agents>>.
+
 //TODO: Improve how content is organized in this section, perhaps by breaking
 //it down into sections like Agent, Fleet Server, etc.
 


### PR DESCRIPTION
Closes #1473 

TODO:

- [ ] This PR also needs to be backported to 8.0 and 8.1, but I'll do that manually because the config setting for exposing /debug/pprof/ endpoints is different in 8.0. 