### PR TITLE
[8.1] Correct improper capitalization (#1600)

### DIFF
--- a/docs/en/observability/observability-ui.asciidoc
+++ b/docs/en/observability/observability-ui.asciidoc
@@ -48,7 +48,7 @@ image::images/apm.png[APM summary]
 The *Logs* chart helps you to detect and inspect possible log anomalies across each of
 your ingested log sources. The visualization helps you determine if the log rate is outside
 of your expected bounds, and therefore could be considered anomalous. Any drop in the log
-rate could suggest a system has stopped responding, or a spike could denote a DDos attack.
+rate could suggest a system has stopped responding, or a spike could denote a DDoS attack.
 
 To drill-down and view these logs in the *Logs app*, click *View in app*. For more information,
 see <<monitor-logs,Monitor logs>>.


### PR DESCRIPTION
Backports the following commits to 8.1:
 - Correct improper capitalization (#1600)