### PR TITLE
Use main for integrations/ecs-logging/elastic-package

### DIFF
--- a/docs/en/integrations/build-integration.asciidoc
+++ b/docs/en/integrations/build-integration.asciidoc
@@ -84,7 +84,7 @@ Jump to <<build-it>> at any point in this documentation to take your integration
 
 A data stream is a logical sub-division of an integration package,
 dealing with a specific observable aspect of the service or product being observed. For example,
-the https://github.com/elastic/integrations/tree/master/packages/apache[Apache integration] has three data streams,
+the https://github.com/elastic/integrations/tree/main/packages/apache[Apache integration] has three data streams,
 each represented by a separate folder of assets in the `data_stream` directory:
 
 [source,text]
@@ -146,7 +146,7 @@ Learn more in the {ref}/ingest.html[ingest pipeline reference].
 Ingest pipelines are defined in the `elasticsearch/ingest_pipeline` directory.
 They only apply to the parent data stream within which they live.
 
-For example, the https://github.com/elastic/integrations/tree/master/packages/apache[Apache integration]:
+For example, the https://github.com/elastic/integrations/tree/main/packages/apache[Apache integration]:
 
 [source,text]
 ----
@@ -475,7 +475,7 @@ Alternatively set `release` to `beta` or higher in your package's `manifest.yml`
 The `elastic-package stack` provides an enrolled instance of the {agent}. Use that one instead of a local application
 if you can run the service (you're integrating with) in the Docker network and you don't need to rebuild the Elastic-Agent
 or it's subprocesses (e.g. {filebeat} or {metricbeat}). The service Docker image can be used for [system
-testing](https://github.com/elastic/elastic-package/blob/master/docs/howto/system_testing.md). If you prefer to use a local
+testing](https://github.com/elastic/elastic-package/blob/main/docs/howto/system_testing.md). If you prefer to use a local
 instance of the {agent}, proceed with steps 4 and 5:
 
 . (Optional) Download the https://www.elastic.co/downloads/elastic-agent[{agent}].
@@ -527,7 +527,7 @@ export ELASTIC_PACKAGE_KIBANA_HOST=http://127.0.0.1:5601
 [[finishing-touches]]
 == Finishing touches
 
-// https://github.com/elastic/integrations/blob/master/docs/fine_tune_integration.md
+// https://github.com/elastic/integrations/blob/main/docs/fine_tune_integration.md
 
 === Words
 

--- a/docs/en/integrations/elastic-package.asciidoc
+++ b/docs/en/integrations/elastic-package.asciidoc
@@ -10,7 +10,7 @@ It can help you lint, format, test, build, and promote your packages.
 [[elastic-package-start]]
 == Get started
 
-. Download and build the latest master of elastic-package binary:
+. Download and build the latest main of elastic-package binary:
 +
 [source,terminal]
 ----
@@ -48,7 +48,7 @@ root folder, and the command will only operate on the contents of that package.
 
 // *************************
 // The following is copied directly from
-// https://github.com/elastic/elastic-package/blob/master/README.md
+// https://github.com/elastic/elastic-package/blob/main/README.md
 // *************************
 
 [discrete]
@@ -99,7 +99,7 @@ Use this command to create a new package or add more data streams.
 
 The command can help bootstrap the first draft of a package using an embedded package template. Then, you can use it to extend the package with more data streams.
 
-For details on creating a new package, review the https://github.com/elastic/elastic-package/blob/master/docs/howto/create_new_package.md[HOWTO guide].
+For details on creating a new package, review the https://github.com/elastic/elastic-package/blob/main/docs/howto/create_new_package.md[HOWTO guide].
 
 [discrete]
 === `elastic-package export`
@@ -182,7 +182,7 @@ _Context: global_
 
 Use this command to spin up a Docker-based {stack} consisting of {es}, {kib}, and the {package-registry}. By default, the latest released version of the {stack} is spun up, but it is possible to specify a different version, including SNAPSHOT versions.
 
-For details on connecting the service with the {stack}, see the https://github.com/elastic/elastic-package/blob/master/README.md#elastic-package-service[service command].
+For details on connecting the service with the {stack}, see the https://github.com/elastic/elastic-package/blob/main/README.md#elastic-package-service[service command].
 
 [discrete]
 === `elastic-package status [package]`
@@ -206,25 +206,25 @@ Use this command to run tests on a package. Currently, the following types of te
 ==== Asset Loading Tests
 These tests ensure that all the Elasticsearch and Kibana assets defined by your package get loaded up as expected.
 
-For details on running asset loading tests for a package, see the https://github.com/elastic/elastic-package/blob/master/docs/howto/asset_testing.md[HOWTO guide].
+For details on running asset loading tests for a package, see the https://github.com/elastic/elastic-package/blob/main/docs/howto/asset_testing.md[HOWTO guide].
 
 [discrete]
 ==== Pipeline Tests
 These tests allow you to exercise any Ingest Node Pipelines defined by your packages.
 
-For details on how configuring a pipeline test for a package, review the https://github.com/elastic/elastic-package/blob/master/docs/howto/pipeline_testing.md[HOWTO guide].
+For details on how configuring a pipeline test for a package, review the https://github.com/elastic/elastic-package/blob/main/docs/howto/pipeline_testing.md[HOWTO guide].
 
 [discrete]
 ==== Static Tests
 These tests allow you to verify if all static resources of the package are valid, e.g. if all fields of the sample_event.json are documented.
 
-For details on  running static tests for a package, see the https://github.com/elastic/elastic-package/blob/master/docs/howto/static_testing.md[HOWTO guide].
+For details on  running static tests for a package, see the https://github.com/elastic/elastic-package/blob/main/docs/howto/static_testing.md[HOWTO guide].
 
 [discrete]
 ==== System Tests
 These tests allow you to test a package ability for ingesting data end-to-end.
 
-For details on configuring amd run system tests, review the https://github.com/elastic/elastic-package/blob/master/docs/howto/system_testing.md[HOWTO guide].
+For details on configuring amd run system tests, review the https://github.com/elastic/elastic-package/blob/main/docs/howto/system_testing.md[HOWTO guide].
 
 [discrete]
 === `elastic-package uninstall`

--- a/docs/en/integrations/index.asciidoc
+++ b/docs/en/integrations/index.asciidoc
@@ -17,8 +17,8 @@ include::{docs-root}/shared/attributes.asciidoc[]
 :package-storage-repo-link: https://github.com/elastic/package-storage
 
 // Additional information that hasn't been copied over yet
-// https://github.com/elastic/integrations/blob/master/docs/definitions.md
-// https://github.com/elastic/integrations/blob/master/docs/definitions.md
+// https://github.com/elastic/integrations/blob/main/docs/definitions.md
+// https://github.com/elastic/integrations/blob/main/docs/definitions.md
 
 = Integrations Developer Guide
 

--- a/docs/en/integrations/integration-example.asciidoc
+++ b/docs/en/integrations/integration-example.asciidoc
@@ -2,7 +2,7 @@
 = Integration example: Apache
 
 Let's look at an example:
-The https://github.com/elastic/integrations/tree/master/packages/apache[Apache integration].
+The https://github.com/elastic/integrations/tree/main/packages/apache[Apache integration].
 This integration periodically:
 
 * fetches **status metrics** from the Apache server

--- a/docs/en/integrations/publish-integration.asciidoc
+++ b/docs/en/integrations/publish-integration.asciidoc
@@ -1,6 +1,6 @@
 = Publish an integration
 
-// source: https://github.com/elastic/integrations/blob/master/docs/developer_workflow_promote_release_integration.md
+// source: https://github.com/elastic/integrations/blob/main/docs/developer_workflow_promote_release_integration.md
 
 When your integration is done, it's time to open a PR to include it in the integrations repository.
 Before opening your PR, run:
@@ -16,7 +16,7 @@ Passing the `check` command is required before adding your integration to the re
 
 When CI is happy, merge your PR into the integrations repo.
 
-CI will kick off a build job for the master branch, which can release your integration to the package-storage. It means that it will open a PR to the Package Storage/snapshot with the built integration if only the package version doesn't already exist in the storage (hasn't been released yet).
+CI will kick off a build job for the main branch, which can release your integration to the package-storage. It means that it will open a PR to the Package Storage/snapshot with the built integration if only the package version doesn't already exist in the storage (hasn't been released yet).
 
 [discrete]
 == Promote

--- a/docs/en/integrations/system-testing.asciidoc
+++ b/docs/en/integrations/system-testing.asciidoc
@@ -149,7 +149,7 @@ The Kubernetes service deployer needs [kind](https://kind.sigs.k8s.io/) to be in
 
 [source,terminal]
 ----
-wget -qO-  https://raw.githubusercontent.com/elastic/elastic-package/master/scripts/kind-config.yaml | kind create cluster --config -
+wget -qO-  https://raw.githubusercontent.com/elastic/elastic-package/main/scripts/kind-config.yaml | kind create cluster --config -
 ----
 
 Before executing system tests, the service deployer applies once the deployment of the Elastic Agent to the cluster and links
@@ -161,7 +161,7 @@ See how to execute system tests for the Kubernetes integration (`pod` data strea
 [source,terminal]
 ----
 elastic-package stack up -d -v # start the Elastic stack
-wget -qO-  https://raw.githubusercontent.com/elastic/elastic-package/master/scripts/kind-config.yaml | kind create cluster --config -
+wget -qO-  https://raw.githubusercontent.com/elastic/elastic-package/main/scripts/kind-config.yaml | kind create cluster --config -
 elastic-package test system --data-streams pod -v # start system tests for the "pod" data stream
 ----
 

--- a/docs/en/observability/monitor-java-app.asciidoc
+++ b/docs/en/observability/monitor-java-app.asciidoc
@@ -1062,7 +1062,7 @@ Also, the ingest pipeline on the {es} side can be deleted
 again.
 +
 . You can configure a few
-https://github.com/elastic/ecs-logging-java/tree/master/log4j2-ecs-layout[more
+https://github.com/elastic/ecs-logging-java/tree/main/log4j2-ecs-layout[more
 parameters] for the `EcsLayout`, but the defaults have been selected wisely. Let’s
 fix the {filebeat} configuration and remove the multiline setup along with
 pipeline:


### PR DESCRIPTION
### What

Some repositories are now main based.


I don't know where these changes should be backported, so please feel free to add the right label :)