### PR TITLE
Spec fallback: use integration type by default

### DIFF
--- a/docs/en/integrations/package-spec.asciidoc
+++ b/docs/en/integrations/package-spec.asciidoc
@@ -77,7 +77,7 @@ Included from the package-spec repository. This will update when the spec is upd
 
 [source,yaml]
 ----
-include::{package-spec}/spec.yml[]
+include::{package-spec}/integration/spec.yml[]
 ----
 
 [[dev-spec]]
@@ -91,7 +91,7 @@ Included from the package-spec repository. This will update when the spec is upd
 
 [source,yaml]
 ----
-include::{package-spec}/_dev/spec.yml[]
+include::{package-spec}/integration/_dev/spec.yml[]
 ----
 
 [[data-stream-spec]]
@@ -105,7 +105,7 @@ Included from the package-spec repository. This will update when the spec is upd
 
 [source,yaml]
 ----
-include::{package-spec}/data_stream/spec.yml[]
+include::{package-spec}/integration/data_stream/spec.yml[]
 ----
 
 [[docs-spec]]
@@ -119,7 +119,7 @@ Included from the package-spec repository. This will update when the spec is upd
 
 [source,yaml]
 ----
-include::{package-spec}/docs/spec.yml[]
+include::{package-spec}/integration/docs/spec.yml[]
 ----
 
 [[kibana-spec]]
@@ -133,7 +133,7 @@ Included from the package-spec repository. This will update when the spec is upd
 
 [source,yaml]
 ----
-include::{package-spec}/kibana/spec.yml[]
+include::{package-spec}/integration/kibana/spec.yml[]
 ----
 
 [[changelog-spec]]
@@ -147,7 +147,7 @@ Included from the package-spec repository. This will update when the spec is upd
 
 [source,yaml]
 ----
-include::{package-spec}/changelog.spec.yml[]
+include::{package-spec}/integration/changelog.spec.yml[]
 ----
 
 [[manifest-spec]]
@@ -162,5 +162,5 @@ Included from the package-spec repository. This will update when the spec is upd
 
 [source,yaml]
 ----
-include::{package-spec}/manifest.spec.yml[]
+include::{package-spec}/integration/manifest.spec.yml[]
 ----


### PR DESCRIPTION
This PR fixes the issue reported by [CI build](https://elasticsearch-ci.elastic.co/job/elastic+docs+master+build/21554/) after we merged this [PR](https://github.com/elastic/package-spec/pull/323).

In general, we didn't expect that there is code accessing those files directly. We should rather migrate this doc to the package-spec repo to prevent such failures in the future.

The reason why we introduced this change to package-spec is that we're working on [supporting another type](https://docs.google.com/document/d/1vzBh2frnlxEBBcab8-ist8pu_PDZUjOHdsV-QuUn_WA/edit#). 