### PR TITLE
Move note about self-hosted fleet server 2/2

### DIFF
--- a/docs/en/ingest-management/fleet/add-fleet-server.asciidoc
+++ b/docs/en/ingest-management/fleet/add-fleet-server.asciidoc
@@ -35,6 +35,11 @@ For more information about hosting {fleet-server} on {ece}, refer to
 The steps for running {fleet-server} on our {ess-product}[hosted {ess}] on
 {ecloud} are different from the steps for running it as self-managed.
 
+NOTE: When using our hosted {ess}, it's recommended that you use our hosted
+version of {integrations-server}. However, you can choose to deploy and
+self-manage your own {fleet-server}s or add an extra self-managed fleet
+server in addition to our hosted one. 
+
 include::{tab-widgets}/add-fleet-server/widget.asciidoc[]
 
 Now you're ready to add {agent}s to your host systems. To learn how, see


### PR DESCRIPTION
I am proposing to move this note to the section before the tab-widget. The reason is that it is buried in the widget and one can miss that this is an option when trying to install extra fleet servers with an ESS deployment (Happened to me and to a customer when trying to figure out how to do this).
See the deletion in PR https://github.com/elastic/observability-docs/pull/1858