### PR TITLE
Add 7.17.1 release notes for Elastic Agent and Fleet

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-7.17.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-7.17.asciidoc
@@ -12,12 +12,23 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-7.17.1>>
+
 * <<release-notes-7.17.0>>
 
 Also see:
 
 * {kibana-ref}/release-notes.html[{kib} release notes]
 * {beats-ref}/release-notes.html[{beats} release notes]
+
+// begin 7.17.1 relnotes
+
+[[release-notes-7.17.1]]
+== {fleet} and {agent} 7.17.1
+
+There are no bug fixes for {fleet} or {agent} in this release.
+
+// end 7.17.1 relnotes
 
 // begin 7.17.0 relnotes
 


### PR DESCRIPTION
Closes #1613

I don't see anything new in the change log for 7.17, but let me know if I've overlooked something. Thanks!