### PR TITLE
Add release notes for Elastic Agent 7.17.0

### DIFF
--- a/docs/en/ingest-management/index.asciidoc
+++ b/docs/en/ingest-management/index.asciidoc
@@ -144,4 +144,4 @@ include::troubleshooting/troubleshooting.asciidoc[leveloffset=+2]
 
 include::troubleshooting/faq.asciidoc[leveloffset=+2]
 
-include::release-notes/release-notes-7.16.asciidoc[leveloffset=+1]
+include::release-notes/release-notes-7.17.asciidoc[leveloffset=+1]

--- a/docs/en/ingest-management/release-notes/release-notes-7.17.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-7.17.asciidoc
@@ -1,0 +1,138 @@
+// Use these for links to issue and pulls.
+:kib-issue: https://github.com/elastic/kibana/issues/
+:kib-pull: https://github.com/elastic/kibana/pull/
+:agent-issue: https://github.com/elastic/beats/issues/
+:agent-pull: https://github.com/elastic/beats/pull/
+:fleet-server-issue: https://github.com/elastic/beats/issues/fleet-server/
+:fleet-server-pull: https://github.com/elastic/beats/pull/fleet-server/
+
+
+[[release-notes]]
+= Release notes
+
+This section summarizes the changes in each release.
+
+* <<release-notes-7.17.0>>
+
+Also see:
+
+* {kibana-ref}/release-notes.html[{kib} release notes]
+* {beats-ref}/release-notes.html[{beats} release notes]
+
+// begin 7.17.0 relnotes
+
+[[release-notes-7.17.0]]
+== {fleet} and {agent} 7.17.0
+
+There are no notable changes to {fleet} or {agent} in 7.17.0.
+
+// end 7.17.0 relnotes
+
+// ---------------------
+//TEMPLATE
+//Use the following text as a template. Remember to replace the version info.
+
+// begin 7.17.x relnotes
+
+//[[release-notes-7.17.x]]
+//== {fleet} and {agent} 7.17.x
+
+//Review important information about the {fleet} and {agent} 7.17.x releases.
+
+//[discrete]
+//[[security-updates-7.17.x]]
+//=== Security updates
+
+//{fleet}::
+//* add info
+
+//{agent}::
+//* add info
+
+//[discrete]
+//[[breaking-changes-7.17.x]]
+//=== Breaking changes
+
+//Breaking changes can prevent your application from optimal operation and
+//performance. Before you upgrade, review the breaking changes, then mitigate the
+//impact to your application.
+
+//[discrete]
+//[[breaking-PR#]]
+//.Short description
+//[%collapsible]
+//====
+//*Details* +
+//<Describe new behavior.> For more information, refer to {kibana-pull}PR[#PR].
+
+//*Impact* +
+//<Describe how users should mitigate the change.> For more information, refer to {fleet-guide}/fleet-server.html[Fleet Server].
+//====
+
+//[discrete]
+//[[known-issues-7.17.x]]
+//=== Known issues
+
+//[[known-issue-issue#]]
+//.Short description
+//[%collapsible]
+//====
+
+//*Details*
+
+//<Describe known issue.>
+
+//*Impact* +
+
+//<Describe impact or workaround.>
+
+//====
+
+//[discrete]
+//[[deprecations-7.17.x]]
+//=== Deprecations
+
+//The following functionality is deprecated in 7.17.x, and will be removed in
+//8.0.0. Deprecated functionality does not have an immediate impact on your
+//application, but we strongly recommend you make the necessary updates after you
+//upgrade to 7.17.x.
+
+//{fleet}::
+//* add info
+
+//{agent}::
+//* add info
+
+//[discrete]
+//[[new-features-7.17.x]]
+//=== New features
+
+//The 7.17.x release adds the following new and notable features.
+
+//{fleet}::
+//* add info
+
+//{agent}::
+//* add info
+
+//[discrete]
+//[[enhancements-7.17.x]]
+//=== Enhancements
+
+//{fleet}::
+//* add info
+
+//{agent}::
+//* add info
+
+//[discrete]
+//[[bug-fixes-7.17.x]]
+//=== Bug fixes
+
+//{fleet}::
+//* add info
+
+//{agent}::
+//* add info
+
+// end 7.17.x relnotes

--- a/docs/en/ingest-management/release-notes/release-notes-7.17.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-7.17.asciidoc
@@ -24,7 +24,7 @@ Also see:
 [[release-notes-7.17.0]]
 == {fleet} and {agent} 7.17.0
 
-There are no notable changes to {fleet} or {agent} in 7.17.0.
+The Docker base image has changed from CentOS 7 to Ubuntu 20.04. {agent-issue}29681[#29681]
 
 // end 7.17.0 relnotes
 


### PR DESCRIPTION
Adds release notes for 7.17.0. Looking at the changelog, I don't see any notable changes for 7.17.0, as expected.