### PR TITLE
Add 8.1.0 Fleet and Elastic Agent release notes

### DIFF
--- a/docs/en/ingest-management/index.asciidoc
+++ b/docs/en/ingest-management/index.asciidoc
@@ -25,9 +25,6 @@ include::{docs-root}/shared/attributes.asciidoc[]
 :apm-go-ref-v:         https://www.elastic.co/guide/en/apm/agent/go/{apm-go-branch}
 :apm-dotnet-ref-v:     https://www.elastic.co/guide/en/apm/agent/dotnet/{apm-dotnet-branch}
 
-//TODO: Remove release-state override before merging
-:release-state: released
-
 = Fleet and Elastic Agent Guide
 
 include::overview.asciidoc[leveloffset=+1]
@@ -148,4 +145,4 @@ include::troubleshooting/troubleshooting.asciidoc[leveloffset=+2]
 
 include::troubleshooting/faq.asciidoc[leveloffset=+2]
 
-include::release-notes/release-notes-8.0.asciidoc[leveloffset=+1]
+include::release-notes/release-notes-8.1.asciidoc[leveloffset=+1]

--- a/docs/en/ingest-management/release-notes/release-notes-8.1.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.1.asciidoc
@@ -1,0 +1,174 @@
+// Use these for links to issue and pulls. 
+:kib-issue: https://github.com/elastic/kibana/issues/
+:kib-pull: https://github.com/elastic/kibana/pull/
+:agent-issue: https://github.com/elastic/beats/issues/
+:agent-pull: https://github.com/elastic/beats/pull/
+:fleet-server-issue: https://github.com/elastic/beats/issues/fleet-server/
+:fleet-server-pull: https://github.com/elastic/beats/pull/fleet-server/
+
+
+[[release-notes]]
+= Release notes
+
+This section summarizes the changes in each release.
+
+* <<release-notes-8.1.0>>
+
+Also see:
+
+* {kibana-ref}/release-notes.html[{kib} release notes]
+* {beats-ref}/release-notes.html[{beats} release notes]
+
+// begin 8.1.0 relnotes
+
+[[release-notes-8.1.0]]
+== {fleet} and {agent} 8.1.0
+
+Review important information about the {fleet} and {agent} 8.1.0 release.
+
+[discrete]
+[[new-features-8.1.0]]
+=== New features
+
+The 8.1.0 release adds the following new and notable features.
+
+{agent}::
+* Add support for loading input configurations from external configuration files
+in standalone mode. You can load inputs from YAML configuration files under the
+folder `{path.config}/inputs.d`. {agent-pull}30087[#30087]
+
+[discrete]
+[[enhancements-8.1.0]]
+=== Enhancements
+
+{fleet}::
+* Add shipper label. {kib-pull}122491[#122491]
+* Add support for non-superuser access to *Fleet* and *Integrations*. {kib-pull}122347[#122347]
+* Add support for bundling packages as zip archives with {kib} source. {kib-pull}122297[#122297]
+* Make the default integration install explicit. {kib-pull}121628[#121628]
+
+//{agent}::
+//* add info
+
+[discrete]
+[[bug-fixes-8.1.0]]
+=== Bug fixes
+
+{fleet}::
+* Re-add missing packages to keep up to date list. {kib-pull}125787[#125787]
+* Trim whitespace from package policy names. {kib-pull}125400[#125400]
+
+{agent}::
+* Fix agent configuration overwritten by default {fleet} config. {agent-pull}29297[#29297]
+
+// end 8.1.0 relnotes
+
+// ---------------------
+//TEMPLATE
+//Use the following text as a template. Remember to replace the version info.
+
+// begin 8.1.x relnotes
+
+//[[release-notes-8.1.x]]
+//== {fleet} and {agent} 8.1.x
+
+//Review important information about the {fleet} and {agent} 8.1.x releases.
+
+//[discrete]
+//[[security-updates-8.1.x]]
+//=== Security updates
+
+//{fleet}::
+//* add info
+
+//{agent}::
+//* add info
+
+//[discrete]
+//[[breaking-changes-8.1.x]]
+//=== Breaking changes
+
+//Breaking changes can prevent your application from optimal operation and
+//performance. Before you upgrade, review the breaking changes, then mitigate the
+//impact to your application.
+
+//[discrete]
+//[[breaking-PR#]]
+//.Short description
+//[%collapsible]
+//====
+//*Details* +
+//<Describe new behavior.> For more information, refer to {kibana-pull}PR[#PR].
+
+//*Impact* +
+//<Describe how users should mitigate the change.> For more information, refer to {fleet-guide}/fleet-server.html[Fleet Server].
+//====
+
+//[discrete]
+//[[known-issues-8.1.x]]
+//=== Known issues
+
+//[[known-issue-issue#]]
+//.Short description
+//[%collapsible]
+//====
+
+//*Details* 
+
+//<Describe known issue.>
+
+//*Impact* +
+
+//<Describe impact or workaround.>
+
+//====
+
+//[discrete]
+//[[deprecations-8.1.x]]
+//=== Deprecations
+
+//The following functionality is deprecated in 8.1.x, and will be removed in
+//8.1.x. Deprecated functionality does not have an immediate impact on your
+//application, but we strongly recommend you make the necessary updates after you
+//upgrade to 8.1.x.
+
+//{fleet}::
+//* add info
+
+//{agent}::
+//* add info
+
+//[discrete]
+//[[new-features-8.1.x]]
+//=== New features
+
+//The 8.1.x release adds the following new and notable features.
+
+//{fleet}::
+//* add info
+
+//{agent}::
+//* add info
+
+//[discrete]
+//[[enhancements-8.1.x]]
+//=== Enhancements
+
+//{fleet}::
+//* add info
+
+//{agent}::
+//* add info
+
+//[discrete]
+//[[bug-fixes-8.1.x]]
+//=== Bug fixes
+
+//{fleet}::
+//* add info
+
+//{agent}::
+//* add info
+
+// end 8.1.x relnotes
+


### PR DESCRIPTION
Please make sure I haven't missed anything for Elastic Agent. We should sort out a better way of handling the changelog now that Elastic Agent will be in a new repo.