### PR TITLE
Add troubleshooting steps for failed 8.x upgrades

### DIFF
--- a/docs/en/ingest-management/troubleshooting/troubleshooting.asciidoc
+++ b/docs/en/ingest-management/troubleshooting/troubleshooting.asciidoc
@@ -623,12 +623,12 @@ In some scenarios, upgrading APM & Fleet to 8.x may fail if the Elastic Cloud ag
 Unable to create package policy. Package 'apm' already exists on this agent policy
 ----
 
-You can work around this problem by resetting the {ecloud} agent policy with an API call. Note: this will remove any custom integration policies that you've added to this policy, such as {synthetics} monitors.
+You can work around this problem by resetting the {ecloud} agent policy with an API call. Note: this will remove any custom integration policies that you've added to this policy, such as Synthetics monitors.
 
 [source,sh]
----
+----
 curl -u elastic:<password> --request POST \
   --url <kibana_url>/internal/fleet/reset_preconfigured_agent_policies/policy-elastic-agent-on-cloud \
   --header 'Content-Type: application/json' \
   --header 'kbn-xsrf: xyz' \
----
+----

--- a/docs/en/ingest-management/troubleshooting/troubleshooting.asciidoc
+++ b/docs/en/ingest-management/troubleshooting/troubleshooting.asciidoc
@@ -616,14 +616,14 @@ To scale the {fleet-server} deployment, {ecloud} starts new containers or shuts 
 [[hosted-agent-8-x-upgrade-fail]]
 == APM & Fleet fails to upgrade to 8.x on {ecloud}
 
-In some scenarios, upgrading APM & Fleet to 8.x may fail if the Elastic Cloud agent policy was modified manually by the user. The {fleet} app in {kib} may show a message like:
+In some scenarios, upgrading APM & Fleet to 8.x may fail if the Elastic Cloud agent policy was modified manually. The {fleet} app in {kib} may show a message like:
 
 [source,sh]
 ----
 Unable to create package policy. Package 'apm' already exists on this agent policy
 ----
 
-You can work around this problem by resetting the {ecloud} agent policy with an API call. Note: this will remove any custom integration policies that you've added to this policy, such as Synthetics monitors.
+To work around this problem, you can reset the {ecloud} agent policy with an API call. Note that this will remove any custom integration policies that you've added to the policy, such as Synthetics monitors.
 
 [source,sh]
 ----

--- a/docs/en/ingest-management/troubleshooting/troubleshooting.asciidoc
+++ b/docs/en/ingest-management/troubleshooting/troubleshooting.asciidoc
@@ -611,3 +611,24 @@ to `false`, and then save the integration.
 == Hosted {agent} is offline
 
 To scale the {fleet-server} deployment, {ecloud} starts new containers or shuts down old ones when hosted {agent}s are required or no longer needed. The old {agent}s will show in the Agents list for 24 hours then automatically disappear.
+
+[discrete]
+[[hosted-agent-8-x-upgrade-fail]]
+== APM & Fleet fails to upgrade to 8.x on {ecloud}
+
+In some scenarios, upgrading APM & Fleet to 8.x may fail if the Elastic Cloud agent policy was modified manually by the user. The {fleet} app in {kib} may show a message like:
+
+[source,sh]
+----
+Unable to create package policy. Package 'apm' already exists on this agent policy
+----
+
+You can work around this problem by resetting the {ecloud} agent policy with an API call. Note: this will remove any custom integration policies that you've added to this policy, such as {synthetics} monitors.
+
+[source,sh]
+---
+curl -u elastic:<password> --request POST \
+  --url <kibana_url>/internal/fleet/reset_preconfigured_agent_policies/policy-elastic-agent-on-cloud \
+  --header 'Content-Type: application/json' \
+  --header 'kbn-xsrf: xyz' \
+---


### PR DESCRIPTION
This adds a workaround / troubleshooting step for the issue in discussed in https://github.com/elastic/kibana/issues/124785.