### PR TITLE
Add info about default policies to Fleet release notes

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-8.1.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.1.asciidoc
@@ -27,6 +27,62 @@ Also see:
 Review important information about the {fleet} and {agent} 8.1.0 release.
 
 [discrete]
+[[known-issues-8.1.0]]
+=== Known issues
+
+[[known-issue-108456]]
+.Default agent policy is no longer created automatically
+[%collapsible]
+====
+
+*Details* 
+
+In prior releases, we provided a default agent policy to make it easier for you
+to get started quickly. Starting in 8.1.0, the default policy is no longer
+created automatically; instead, you need to create it explicitly.
+
+*Impact* +
+
+The default policy is no longer available, but we make it easy to create one. To
+create a default policy, do one of the following:
+
+* In the *Add agent* flyout, click the *Create policy* button. If
+*Collect system logs and metrics* is selected, {fleet} will create a policy that
+includes the system integration.
+
+* Use the {fleet} API or preconfiguration to create the policy. To learn how,
+refer to <<create-a-policy-no-ui>>.
+
+====
+
+[[known-issue-108456-2]]
+.For self-managed deployments, {fleet-server} policy is no longer created automatically
+[%collapsible]
+====
+
+*Details* 
+
+In prior releases, we provided a default {fleet-server} policy. Starting in
+8.1.0, the default {fleet-server} policy is no longer created automatically for
+self-managed deployments; instead, you need to create it explicitly.
+
+The Elastic Cloud agent policy is not changed; it is still available by default
+when using our hosted {ess} on {ecloud}.
+
+*Impact* +
+
+The default {fleet-server} policy is no longer available, but we make it easy to
+create one. To create a {fleet-server} policy, do one of the following:
+
+* Use {fleet} to <<create-a-policy-no-ui,Create a policy>> and
+<<add-integration,add a {fleet-server} integration>> to it.
+
+* Use the {fleet} API or preconfiguration to create the policy. To learn how,
+refer to <<create-a-policy-no-ui>>.
+
+====
+
+[discrete]
 [[new-features-8.1.0]]
 === New features
 


### PR DESCRIPTION
Closes #1649 

I put these release notes under "known issues" because they don't seem like breaking changes. Let me know what you think. 