### PR TITLE
[CI/CD Observability] Bump Maven Extension version

### DIFF
--- a/docs/en/observability/ci-cd-observability.asciidoc
+++ b/docs/en/observability/ci-cd-observability.asciidoc
@@ -267,7 +267,7 @@ For example, you can add the following snippet to your pom.xml file:
       <extension>
           <groupId>io.opentelemetry.contrib</groupId>
           <artifactId>opentelemetry-maven-extension</artifactId>
-          <version>1.9.0-alpha</version>
+          <version>1.10.0-alpha</version>
       </extension>
     </extensions>
   </build>


### PR DESCRIPTION
[CI/CD Observability] Bump Maven Extension version.

Can we backport on the 7.16 branch please?