### PR TITLE
Fix log file names in 7.17 docs

### DIFF
--- a/docs/en/ingest-management/elastic-agent/configuration/elastic-agent-standalone-logging.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/elastic-agent-standalone-logging.asciidoc
@@ -91,7 +91,7 @@ Default: `true`
 
 include::{tab-widgets}/logging-widget.asciidoc[]
 
-Logs are numbered log.1, log.2, and so on as they are rotated off the main log.
+Log file names end with a number that includes a date: `elastic-agent-json.log-20220503173131`, `elastic-agent-json.log-20220503173135`, and so on as new files are created during rotation.
 
 | `agent.logging.files.name` | The name of the file that logs are written to.
 

--- a/docs/en/ingest-management/tab-widgets/install-layout.asciidoc
+++ b/docs/en/ingest-management/tab-widgets/install-layout.asciidoc
@@ -7,7 +7,7 @@ Main {agent} configuration
 `/Library/Elastic/Agent/fleet.yml`::
 Main {agent} {fleet} configuration
 `/Library/Elastic/Agent/data/elastic-agent-*/logs/elastic-agent-json.log`::
-Log files for {agent}footnote:lognumbering[Logs are numbered log.1, log.2, and so on as they are rotated off the main log.]
+Log files for {agent}footnote:lognumbering[Log file names end with a number that includes a date: `elastic-agent-json.log-20220503173131`, `elastic-agent-json.log-20220503173135`, and so on as new files are created during rotation.]
 `/Library/Elastic/Agent/data/elastic-agent-*/logs/default/*-json.log`::
 Log files for {beats} shippers
 `/usr/bin/elastic-agent`::

--- a/docs/en/ingest-management/troubleshooting/faq.asciidoc
+++ b/docs/en/ingest-management/troubleshooting/faq.asciidoc
@@ -25,12 +25,13 @@ The location of {agent} logs varies by platform. In general, {agent} stores
 logs under the `data` directory where {agent} was started. For example, on
 macOS, you'll find logs for the running {agent} under path similar to:
 
-`/Library/Elastic/Agent/data/elastic-agent-08e204/logs/elastic-agent-json.log`
+`/Library/Elastic/Agent/data/elastic-agent-08e204/logs/elastic-agent-json.log-20220503173131`
 
 You'll find logs for the {beats} shippers, such as {metricbeat}, under paths
 like:
 
-`/Library/Elastic/Agent/data/elastic-agent-08e204/logs/default/metricbeat-json.log`
+`/Library/Elastic/Agent/data/elastic-agent-08e204/logs/default/metricbeat-json.log` and
+`/Library/Elastic/Agent/data/elastic-agent-08e204/logs/default/metricbeat-json.log-2022-05-03-17-1`
 
 If the log path does not exist, {agent} was unable to start {metricbeat}, which
 is a higher level problem to triage. Usually you can see these logs in the


### PR DESCRIPTION
Closes #954.

Minor patch to resolve old issue that is already [fixed in 8.0](https://github.com/elastic/observability-docs/pull/1499)+

Trying to keep the changes minimal because the old log file naming strategy is a bit eccentric and is changed in 8.0+ anyhow.