### PR TITLE
Update fleet-agent-proxy-support.asciidoc

### DIFF
--- a/docs/en/ingest-management/fleet-agent-proxy-support.asciidoc
+++ b/docs/en/ingest-management/fleet-agent-proxy-support.asciidoc
@@ -133,12 +133,13 @@ After adding environment variables, restart the service.
 
 [discrete]
 [[proxy-settings-in-agent-policy]]
-== Set {agent} proxy settings in the agent policy
+== Set {agent} proxy settings in a standalone agent policy
 
 Proxy settings in the {agent} policy override proxy settings specified by
 environment variables. This means you can specify proxy settings for {agent}
-that are different from host or system-level environment settings. The following
-proxy settings are valid in the agent policy:
+that are different from host or system-level environment settings. Currently, we only offer a way to modify these for standalone agents. The ability to set these for for Fleet-managed agents is https://github.com/elastic/beats/issues/29542[under consideration]. 
+
+The following proxy settings are valid in the agent policy:
 
 |===
 |Setting | Description


### PR DESCRIPTION
Clarifying that specific settings are only available for standalone mode. We had a few users who were confused about how to add this for fleet-managed agents.