### PR TITLE
Incorporate blog content into synthetic monitoring docs

### DIFF
--- a/docs/en/observability/monitor-uptime-synthetics.asciidoc
+++ b/docs/en/observability/monitor-uptime-synthetics.asciidoc
@@ -5,9 +5,20 @@
 <titleabbrev>Synthetic monitoring</titleabbrev>
 ++++
 
-The {uptime-app} in {kib} lets you monitor user journeys and full page loads using our browser monitor,
-and also monitor the availability and response times of applications and services using our lightweight HTTP/S,
-TCP, and ICMP monitors.
+Synthetic monitors go beyond classic end-to-end tests and monitoring practices to ensure that your software continues to work as expected in many conditions. 
+
+Even the most thorough end-to-end tests can't prove your software works because you can't validate all possible states of your application.
+And while improving your monitoring practices could help, it might not be sufficient for features that don't get enough traffic.
+
+Synthetic monitoring solves these problems.
+Start by building _synthetic journeys_, end-to-end tests executed by a real browser that you can run both on your machine and CI.
+Then, use Kibana to create _synthetic monitors_ to periodically run those synthetic journeys against any desired deployment environments (including production) and help you catch and fix problems before your users notice them.
+// Elastic's machine learning capabilities can also automatically detect anomalies and send out alerts to your team.
+
+The {uptime-app} in {kib} includes two types of synthetic monitoring:
+
+* Browser checks
+* Lightweight HTTP/S, TCP, and ICMP checks
 
 [discrete]
 [[monitoring-synthetics]]

--- a/docs/en/observability/monitor-uptime-synthetics.asciidoc
+++ b/docs/en/observability/monitor-uptime-synthetics.asciidoc
@@ -5,20 +5,17 @@
 <titleabbrev>Synthetic monitoring</titleabbrev>
 ++++
 
-Synthetic monitors go beyond classic end-to-end tests and monitoring practices to ensure that your software continues to work as expected in many conditions. 
+Synthetic monitoring extends traditional end-to-end testing techniques because it allows your tests to run continuously on the cloud.
+With Elastic's Synthetic Monitoring product, you can reuse the same journeys that you've used to validate the software on your machine
+to assert that your application continues to work after a deployment.
 
-Even the most thorough end-to-end tests can't prove your software works because you can't validate all possible states of your application.
-And while improving your monitoring practices could help, it might not be sufficient for features that don't get enough traffic.
-
-Synthetic monitoring solves these problems.
-Start by building _synthetic journeys_, end-to-end tests executed by a real browser that you can run both on your machine and CI.
-Then, use Kibana to create _synthetic monitors_ to periodically run those synthetic journeys against any desired deployment environments (including production) and help you catch and fix problems before your users notice them.
-// Elastic's machine learning capabilities can also automatically detect anomalies and send out alerts to your team.
+You can use synthetic monitors to detect bugs caused by invalid states you couldn't anticipate and didn't write tests for.
+Synthetic monitors can also help you catch bugs in features that don't get enough traffic by allowing you to periodically simulate users' actions.
 
 The {uptime-app} in {kib} includes two types of synthetic monitoring:
 
-* Browser checks
-* Lightweight HTTP/S, TCP, and ICMP checks
+* <<monitoring-synthetics>>
+* <<monitoring-uptime>>
 
 [discrete]
 [[monitoring-synthetics]]

--- a/docs/en/observability/monitor-uptime-synthetics.asciidoc
+++ b/docs/en/observability/monitor-uptime-synthetics.asciidoc
@@ -6,8 +6,7 @@
 ++++
 
 Synthetic monitoring extends traditional end-to-end testing techniques because it allows your tests to run continuously on the cloud.
-With Elastic's Synthetic Monitoring product, you can reuse the same journeys that you've used to validate the software on your machine
-to assert that your application continues to work after a deployment.
+With Elastic's Synthetic Monitoring product, you can assert that your application continues to work after a deployment by reusing the same journeys that you used to validate the software on your machine.
 
 You can use synthetic monitors to detect bugs caused by invalid states you couldn't anticipate and didn't write tests for.
 Synthetic monitors can also help you catch bugs in features that don't get enough traffic by allowing you to periodically simulate users' actions.

--- a/docs/en/observability/synthetics-create-test.asciidoc
+++ b/docs/en/observability/synthetics-create-test.asciidoc
@@ -36,8 +36,7 @@ It is reliable and fast and features a modern API that auto waits for page eleme
 [[synthetics-install]]
 == Install Elastic Synthetics
 
-Before creating your first synthetic journey, create a `package.json` file within your test's directory. To do this quickly, you can run `npm init -y`.
-
+Create a new https://docs.npmjs.com/cli/v7/commands/npm-init[NPM/Node.js project].
 Then, install the synthetics runner as a dev-dependency using `npm install -D @elastic/synthetics`.
 
 [discrete]
@@ -47,13 +46,11 @@ Then, install the synthetics runner as a dev-dependency using `npm install -D @e
 A journey tests one discrete unit of functionality.
 For example, logging into a website, adding something to a cart, or joining a mailing list.
 
-Start by creating a new file called that follows the pattern `*.journey.js`,
+Start by creating a new file called using the `.journey.ts` or `.journey.js` file extension,
 importing the synthetics library, and adding a new journey.
 
 [source,js]
 ----
-import { journey } from '@elastic/synthetics';
-
 journey('Journey name', ({ page, browser, context, params }) => {
   // Add steps here
 });
@@ -87,8 +84,6 @@ A basic two-step journey would look like this:
 
 [source,js]
 ----
-import { journey, step, expect } from '@elastic/synthetics';
-
 journey('Journey name', ({ page, browser, client, params }) => {
     step('Step 1 name', () => {
       // Do something here
@@ -166,35 +161,29 @@ journey('Ensure placeholder is correct', ({ page }) => {
 });
 ----
 
-[discrete]
 [[synthetic-run-tests]]
-== Running synthetic tests
+== Run synthetic tests
 
-As explained in the <<synthetics-quickstart,quickstart>>, there are two ways to run synthetic tests:
+There are two ways to run synthetic tests:
 
-* Run as an inline journey -- embed into `heartbeat.yml`
-* Run a test suite -- import your tests into Heartbeat
-
-Which option is right for you? That depends.
-If you want to invoke a single journey with few steps, an inline journey might be the easiest workflow --
-you only need to write your tests into your `heartbeat.yml` file.
-
-Note that you can only paste the steps into an inline script, so these cannot be dependent on any packages that you may want to `import`. If you do have any dependencies, these would need to be defined with an `import` outside of the `journey` object and run via a test suite.
-If you have a complex test suite, or your tests need to live with your application code,
-you're likely better off setting up a synthetic test suite.
+* **If you want to invoke a single journey with few steps: <<synthetics-inline-journey>>.**
+This can be more efficienct since you only need to write your tests into your `heartbeat.yml` file.
+However, you can only paste the steps into an inline script, so the test cannot have any other dependencies.
+* **If you have any dependencies, you have a complex test suite, or your tests need to live with your
+application code: <<synthetics-test-suite>>.**
+Any dependencies need to be defined with an `import` outside of the `journey` object and run via the test suite.
 
 [discrete]
 [[synthetics-inline-journey]]
 === Run an inline journey
 
 The easiest way to run a synthetic test is by creating an inline journey.
-The `journey` keyword isn't required, and access to variables like `page` and `params` is automatic. Remember you cannot `import` any dependencies using inline scripts.
+The `journey` keyword isn't required, and access to variables like `page` and `params` is automatic. You cannot `import` any dependencies using inline scripts.
 
 Copy and paste your test steps into `heartbeat.yml`.
-Heartbeat spawns a separate Node.js process, schedules your tests, and runs them on a chromium browser.
-You don't need to worry about anything else.
+{heartbeat} spawns a separate Node.js process, schedules your tests, and runs them on a chromium browser.
 
-An example, `short.js`, is provided in the
+There is an example inline journey in the
 https://github.com/elastic/synthetics-demo/blob/main/heartbeat/monitors.d/browser-inline.yml[elastic/synthetics] GitHub repository:
 
 [source,js]
@@ -208,9 +197,8 @@ step("hover over products menu", async () => {
 });
 ----
 
-To run this, or any other inline example locally, change into the directory of your test,
+To run an inline example locally change into the directory of your test
 and pipe the file contents to the `npx @elastic/synthetics` command.
-
 For example:
 
 [source,sh]
@@ -218,7 +206,7 @@ For example:
 cat examples/inline/short.js | npx @elastic/synthetics --inline
 ----
 
-If everything works as expected, you'll get the similar response:
+And you'll get a response similar to:
 
 [source,sh]
 ----
@@ -249,41 +237,32 @@ heartbeat.monitors:
         });
 ----
 
-That's it! You can either spin up Heartbeat yourself, or jump to <<synthetics-quickstart-step-three>>
-of the Quickstart to use the provided Docker project template.
+You can either spin up {heartbeat} yourself, or jump to <<synthetics-quickstart-step-three>>
+to use the provided Docker project template.
 
 [discrete]
 [[synthetics-test-suite]]
 === Run a test suite
 
-If you have a suite of tests you'd like to implement, you can use Elastic synthetics as a library.
-In this method, you use Docker to run both Heartbeat and `elastic-synthetics`.
+If you have a suite of tests to implement, you can use Elastic Synthetics as a library.
+In this method, you use Docker to run both {heartbeat} and `elastic-synthetics`.
 
-// [discrete]
-// [[synthetics-suite-install]]
-// ==== Step 1: Install `@elastic/synthetics`
-
-Install the `@elastic/synthetics` package globally to get started:
+Start by installing the `@elastic/synthetics` package globally:
 
 [source,sh]
 ----
 npm install -g @elastic/synthetics
 ----
 
-// [discrete]
-// [[synthetics-suite-create]]
-// ==== Step 2: Create your tests
-
-Now it's time to write your tests:
+Then write your tests:
 
 . Create a new https://docs.npmjs.com/cli/v7/commands/npm-init[NPM/Node.js project].
 . Create a `javascript` or `typescript` file that imports your tests.
 All synthetic test files must use the `.journey.ts` or `.journey.js` file extension.
 . Compile everything together.
 
-At Elastic, we're fans of examples, so one is provided in the
-https://github.com/elastic/synthetics[elastic/synthetics] repository.
-If you'd like to test it locally, clone the repo, and install the example:
+Find examples in the https://github.com/elastic/synthetics[elastic/synthetics] repository.
+If you'd like to test an example locally, clone the repo and install the example:
 
 [source,sh]
 ----
@@ -295,7 +274,7 @@ npm install
 ----
 
 You are now inside the a synthetics test-suite, which is also an NPM project.
-You can now run the provided tests; Note that, by default, only files matching the filename `*.journey.(ts|js)*`
+You can now run the provided tests. By default only files matching the filename `*.journey.(ts|js)*`
 will be run.
 
 [source,sh]
@@ -305,7 +284,7 @@ will be run.
 npx @elastic/synthetics .
 ----
 
-Once you have your tests up and running, follow the steps in the <<synthetics-quickstart,quickstart guide>>
+Once you have your tests up and running, follow the steps in <<synthetics-quickstart,Synthetic monitoring using Docker>>
 to integrate with the provided Docker project template.
 
 // Results. . .

--- a/docs/en/observability/synthetics-create-test.asciidoc
+++ b/docs/en/observability/synthetics-create-test.asciidoc
@@ -43,11 +43,14 @@ It is reliable and fast and features a modern API that auto waits for page eleme
 [[synthetics-create-journey]]
 == Write a synthetic test
 
+Start by creating a new file called using the `.journey.ts` or `.journey.js` file extension,
+importing the synthetics library, and adding a new journey.
 A journey tests one discrete unit of functionality.
 For example, logging into a website, adding something to a cart, or joining a mailing list.
 
-Start by creating a new file called using the `.journey.ts` or `.journey.js` file extension,
-importing the synthetics library, and adding a new journey.
+The journey function takes two parameters: a `name`, and a `callback`.
+The `name` helps you identify an individual journey.
+The `callback` argument is a function that encapsulates what the journey does.
 
 [source,js]
 ----
@@ -56,9 +59,7 @@ journey('Journey name', ({ page, browser, context, params }) => {
 });
 ----
 
-The `journey` function takes a single parameter, `name` ('Journey name' in the example above).
-Then you pass a callback to the global `journey` function to encapsulate the whole test.
-This callback function provides access to fresh Playwright `page`, `params`, `browser`, and `context` instances.
+The callback provides access to fresh Playwright `page`, `params`, `browser`, and `context` instances:
 
 [horizontal]
 `name`::        A string you provide to describe the journey.
@@ -78,7 +79,7 @@ This callback function provides access to fresh Playwright `page`, `params`, `br
 === Add steps
 
 A journey consists of multiple _steps_. Steps are actions that should be completed in a specific order.
-Steps are displayed individually in the {uptime-app} for easy debugging and error tracking.
+Steps are displayed individually in the {uptime-app} along with screenshots for easy debugging and error tracking.
 
 A basic two-step journey would look like this:
 
@@ -167,15 +168,16 @@ journey('Ensure placeholder is correct', ({ page }) => {
 
 There are two ways to run synthetic tests:
 
-* If you want to invoke a single journey with few steps, <<synthetics-inline-journey,run an inline journey>>.
-This can be more efficient, but has some limitations like not supporting dependencies.
-* If you have any dependencies, you have a complex test suite, or your tests need to live with your
-application code, <<synthetics-test-suite,run a test suite>>. Any dependencies need to be defined with an
+* If you want to create a single journey and manage it in isolation from monitors containing other journeys,
+<<synthetics-inline-journey,use an inline journey>>.
+Inline journeys can be more efficient, but have some limitations like not supporting multiple journeys and other dependencies.
+* If you have multiple journeys, rely on dependencies, or your tests need to live with your
+application code, <<synthetics-test-suite,use a test suite>>. Any dependencies need to be defined with an
 `import` outside of the `journey` object and run via the test suite.
 
 [discrete]
 [[synthetics-inline-journey]]
-=== Run an inline journey
+=== Use an inline journey
 
 The easiest way to run a synthetic test is by creating an inline journey.
 The `journey` keyword isn't required, and access to variables like `page` and `params` is automatic.
@@ -227,7 +229,7 @@ project template or spin up {heartbeat} yourself.
 
 [discrete]
 [[synthetics-test-suite]]
-=== Run a test suite
+=== Use a test suite
 
 If you have a suite of tests to implement, you can use Elastic Synthetics as a library.
 In this method, you use Docker to run both {heartbeat} and `elastic-synthetics`.
@@ -286,7 +288,7 @@ project template or spin up {heartbeat} yourself.
 In addition to replacing your end-to-end tests locally, you can run a synthetic test suite on your CI environment.
 
 You can run `@elastic/synthetics` in a CI environment to execute journeys.
-Elastic's synthetics runnercan output results in multiple formats, including JSON and JUnit
+Elastic's synthetics runner can output results in multiple formats, including JSON and JUnit
 (the standard format supported by most CI platforms).
 If any of your journeys fail, it will yield a non-zero exit code, which most CI systems pick up as a failure. 
 

--- a/docs/en/observability/synthetics-create-test.asciidoc
+++ b/docs/en/observability/synthetics-create-test.asciidoc
@@ -11,7 +11,7 @@
 
 beta[] To write synthetic tests for your application, you'll need to know basic JavaScript and
 {playwright-url}[Playwright] syntax.
-The Elastic Synthetics agent exposes a an API for creating and running tests:
+The Elastic Synthetics agent exposes an API for creating and running tests:
 
 * `journey(name, ({ page, browser, context, params }) => {})` -- A journey tests one discrete unit of functionality.
 For example, logging into a website, adding something to a cart, or joining a mailing list.
@@ -29,7 +29,7 @@ This function is useful for removing global state or closing a server that was u
 * `after(({ params }) => {})` -- Runs a provided function after a single journey has completed.
 This function is useful for removing global state or closing a server that was used in a single journey.
 
-TIP: {playwright-url}[Playwright] is browser testing library developed by Microsoft.
+TIP: {playwright-url}[Playwright] is a browser testing library developed by Microsoft.
 It is reliable and fast and features a modern API that auto waits for page elements to be ready.
 
 [discrete]
@@ -173,10 +173,10 @@ application code, <<synthetics-test-suite,use a test suite>>.
 === Use an inline journey
 
 The easiest way to run a synthetic test is by creating an inline journey.
-The `journey` keyword isn't required and access to variables like `page` and `params` is automatic.
+The `journey` keyword isn't required, and access to variables like `page` and `params` is automatic.
 You cannot `import` any dependencies using inline scripts.
 
-To test an inline example locally, change into the directory of your test
+To test an inline example locally, change into your test's directory
 and pipe the file contents to the `npx @elastic/synthetics` command.
 
 For example, create a `sample.js` file containing steps:
@@ -216,7 +216,7 @@ Elastic Synthetics integration or `heartbeat.yml`.
 In Monitor settings, use Monitor Type "Browser" and switch the Source Type to "Inline script".
 See <<synthetics-quickstart-fleet>> for details.
 * **{heartbeat}**: Copy and paste your test steps into `heartbeat.yml`.
-{heartbeat} spawns a separate Node.js process, schedules your tests, and runs them on a chromium browser.
+{heartbeat} spawns a separate Node.js process, schedules your tests, and runs them on a Chromium browser.
 See <<synthetics-quickstart-step-two>> for details.
 
 [discrete]

--- a/docs/en/observability/synthetics-create-test.asciidoc
+++ b/docs/en/observability/synthetics-create-test.asciidoc
@@ -32,13 +32,6 @@ This function is useful for removing global state or closing a server that was u
 TIP: {playwright-url}[Playwright] is browser testing library developed by Microsoft.
 It is reliable and fast and features a modern API that auto waits for page elements to be ready.
 
-// [discrete]
-// [[synthetics-install]]
-// == Install Elastic Synthetics
-
-// Create a new https://docs.npmjs.com/cli/v7/commands/npm-init[NPM/Node.js project].
-// Then, install the synthetics runner as a dev-dependency using `npm install -D @elastic/synthetics`.
-
 [discrete]
 [[synthetics-create-journey]]
 == Write a synthetic test
@@ -224,7 +217,7 @@ In Monitor settings, use Monitor Type "Browser" and switch the Source Type to "I
 See <<synthetics-quickstart-fleet>> for details.
 * **{heartbeat}**: Copy and paste your test steps into `heartbeat.yml`.
 {heartbeat} spawns a separate Node.js process, schedules your tests, and runs them on a chromium browser.
-You can jump to <<synthetics-quickstart-step-two>> if you're using the the provided Docker
+You can jump to <<synthetics-quickstart-step-two>> if you're using the provided Docker
 project template or spin up {heartbeat} yourself.
 
 [discrete]
@@ -249,7 +242,7 @@ All synthetic test files must use the `.journey.ts` or `.journey.js` file extens
 . Compile everything together.
 
 Find examples in the https://github.com/elastic/synthetics[elastic/synthetics] repository.
-If you'd like to test an example locally, clone the repo and install the example:
+If you'd like to test an example locally, clone the repository and install the example:
 
 [source,sh]
 ----
@@ -278,7 +271,7 @@ Elastic Synthetics integration configuration or `heartbeat.yml`.
 Use Monitor Type "Browser" and use the Source Type "Zip URL" pointing to a zip file containing the test project.
 See <<synthetics-quickstart-fleet>> for details.
 * **{heartbeat}**: Copy and paste the path to your zip file into `heartbeat.yml`.
-You can jump to <<synthetics-quickstart-step-two>> if you're using the the provided Docker
+You can jump to <<synthetics-quickstart-step-two>> if you're using the provided Docker
 project template or spin up {heartbeat} yourself.
 
 [discrete]

--- a/docs/en/observability/synthetics-create-test.asciidoc
+++ b/docs/en/observability/synthetics-create-test.asciidoc
@@ -32,16 +32,16 @@ This function is useful for removing global state or closing a server that was u
 TIP: {playwright-url}[Playwright] is browser testing library developed by Microsoft.
 It is reliable and fast and features a modern API that auto waits for page elements to be ready.
 
-[discrete]
-[[synthetics-install]]
-== Install Elastic Synthetics
+// [discrete]
+// [[synthetics-install]]
+// == Install Elastic Synthetics
 
-Create a new https://docs.npmjs.com/cli/v7/commands/npm-init[NPM/Node.js project].
-Then, install the synthetics runner as a dev-dependency using `npm install -D @elastic/synthetics`.
+// Create a new https://docs.npmjs.com/cli/v7/commands/npm-init[NPM/Node.js project].
+// Then, install the synthetics runner as a dev-dependency using `npm install -D @elastic/synthetics`.
 
 [discrete]
 [[synthetics-create-journey]]
-== Create a `journey`
+== Write a synthetic test
 
 A journey tests one discrete unit of functionality.
 For example, logging into a website, adding something to a cart, or joining a mailing list.
@@ -167,29 +167,27 @@ journey('Ensure placeholder is correct', ({ page }) => {
 
 There are two ways to run synthetic tests:
 
-* **If you want to invoke a single journey with few steps: <<synthetics-inline-journey>>.**
-This can be more efficienct since you only need to write your tests into your `heartbeat.yml` file.
-However, you can only paste the steps into an inline script, so the test cannot have any other dependencies.
-* **If you have any dependencies, you have a complex test suite, or your tests need to live with your
-application code: <<synthetics-test-suite>>.**
-Any dependencies need to be defined with an `import` outside of the `journey` object and run via the test suite.
+* If you want to invoke a single journey with few steps, <<synthetics-inline-journey,run an inline journey>>.
+This can be more efficient, but has some limitations like not supporting dependencies.
+* If you have any dependencies, you have a complex test suite, or your tests need to live with your
+application code, <<synthetics-test-suite,run a test suite>>. Any dependencies need to be defined with an
+`import` outside of the `journey` object and run via the test suite.
 
 [discrete]
 [[synthetics-inline-journey]]
 === Run an inline journey
 
 The easiest way to run a synthetic test is by creating an inline journey.
-The `journey` keyword isn't required, and access to variables like `page` and `params` is automatic. You cannot `import` any dependencies using inline scripts.
+The `journey` keyword isn't required, and access to variables like `page` and `params` is automatic.
+You cannot `import` any dependencies using inline scripts.
 
-Copy and paste your test steps into `heartbeat.yml`.
-{heartbeat} spawns a separate Node.js process, schedules your tests, and runs them on a chromium browser.
+To test an inline example locally, change into the directory of your test
+and pipe the file contents to the `npx @elastic/synthetics` command.
 
-There is an example inline journey in the
-https://github.com/elastic/synthetics-demo/blob/main/heartbeat/monitors.d/browser-inline.yml[elastic/synthetics] GitHub repository:
+For example, create a `sample.js` file containing steps:
 
 [source,js]
 ----
-// test-homepage-hover.js
 step("load homepage", async () => {
     await page.goto('https://www.elastic.co');
 });
@@ -198,13 +196,11 @@ step("hover over products menu", async () => {
 });
 ----
 
-To run an inline example locally change into the directory of your test
-and pipe the file contents to the `npx @elastic/synthetics` command.
-For example:
+Then test the sample file:
 
 [source,sh]
 ----
-cat examples/inline/short.js | npx @elastic/synthetics --inline
+cat path/to/sample.js | npx @elastic/synthetics --inline
 ----
 
 And you'll get a response similar to:
@@ -218,28 +214,16 @@ Journey: inline
  2 passed (2511 ms)
 ----
 
-The script can then be copied into your in your `heartbeat.yml`:
+After testing locally, you can copy the script into your
+Elastic Synthetics integration configuration or `heartbeat.yml`.
 
-[source,yml]
-----
-heartbeat.monitors:
-- type: browser
-  id: elastic-website
-  name: Elastic website
-  schedule: "@every 1m"
-  source:
-    inline:
-      script: |-
-        step("load homepage", async () => {
-            await page.goto('https://www.elastic.co');
-        });
-        step("hover over products menu", async () => {
-            await page.hover('css=[data-nav-item=products]');
-        });
-----
-
-You can either spin up {heartbeat} yourself, or jump to <<synthetics-quickstart-step-three>>
-to use the provided Docker project template.
+* **{agent} and {fleet}**: Add an inline journey when configuring the Elastic Synthetics integration.
+In Monitor settings, use Monitor Type "Browser" and switch the Source Type to "Inline script".
+See <<synthetics-quickstart-fleet>> for details.
+* **{heartbeat}**: Copy and paste your test steps into `heartbeat.yml`.
+{heartbeat} spawns a separate Node.js process, schedules your tests, and runs them on a chromium browser.
+You can jump to <<synthetics-quickstart-step-two>> if you're using the the provided Docker
+project template or spin up {heartbeat} yourself.
 
 [discrete]
 [[synthetics-test-suite]]
@@ -248,7 +232,7 @@ to use the provided Docker project template.
 If you have a suite of tests to implement, you can use Elastic Synthetics as a library.
 In this method, you use Docker to run both {heartbeat} and `elastic-synthetics`.
 
-Start by installing the `@elastic/synthetics` package globally:
+To test an inline example locally, start by installing the `@elastic/synthetics` package globally:
 
 [source,sh]
 ----
@@ -274,59 +258,38 @@ cd synthetics/examples/todos/ &&\
 npm install
 ----
 
-You are now inside the a synthetics test-suite, which is also an NPM project.
+You are now inside the a synthetics test suite, which is also an NPM project.
 You can now run the provided tests. By default only files matching the filename `*.journey.(ts|js)*`
 will be run.
 
 [source,sh]
 ----
-# Run tests on the current directory. Please note the dot `.` which indicates 
-# that we want to run tests on the current directory
+# Run tests on the current directory. The dot `.` indicates
+# that it should run all tests in the current directory.
 npx @elastic/synthetics .
 ----
 
-Once you have your tests up and running, follow the steps in <<synthetics-quickstart,Synthetic monitoring using Docker>>
-to integrate with the provided Docker project template.
+After testing locally, you can run the test suite using the
+Elastic Synthetics integration configuration or `heartbeat.yml`.
+
+* **{agent} and {fleet}**: Add a test suite when configuring the Elastic Synthetics integration.
+Use Monitor Type "Browser" and use the Source Type "Zip URL" pointing to a zip file containing the test project.
+See <<synthetics-quickstart-fleet>> for details.
+* **{heartbeat}**: Copy and paste the path to your zip file into `heartbeat.yml`.
+You can jump to <<synthetics-quickstart-step-two>> if you're using the the provided Docker
+project template or spin up {heartbeat} yourself.
 
 [discrete]
 [[synthetics-ci]]
-==== Run a test suite on CI
+=== Run on CI
 
 In addition to replacing your end-to-end tests locally, you can run a synthetic test suite on your CI environment.
 
-You can run `@elastic/synthetics` in a CI environment to execute journeys. Elastic's synthetics runner can output results in multiple formats, including JSON and JUnit (the standard format supported by most CI platforms). If any of your journeys fail, it will yield a non-zero exit code, which most CI systems pick up as a failure. 
+You can run `@elastic/synthetics` in a CI environment to execute journeys.
+Elastic's synthetics runnercan output results in multiple formats, including JSON and JUnit
+(the standard format supported by most CI platforms).
+If any of your journeys fail, it will yield a non-zero exit code, which most CI systems pick up as a failure. 
 
-You can see an example using GitHub Actions in the https://github.com/elastic/synthetics-demo/blob/main/.github/workflows/run-synthetics.yml[elastic/synthetics] repository. This example sets up a job that executes the synthetics runner and tells the runner to yield results in a JUnit format.
-
-// Results. . .
-// [source,sh]
-// ----
-// Journey: basic addition and completion of single task
-//    ✓  Step: 'go to app' succeeded (150 ms)
-//    ✓  Step: 'add task Dont put salt in your eyes' succeeded (79 ms)
-//    ✓  Step: 'check that task list has exactly 1 elements' succeeded (7 ms)
-//    ✓  Step: 'check for task 'Don't put salt in your eyes' in list' succeeded (50 ms)
-//    ✓  Step: 'destroy task 'Don't put salt in your eyes'' succeeded (75 ms)
-//    ✓  Step: 'check that task list has exactly 0 elements' succeeded (2 ms)
-
-// Journey: adding and removing a few tasks
-//    ✓  Step: 'go to app' succeeded (125 ms)
-//    ✓  Step: 'add task Task 1' succeeded (40 ms)
-//    ✓  Step: 'add task Task 2' succeeded (49 ms)
-//    ✓  Step: 'add task Task 3' succeeded (21 ms)
-//    ✓  Step: 'check that task list has exactly 3 elements' succeeded (8 ms)
-//    ✓  Step: 'destroy task 'Task 2'' succeeded (94 ms)
-//    ✓  Step: 'check that task list has exactly 2 elements' succeeded (5 ms)
-//    ✓  Step: 'add task Task 4' succeeded (36 ms)
-//    ✓  Step: 'check that task list has exactly 3 elements' succeeded (4 ms)
-
-// Journey: check that title is present
-//    ✓  Step: 'go to app' succeeded (139 ms)
-//    ✓  Step: 'check title is present' succeeded (27 ms)
-
-// Journey: check that input placeholder is correct
-//    ✓  Step: 'go to app' succeeded (121 ms)
-//    ✓  Step: 'check title is present' succeeded (18 ms)
-
-//  19 passed (2983 ms)
-// ----
+You can see an example using GitHub Actions in the
+https://github.com/elastic/synthetics-demo/blob/main/.github/workflows/run-synthetics.yml[elastic/synthetics] repository.
+This example sets up a job that executes the synthetics runner and tells the runner to yield results in a JUnit format.

--- a/docs/en/observability/synthetics-create-test.asciidoc
+++ b/docs/en/observability/synthetics-create-test.asciidoc
@@ -210,7 +210,7 @@ Journey: inline
 ----
 
 After testing locally, you can copy the script into your
-Elastic Synthetics integration configuration or `heartbeat.yml`.
+Elastic Synthetics integration or `heartbeat.yml`.
 
 * **{agent} and {fleet}**: Add an inline journey when configuring the Elastic Synthetics integration.
 In Monitor settings, use Monitor Type "Browser" and switch the Source Type to "Inline script".
@@ -254,7 +254,7 @@ npm install
 ----
 
 You are now inside the synthetics test suite, which is also an NPM project.
-You can now run the provided tests.
+From this folder, you can run the provided tests.
 By default only files matching the filename `*.journey.(ts|js)*` will be run.
 
 [source,sh]
@@ -265,7 +265,7 @@ npx @elastic/synthetics .
 ----
 
 After testing locally, you can run the test suite using the
-Elastic Synthetics integration configuration or `heartbeat.yml`.
+Elastic Synthetics integration or `heartbeat.yml`.
 
 * **{agent} and {fleet}**: Add a test suite when configuring the Elastic Synthetics integration.
 Use Monitor Type "Browser" and use the Source Type "Zip URL" pointing to a zip file containing the test project.

--- a/docs/en/observability/synthetics-create-test.asciidoc
+++ b/docs/en/observability/synthetics-create-test.asciidoc
@@ -161,6 +161,7 @@ journey('Ensure placeholder is correct', ({ page }) => {
 });
 ----
 
+[discrete]
 [[synthetic-run-tests]]
 == Run synthetic tests
 
@@ -286,6 +287,16 @@ npx @elastic/synthetics .
 
 Once you have your tests up and running, follow the steps in <<synthetics-quickstart,Synthetic monitoring using Docker>>
 to integrate with the provided Docker project template.
+
+[discrete]
+[[synthetics-ci]]
+==== Run a test suite on CI
+
+In addition to replacing your end-to-end tests locally, you can run a synthetic test suite on your CI environment.
+
+You can run `@elastic/synthetics` in a CI environment to execute journeys. Elastic's synthetics runner can output results in multiple formats, including JSON and JUnit (the standard format supported by most CI platforms). If any of your journeys fail, it will yield a non-zero exit code, which most CI systems pick up as a failure. 
+
+You can see an example using GitHub Actions in the https://github.com/elastic/synthetics-demo/blob/main/.github/workflows/run-synthetics.yml[elastic/synthetics] repository. This example sets up a job that executes the synthetics runner and tells the runner to yield results in a JUnit format.
 
 // Results. . .
 // [source,sh]

--- a/docs/en/observability/synthetics-create-test.asciidoc
+++ b/docs/en/observability/synthetics-create-test.asciidoc
@@ -11,7 +11,7 @@
 
 beta[] To write synthetic tests for your application, you'll need to know basic JavaScript and
 {playwright-url}[Playwright] syntax.
-Synthetics agent exposes a an API for creating and running tests:
+The Elastic Synthetics agent exposes a an API for creating and running tests:
 
 * `journey(name, ({ page, browser, context, params }) => {})` -- A journey tests one discrete unit of functionality.
 For example, logging into a website, adding something to a cart, or joining a mailing list.
@@ -36,12 +36,12 @@ It is reliable and fast and features a modern API that auto waits for page eleme
 [[synthetics-create-journey]]
 == Write a synthetic test
 
-Start by creating a new file called using the `.journey.ts` or `.journey.js` file extension,
+Start by creating a new file using the `.journey.ts` or `.journey.js` file extension,
 importing the synthetics library, and adding a new journey.
-A journey tests one discrete unit of functionality.
+A _journey_ tests one discrete unit of functionality.
 For example, logging into a website, adding something to a cart, or joining a mailing list.
 
-The journey function takes two parameters: a `name`, and a `callback`.
+The journey function takes two parameters: a `name` and a `callback`.
 The `name` helps you identify an individual journey.
 The `callback` argument is a function that encapsulates what the journey does.
 
@@ -63,7 +63,7 @@ The callback provides access to fresh Playwright `page`, `params`, `browser`, an
                 that doesn't share cookies or cache with other browser contexts.
 `params`::      User-defined variables that allow you to invoke the Synthetics suite with custom parameters.
                 For example, if you want to use a different homepage depending on the `env`
-                (localhost for `dev`, and a URL for `prod`). See <<synthetics-params-secrets>>
+                (`localhost` for `dev` and a URL for `prod`). See <<synthetics-params-secrets>>
                 for more information.
 
 
@@ -127,7 +127,8 @@ step('Assert placeholder text', async () => {
   expect(placeholderValue).toBe('What needs to be done?'); <2>
 });
 ----
-<1> Find the `input` element with class `new-todo` and get the value of the `placeholder` attribute. See the https://playwright.dev/docs/api/class-page#page-get-attribute[`page.getAttribute` reference] for more information.
+<1> Find the `input` element with class `new-todo` and get the value of the `placeholder` attribute.
+See the https://playwright.dev/docs/api/class-page#page-get-attribute[`page.getAttribute` reference] for more information.
 <2> Use the assertion library provided by the Synthetics agent to look for the
 expected value. See https://jestjs.io/docs/expect[Jest expect docs] for more information.
 
@@ -163,17 +164,16 @@ There are two ways to run synthetic tests:
 
 * If you want to create a single journey and manage it in isolation from monitors containing other journeys,
 <<synthetics-inline-journey,use an inline journey>>.
-Inline journeys can be more efficient, but have some limitations like not supporting multiple journeys and other dependencies.
+Inline journeys can be more efficient, but have some limitations like not supporting dependencies or multiple journeys.
 * If you have multiple journeys, rely on dependencies, or your tests need to live with your
-application code, <<synthetics-test-suite,use a test suite>>. Any dependencies need to be defined with an
-`import` outside of the `journey` object and run via the test suite.
+application code, <<synthetics-test-suite,use a test suite>>.
 
 [discrete]
 [[synthetics-inline-journey]]
 === Use an inline journey
 
 The easiest way to run a synthetic test is by creating an inline journey.
-The `journey` keyword isn't required, and access to variables like `page` and `params` is automatic.
+The `journey` keyword isn't required and access to variables like `page` and `params` is automatic.
 You cannot `import` any dependencies using inline scripts.
 
 To test an inline example locally, change into the directory of your test
@@ -183,10 +183,10 @@ For example, create a `sample.js` file containing steps:
 
 [source,js]
 ----
-step("load homepage", async () => {
+step('load homepage', async () => {
     await page.goto('https://www.elastic.co');
 });
-step("hover over products menu", async () => {
+step('hover over products menu', async () => {
     await page.hover('css=[data-nav-item=products]');
 });
 ----
@@ -217,8 +217,7 @@ In Monitor settings, use Monitor Type "Browser" and switch the Source Type to "I
 See <<synthetics-quickstart-fleet>> for details.
 * **{heartbeat}**: Copy and paste your test steps into `heartbeat.yml`.
 {heartbeat} spawns a separate Node.js process, schedules your tests, and runs them on a chromium browser.
-You can jump to <<synthetics-quickstart-step-two>> if you're using the provided Docker
-project template or spin up {heartbeat} yourself.
+See <<synthetics-quickstart-step-two>> for details.
 
 [discrete]
 [[synthetics-test-suite]]
@@ -239,6 +238,7 @@ Then write your tests:
 . Create a new https://docs.npmjs.com/cli/v7/commands/npm-init[NPM/Node.js project].
 . Create a `javascript` or `typescript` file that imports your tests.
 All synthetic test files must use the `.journey.ts` or `.journey.js` file extension.
+. Make sure any dependencies are defined with an `import` outside of the `journey` object.
 . Compile everything together.
 
 Find examples in the https://github.com/elastic/synthetics[elastic/synthetics] repository.
@@ -253,9 +253,9 @@ cd synthetics/examples/todos/ &&\
 npm install
 ----
 
-You are now inside the a synthetics test suite, which is also an NPM project.
-You can now run the provided tests. By default only files matching the filename `*.journey.(ts|js)*`
-will be run.
+You are now inside the synthetics test suite, which is also an NPM project.
+You can now run the provided tests.
+By default only files matching the filename `*.journey.(ts|js)*` will be run.
 
 [source,sh]
 ----
@@ -271,8 +271,7 @@ Elastic Synthetics integration configuration or `heartbeat.yml`.
 Use Monitor Type "Browser" and use the Source Type "Zip URL" pointing to a zip file containing the test project.
 See <<synthetics-quickstart-fleet>> for details.
 * **{heartbeat}**: Copy and paste the path to your zip file into `heartbeat.yml`.
-You can jump to <<synthetics-quickstart-step-two>> if you're using the provided Docker
-project template or spin up {heartbeat} yourself.
+See <<synthetics-quickstart-step-two>> for details.
 
 [discrete]
 [[synthetics-ci]]
@@ -280,11 +279,10 @@ project template or spin up {heartbeat} yourself.
 
 In addition to replacing your end-to-end tests locally, you can run a synthetic test suite on your CI environment.
 
-You can run `@elastic/synthetics` in a CI environment to execute journeys.
 Elastic's synthetics runner can output results in multiple formats, including JSON and JUnit
 (the standard format supported by most CI platforms).
 If any of your journeys fail, it will yield a non-zero exit code, which most CI systems pick up as a failure. 
 
 You can see an example using GitHub Actions in the
-https://github.com/elastic/synthetics-demo/blob/main/.github/workflows/run-synthetics.yml[elastic/synthetics] repository.
+https://github.com/elastic/synthetics-demo/blob/main/.github/workflows/run-synthetics.yml[elastic/synthetics-demo] repository.
 This example sets up a job that executes the synthetics runner and tells the runner to yield results in a JUnit format.

--- a/docs/en/observability/synthetics-create-test.asciidoc
+++ b/docs/en/observability/synthetics-create-test.asciidoc
@@ -13,7 +13,7 @@ beta[] To write synthetic tests for your application, you'll need to know basic 
 {playwright-url}[Playwright] syntax.
 Synthetics agent exposes a an API for creating and running tests:
 
-* `journey(name, ({ page, browser, client, params }) => {})` -- A journey tests one discrete unit of functionality.
+* `journey(name, ({ page, browser, context, params }) => {})` -- A journey tests one discrete unit of functionality.
 For example, logging into a website, adding something to a cart, or joining a mailing list.
 Each journey provides a fresh playwright `browser`, `context`, and `page` instance.
 See <<synthetics-create-journey>> for more information.
@@ -33,52 +33,87 @@ TIP: {playwright-url}[Playwright] is browser testing library developed by Micros
 It is reliable and fast and features a modern API that auto waits for page elements to be ready.
 
 [discrete]
+[[synthetics-install]]
+== Install Elastic Synthetics
+
+Before creating your first synthetic journey, create a `package.json` file within your test's directory. To do this quickly, you can run `npm init -y`.
+
+Then, install the synthetics runner as a dev-dependency using `npm install -D @elastic/synthetics`.
+
+[discrete]
 [[synthetics-create-journey]]
-=== Create a `journey`
+== Create a `journey`
 
-The `journey` function takes a single parameter, `name`,
-and provides access to `page`, `params`, `browser`, and `context`:
+A journey tests one discrete unit of functionality.
+For example, logging into a website, adding something to a cart, or joining a mailing list.
 
-* `browser` -- A {playwright-api-docs}[browser] object created by Playwright.
-* `page` -- A https://playwright.dev/docs/api/class-page[page] object from Playwright that lets you control the browser's current page.
-* `context` -- A https://playwright.dev/docs/api/class-browsercontext[browser context] that doesn't share cookies or cache with other browser contexts.
-* `params` -- User-defined variables that allow you to invoke the Synthetics suite with custom parameters.
-For example, if you want to use a different homepage depending on the `env`
-(localhost for `dev`, and a URL for `prod`). See <<synthetics-params-secrets>>
-for more information.
-
-Putting it all together, a basic, two step journey might look something like this:
+Start by creating a new file called that follows the pattern `*.journey.js`,
+importing the synthetics library, and adding a new journey.
 
 [source,js]
 ----
-journey("Journey name", ({ page }) => {
-    step("Step 1 name", () => {
-      // Do something here
-    })
-    step("Step 2 name", () => {
-      // Do something else here
-    })
+import { journey } from '@elastic/synthetics';
+
+journey('Journey name', ({ page, browser, context, params }) => {
+  // Add steps here
 });
 ----
 
+The `journey` function takes a single parameter, `name` ('Journey name' in the example above).
+Then you pass a callback to the global `journey` function to encapsulate the whole test.
+This callback function provides access to fresh Playwright `page`, `params`, `browser`, and `context` instances.
+
+[horizontal]
+`name`::        A string you provide to describe the journey.
+`page`::        A https://playwright.dev/docs/api/class-page[page] object from Playwright
+                that lets you control the browser's current page.
+`browser`::     A {playwright-api-docs}[browser] object created by Playwright.
+`context`::     A https://playwright.dev/docs/api/class-browsercontext[browser context] 
+                that doesn't share cookies or cache with other browser contexts.
+`params`::      User-defined variables that allow you to invoke the Synthetics suite with custom parameters.
+                For example, if you want to use a different homepage depending on the `env`
+                (localhost for `dev`, and a URL for `prod`). See <<synthetics-params-secrets>>
+                for more information.
+
+
 [discrete]
 [[synthetics-create-step]]
-=== Create a `step`
+=== Add steps
 
-Steps can be as simple or complex as you need them to be.
-The {playwright-api-docs}[Playwright page API reference] will be your friend while writing tests.
+A journey consists of multiple _steps_. Steps are actions that should be completed in a specific order.
+Steps are displayed individually in the {uptime-app} for easy debugging and error tracking.
 
-A basic first step might simply load a page:
+A basic two-step journey would look like this:
 
 [source,js]
 ----
-await page.goto('https://elastic.github.io/synthetics-demo/'); <1>
+import { journey, step, expect } from '@elastic/synthetics';
+
+journey('Journey name', ({ page, browser, client, params }) => {
+    step('Step 1 name', () => {
+      // Do something here
+    });
+    step('Step 2 name', () => {
+      // Do something else here
+    });
+});
+----
+
+Steps can be as simple or complex as you need them to be.
+For example, a basic first step might load a web page:
+
+[source,js]
+----
+step('Load the demo page', () => {
+  await page.goto('https://elastic.github.io/synthetics-demo/'); <1>
+});
 ----
 <1> See the https://playwright.dev/docs/api/class-page#page-goto[`page.goto` reference] for more information.
 
-A more complex second step might wait for a page element to be selected,
+A more complex step might wait for a page element to be selected
 and then ensure that it matches an expected value.
-Consider the following HTML snippet:
+
+For example, on a page using the following HTML:
 
 [source,html]
 ----
@@ -90,27 +125,26 @@ Consider the following HTML snippet:
 </header>
 ----
 
-You can verify that `new-todo` class element contains the expected `placeholder` (input hint)
-with the following test:
+You can verify that the `input` element with class `new-todo` contains the expected `placeholder` value
+(the hint text for `input` elements) with the following test:
 
 [source,js]
 ----
-step("Check placeholder text", async () => {
+step('Assert placeholder text', async () => {
   const placeholderValue = await page.getAttribute(
       'input.new-todo',
       'placeholder'
   ); <1>
   expect(placeholderValue).toBe('What needs to be done?'); <2>
-})
+});
 ----
-<1> Query the page for the `input.new-todo` selector and get the `placeholder`
-attribute value. See the https://playwright.dev/docs/api/class-page#page-get-attribute[`page.getAttribute` reference] for more information.
+<1> Find the `input` element with class `new-todo` and get the value of the `placeholder` attribute. See the https://playwright.dev/docs/api/class-page#page-get-attribute[`page.getAttribute` reference] for more information.
 <2> Use the assertion library provided by the Synthetics agent to look for the
 expected value. See https://jestjs.io/docs/expect[Jest expect docs] for more information.
 
 [discrete]
 [[synthetics-sample-test]]
-=== Sample Synthetic test
+=== Sample synthetic test
 
 A complete example of a basic synthetic test looks like this:
 
@@ -118,17 +152,17 @@ A complete example of a basic synthetic test looks like this:
 ----
 import { journey, step, expect } from '@elastic/synthetics';
 
-journey("Ensure placeholder is correct", ({page}) => {
-    step("go to todos demo page", async () => {
-      await page.goto('https://elastic.github.io/synthetics-demo/');
-    })
-    step("assert placeholder text", async () => {
-      const placeholderValue = await page.getAttribute(
-        'input.new-todo',
-        'placeholder'
-      );
-      expect(placeholderValue).toBe('What needs to be done?');
-    })
+journey('Ensure placeholder is correct', ({ page }) => {
+  step('Load the demo page', async () => {
+    await page.goto('https://elastic.github.io/synthetics-demo/');
+  });
+  step('Assert placeholder text', async () => {
+    const placeholderValue = await page.getAttribute(
+      'input.new-todo',
+      'placeholder'
+    );
+    expect(placeholderValue).toBe('What needs to be done?');
+  });
 });
 ----
 


### PR DESCRIPTION
Fixes #1611 

Incorporates content from the [Why and how to replace end-to-end tests with synthetic monitors](https://www.elastic.co/blog/why-and-how-replace-end-to-end-tests-synthetic-monitors) blog into synthetic monitoring docs and proposes some restructuring including:

- [x] **Update content on creating your first synthetic journeys** (https://github.com/elastic/observability-docs/commit/5253a1f46ea707bd2861cfd0d97f64f7c7681099)
    * Consistently use `context` (instead of `client`). 
    * Explain what's happening in steps in more detail.
- [x] **Add more about why synthetic monitoring is beneficial to intro** (https://github.com/elastic/observability-docs/commit/9bcb0cee44d75378a9214961ee68cd2f512d8b58)
    * Start with "why" so readers can quickly decide if this topic is relevant to them.
    * Be explicit about the problem we're solving (i.e. end-to-end tests alone can't prove your software works).
    * Outline how the solution works at a high level.
    * Then get into the details of the two types of synthetic monitoring (real browser and lightweight) and link out for more details.
- [x] **Restructure section on running synthetic tests** (https://github.com/elastic/observability-docs/commit/e2714adfbcca1920738152c55168854320f00764 + https://github.com/elastic/observability-docs/commit/6394671ebd1ae4cb33659fa5b225601f7554bf40)
    * Start with "if these conditions are true..." so the reader first sees their situation reflected then lead into "...then use x approach". This helps the reader identify what content is relevant to them quickly and skip content that is not relevant.
    * Stop referring to set up guides on Elastic Agent / Fleet and Docker as "quickstarts" since we don't call them that anywhere except the URL.
    * Use `{heartbeat}`.
- [x] **Add a section on running a synthetics test suite on CI** (https://github.com/elastic/observability-docs/commit/a2c88490190bbbd30c186537d3ef365118c584eb)
- [x] ~~**Automatically update monitors** (https://github.com/elastic/observability-docs/pull/1693/commits/f005c0a9e4f254e5d93f813ba0b0a880cd6b889f)~~ Already included in [Configure an Elastic Synthetics integration policy](https://www.elastic.co/guide/en/observability/current/synthetics-quickstart-fleet.html#synthetics-quickstart-fleet-configure-policy)
- [x] ~~**Running tests against multiple environments**~~ maybe covered in [Working with params and secrets](https://www.elastic.co/guide/en/observability/current/synthetics-params-secrets.html)? though maybe spelling out an example would be helpful.

@lucasfcosta are there any other topics you think we should transfer over from the blog to the docs? 

cc @ollyhowell @andrewvc 