### PR TITLE
Remove duplicate text from Synthetics quickstart

### DIFF
--- a/docs/en/observability/synthetics-quickstart-fleet.asciidoc
+++ b/docs/en/observability/synthetics-quickstart-fleet.asciidoc
@@ -34,7 +34,7 @@ image::images/synthetics-agent-policy.png[Synthetics integration]
 
 To run synthetics tests, you must use the *elastic-agent-complete* Docker image to create a self-hosted {agent} node. This image contains the dependencies to run synthetic monitors. The standard Elastic Cloud or self-hosted {agent} will not work.
 
-To add an {agent} to {fleet}, you'll need an enrollment token and the URL of your fleet server. You can use the default enrollment token for your policy or create new enrollment tokens as needed. To learn more, see {fleet-guide}/elastic-agent-container.html[Run Elastic {agent} in a container] and {fleet-guide}/fleet-enrollment-tokens.html[{fleet} enrollment tokens] for more information.
+To add an {agent} to {fleet}, you'll need an enrollment token and the URL of your fleet server. You can use the default enrollment token for your policy or create new enrollment tokens as needed. To learn more, see {fleet-guide}/elastic-agent-container.html[Run {agent} in a container] and {fleet-guide}/fleet-enrollment-tokens.html[{fleet} enrollment tokens] for more information.
 
 You may need to set additional environment variables. See the {fleet-guide}/agent-environment-variables.html[{agent} environment variables guide] for more information. See {fleet-guide}/elastic-agent-container.html[Run {agent} in a container] for more information on running {agent} with Docker.
 


### PR DESCRIPTION
Fixes the duplicate "Elastic Elastic Agent agent in a container" link

<img width="759" alt="image" src="https://user-images.githubusercontent.com/1813008/157441296-d078c6c5-15da-4603-b311-706d59163b8b.png">
