### PR TITLE
Move note about self-hosted fleet server 1/2

### DIFF
--- a/docs/en/ingest-management/tab-widgets/add-fleet-server/content.asciidoc
+++ b/docs/en/ingest-management/tab-widgets/add-fleet-server/content.asciidoc
@@ -21,10 +21,6 @@ Don't see the agent? Make sure your deployment includes an
 image::images/integrations-server-hosted-container.png[Hosted {integrations-server}]
 ====
 
-NOTE: When using our hosted {ess}, it's recommended that you use our hosted
-version of {integrations-server}. However, you can choose to deploy and
-self-manage your own {fleet-server}s.
-
 // end::ess[]
 
 // tag::self-managed[]


### PR DESCRIPTION
I am proposing to move this note to the section before the tab-widget. The reason is that it is buried in the widget and one can miss that this is an option when trying to install extra fleet servers with an ESS deployment (Happened to me and to a customer when trying to figure out how to do this). 
See the move in the my next PR.