### PR TITLE
add minimal agent install docs

### DIFF
--- a/docs/en/observability/index.asciidoc
+++ b/docs/en/observability/index.asciidoc
@@ -46,6 +46,8 @@ include::ingest-traces.asciidoc[leveloffset=+3]
 
 include::ingest-splunk.asciidoc[leveloffset=+3]
 
+include::install-fleet-managed-agent.asciidoc[leveloffset=+3]
+
 include::deploy-beats-to-send-data.asciidoc[leveloffset=+2]
 
 include::ingest-logs.asciidoc[leveloffset=+3]

--- a/docs/en/observability/install-fleet-managed-agent.asciidoc
+++ b/docs/en/observability/install-fleet-managed-agent.asciidoc
@@ -1,0 +1,25 @@
+[[install-fleet-managed-agent]]
+= Install {fleet} managed {agent}
+
+This guide describes how to:
+
+* Install an {agent} that will be managed with {fleet}
+* Enroll the {agent} with {fleet}
+
+If you have come here from the {agent} download page, then you are in the right place.
+
+[discrete]
+[[minimal-add-agent-to-fleet]]
+== Step 1: Add an {agent} to {fleet}
+
+{agent} is a single, unified agent that you can deploy to hosts or containers to
+collect data and send it to the {stack}. Behind the scenes, {agent} runs the
+{beats} shippers or {elastic-endpoint} required for your configuration.
+
+include::{fleet-repo-dir}/elastic-agent/install-fleet-managed-elastic-agent.asciidoc[tag=install-elastic-agent]
+
+[[enroll-agent]]
+== Step 2: Enroll and start the {agent}
+
+Return to {kib} and follow the **Enroll and start the Elastic Agent** instructions.  The command provided in {kib} includes the information that {agent} needs to connect and authenticate with the {stack}.  When the {agent} enrolls it will be configured to send the data associated with the policy that you created.
+


### PR DESCRIPTION
This is to support the workflow from Kibana > Add Integrations > Agent > Fleet Managed.  In the Kibana flyout there is a step that tells the reader to download the agent, and that goes to a download page that does not have enough information, or a download page that includes too much information (info about installing Fleet, etc.).