### PR TITLE
Mention that only one Elastic Agent can run on a host

### DIFF
--- a/docs/en/ingest-management/elastic-agent/install-elastic-agent.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/install-elastic-agent.asciidoc
@@ -12,6 +12,8 @@ data sources, security protections, and more.
 // end::agent-install-intro[]
 ****
 
+NOTE: You can install only a single {agent} per host.
+
 //TODO: Follow up with Jason to see where and what we need to say about allowlists
 //for restricting access to the file system.
 You have a few options for installing and managing an {agent}:

--- a/docs/en/ingest-management/elastic-agent/install-fleet-managed-agent.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/install-fleet-managed-agent.asciidoc
@@ -12,6 +12,8 @@ out one of the
 link:https://www.elastic.co/training/free#quick-starts[Quick Starts]
 and get started with {ecloud}.
 
+NOTE: You can install only a single {agent} per host.
+
 [discrete]
 [[minimal-elastic-agent-prereqs]]
 == Prerequisites

--- a/docs/en/ingest-management/elastic-agent/install-fleet-managed-elastic-agent.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/install-fleet-managed-elastic-agent.asciidoc
@@ -48,6 +48,8 @@ it from your host.
 [[elastic-agent-installation-steps]]
 == Installation steps
 
+NOTE: You can install only a single {agent} per host.
+
 To install an {agent} and enroll it in {fleet}:
 
 // tag::agent-enroll[]

--- a/docs/en/ingest-management/elastic-agent/install-standalone-elastic-agent.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/install-standalone-elastic-agent.asciidoc
@@ -17,6 +17,8 @@ IMPORTANT: Standalone agents are unable to upgrade to new integration package
 versions automatically. When you upgrade the integration in {kib}, you'll
 need to update the standalone policy manually.
 
+NOTE: You can install only a single {agent} per host.
+
 To install and run {agent} standalone:
 
 . On your host, download and extract the installation package.

--- a/docs/en/ingest-management/tab-widgets/add-fleet-server/content.asciidoc
+++ b/docs/en/ingest-management/tab-widgets/add-fleet-server/content.asciidoc
@@ -32,10 +32,13 @@ self-manage your own {fleet-server}s.
 To deploy a self-managed {fleet-server}, install an {agent} and enroll it in an
 agent policy containing the {fleet-server} integration.
 
+NOTE: You can install only a single {agent} per host, which means you cannot run
+{fleet-server} and another {agent} on the same host unless you deploy a
+containerized {fleet-server}.
+
 . Log in to {kib} and go to *Management > {fleet} > Settings*. For more
 information about these settings, see
 {fleet-guide}/fleet-settings.html[{fleet} settings].
-
 // lint ignore fleet-server
 . Under *Fleet Server hosts*, click *Edit hosts* and specify one or more host
 URLs your {agent}s will use to connect to {fleet-server}. For example,


### PR DESCRIPTION
Closes #982 

Hopefully removing -f from the command examples helped a lot of users avoid this problem. 

I'm being very optimistic about backports here. :-) 