### PR TITLE
Remove locally defined `release-state` variable

### DIFF
--- a/docs/en/observability/ingest-logs.asciidoc
+++ b/docs/en/observability/ingest-logs.asciidoc
@@ -7,7 +7,6 @@
 :beatname_url: {beats-ref-root}/{beatname_lc}/{branch}
 :modulename: nginx
 :has_modules_command:
-:release-state: released
 
 [[ingest-logs]]
 = Ingest logs with {filebeat}
@@ -208,4 +207,3 @@ Now let's have a look at the <<monitor-logs,Logs app>>.
 :!beatname_pkg:
 :!modulename:
 :!has_modules_command:
-:!release-state:


### PR DESCRIPTION
Ref https://github.com/elastic/observability-docs/pull/1725#discussion_r848863081

From @bmorelli25 on the inclusion of `:release-state: released` and `:!release-state:` in [`/docs/en/observability/ingest-logs.asciidoc`](https://raw.githubusercontent.com/elastic/observability-docs/main/docs/en/observability/ingest-logs.asciidoc):

>That's a mistake and should be removed. That was added to overwrite the `:release-state:` attribute in the docs repo (https://github.com/elastic/docs/blob/master/shared/versions/stack/master.asciidoc#L21) which is always set to `unreleased` in `main` and `master`. Adding the overwrite at the beginning of the file (and then unsetting it at the end) allows the page contents to render for review purposes.

Not sure about backporting on a PR like this one! 