### PR TITLE
Change module references to integrations in Logs and Metrics intros

### DIFF
--- a/docs/en/observability/analyze-metrics.asciidoc
+++ b/docs/en/observability/analyze-metrics.asciidoc
@@ -12,9 +12,9 @@ to help diagnose problematic spikes, identify high resource utilization,
 automatically discover and track pods, and unify your metrics
 with logs and APM data in {es}.
 
-Using {metricbeat} modules, you can ingest and analyze
-metrics from servers, Docker containers, Kubernetes orchestrations, explore and
-analyze Prometheus-style metrics or application telemetries, and many more.
+Using {agent} integrations, you can ingest and analyze metrics from servers, Docker containers,
+Kubernetes orchestrations, explore and analyze Prometheus-style metrics or application
+telemetries, and many more.
 
 // Conditionally display a screenshot or video depending on what the
 // current documentation version is.

--- a/docs/en/observability/analyze-metrics.asciidoc
+++ b/docs/en/observability/analyze-metrics.asciidoc
@@ -13,7 +13,7 @@ automatically discover and track pods, and unify your metrics
 with logs and APM data in {es}.
 
 Using {agent} integrations, you can ingest and analyze metrics from servers, Docker containers,
-Kubernetes orchestrations, explore and analyze Prometheus-style metrics or application
+Kubernetes orchestrations, explore and analyze application
 telemetries, and many more.
 
 // Conditionally display a screenshot or video depending on what the

--- a/docs/en/observability/monitor-logs.asciidoc
+++ b/docs/en/observability/monitor-logs.asciidoc
@@ -5,9 +5,9 @@ The {logs-app} in {kib} enables you to search, filter, and tail all your logs
 ingested into {es}. Instead of having to log into different servers, change
 directories, and tail individual files, all your logs are available in the {logs-app}.
 
-Using {filebeat} {filebeat-ref}/filebeat-modules.html[modules], you can ingest
-logs from Kubernetes, MySQL, and many more data sources. Log events are indexed
-into {es} and are sorted from older to newer, with infinite scrolling in both directions.
+Using {agent} integrations, you can ingest logs from Kubernetes, MySQL, and many
+more data sources. Log events are indexed into {es} and are sorted from older to newer,
+with infinite scrolling in both directions.
 
 There is live streaming of logs, filtering using auto-complete, and a logs histogram
 for quick navigation. You can also use {ml} to detect specific log


### PR DESCRIPTION
Fixes https://github.com/elastic/observability-docs/issues/1323

Changes module references to integrations in [Log monitoring](https://www.elastic.co/guide/en/observability/current/monitor-logs.html) and [Metrics monitoring](https://www.elastic.co/guide/en/observability/current/analyze-metrics.html).