### PR TITLE
Add docs on upgrading Agent in air-gapped environment

### DIFF
--- a/docs/en/ingest-management/fleet/air-gapped.asciidoc
+++ b/docs/en/ingest-management/fleet/air-gapped.asciidoc
@@ -127,13 +127,13 @@ docker run -it -p 443:443 \
 
 [discrete]
 [[air-gapped-limitations]]
-== Limitations for Agent Upgrades
+== Limitations for {agent} upgrades
 
-The [[upgrade-elastic-agent]] feature in technical preview does not currently support network restricted environments without access to artifacts.elastic.co.
+The <<upgrade-elastic-agent>> feature in technical preview does not currently support network restricted environments without access to artifacts.elastic.co.
 To upgrade {agent}s:
 
 1. Download the new version from the https://www.elastic.co/downloads/elastic-agent[download page]
-2. Place the tarball on a secure internal network location
+2. Place the tarball in a secure internal network location
 3. Use the <<elastic-agent-upgrade-command,`upgrade`>> command with a custom `--source-uri` option
 
 [discrete]

--- a/docs/en/ingest-management/fleet/air-gapped.asciidoc
+++ b/docs/en/ingest-management/fleet/air-gapped.asciidoc
@@ -124,3 +124,20 @@ docker run -it -p 443:443 \
   -e EPR_TLS_CERT=/etc/ssl/package-registry.crt \
   docker.elastic.co/package-registry/distribution:{version}
 ----
+
+[discrete]
+[[air-gapped-limitations]]
+== Limitations for Agent Upgrades
+
+The [[upgrade-elastic-agent]] feature in technical preview does not currently support network restricted environments without access to artifacts.elastic.co.
+To upgrade {agent}s:
+1. Download the new version from https://www.elastic.co/downloads/elastic-agent[download page]
+2. Place the artifact on a secure internal network location
+3. Use the <<elastic-agent-upgrade-command,`upgrade`>> command with a custom `--source-uri` option
+
+=== Example
+
+["source", "sh"]
+----
+elastic-agent upgrade {version} --source-uri https://myinternaldomain.com/elastic-agent/elastic-agent-{version}-<platform>-x86_64.tar.gz
+----

--- a/docs/en/ingest-management/fleet/air-gapped.asciidoc
+++ b/docs/en/ingest-management/fleet/air-gapped.asciidoc
@@ -131,10 +131,12 @@ docker run -it -p 443:443 \
 
 The [[upgrade-elastic-agent]] feature in technical preview does not currently support network restricted environments without access to artifacts.elastic.co.
 To upgrade {agent}s:
-1. Download the new version from https://www.elastic.co/downloads/elastic-agent[download page]
-2. Place the artifact on a secure internal network location
+
+1. Download the new version from the https://www.elastic.co/downloads/elastic-agent[download page]
+2. Place the tarball on a secure internal network location
 3. Use the <<elastic-agent-upgrade-command,`upgrade`>> command with a custom `--source-uri` option
 
+[discrete]
 === Example
 
 ["source", "sh"]

--- a/docs/en/ingest-management/fleet/air-gapped.asciidoc
+++ b/docs/en/ingest-management/fleet/air-gapped.asciidoc
@@ -139,7 +139,7 @@ To upgrade {agent}s:
 [discrete]
 === Example
 
-["source", "sh"]
+["source", "sh", subs="attributes"]
 ----
 elastic-agent upgrade {version} --source-uri https://myinternaldomain.com/elastic-agent/elastic-agent-{version}-<platform>-x86_64.tar.gz
 ----


### PR DESCRIPTION
We've gotten several questions about how to upgrade Agents via the UI when in an air-gapped environment. This is not yet supported until https://github.com/elastic/kibana/issues/100413 is implemented.

This adds a note to our air-gapped documentation about this limitation and how to workaround it.

Open questions:
- [ ] These instructions work for users who installed via the tarball distribution (not DEB or RPM). Do we need to include documentation for users who are using an internal DEB or RPM repository as well or should they already know what they're doing in that case?