### PR TITLE
Add metrics buffer documentation

### DIFF
--- a/docs/en/ingest-management/commands.asciidoc
+++ b/docs/en/ingest-management/commands.asciidoc
@@ -36,7 +36,7 @@ Gather diagnostics information from the {agent} and applications it's running.
 
 If no options are specified, this command displays version numbers and application metadata.
 
-If `collect` is specified, it produces an archive containing application metadata, configuration information, the policy, and any local logs.
+If `collect` is specified, it produces an archive containing application metadata, configuration information, the policy, local logs, and metics data (if the buffer is enabled).
 
 Note that *credentials are not redacted* in the archive; they may appear in plain text in the configuration or policy files inside the archive.
 

--- a/docs/en/ingest-management/elastic-agent/configuration/elastic-agent-monitoring.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/elastic-agent-monitoring.asciidoc
@@ -26,6 +26,9 @@ agent.monitoring:
   pprof.enabled: false
   # specifies output to be used
   use_output: monitoring
+  http:
+    # exposes a /buffer endpoint that holds a history of recent metrics
+    buffer.enablde: false
 ----
 
 To turn off monitoring, set `agent.monitoring.enabled` to `false`. When set to
@@ -42,3 +45,9 @@ The `agent.monitoring.pprof.enabled` option controls whether the {agent} and {be
 by default. Data produced by these endpoints can be useful for debugging but present a
 security risk. It is recommended that this option remains `false` if the monitoring endpoint
 is accessible over a network.
+
+The `agent.monitoring.http.buffer.enabled` option controls whether the {agent} and {beats}
+collect metrics into an in-memory buffer and expose these through a `/buffer` endpoint.
+It is set to `false` by default. This data can be useful for debugging or if the {agent}
+has issues communicating with {es}. Enabling this option may slightly increase process
+memory usage.

--- a/docs/en/ingest-management/elastic-agent/configuration/elastic-agent-monitoring.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/elastic-agent-monitoring.asciidoc
@@ -28,7 +28,7 @@ agent.monitoring:
   use_output: monitoring
   http:
     # exposes a /buffer endpoint that holds a history of recent metrics
-    buffer.enablde: false
+    buffer.enabled: false
 ----
 
 To turn off monitoring, set `agent.monitoring.enabled` to `false`. When set to

--- a/docs/en/ingest-management/troubleshooting/troubleshooting.asciidoc
+++ b/docs/en/ingest-management/troubleshooting/troubleshooting.asciidoc
@@ -338,7 +338,7 @@ These will need to be manually redacted before the archive is shared.
 
 The diagnostics command is also able to collect `pprof` data in the archive if the `--pprof` flag is passed:
 
-If `agent.monitoring.http.buffer.enabled` is set to `true` the archive will also contain recent metrics from the {agent} and {beats} processes.
+If `agent.monitoring.http.buffer.enabled` is set to `true`, the archive will also contain recent metrics from the {agent} and {beats} processes.
 
 [source,shell]
 ----

--- a/docs/en/ingest-management/troubleshooting/troubleshooting.asciidoc
+++ b/docs/en/ingest-management/troubleshooting/troubleshooting.asciidoc
@@ -338,6 +338,8 @@ These will need to be manually redacted before the archive is shared.
 
 The diagnostics command is also able to collect `pprof` data in the archive if the `--pprof` flag is passed:
 
+If `agent.monitoring.http.buffer.enabled` is set to `true` the archive will also contain recent metrics from the {agent} and {beats} processes.
+
 [source,shell]
 ----
 elastic-agent diagnostics collect --pprof


### PR DESCRIPTION
Add documentation for enabling the metrics buffer in the agent: https://github.com/elastic/beats/pull/30471 

- Relates https://github.com/elastic/beats/issues/29776