### PR TITLE
Elastic-agent: add documentation about running agent on managed kubenetes environmets, need to adjust resource configuration

### DIFF
--- a/docs/en/ingest-management/elastic-agent/running-on-kubernetes-managed-by-fleet.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/running-on-kubernetes-managed-by-fleet.asciidoc
@@ -167,7 +167,7 @@ a Deployment in addition to the DaemonSet.
 [discrete]
 == Deploying {agent} to managed Kubernetes environment
 
-On managed Kubernetes solutions, such as AKS, GKE or EKS, {agent} has no access to collect metrics from the [Kubernetes control plane](https://kubernetes.io/docs/concepts/overview/components/#control-plane-components)
+On managed Kubernetes solutions, such as AKS, GKE or EKS, {agent} has no access to collect metrics from the https://kubernetes.io/docs/concepts/overview/components/#control-plane-components[Kubernetes control plane]
 components, like `kube-scheduler` and `kube-controller-manager`, that are scheduled on Kubernetes master nodes.
 
 Audit logs are available only on Kubernetes master nodes as well and hence cannot be collected by {agent}.

--- a/docs/en/ingest-management/elastic-agent/running-on-kubernetes-managed-by-fleet.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/running-on-kubernetes-managed-by-fleet.asciidoc
@@ -147,8 +147,8 @@ elastic-agent-hrjbg   1/1     Running   0          12m
 elastic-agent-olpsd   1/1     Running   0          12m
 ------------------------------------------------
 
-NOTE: you might need to adjust https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/[resource limits] of elastic-agent container
-in the `elastic-agent-managed-kubernetes.yaml` manifest: container resources usage depends on number of datastreams
+NOTE: You might need to adjust https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/[resource limits] of the elastic-agent container
+in the `elastic-agent-managed-kubernetes.yaml` manifest. Container resource usage depends on the number of datastreams
 and the environment size.
 
 {agent}s should be enrolled to Fleet and users should be able to deploy the Kubernetes package accordingly.
@@ -165,9 +165,9 @@ leader election strategy and instead run a dedicated, standalone {agent} instanc
 a Deployment in addition to the DaemonSet.
 
 [discrete]
-== Deploying {agent} to managed kubenetes environment
+== Deploying {agent} to managed Kubernetes environment
 
-On managed kubernetes solutions such as AKS, GKE or EKS, elastic-agent has no access to collect metrics from the [kubernetes control plane](https://kubernetes.io/docs/concepts/overview/components/#control-plane-components)
-components, like `kube-scheduler` and `kube-controller-manager`, that are scheduled on kubernetes master nodes.
+On managed Kubernetes solutions, such as AKS, GKE or EKS, {agent} has no access to collect metrics from the [Kubernetes control plane](https://kubernetes.io/docs/concepts/overview/components/#control-plane-components)
+components, like `kube-scheduler` and `kube-controller-manager`, that are scheduled on Kubernetes master nodes.
 
-Audit logs are available only on kubernetes master nodes as well, hense can not be collected by elastic-agent.
+Audit logs are available only on Kubernetes master nodes as well and hence cannot be collected by {agent}.

--- a/docs/en/ingest-management/elastic-agent/running-on-kubernetes-managed-by-fleet.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/running-on-kubernetes-managed-by-fleet.asciidoc
@@ -147,6 +147,9 @@ elastic-agent-hrjbg   1/1     Running   0          12m
 elastic-agent-olpsd   1/1     Running   0          12m
 ------------------------------------------------
 
+NOTE: you might need to adjust https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/[resource limits] of elastic-agent container
+in the `elastic-agent-managed-kubernetes.yaml` manifest: container resources usage depends on number of datastreams
+and the environment size.
 
 {agent}s should be enrolled to Fleet and users should be able to deploy the Kubernetes package accordingly.
 This can be confirmed in {kib} under Fleet  / Agents section.
@@ -160,3 +163,11 @@ and in such cases the Pod that will be collecting cluster level metrics might fa
 issues due to resources limitations. In this case users might consider to avoid using the
 leader election strategy and instead run a dedicated, standalone {agent} instance using
 a Deployment in addition to the DaemonSet.
+
+[discrete]
+== Deploying {agent} to managed kubenetes environment
+
+On managed kubernetes solutions such as AKS, GKE or EKS, elastic-agent has no access to collect metrics from the [kubernetes control plane](https://kubernetes.io/docs/concepts/overview/components/#control-plane-components)
+components, like `kube-scheduler` and `kube-controller-manager`, that are scheduled on kubernetes master nodes.
+
+Audit logs are available only on kubernetes master nodes as well, hense can not be collected by elastic-agent.

--- a/docs/en/ingest-management/elastic-agent/running-on-kubernetes-standalone.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/running-on-kubernetes-standalone.asciidoc
@@ -124,8 +124,8 @@ elastic-agent-fj2z9             1/1     Running   0          81m
 elastic-agent-hs4pb             1/1     Running   0          81m
 ------------------------------------------------
 
-NOTE: you might need to adjust https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/[resource limits] of elastic-agent container
-in `elastic-agent-standalone-kubernetes.yaml` manifest: container resources usage depends on number of datastreams
+NOTE: You might need to adjust https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/[resource limits] of the elastic-agent container
+in the `elastic-agent-standalone-kubernetes.yaml` manifest. Container resource usage depends on the number of datastreams
 and the environment size.
 
 [discrete]
@@ -270,9 +270,9 @@ leader election strategy and instead run a dedicated, standalone {agent} instanc
 a Deployment in addition to the DaemonSet.
 
 [discrete]
-== Deploying {agent} to managed kubenetes environment
+== Deploying {agent} to managed Kubernetes environment
 
-On managed kubernetes solutions such as AKS, GKE or EKS, elastic-agent has no access to collect metrics from the [kubernetes control plane](https://kubernetes.io/docs/concepts/overview/components/#control-plane-components)
-components, like `kube-scheduler` and `kube-controller-manager`, that are scheduled on kubernetes master nodes.
+On managed Kubernetes solutions, such as AKS, GKE or EKS, {agent} has no access to collect metrics from the [Kubernetes control plane](https://kubernetes.io/docs/concepts/overview/components/#control-plane-components)
+components, like `kube-scheduler` and `kube-controller-manager`, that are scheduled on Kubernetes master nodes.
 
-Audit logs are available only on kubernetes master nodes as well, hense can not be collected by elastic-agent.
+Audit logs are available only on Kubernetes master nodes as well, and hence cannot be collected by {agent}.

--- a/docs/en/ingest-management/elastic-agent/running-on-kubernetes-standalone.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/running-on-kubernetes-standalone.asciidoc
@@ -272,7 +272,7 @@ a Deployment in addition to the DaemonSet.
 [discrete]
 == Deploying {agent} to managed Kubernetes environment
 
-On managed Kubernetes solutions, such as AKS, GKE or EKS, {agent} has no access to collect metrics from the [Kubernetes control plane](https://kubernetes.io/docs/concepts/overview/components/#control-plane-components)
+On managed Kubernetes solutions, such as AKS, GKE or EKS, {agent} has no access to collect metrics from the https://kubernetes.io/docs/concepts/overview/components/#control-plane-components[Kubernetes control plane]
 components, like `kube-scheduler` and `kube-controller-manager`, that are scheduled on Kubernetes master nodes.
 
 Audit logs are available only on Kubernetes master nodes as well, and hence cannot be collected by {agent}.

--- a/docs/en/ingest-management/elastic-agent/running-on-kubernetes-standalone.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/running-on-kubernetes-standalone.asciidoc
@@ -124,6 +124,10 @@ elastic-agent-fj2z9             1/1     Running   0          81m
 elastic-agent-hs4pb             1/1     Running   0          81m
 ------------------------------------------------
 
+NOTE: you might need to adjust https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/[resource limits] of elastic-agent container
+in `elastic-agent-standalone-kubernetes.yaml` manifest: container resources usage depends on number of datastreams
+and the environment size.
+
 [discrete]
 == Red Hat OpenShift configuration
 
@@ -264,3 +268,11 @@ and in such cases the Pod that will be collecting cluster level metrics might fa
 issues due to resources limitations. In this case users might consider to avoid using the
 leader election strategy and instead run a dedicated, standalone {agent} instance using
 a Deployment in addition to the DaemonSet.
+
+[discrete]
+== Deploying {agent} to managed kubenetes environment
+
+On managed kubernetes solutions such as AKS, GKE or EKS, elastic-agent has no access to collect metrics from the [kubernetes control plane](https://kubernetes.io/docs/concepts/overview/components/#control-plane-components)
+components, like `kube-scheduler` and `kube-controller-manager`, that are scheduled on kubernetes master nodes.
+
+Audit logs are available only on kubernetes master nodes as well, hense can not be collected by elastic-agent.


### PR DESCRIPTION
Extend elastic-agent documentation:
- about running agent on managed kubenetes environments, that not all metrics and logs can be available
- add note, that container resources might be needed to adjust

Signed-off-by: Tetiana Kravchenko <tetiana.kravchenko@elastic.co>