### PR TITLE
Add temporary redirect for Synthetics Agent/Fleet quickstart guide

### DIFF
--- a/docs/en/observability/redirects.asciidoc
+++ b/docs/en/observability/redirects.asciidoc
@@ -23,3 +23,8 @@ Refer to <<monitoring-uptime>>.
 === Synthetic monitoring using Docker
 
 Refer to <<uptime-set-up>>.
+
+[role="exclude",id="synthetics-quickstart-fleet"]
+=== Synthetic monitoring using Elastic Agent and Fleet
+
+Refer to <<uptime-set-up>>.


### PR DESCRIPTION
In #1725 we combined the Docker and Agent/Fleet quickstart guides. I created a redirect for the Docker guide, but missed a redirect for Agent/Fleet (because there were no links from other docs to this page). This PR adds a temporary redirect for the Agent/Fleet quickstart guide. I will open another issue to request a permanent redirect now. 

@paulb-elastic @dominiqueclarke @jeffvestal 