### PR TITLE
Replace "index patterns" with `data-source` shared attribute

### DIFF
--- a/docs/en/ingest-management/data-streams.asciidoc
+++ b/docs/en/ingest-management/data-streams.asciidoc
@@ -39,7 +39,8 @@ and another dataset for disk I/O metrics with a field describing the number of b
 A user-configurable arbitrary grouping, such as an environment (`dev`, `prod`, or `qa`),
 a team, or a strategic business unit.
 A `namespace` can be up to 100 bytes in length (multibyte characters will count toward this limit faster).
-Using a namespace makes it easier to search the data from a given source by using index patterns, or to give users permissions to data by assigning an index pattern to user roles.
+Using a namespace makes it easier to search data from a given source by using a matching pattern.
+You can also use matching patterns to give users access to data when creating user roles.
 // Corresponds to the `data_stream.dataset` field.
 
 The naming scheme separates each components with a `-` character:

--- a/docs/en/ingest-management/data-streams.asciidoc
+++ b/docs/en/ingest-management/data-streams.asciidoc
@@ -76,10 +76,10 @@ Under the hood though, things are a bit more complex.
 All of the juicy details are available in {ref}/data-streams.html[{es} Data streams].
 
 [discrete]
-[[data-streams-index-pattern]]
-== Index patterns
+[[data-streams-data-view]]
+== {data-sources-cap}
 
-When searching your data in {kib}, you can use an {kibana-ref}/index-patterns.html[index pattern]
+When searching your data in {kib}, you can use a {kibana-ref}/data-views.html[{data-source}]
 to search across all or some of your data streams.
 
 [discrete]

--- a/docs/en/integrations/package-spec.asciidoc
+++ b/docs/en/integrations/package-spec.asciidoc
@@ -45,7 +45,7 @@ The following assets are typically found in an Elastic package:
 * {kib}
 ** Dashboards
 ** Visualization
-** {Data-sources}
+** {data-sources-cap}
 ** ML Modules
 ** Map
 ** Search

--- a/docs/en/integrations/package-spec.asciidoc
+++ b/docs/en/integrations/package-spec.asciidoc
@@ -45,7 +45,7 @@ The following assets are typically found in an Elastic package:
 * {kib}
 ** Dashboards
 ** Visualization
-** Index patterns
+** {Data-sources}
 ** ML Modules
 ** Map
 ** Search

--- a/docs/en/observability/configure-logs-sources.asciidoc
+++ b/docs/en/observability/configure-logs-sources.asciidoc
@@ -28,13 +28,17 @@ default configuration settings.
 to read log data from.
 
 Each log source now integrates with {kib} index patterns which support creating and
-querying {kibana-ref}/managing-index-patterns.html[runtime fields]. You can continue
+querying {kibana-ref}/managing-data-views.html[runtime fields]. You can continue
 to use log sources configured to use an index name pattern, such as `filebeat-*`,
 instead of a {kib} index pattern. However, some features like those depending on
 runtime fields may not be available.
 
 Instead of entering an index pattern name,
 click *Use {kib} index patterns* and select the `filebeat-*` log index pattern.
+
+| *{data-source-cap}* | This is a new configuration option that can be used
+instead of index pattern. The Logs UI can now integrate with {data-sources} to
+configure the used indices by clicking *Use {data-sources}*.
 
 | *Fields* | Configuring fields input has been deprecated. You should adjust your indexing using the
 <<logs-app-fields,Logs app fields>>, which use the {ecs-ref}/index.html[Elastic Common Schema (ECS) specification].

--- a/docs/en/observability/ingest-logs.asciidoc
+++ b/docs/en/observability/ingest-logs.asciidoc
@@ -192,9 +192,9 @@ include::{beats-repo-dir}/tab-widgets/open-kibana-widget.asciidoc[]
 
 . Open the main menu, then click *Discover*.
 +
-. Select `filebeat-*` as your index pattern.
+. Select `filebeat-*` as your {data-source}.
 +
-Each document in the index that matches the `filebeat-*` index pattern
+Each document in the index that matches the `filebeat-*` {data-source}
 is displayed. By default, *Discover* shows data for the last 15 minutes.  If you have
 a time-based index, and no data displays, you might need to increase the time range.
 +

--- a/docs/en/observability/ingest-metrics.asciidoc
+++ b/docs/en/observability/ingest-metrics.asciidoc
@@ -159,9 +159,9 @@ include::{beats-repo-dir}/tab-widgets/open-kibana-widget.asciidoc[]
 
 . Open the main menu, then click *Discover*
 +
-. Select `metricbeat-*` as your index pattern.
+. Select `metricbeat-*` as your {data-source}.
 +
-Each document in the index that matches the `metricbeat-*` index pattern
+Each document in the index that matches the `metricbeat-*` {data-source}
 is displayed. By default, *Discover* shows data for the last 15 minutes.
 
 Now let's have a look at the <<analyze-metrics,Metrics app>>.


### PR DESCRIPTION
Related https://github.com/elastic/observability-docs/issues/1096
Related https://github.com/elastic/kibana/issues/100844

The term "index patterns" (or `index-pattern` in URLs) appears on 10 pages. It looks like it's primarily in various **Settings** pages and after looking at the Kibana UI, it looks like some of these references have been changed to "data views" but others still use index patterns.

I'm trying to figure out if all references to "index patterns" should be changed or only where the UI text has changed. Here's what I found: 

### UI now using "data view":

**Logs** > **Settings** > **Data view** (new option)

Pages that mention this part of the UI: 
- [x] [Log monitoring » Configure data sources](https://www.elastic.co/guide/en/observability/current/configure-data-sources.html)
- [x] [Send data to Elasticsearch » Deploy Beats to send data » Ingest logs with Filebeat](https://www.elastic.co/guide/en/observability/current/ingest-logs.html)
- [x] [Send data to Elasticsearch » Deploy Beats to send data » Ingest metrics with Metricbeat](https://www.elastic.co/guide/en/observability/current/ingest-metrics.html)
- [x] [Centrally manage Elastic Agents in Fleet » Data streams](https://www.elastic.co/guide/en/fleet/current/data-streams.html)
    - Also line 42?

### UI using "index pattern":

**Metrics** > **Settings** > **Indices** > **Metric indices**

Pages that mention this part of the UI: 
- [ ] [Metrics monitoring » Configure settings](https://www.elastic.co/guide/en/observability/current/configure-settings.html)
- [ ] [Alerting » Create a metrics threshold rule](https://www.elastic.co/guide/en/observability/current/metrics-threshold-alert.html)
- [ ] [Alerting » Create an infrastructure threshold rule](https://www.elastic.co/guide/en/observability/current/infrastructure-threshold-alert.html)

**Uptime** > **Settings** > **Indices** > **Uptime indices**

Pages that mention this part of the UI: 
- [ ] [Synthetic monitoring via the Uptime app » Lightweight synthetic monitoring » Configure settings](https://www.elastic.co/guide/en/observability/current/configure-uptime-settings.html)

### Not sure: 

Pages that mention "index pattern" that I'm not sure if I should replace: 
- [x] [Alerting » Create a logs threshold rule](https://www.elastic.co/guide/en/observability/current/logs-threshold-alert.html)
- [x] [Package specification](https://www.elastic.co/guide/en/integrations-developer/current/package-spec.html)

### Question for @dedemorton:

Should I update references in the pages listed under "UI using index pattern" and "Not sure"? 
