### PR TITLE
Add GitHub Actions

### DIFF
--- a/.github/workflows/add-issue-to-project.yml
+++ b/.github/workflows/add-issue-to-project.yml
@@ -11,7 +11,6 @@ jobs:
       - uses: octokit/graphql-action@v2.x
         id: add_issue
         with:
-          headers: '{"GraphQL-Features": "projects_next_graphql"}'
           query: |
             mutation($project:ID!, $issue:ID!){
               addProjectNextItem(input: {projectId: $project, contentId: $issue}){

--- a/.github/workflows/add-issue-to-project.yml
+++ b/.github/workflows/add-issue-to-project.yml
@@ -1,0 +1,27 @@
+name: add-issue-to-project
+on:
+  issues:
+    types:
+      - opened
+jobs:
+  add_issue_to_inbox:
+    name: Add issue to inbox
+    runs-on: ubuntu-latest
+    steps:
+      - uses: octokit/graphql-action@v2.x
+        id: add_issue
+        with:
+          headers: '{"GraphQL-Features": "projects_next_graphql"}'
+          query: |
+            mutation($project:ID!, $issue:ID!){
+              addProjectNextItem(input: {projectId: $project, contentId: $issue}){
+                projectNextItem{
+                  id
+                }
+              }
+            }
+          project: ${{ env.PROJECT_ID }}
+          issue: ${{ github.event.issue.node_id }}
+        env:
+          PROJECT_ID: "PNI_lADOAGc3Zs0iZ84AOxSz"
+          GITHUB_TOKEN: ${{ secrets.APM_TECH_USER_TOKEN }}

--- a/.github/workflows/add-issue-to-project.yml
+++ b/.github/workflows/add-issue-to-project.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: octokit/graphql-action@v2.x
-        id: add_issue
+        id: add_issue_to_board
         with:
           query: |
             mutation($project:ID!, $issue:ID!){
@@ -21,6 +21,24 @@ jobs:
             }
           project: ${{ env.PROJECT_ID }}
           issue: ${{ github.event.issue.node_id }}
+        env:
+          PROJECT_ID: "PNI_lADOAGc3Zs0iZ84AOxSz"
+          GITHUB_TOKEN: ${{ secrets.APM_TECH_USER_TOKEN }}
+      - uses: octokit/graphql-action@v2.x
+        id: move_issue_to_inbox
+        with:
+          query: |
+            mutation label_team($project:ID!, $item:ID!, $field:ID!, $value:String!){
+              updateProjectNextItemField(input: { projectId: $project, itemId: $item, fieldId: $field, value: $value }){
+                projectNextItem {
+                  id
+                }
+              }
+            }
+          project: ${{ env.PROJECT_ID }}
+          item: ${{ fromJSON(steps.add_issue_to_board.outputs.data).addProjectNextItem.projectNextItem.id }}
+          field: "MDE2OlByb2plY3ROZXh0RmllbGQ2NjA2OA=="
+          value: "947d05a0"
         env:
           PROJECT_ID: "PNI_lADOAGc3Zs0iZ84AOxSz"
           GITHUB_TOKEN: ${{ secrets.APM_TECH_USER_TOKEN }}

--- a/.github/workflows/add-issue-to-project.yml
+++ b/.github/workflows/add-issue-to-project.yml
@@ -8,6 +8,12 @@ jobs:
     name: Add issue to inbox
     runs-on: ubuntu-latest
     steps:
+      - name: Get token
+        id: get_token
+        uses: elastic/actions-app-token@master
+        with:
+          APP_PEM: ${{ secrets.OBS_DOCS_AUTOMATION_PRIVATE_KEY }}
+          APP_ID: 203735
       - uses: octokit/graphql-action@v2.x
         id: add_issue_to_board
         with:
@@ -23,7 +29,7 @@ jobs:
           issue: ${{ github.event.issue.node_id }}
         env:
           PROJECT_ID: "PN_kwDOAGc3Zs0iZw"
-          GITHUB_TOKEN: ${{ secrets.APM_TECH_USER_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.get_token.outputs.app_token }}
       - uses: octokit/graphql-action@v2.x
         id: move_issue_to_inbox
         with:
@@ -44,4 +50,4 @@ jobs:
           value: "947d05a0"
         env:
           PROJECT_ID: "PN_kwDOAGc3Zs0iZw"
-          GITHUB_TOKEN: ${{ secrets.APM_TECH_USER_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.get_token.outputs.app_token }}

--- a/.github/workflows/add-pr-to-project.yml
+++ b/.github/workflows/add-pr-to-project.yml
@@ -46,3 +46,18 @@ jobs:
         env:
           PROJECT_ID: "PN_kwDOAGc3Zs0iZw"
           GITHUB_TOKEN: ${{ secrets.APM_TECH_USER_TOKEN }}
+      - uses: octokit/graphql-action@v2.x
+        id: add_needs-writer-review_label
+        with:
+          query: |
+            mutation($item: ID!, $label: [ID!]!) {
+              addLabelsToLabelable(input: {labelableId: $item, labelIds:$label}) {
+                clientMutationId
+              }
+            }
+          # `item` is the ID returned by the first step
+          item: ${{ fromJSON(steps.add_pr_to_board.outputs.data).addProjectNextItem.projectNextItem.id }}
+          # an array of label IDs to add — just one in this case
+          label: "['LA_kwDOEHZbcs7wV_c6']"
+        env:
+          GITHUB_TOKEN: ${{ secrets.APM_TECH_USER_TOKEN }}

--- a/.github/workflows/add-pr-to-project.yml
+++ b/.github/workflows/add-pr-to-project.yml
@@ -1,31 +1,32 @@
-name: add-issue-to-project
+name: add-pr-to-project
 on:
-  issues:
-    types:
-      - opened
+  pull_request:
+    types: [review_requested]
 jobs:
-  add_issue_to_inbox:
-    name: Add issue to inbox
+  specific_review_requested:
     runs-on: ubuntu-latest
+    # The steps below only run for PRs where `obs-docs` has been added as a reviewer
+    if: ${{ github.event.requested_team.name == 'obs-docs'}}
     steps:
+      - run: echo 'A review from obs-docs was requested'
       - uses: octokit/graphql-action@v2.x
-        id: add_issue_to_board
+        id: add_pr_to_board
         with:
           query: |
-            mutation($project:ID!, $issue:ID!){
-              addProjectNextItem(input: {projectId: $project, contentId: $issue}){
+            mutation($project:ID!, $pull_request:ID!){
+              addProjectNextItem(input: {projectId: $project, contentId: $pull_request}){
                 projectNextItem{
                   id
                 }
               }
             }
           project: ${{ env.PROJECT_ID }}
-          issue: ${{ github.event.issue.node_id }}
+          pull_request: ${{ github.event.pull_request.node_id }}
         env:
           PROJECT_ID: "PN_kwDOAGc3Zs0iZw"
           GITHUB_TOKEN: ${{ secrets.APM_TECH_USER_TOKEN }}
       - uses: octokit/graphql-action@v2.x
-        id: move_issue_to_inbox
+        id: move_pr_to_review_column
         with:
           query: |
             mutation label_team($project:ID!, $item:ID!, $field:ID!, $value:String!){
@@ -37,11 +38,11 @@ jobs:
             }
           project: ${{ env.PROJECT_ID }}
           # `item` is the ID returned by the previous step
-          item: ${{ fromJSON(steps.add_issue_to_board.outputs.data).addProjectNextItem.projectNextItem.id }}
+          item: ${{ fromJSON(steps.add_pr_to_board.outputs.data).addProjectNextItem.projectNextItem.id }}
           # This is the ID for the project "status" attribute
           field: "MDE2OlByb2plY3ROZXh0RmllbGQ2NjA2OA=="
-          # This is the ID for the status sub-attribute "Inbox"
-          value: "947d05a0"
+          # This is the ID for the status sub-attribute "In Review"
+          value: "2d732740"
         env:
           PROJECT_ID: "PN_kwDOAGc3Zs0iZw"
           GITHUB_TOKEN: ${{ secrets.APM_TECH_USER_TOKEN }}

--- a/.github/workflows/add-pr-to-project.yml
+++ b/.github/workflows/add-pr-to-project.yml
@@ -8,7 +8,12 @@ jobs:
     # The steps below only run for PRs where `obs-docs` has been added as a reviewer
     if: ${{ github.event.requested_team.name == 'obs-docs'}}
     steps:
-      - run: echo 'A review from obs-docs was requested'
+      - name: Get token
+        id: get_token
+        uses: elastic/actions-app-token@master
+        with:
+          APP_PEM: ${{ secrets.OBS_DOCS_AUTOMATION_PRIVATE_KEY }}
+          APP_ID: 203735
       - uses: octokit/graphql-action@v2.x
         id: add_pr_to_board
         with:
@@ -24,7 +29,7 @@ jobs:
           pull_request: ${{ github.event.pull_request.node_id }}
         env:
           PROJECT_ID: "PN_kwDOAGc3Zs0iZw"
-          GITHUB_TOKEN: ${{ secrets.APM_TECH_USER_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.get_token.outputs.app_token }}
       - uses: octokit/graphql-action@v2.x
         id: move_pr_to_review_column
         with:
@@ -60,4 +65,4 @@ jobs:
           # an array of label IDs to add — just one in this case
           label: "['LA_kwDOEHZbcs7wV_c6']"
         env:
-          GITHUB_TOKEN: ${{ secrets.APM_TECH_USER_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.get_token.outputs.app_token }}


### PR DESCRIPTION
### Summary

This PR adds two GitHub Actions to the observability-docs repo:

#### `add-issue-to-project`
**Event**: When an issue is opened
**Job 1**: Add the issue to the obs-docs-project board
**Job 2**: Move the issue to the _Inbox_ column

#### `add-pr-to-project`

**Event**: When a PR review is requested
**If**: If `elastic/obs-docs` is a reviewer
**Job 1**:  Add the issue to the obs-docs-project board
**Job 2**: Move the issue to the _In review_ column
**Job 3**: Add the `needs-writer-review` label

I tested the mutations with Graph<i>i</i>QL and they work. I'm not sure how to test this PR though.

~The `APM_TECH_USER_TOKEN` must be added as a repository secret for this action to work.~ It sounds like that token is APM-specific. We're working on getting a different token added to this repository.