### PR TITLE
Update beats-agent-comparison.asciidoc

### DIFF
--- a/docs/en/ingest-management/beats-agent-comparison.asciidoc
+++ b/docs/en/ingest-management/beats-agent-comparison.asciidoc
@@ -271,7 +271,7 @@ configuration experience.
 |New {agent} workflow doesn’t need this.
 
 |{filebeat-ref}/defining-processors.html[Processors]
-|Processors can be defined at the integration level.
+|Processors can be defined at the integration level. Global processors are currently not supported.
 
 |{filebeat-ref}/configuration-autodiscover.html[Autodiscover]
 |Autodiscover is facilitated through <<dynamic-input-configuration,dynamic inputs>>. {agent} does not support hints-based autodiscovery.


### PR DESCRIPTION
Need a small correction to Elastic Agent support for processors. We currently don't have support for Global processors.