### PR TITLE
docs: Mention Fleet-managed requirement in APM quick start

### DIFF
--- a/docs/en/observability/ingest-traces.asciidoc
+++ b/docs/en/observability/ingest-traces.asciidoc
@@ -50,6 +50,9 @@ include::../ingest-management/tab-widgets/add-fleet-server/widget.asciidoc[]
 
 For more information, refer to {fleet-guide}/fleet-server.html[{fleet-server}].
 
+NOTE: The APM integration does not support running {agent} in standalone mode;
+you must use {fleet} to manage {agent}.
+
 [discrete]
 [[add-agent-to-fleet-traces]]
 == Step 2: Add an {agent} to {fleet}


### PR DESCRIPTION
### Summary

Fleet-managed EA's are required for the APM integration. This PR adds a note to the APM integration quickstart.

Closes https://github.com/elastic/apm-server/issues/6921.