### PR TITLE
Update beats-agent-comparison.asciidoc for osquery

### DIFF
--- a/docs/en/ingest-management/beats-agent-comparison.asciidoc
+++ b/docs/en/ingest-management/beats-agent-comparison.asciidoc
@@ -139,7 +139,7 @@ The following table shows the inputs supported by the {agent} in {version}:
 
 |Osquery
 |{n}
-|{y} (beta)
+|{y}
 |{n}
 
 |Redis


### PR DESCRIPTION
Osquery Manager is no longer beta. It was released for general availability in 7.16.

Please let me know if I selected the backport labels correctly; this update applies to all doc versions from 7.16 and forward. Thanks!