### PR TITLE
Make http json input green in support table

### DIFF
--- a/docs/en/ingest-management/beats-agent-comparison.asciidoc
+++ b/docs/en/ingest-management/beats-agent-comparison.asciidoc
@@ -109,7 +109,7 @@ The following table shows the inputs supported by the {agent} in {version}:
 
 |HTTP JSON
 |{y}
-|{n}
+|{y}
 |{y}
 
 |Kafka


### PR DESCRIPTION
Changes the input to green.

Questions:

- [x] Which versions does this change apply to?
- [x] Do we need to add Filestream?