### PR TITLE
Add elastic-agent min requirements

### DIFF
--- a/docs/en/ingest-management/elastic-agent/install-elastic-agent.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/install-elastic-agent.asciidoc
@@ -57,8 +57,9 @@ Refer to:
 Minimum requirements have been determined by running the {agent} (`v8.0.0`) on a GCP `e2-micro` instance (2vCPU/1GB).
 The {agent} used the default policy, running the system integration and self-monitoring.
 
-+ **CPU** Under 2% total, including all monitoring processes
-+ **Disk** 640MB
-+ **RSS Mem Size** 300 MB
-
+|===
+| **CPU** | Under 2% total, including all monitoring processes
+| **Disk** | 640MB
+| **RSS Mem Size** | 300 MB
+|===
 Adding integrations will increase the memory used by the agent and its processes.

--- a/docs/en/ingest-management/elastic-agent/install-elastic-agent.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/install-elastic-agent.asciidoc
@@ -20,7 +20,7 @@ use {fleet} in {kib} to define, configure, and manage your agents in a central
 location.
 +
 We recommend using {fleet} management because it makes the management and
-upgrade of your agents considerably easier. 
+upgrade of your agents considerably easier.
 +
 Refer to <<install-fleet-managed-elastic-agent>>.
 
@@ -51,3 +51,13 @@ Refer to:
 * {eck-ref}/k8s-elastic-agent.html[Run {agent} on ECK] -- for {eck} users
 --
 
+== Minimum Requirements
+
+An example of the {agent} resource consumption is below.
+The {agent} (`v7.16.3`) was running running the default policy (system integration with monitoring enabled) on a GCP `e2-micro` instance (2vCPU/1GB).
+Adding additional integrations will increase the memory used by the agent and it's processes.
+
++ **CPU** Under 2% total, including all monitoring processes.
++ **Disk** 640MB
++ **RSS Mem Size** 400 MB
++ **Go Runtime Mem Size** 128 MB

--- a/docs/en/ingest-management/elastic-agent/install-elastic-agent.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/install-elastic-agent.asciidoc
@@ -51,13 +51,14 @@ Refer to:
 * {eck-ref}/k8s-elastic-agent.html[Run {agent} on ECK] -- for {eck} users
 --
 
+[discrete]
 == Minimum Requirements
 
-Minimum requirements have been determined from running the {agent} (`v8.0.0`) on a GCP `e2-micro` instance (2vCPU/1GB).
+Minimum requirements have been determined by running the {agent} (`v8.0.0`) on a GCP `e2-micro` instance (2vCPU/1GB).
 The {agent} used the default policy, running the system integration and self-monitoring.
 
-+ **CPU** Under 2% total, including all monitoring processes.
++ **CPU** Under 2% total, including all monitoring processes
 + **Disk** 640MB
 + **RSS Mem Size** 300 MB
 
-Adding additional integrations will increase the memory used by the agent and it's processes.
+Adding integrations will increase the memory used by the agent and its processes.

--- a/docs/en/ingest-management/elastic-agent/install-elastic-agent.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/install-elastic-agent.asciidoc
@@ -53,11 +53,11 @@ Refer to:
 
 == Minimum Requirements
 
-An example of the {agent} resource consumption is below.
-The {agent} (`v7.16.3`) was running running the default policy (system integration with monitoring enabled) on a GCP `e2-micro` instance (2vCPU/1GB).
-Adding additional integrations will increase the memory used by the agent and it's processes.
+Minimum requirements have been determined from running the {agent} (`v8.0.0`) on a GCP `e2-micro` instance (2vCPU/1GB).
+The {agent} used the default policy, running the system integration and self-monitoring.
 
 + **CPU** Under 2% total, including all monitoring processes.
 + **Disk** 640MB
-+ **RSS Mem Size** 400 MB
-+ **Go Runtime Mem Size** 128 MB
++ **RSS Mem Size** 300 MB
+
+Adding additional integrations will increase the memory used by the agent and it's processes.


### PR DESCRIPTION
Add a section on agent min requirements to the installation docs

- Closes #1543 