### PR TITLE
Update set-elastic-agent-enrollment-timeout.asciidoc

### DIFF
--- a/docs/en/ingest-management/fleet/set-elastic-agent-enrollment-timeout.asciidoc
+++ b/docs/en/ingest-management/fleet/set-elastic-agent-enrollment-timeout.asciidoc
@@ -1,41 +1,41 @@
 [[set-enrollment-timeout]]
-= Set enrollment timeout for ephemeral hosts
+= Set unenrollment timeout for ephemeral hosts
 
 ++++
-<titleabbrev>Set enrollment timeout</titleabbrev>
+<titleabbrev>Set unenrollment timeout</titleabbrev>
 ++++
 
 IMPORTANT: This setting is only valid for {fleet}-managed agents.
 
-Set the enrollment timeout in the agent policy to specify the amount of time
+Set the unenrollment timeout in the agent policy to specify the amount of time
 {fleet} waits for an {agent} to check in before forcing unenrollment.
 
 This setting is useful for {agent}s running on ephemeral hosts, such as docker
 containers, which can disappear at any time.
 
-To set the enrollment timeout:
+To set the unenrollment timeout:
 
 . In *Fleet*, select *Agent policies*.
 
 . Click the policy name, then click *Settings*.
 
-. In the *Enrollment timeout* field, enter a value in seconds. 
+. In the *Unenrollment timeout* field, enter a value in seconds. 
 +
-Set the enrollment timeout to a value that's high enough to prevent {fleet} from
+Set the unenrollment timeout to a value that's high enough to prevent {fleet} from
 accidentally unenrolling agents during a temporary outage. For example, `1440`.
 
 [[why-set-timeout]]
-== Why set an enrollment timeout?
+== Why set an unenrollment timeout?
 
 Containers might be killed, deleted, or moved, preventing agents from
-unenrolling gracefully. If there's no enrollment timeout specified, the agent
+unenrolling gracefully. If there's no unenrollment timeout specified, the agent
 will continue to appear as `Offline` in {fleet}, and its API keys will remain
 active until explicitly revoked. To remove these "orphan" agents from the main
 Agent list and make them inactive, you need to force unenroll them in {fleet}.
 However, in some environments, like {ess} on {ecloud}, you may not be allowed to
 unenroll agents, which means the agents will appear as `Offline` indefinitely.
 
-To avoid this problem, set the enrollment timeout in the agent policy for
+To avoid this problem, set the unenrollment timeout in the agent policy for
 {agent}s running on ephemeral hosts. If an {agent} fails to check in with
 {fleet} during the timeout period, {fleet} will:
 
@@ -47,17 +47,17 @@ The agent's ID and logs will be preserved in {es}, but container logs will be
 lost.
 
 NOTE: The Elastic Cloud Agent Policy, which is used by {fleet-server} in
-{ecloud}, already has an enrollment timeout specified. You cannot change this
+{ecloud}, already has an unenrollment timeout specified. You cannot change this
 setting.
 
-== What if I don't set an enrollment timeout?
+== What if I don't set an unenrollment timeout?
 
-If there is no enrollment timeout specified and an {agent} fails to check in,
+If there is no unenrollment timeout specified and an {agent} fails to check in,
 the agent remains enrolled in {fleet} and its status is set to `Offline`. When
 the agent checks in with {fleet} again, the status changes to `Healthy`, and the
 agent receives updates, as needed.
 
-In most cases, you should avoid setting an enrollment timeout for {agent}s
+In most cases, you should avoid setting an unenrollment timeout for {agent}s
 running on laptops or servers that may be shut down, paused, or restarted for
 short periods of time before coming back online.
 


### PR DESCRIPTION
We call it unenrollment in the product, just making it consistent