### PR TITLE
[Fleet] Do not recommand user to run Fleet server in http

### DIFF
--- a/docs/en/ingest-management/tab-widgets/add-fleet-server/content.asciidoc
+++ b/docs/en/ingest-management/tab-widgets/add-fleet-server/content.asciidoc
@@ -81,8 +81,7 @@ sudo ./elastic-agent install \
   --fleet-server-es=http://localhost:9200 \
   --fleet-server-service-token=AAEbAWVsYXN0aWMvZmxlaXQtc2VydmVzL3Rva2VuLTE2MeIzNTY1NTQ3Mji6dERXeE9XbW5RRTZqNlJMWEdIRzAtZw \
   --fleet-server-policy=27467ed1-1bfd-11ec-9b88-a7c3d83e2897 \
-  --fleet-server-es-ca-trusted-fingerprint=3b24d33844d65532f0584d198b45006747521493522c1912608522bf175bc826 \
-  --fleet-server-insecure-http
+  --fleet-server-es-ca-trusted-fingerprint=3b24d33844d65532f0584d198b45006747521493522c1912608522bf175bc826 
 ----
 +
 The following command installs a {fleet-server} and uses certificates you


### PR DESCRIPTION
## Description 

Related to https://github.com/elastic/kibana/pull/129371

We should not recommend user to run Fleet server in http and should use the default self generated certificate instead.