### PR TITLE
Add placeholder topic about generating certs for Logstash

### DIFF
--- a/docs/en/ingest-management/index.asciidoc
+++ b/docs/en/ingest-management/index.asciidoc
@@ -57,8 +57,6 @@ include::elastic-agent/install-elastic-agent.asciidoc[leveloffset=+1]
 
 include::elastic-agent/install-fleet-managed-elastic-agent.asciidoc[leveloffset=+2]
 
-include::security/certificates.asciidoc[leveloffset=+3]
-
 include::elastic-agent/install-standalone-elastic-agent.asciidoc[leveloffset=+2]
 
 include::elastic-agent/upgrade-standalone-elastic-agent.asciidoc[leveloffset=+3]
@@ -80,6 +78,12 @@ include::fleet-agent-proxy-support.asciidoc[leveloffset=+2]
 include::elastic-agent/uninstall-elastic-agent.asciidoc[leveloffset=+2]
 
 include::elastic-agent/start-stop-elastic-agent.asciidoc[leveloffset=+2]
+
+include::security/generate-certificates.asciidoc[leveloffset=+1]
+
+include::security/certificates.asciidoc[leveloffset=+2]
+
+include::security/logstash-certificates.asciidoc[leveloffset=+2]
 
 include::fleet/fleet.asciidoc[leveloffset=+1]
 

--- a/docs/en/ingest-management/security/certificates.asciidoc
+++ b/docs/en/ingest-management/security/certificates.asciidoc
@@ -1,5 +1,5 @@
 [[secure-connections]]
-= Encrypt traffic in clusters with a self-managed {fleet-server}
+= Configure SSL/TLS for self-managed {fleet-server}s
 
 If you're running a self-managed cluster, configure Transport Layer Security
 (TLS) to encrypt traffic between {agent}s, {fleet-server}, and other components

--- a/docs/en/ingest-management/security/generate-certificates.asciidoc
+++ b/docs/en/ingest-management/security/generate-certificates.asciidoc
@@ -1,0 +1,7 @@
+[[secure]]
+= Secure {agent} connections
+
+Some connections may require you to generate and configure SSL/TLS.
+
+* <<secure-connections>>
+* <<secure-logstash-connections>>

--- a/docs/en/ingest-management/security/generate-certificates.asciidoc
+++ b/docs/en/ingest-management/security/generate-certificates.asciidoc
@@ -1,7 +1,7 @@
 [[secure]]
 = Secure {agent} connections
 
-Some connections may require you to generate and configure SSL/TLS.
+Some connections may require you to generate certificates and configure SSL/TLS.
 
 * <<secure-connections>>
 * <<secure-logstash-connections>>

--- a/docs/en/ingest-management/security/logstash-certificates.asciidoc
+++ b/docs/en/ingest-management/security/logstash-certificates.asciidoc
@@ -1,0 +1,7 @@
+[[secure-logstash-connections]]
+= Configure SSL/TLS for {ls}
+
+coming[8.2.0]
+
+To send data from {agent} to {ls} securely, you need to configure Transport
+Layer Security (TLS).

--- a/docs/en/ingest-management/tab-widgets/add-fleet-server/content.asciidoc
+++ b/docs/en/ingest-management/tab-widgets/add-fleet-server/content.asciidoc
@@ -64,8 +64,8 @@ image::images/add-fleet-server.png[In-product instructions for adding a {fleet-s
 then select the policy here.
 
 * If you choose *Production* deployment mode, learn how to generate certs in
-{fleet-guide}/secure-connections.html[Encrypt traffic in clusters with a
-self-managed {fleet-server}].
+{fleet-guide}/secure-connections.html[Configure SSL/TLS for self-managed
+{fleet-server}s].
 
 * It's recommended you generate a unique service token for each
 {fleet-server}. For other ways to generate service tokens, see


### PR DESCRIPTION
Adds a placeholder topic about configuring TLS for Logstash. Preview link: https://observability-docs_1795.docs-preview.app.elstc.co/guide/en/fleet/master/secure-logstash-connections.html 

I've also reworked the TOC by adding a section about securing connections and made the section titles more consistent:

![image](https://user-images.githubusercontent.com/14206422/163863460-67292bb3-94f9-4c3b-b4ef-810fca6398e0.png)

We can revisit the structure when I work on the docs.

