### PR TITLE
docs: log correlation is auto enabled

### DIFF
--- a/docs/en/observability/monitor-java-app.asciidoc
+++ b/docs/en/observability/monitor-java-app.asciidoc
@@ -1929,16 +1929,8 @@ find bottlenecks faster.
 [discrete]
 ==== Log correlation
 
-By configuring the agent, let's ease the
-{apm-java-ref}/config-logging.html#config-enable-log-correlation[correlation
-of logs] by adding the transaction ids to our logs.
-
-[source,bash]
-----
-ELASTIC_APM_ENABLE_LOG_CORRELATION=true
-----
-
-You can now check the generated log files that are sent
+Transaction ids are automatically added to logs.
+You can check the generated log files that are sent
 to {es} via {filebeat}. An entry looks like this.
 
 [source,json]


### PR DESCRIPTION
Fixes:

```
08:40:20 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/observability/7.10/monitor-java-app.html contains broken links to:
08:40:20 INFO:build_docs:   - en/apm/agent/java/current/config-logging.html#config-enable-log-correlation
08:40:20 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/observability/7.11/monitor-java-app.html contains broken links to:
08:40:20 INFO:build_docs:   - en/apm/agent/java/current/config-logging.html#config-enable-log-correlation
08:40:20 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/observability/7.12/monitor-java-app.html contains broken links to:
08:40:20 INFO:build_docs:   - en/apm/agent/java/current/config-logging.html#config-enable-log-correlation
08:40:20 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/observability/7.13/monitor-java-app.html contains broken links to:
08:40:20 INFO:build_docs:   - en/apm/agent/java/current/config-logging.html#config-enable-log-correlation
08:40:20 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/observability/7.14/monitor-java-app.html contains broken links to:
08:40:20 INFO:build_docs:   - en/apm/agent/java/current/config-logging.html#config-enable-log-correlation
08:40:20 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/observability/7.15/monitor-java-app.html contains broken links to:
08:40:20 INFO:build_docs:   - en/apm/agent/java/current/config-logging.html#config-enable-log-correlation
08:40:20 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/observability/7.16/monitor-java-app.html contains broken links to:
08:40:20 INFO:build_docs:   - en/apm/agent/java/current/config-logging.html#config-enable-log-correlation
08:40:20 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/observability/7.17/monitor-java-app.html contains broken links to:
08:40:20 INFO:build_docs:   - en/apm/agent/java/current/config-logging.html#config-enable-log-correlation
08:40:20 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/observability/8.0/monitor-java-app.html contains broken links to:
08:40:20 INFO:build_docs:   - en/apm/agent/java/current/config-logging.html#config-enable-log-correlation
08:40:20 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/observability/8.1/monitor-java-app.html contains broken links to:
08:40:20 INFO:build_docs:   - en/apm/agent/java/current/config-logging.html#config-enable-log-correlation
08:40:20 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/observability/current/monitor-java-app.html contains broken links to:
08:40:20 INFO:build_docs:   - en/apm/agent/java/current/config-logging.html#config-enable-log-correlation
08:40:20 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/observability/master/monitor-java-app.html contains broken links to:
08:40:20 INFO:build_docs:   - en/apm/agent/java/current/config-logging.html#config-enable-log-correlation
```

For https://github.com/elastic/apm-agent-java/issues/2535.