### PR TITLE
Update create-cases.asciidoc

### DIFF
--- a/docs/en/observability/create-cases.asciidoc
+++ b/docs/en/observability/create-cases.asciidoc
@@ -9,7 +9,7 @@ You can also send cases to third party systems by <<cases-external-connectors,co
 image::images/cases.png[Cases page]
 
 NOTE: If you create cases in {stack-manage-app} or the {security-app}, they are not
-visible in *{observability}*. Likewise, the cases you create in {observability}
+visible in {observability}. Likewise, the cases you create in {observability}
 are not visible in {stack-manage-app} or the {security-app}.
 You also cannot attach alerts from {stack-manage-app} or the {security-app} to
 cases in {observability}.

--- a/docs/en/observability/create-cases.asciidoc
+++ b/docs/en/observability/create-cases.asciidoc
@@ -8,3 +8,8 @@ You can also send cases to third party systems by <<cases-external-connectors,co
 [role="screenshot"]
 image::images/cases.png[Cases page]
 
+NOTE: If you create cases in {stack-manage-app} or the {security-app}, they are not
+visible in *{observability}*. Likewise, the cases you create in {observability}
+are not visible in {stack-manage-app} or the {security-app}.
+You also cannot attach alerts from {stack-manage-app} or the {security-app} to
+cases in {observability}.


### PR DESCRIPTION
### Summary

This PR adds a `NOTE` to the Observability [Cases](https://www.elastic.co/guide/en/observability/master/create-cases.html) documentation explaining the current disconnect between Cases opened in different Kibana apps. The wording is copied from Stack management's [Cases](https://www.elastic.co/guide/en/kibana/master/cases.html) documentation.