### PR TITLE
[7.13] docs: log correlation is auto enabled (#1709)

### DIFF
--- a/docs/en/observability/monitor-java-app.asciidoc
+++ b/docs/en/observability/monitor-java-app.asciidoc
@@ -1929,16 +1929,8 @@ find bottlenecks faster.
 [discrete]
 ==== Log correlation
 
-By configuring the agent, let's ease the
-{apm-java-ref}/config-logging.html#config-enable-log-correlation[correlation
-of logs] by adding the transaction ids to our logs.
-
-[source,bash]
-----
-ELASTIC_APM_ENABLE_LOG_CORRELATION=true
-----
-
-You can now check the generated log files that are sent
+Transaction ids are automatically added to logs.
+You can check the generated log files that are sent
 to {es} via {filebeat}. An entry looks like this.
 
 [source,json]


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.13`:
 - [docs: log correlation is auto enabled (#1709)](https://github.com/elastic/observability-docs/pull/1709)

<!--- Backport version: 8.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)