### PR TITLE
Remove section about setting proxy for downloading artifacts

### DIFF
--- a/docs/en/ingest-management/fleet-agent-proxy-support.asciidoc
+++ b/docs/en/ingest-management/fleet-agent-proxy-support.asciidoc
@@ -206,30 +206,6 @@ outputs:
 For more information, refer to <<elastic-agent-configuration>>.
 
 [discrete]
-=== Set the proxy for downloading artifacts
-
-experimental::[]
-
-To set the proxy for downloading artifacts or binary upgrades from
-`artifacts.elastic.co`, add proxy settings under `agent.download` in the
-either the `fleet.yml` file for {fleet}-managed agents, or
-the `elastic-agent.yml` file for standalone agents.
-
-For example:
-
-[source,yaml]
-----
-agent:
-  id: fe277816-8736-4871-9de0-4850d0af21e5
-  download.proxy_url: http://10.0.1.3:3128
-  logging.level: info
-----
-
-IMPORTANT: There is currently no way to configure the `agent.download.proxy_url`
-setting through a command-line flag or the {fleet} UI. If this capability is
-added in the future, the setting you specify here will be overridden.
-
-[discrete]
 [[cli-proxy-settings]]
 == Set the proxy for retrieving agent policies from {fleet}
 


### PR DESCRIPTION
Closes #1470 

@mostlyjason From the description in the issue, it sounds like this section is not required and maybe doesn't even work? Please confirm that your request was to remove this entire section. Thanks!