### PR TITLE
Adjust names of log files in Elastic Agent documentation

### DIFF
--- a/docs/en/ingest-management/elastic-agent/configuration/elastic-agent-standalone-logging.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/elastic-agent-standalone-logging.asciidoc
@@ -91,7 +91,7 @@ Default: `true`
 
 include::{tab-widgets}/logging-widget.asciidoc[]
 
-Logs are numbered log.1, log.2, and so on as they are rotated off the main log.
+Logs file names end with date and an optional number: log-date.ndjson, log-date-1.ndjson, and so on as new files are created on rotation.
 
 | `agent.logging.files.name` | The name of the file that logs are written to.
 

--- a/docs/en/ingest-management/elastic-agent/configuration/elastic-agent-standalone-logging.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/elastic-agent-standalone-logging.asciidoc
@@ -91,7 +91,7 @@ Default: `true`
 
 include::{tab-widgets}/logging-widget.asciidoc[]
 
-Logs file names end with date and an optional number: log-date.ndjson, log-date-1.ndjson, and so on as new files are created on rotation.
+Logs file names end with a date and optional number: log-date.ndjson, log-date-1.ndjson, and so on as new files are created during rotation.
 
 | `agent.logging.files.name` | The name of the file that logs are written to.
 

--- a/docs/en/ingest-management/tab-widgets/install-layout.asciidoc
+++ b/docs/en/ingest-management/tab-widgets/install-layout.asciidoc
@@ -7,7 +7,7 @@ Main {agent} configuration
 `/Library/Elastic/Agent/fleet.yml`::
 Main {agent} {fleet} configuration
 `/Library/Elastic/Agent/data/elastic-agent-*/logs/elastic-agent-json.log`::
-Log files for {agent}footnote:lognumbering[Logs are numbered log.1, log.2, and so on as they are rotated off the main log.]
+Log files for {agent}footnote:lognumbering[Logs file names end with date and an optional number: log-date.ndjson, log-date-1.ndjson, and so on as new files are created on rotation.]
 `/Library/Elastic/Agent/data/elastic-agent-*/logs/default/*-json.log`::
 Log files for {beats} shippers
 `/usr/bin/elastic-agent`::

--- a/docs/en/ingest-management/tab-widgets/install-layout.asciidoc
+++ b/docs/en/ingest-management/tab-widgets/install-layout.asciidoc
@@ -7,7 +7,7 @@ Main {agent} configuration
 `/Library/Elastic/Agent/fleet.yml`::
 Main {agent} {fleet} configuration
 `/Library/Elastic/Agent/data/elastic-agent-*/logs/elastic-agent-json.log`::
-Log files for {agent}footnote:lognumbering[Logs file names end with date and an optional number: log-date.ndjson, log-date-1.ndjson, and so on as new files are created on rotation.]
+Log files for {agent}footnote:lognumbering[Logs file names end with a date and optional number: log-date.ndjson, log-date-1.ndjson, and so on as new files are created during rotation.]
 `/Library/Elastic/Agent/data/elastic-agent-*/logs/default/*-json.log`::
 Log files for {beats} shippers
 `/usr/bin/elastic-agent`::

--- a/docs/en/ingest-management/troubleshooting/faq.asciidoc
+++ b/docs/en/ingest-management/troubleshooting/faq.asciidoc
@@ -25,12 +25,12 @@ The location of {agent} logs varies by platform. In general, {agent} stores
 logs under the `data` directory where {agent} was started. For example, on
 macOS, you'll find logs for the running {agent} under path similar to:
 
-`/Library/Elastic/Agent/data/elastic-agent-08e204/logs/elastic-agent-json.log`
+`/Library/Elastic/Agent/data/elastic-agent-08e204/logs/elastic-agent-20220105.ndjson`
 
 You'll find logs for the {beats} shippers, such as {metricbeat}, under paths
 like:
 
-`/Library/Elastic/Agent/data/elastic-agent-08e204/logs/default/metricbeat-json.log`
+`/Library/Elastic/Agent/data/elastic-agent-08e204/logs/default/metricbeat-20220105.ndjson`
 
 If the log path does not exist, {agent} was unable to start {metricbeat}, which
 is a higher level problem to triage. Usually you can see these logs in the


### PR DESCRIPTION
We changed the log rotation method and the log file names for all Beats and Elastic Agent in 8.0. Agent starts to log into the file `elastic-agent-{date}.ndjson`. On rotation it starts a new file `elastic-agent-{date}-1.ndjon`. I updated the footnotes and other places I had found. Let me know if I missed anything.