### PR TITLE
Add temporary redirect for former intro to Synthetics/browser monitors page

### DIFF
--- a/docs/en/observability/redirects.asciidoc
+++ b/docs/en/observability/redirects.asciidoc
@@ -28,3 +28,8 @@ Refer to <<uptime-set-up>>.
 === Synthetic monitoring using Elastic Agent and Fleet
 
 Refer to <<uptime-set-up>>.
+
+[role="exclude" id="synthetic-monitoring"]
+=== Real browser synthetic monitoring
+
+Refer to <<monitoring-synthetics>>.


### PR DESCRIPTION
In #1725 we combined the intro to Synthetics/browser monitors and lightweight monitors into one intro page. This PR adds a temporary redirect for the former individual Synthetics/browser monitors intro page. I will open another issue to request a permanent redirect now. 

cc @paulb-elastic 