### PR TITLE
[8.2] Lints all docs for shared attributes use (#1820)

### DIFF
--- a/docs/en/ingest-management/agent-policies.asciidoc
+++ b/docs/en/ingest-management/agent-policies.asciidoc
@@ -240,7 +240,7 @@ Unable to select a different output? Confirm that your subscription level
 supports per-policy outputs in {fleet}.
 +
 [role="screenshot"]
-image::images/agent-output-settings.png[Screen capture showing the Logstash output policy selected in an agent policy]
+image::images/agent-output-settings.png[Screen capture showing the {ls} output policy selected in an agent policy]
 
 . Save your changes.
 

--- a/docs/en/ingest-management/beats-agent-comparison.asciidoc
+++ b/docs/en/ingest-management/beats-agent-comparison.asciidoc
@@ -71,7 +71,7 @@ NOTE: {endpoint-sec} has a different output matrix.
 
 [options,header]
 |===
-|Output |Beats |{fleet}-managed {agent} |Standalone {agent}
+|Output |{beats} |{fleet}-managed {agent} |Standalone {agent}
 
 |{es} Service
 |{y}
@@ -117,7 +117,7 @@ Currently, {agent}s managed by {fleet} can only output to the same {es} cluster 
 
 [options,header]
 |===
-|Beats configuration |{agent} support
+|{beats} configuration |{agent} support
 
 |{filebeat-ref}/configuration-filebeat-modules.html[Modules]
 |Supported via integrations.
@@ -145,7 +145,7 @@ configuration experience.
 |{filebeat-ref}/configuration-ssl.html[SSL]
 |Supported
 
-|{filebeat-ref}/ilm.html[Index lifecycle management]
+|{filebeat-ref}/ilm.html[{ilm-cap}]
 |Enabled by default although the Agent uses <<data-streams,data streams>>.
 
 |{filebeat-ref}/configuration-template.html[{es} index template loading]
@@ -251,13 +251,13 @@ The following table shows a comparison of capabilities supported by {beats} and 
 |{n}
 |{y} (limited)
 |{y}
-|{agent} offers {fleet-guide}/dynamic-input-configuration.html[variables and input conditions] to dynamically adjust based on the local host environment. Users can configure these directly in YAML for standalone {agent} or using the Fleet API for {fleet}-managed {agent}. The Integrations app allows users to enter variables, and we are considering a https://github.com/elastic/kibana/issues/108525[UI to edit conditions]. {beats} only offers static configuration.
+|{agent} offers {fleet-guide}/dynamic-input-configuration.html[variables and input conditions] to dynamically adjust based on the local host environment. Users can configure these directly in YAML for standalone {agent} or using the {fleet} API for {fleet}-managed {agent}. The Integrations app allows users to enter variables, and we are considering a https://github.com/elastic/kibana/issues/108525[UI to edit conditions]. {beats} only offers static configuration.
 
 |Allow non-superusers to manage assets and agents
 |{y}
 |{y}
 |{y} (it's optional)
-|Starting with version 8.1.0, a superuser role is no longer required to use the Fleet and Integrations apps and corresponding APIs. These apps are optional for standalone {agent}. {beats} offers {filebeat-ref}/feature-roles.html[finer grained] roles.
+|Starting with version 8.1.0, a superuser role is no longer required to use the {fleet} and Integrations apps and corresponding APIs. These apps are optional for standalone {agent}. {beats} offers {filebeat-ref}/feature-roles.html[finer grained] roles.
 
 |Air-gapped network support
 |{y}
@@ -269,7 +269,7 @@ The following table shows a comparison of capabilities supported by {beats} and 
 |{y}
 |{n}
 |{y}
-|{fleet}-managed {agent}s require root permission, in particular for Endpoint Security. Standalone {agent}s and {beats} do not.
+|{fleet}-managed {agent}s require root permission, in particular for {endpoint-sec}. Standalone {agent}s and {beats} do not.
 
 |Multiple outputs
 |{y}
@@ -328,9 +328,9 @@ There are also pre-built dashboards for agent metrics that you can access
 under *Assets* in the {agent} integration:
 
 [role="screenshot"]
-image::images/agent-monitoring-assets.png[Screen capture of Elastic Agent monitoring assets]
+image::images/agent-monitoring-assets.png[Screen capture of {agent} monitoring assets]
 
-The *[Elastic Agent] Agent metrics* dashboard shows an aggregated view of agent metrics:
+The *[{agent}] Agent metrics* dashboard shows an aggregated view of agent metrics:
 
 [role="screenshot"]
-image::images/agent-metrics-dashboard.png[Screen capture showing Elastic Agent metrics]
+image::images/agent-metrics-dashboard.png[Screen capture showing {agent} metrics]

--- a/docs/en/ingest-management/commands.asciidoc
+++ b/docs/en/ingest-management/commands.asciidoc
@@ -293,7 +293,7 @@ verified. The content is encrypted, but the certificate is not verified.
 We strongly recommend that you use a secure connection.
 
 `--url <string>`::
-Fleet Server URL to use to enroll the {agent} into {fleet}.
+{fleet-server} URL to use to enroll the {agent} into {fleet}.
 
 // end::enroll-install-options[]
 
@@ -683,8 +683,8 @@ elastic-agent run -c myagentconfig.yml
 [[elastic-agent-status-command]]
 == elastic-agent status
 
-Returns the current status of the running Elastic Agent daemon and of each process
-in the Elastic Agent.
+Returns the current status of the running {agent} daemon and of each process
+in the {agent}.
 
 [discrete]
 === Synopsis

--- a/docs/en/ingest-management/data-streams.asciidoc
+++ b/docs/en/ingest-management/data-streams.asciidoc
@@ -67,7 +67,7 @@ traces-apm-dev
 --
 
 All data streams, and the pre-built dashboards that they ship with,
-are viewable on the Fleet Data Streams page:
+are viewable on the {fleet} Data Streams page:
 
 [role="screenshot"]
 image::images/kibana-fleet-datastreams.png[Data streams page]
@@ -96,39 +96,39 @@ These templates are loaded when the integration is installed, and are used to co
 
 [discrete]
 [[data-streams-ilm]]
-== Configure an index lifecycle management (ILM) policy
+== Configure an {ilm} ({ilm-init}) policy
 
 Use the {ref}/index-lifecycle-management.html[index lifecycle
-management] (ILM) feature in {es} to manage your {agent} data stream indices as they age.
+management] ({ilm-init}) feature in {es} to manage your {agent} data stream indices as they age.
 For example, create a new index after a certain period of time,
 or delete stale indices to enforce data retention standards.
 
-Installed integrations may have one or many associated data streams--each with an associated ILM policy.
-By default, these data streams use an ILM policy that matches their data type.
+Installed integrations may have one or many associated data streams--each with an associated {ilm-init} policy.
+By default, these data streams use an {ilm-init} policy that matches their data type.
 For example, the data stream `metrics-system.logs-*`,
-uses the metrics ILM policy as defined in the `metrics-system.logs` index template.
+uses the metrics {ilm-init} policy as defined in the `metrics-system.logs` index template.
 
 [discrete]
 [[data-streams-ilm-tutorial]]
 == Tutorial: Customize data retention for integrations
 
-This tutorial explains how to apply a custom ILM policy to an integration's data stream.
+This tutorial explains how to apply a custom {ilm-init} policy to an integration's data stream.
 
 **Scenario:** You have {agent}s collecting system metrics with the System integration in two environments--one with the namespace `development`, and one with `production`.
 
-**Goal:** Customize the ILM policy for the `system.network` data stream in the `production` namespace.
-Specifically, apply the built-in `90-days-default` ILM policy so that data is deleted after 90 days.
+**Goal:** Customize the {ilm-init} policy for the `system.network` data stream in the `production` namespace.
+Specifically, apply the built-in `90-days-default` {ilm-init} policy so that data is deleted after 90 days.
 
 [discrete]
 [[data-streams-ilm-one]]
 === Step 1: View data streams
 
 The **Data Streams** view in {kib} shows you the data streams,
-index templates, and ILM policies associated with a given integration.
+index templates, and {ilm-init} policies associated with a given integration.
 
-. Navigate to **Stack Management** > **Index Management** > **Data Streams**.
+. Navigate to **{stack-manage-app}** > **Index Management** > **Data Streams**.
 . Search for `system` to see all data streams associated with the System integration.
-. Select the `metrics-system.network-{namespace}` data stream to view its associated index template and ILM policy.
+. Select the `metrics-system.network-{namespace}` data stream to view its associated index template and {ilm-init} policy.
 As you can see, the data stream follows the <<data-streams-naming-scheme>> and starts with its type, `metrics-`.
 +
 [role="screenshot"]
@@ -156,10 +156,10 @@ the component template name would be:
 metrics-system.network-production@custom
 ----
 
-. Navigate to **Stack Management** > **Index Management** > **Component Templates**
+. Navigate to **{stack-manage-app}** > **Index Management** > **Component Templates**
 . Click **Create component template**.
 . Use the template above to set the name--in this case, `metrics-system.network-production@custom`. Click **Next**.
-. Under **Index settings**, set the ILM policy name under the `lifecycle.name` key:
+. Under **Index settings**, set the {ilm-init} policy name under the `lifecycle.name` key:
 +
 [source,json]
 ----
@@ -185,7 +185,7 @@ The easiest way to do this is to duplicate and modify the integration's existing
 
 WARNING: When duplicating the index template, do not change or remove any managed properties. This may result in problems when upgrading.
 
-. Navigate to **Stack Management** > **Index Management** > **Index Templates**.
+. Navigate to **{stack-manage-app}** > **Index Management** > **Index Templates**.
 . Find the index template you want to clone. The index template will have the `<type>` and `<dataset>` in its name,
 but not the `<namespace>`. In this case, it's `metrics-system.network`.
 . Select **Actions** > **Clone**.
@@ -205,8 +205,8 @@ image::images/create-index-template.png[Create index template]
 [[data-streams-ilm-four]]
 === Step 4: Roll over the data stream (optional)
 
-To confirm that the data stream is now using the new index template and ILM policy,
-you can either repeat <<data-streams-ilm-one,step one>>, or navigate to **Dev Tools ** and run the following:
+To confirm that the data stream is now using the new index template and {ilm-init} policy,
+you can either repeat <<data-streams-ilm-one,step one>>, or navigate to **{dev-tools-app}** and run the following:
 
 [source,bash]
 ----
@@ -230,9 +230,9 @@ The result should include the following:
 }
 ----
 <1> The name of the custom index template created in step three
-<2> The name of the ILM policy applied to the new component template in step two
+<2> The name of the {ilm-init} policy applied to the new component template in step two
 
-New ILM policies only take effect when new indices are created,
+New {ilm-init} policies only take effect when new indices are created,
 so you either must wait for a rollover to occur (usually after 30 days or when the index size reaches 50GB),
 or force a rollover using the {ref}/indices-rollover-index.html[{es} rollover API]:
 

--- a/docs/en/ingest-management/elastic-agent/configuration/env/shared-env.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/env/shared-env.asciidoc
@@ -24,7 +24,7 @@ OPTIONAL INFO AND EXAMPLE
 
 | (int) Set to `1` to enable {fleet} setup.
 Enabling {fleet} is required before {fleet-server} will start.
-When this action is not performed, a user must manually log in to Kibana and visit the Fleet page to enable setup.
+When this action is not performed, a user must manually log in to {kib} and visit the {fleet} page to enable setup.
 
 *Default:* none
 
@@ -160,7 +160,7 @@ Overrides `FLEET_TOKEN_POLICY_NAME` when set.
 [id="env-{type}-fleet-server-service-token"]
 `FLEET_SERVER_SERVICE_TOKEN`
 
-| (string) Service token to use for communication with Elasticsearch.
+| (string) Service token to use for communication with {es}.
 
 *Default:* none
 

--- a/docs/en/ingest-management/elastic-agent/configuration/outputs/output-elasticsearch.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/outputs/output-elasticsearch.asciidoc
@@ -4,7 +4,7 @@
 = Configure the {es} output
 
 ++++
-<titleabbrev>Elasticsearch</titleabbrev>
+<titleabbrev>{es}</titleabbrev>
 ++++
 
 include::{fleet-repo-dir}/standalone-note.asciidoc[]
@@ -287,6 +287,7 @@ include::../authentication/kerberos-shared-settings.asciidoc[tag=kerberos-all-se
 
 [[output-elasticsearch-data-parsing-settings]]
 === Data parsing, filtering, and manipulation settings
+
 Settings used to parse, filter, and transform data.
 
 [cols="2*<a"]

--- a/docs/en/ingest-management/elastic-agent/configuration/outputs/output-logstash.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/outputs/output-logstash.asciidoc
@@ -4,7 +4,7 @@
 = {ls} output
 
 ++++
-<titleabbrev>Logstash</titleabbrev>
+<titleabbrev>{ls}</titleabbrev>
 ++++
 
 include::{fleet-repo-dir}/standalone-note.asciidoc[]
@@ -159,7 +159,7 @@ server.
 Settings for authenticating with {ls}.
 
 To use SSL, you must also configure the
-{logstash-ref}/plugins-inputs-beats.html[{agent} input plugin for Logstash] to
+{logstash-ref}/plugins-inputs-beats.html[{agent} input plugin for {ls}] to
 use SSL/TLS.
 
 include::../authentication/ssl-shared-settings.asciidoc[tag=ssl-all-settings]

--- a/docs/en/ingest-management/elastic-agent/debug-standalone-elastic-agent.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/debug-standalone-elastic-agent.asciidoc
@@ -50,7 +50,7 @@ of the running {agent}.
 
 The log location varies by platform. {agent} logs are in the folders described
 in <<installation-layout>>. {beats} and {fleet-server} logs are in folders named
-for the output (for example, `default`). Elastic Endpoint logs are in the
+for the output (for example, `default`). {elastic-endpoint} logs are in the
 installation directory.
 
 Start by investigating any errors you see in the {agent} and related logs. Also

--- a/docs/en/ingest-management/elastic-agent/elastic-agent-container.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/elastic-agent-container.asciidoc
@@ -1,14 +1,14 @@
 [[elastic-agent-container]]
 = Run {agent} in a container
 
-You can run {agent} inside of a container -- either with Fleet Server or standalone.
+You can run {agent} inside of a container -- either with {fleet-server} or standalone.
 Docker images for all versions of {agent} are available from the
 https://www.docker.elastic.co/r/beats/elastic-agent[Elastic Docker registry].
-If you are running in Kubernetes, refer to {eck-ref}/k8s-elastic-agent.html[run Elastic Agent on ECK].
+If you are running in Kubernetes, refer to {eck-ref}/k8s-elastic-agent.html[run {agent} on ECK].
 
 Considerations:
 
-* When {agent} runs inside of a container, it cannot be upgraded through Fleet as it expects that the container itself is upgraded.
+* When {agent} runs inside of a container, it cannot be upgraded through {fleet} as it expects that the container itself is upgraded.
 * Enrolling and running an {agent} is usually a two-step process.
 However, this doesn't work in a container, so a special subcommand, `container`, is called.
 This command allows environment variables to configure all properties, and runs the `enroll` and `run` commands as a single command.
@@ -17,7 +17,7 @@ This command allows environment variables to configure all properties, and runs 
 [[agent-in-container-pull]]
 == Pull the image
 
-There are two images for {agent}, *elastic-agent* and *elastic-agent-complete*. The *elastic-agent* image contains all the binaries for running Beats, while the *elastic-agent-complete* image contains these binaries plus additional dependencies to run browser monitors through Elastic Synthetics. Refer to {observability-guide}/uptime-set-up.html[Synthetic monitoring via {agent} and {fleet}] for more information.
+There are two images for {agent}, *elastic-agent* and *elastic-agent-complete*. The *elastic-agent* image contains all the binaries for running {beats}, while the *elastic-agent-complete* image contains these binaries plus additional dependencies to run browser monitors through Elastic Synthetics. Refer to {observability-guide}/uptime-set-up.html[Synthetic monitoring via {agent} and {fleet}] for more information.
 
 Run the `docker pull` command against the Elastic Docker registry:
 
@@ -51,7 +51,8 @@ elastic-agent container -h
 
 The easiest way to get started is by using an Elastic cluster running on {ecloud}.
 
-. In Kibana, select *Fleet* > *Fleet Settings*, and copy the Fleet Server host URL.
+// lint ignore fleet
+. In {kib}, select *{fleet}* > *Fleet Settings*, and copy the {fleet-server} host URL.
 
 . Close the flyout panel and select *Enrollment tokens*.
 Find the Agent policy you want to enroll {agent} into, and display and copy the secret token.
@@ -67,13 +68,13 @@ docker run \
   --rm docker.elastic.co/beats/elastic-agent:{version}
 ----
 
-NOTE: Replace `docker.elastic.co/beats/elastic-agent` with `docker.elastic.co/beats/elastic-agent-complete` and use the `elastic-agent` user instead of root to run Synthetics Browser tests. Synthetics tests cannot run under the root user. Refer to {observability-guide}/uptime-set-up.html[Synthetics Fleet Quickstart] for more information.
+NOTE: Replace `docker.elastic.co/beats/elastic-agent` with `docker.elastic.co/beats/elastic-agent-complete` and use the `elastic-agent` user instead of root to run Synthetics Browser tests. Synthetics tests cannot run under the root user. Refer to {observability-guide}/uptime-set-up.html[Synthetics {fleet} Quickstart] for more information.
 
 [discrete]
 [[agent-in-container-self]]
 == Self-managed example
 
-If you're running a self-managed cluster and want to run your own Fleet Server, run the following command, which will spin up {agent} and Fleet Server in a container:
+If you're running a self-managed cluster and want to run your own {fleet-server}, run the following command, which will spin up {agent} and {fleet-server} in a container:
 
 [source,terminal]
 ----
@@ -85,13 +86,13 @@ docker run \
   --rm docker.elastic.co/beats/elastic-agent:{version}
 ----
 <1> Your cluster's {es} host URL
-<2> The Fleet service token -- generate one in the Fleet UI if you don't have one already
-<3> ID of the Fleet Server policy. To learn how to create a policy, refer
+<2> The {fleet} service token -- generate one in the {fleet} UI if you don't have one already
+<3> ID of the {fleet-server} policy. To learn how to create a policy, refer
 <<create-a-policy-no-ui>>.
 
 We recommend only having one fleet-server policy.
 
-NOTE: Replace `docker.elastic.co/beats/elastic-agent` with `docker.elastic.co/beats/elastic-agent-complete` and use the `elastic-agent` user instead of root to run Synthetics Browser tests. Synthetics tests cannot run under the root user. Refer to {observability-guide}/uptime-set-up.html[Synthetics Fleet Quickstart] for more information.
+NOTE: Replace `docker.elastic.co/beats/elastic-agent` with `docker.elastic.co/beats/elastic-agent-complete` and use the `elastic-agent` user instead of root to run Synthetics Browser tests. Synthetics tests cannot run under the root user. Refer to {observability-guide}/uptime-set-up.html[Synthetics {fleet} Quickstart] for more information.
 
 [discrete]
 [[agent-in-container-docker]]
@@ -115,7 +116,7 @@ services:
       - FLEET_URL={fleet-server-url}
 ----
 
-Need to run Fleet Server as well?
+Need to run {fleet-server} as well?
 Adjust the docker-compose file above by adding these environment variables:
 
 [source,yaml]
@@ -125,7 +126,7 @@ Adjust the docker-compose file above by adding these environment variables:
       - FLEET_SERVER_SERVICE_TOKEN={service-token}
 ----
 
-NOTE: Replace `docker.elastic.co/beats/elastic-agent` with `docker.elastic.co/beats/elastic-agent-complete` and use the `elastic-agent` user instead of root to run Synthetics Browser tests. Synthetics tests cannot run under the root user. Refer to {observability-guide}/uptime-set-up.html[Synthetics Fleet Quickstart] for more information.
+NOTE: Replace `docker.elastic.co/beats/elastic-agent` with `docker.elastic.co/beats/elastic-agent-complete` and use the `elastic-agent` user instead of root to run Synthetics Browser tests. Synthetics tests cannot run under the root user. Refer to {observability-guide}/uptime-set-up.html[Synthetics {fleet} Quickstart] for more information.
 
 [discrete]
 [[agent-in-container-docker-logs]]
@@ -144,7 +145,7 @@ Each subprocess writes its own logs to the `default` directory inside the logs d
 /usr/share/elastic-agent/state/data/logs/default/*
 ----
 
-TIP: Running into errors with Fleet Server?
+TIP: Running into errors with {fleet-server}?
 Check the fleet-server subprocess logs for more information.
 
 [discrete]

--- a/docs/en/ingest-management/elastic-agent/grant-access-to-elasticsearch.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/grant-access-to-elasticsearch.asciidoc
@@ -34,7 +34,7 @@ can create as many API keys per user as necessary.
 
 To create an API key for {agent}:
 
-. In {kib}, navigate to *Stack Management > API keys* and click
+. In {kib}, navigate to *{stack-manage-app} > API keys* and click
 *Create API key*.
 
 . Enter a name for your API key and select *Restrict privileges*. In the role
@@ -74,6 +74,7 @@ You'll see a message indicating that the key was created, along with the
 encoded key. By default, the API key is Base64 encoded, but that won't work for
 {agent}.
 
+// lint ignore beats
 . Click the down arrow next to Base64 and select *Beats*.
 +
 [role="screenshot"]
@@ -111,7 +112,7 @@ password to access {es}, you can create a role with the required privileges,
 assign it to a user, and specify the user's credentials in the
 `elastic-agent.yml` file.
 
-. In {kib}, go to *Stack Management > Roles*.
+. In {kib}, go to *{stack-manage-app} > Roles*.
 
 . Click *Create role* and enter a name for the role.
 

--- a/docs/en/ingest-management/elastic-agent/install-fleet-managed-agent.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/install-fleet-managed-agent.asciidoc
@@ -38,5 +38,6 @@ include::../tab-widgets/download-widget.asciidoc[]
 [[enroll-agent]]
 == Step 2: Enroll and start the {agent}
 
+// lint ignore elastic-agent
 Return to {kib} and follow the **Enroll and start the Elastic Agent** instructions.  The command provided in {kib} includes the information that {agent} needs to connect and authenticate with the {stack}.  When the {agent} enrolls it will be configured to send the data associated with the policy that you created.
 

--- a/docs/en/ingest-management/elastic-agent/install-fleet-managed-elastic-agent.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/install-fleet-managed-elastic-agent.asciidoc
@@ -36,7 +36,7 @@ all spaces.
 {fleet-server} is already available as part of the {integrations-server}.
 
 * Internet connection for {kib} to download integration packages
-from the Elastic Package Registry. Make sure the {kib} server can connect to
+from the {package-registry}. Make sure the {kib} server can connect to
 `https://epr.elastic.co` on port `443`. If your environment has network traffic
 restrictions, there are ways to work around this requirement. See
 {fleet-guide}/air-gapped.html[Air-gapped environments] for more information.
@@ -52,6 +52,7 @@ To install an {agent} and enroll it in {fleet}:
 
 // tag::agent-enroll[]
 
+// lint disable fleet
 . In {kib}, go to **{fleet} > Agents**, and click **Add agent**.
 
 . In the *Add agent* flyout, select an existing agent policy or create a new
@@ -68,6 +69,7 @@ step.
 [role="screenshot"]
 image::images/kibana-agent-flyout.png[Add agent flyout in {kib}]
 --
+// lint enable fleet
 
 After about a minute, the agent will enroll in {fleet}, download the
 configuration specified in the agent policy, and start collecting data. 

--- a/docs/en/ingest-management/elastic-agent/running-on-kubernetes-managed-by-fleet.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/running-on-kubernetes-managed-by-fleet.asciidoc
@@ -154,8 +154,8 @@ NOTE: You might need to adjust https://kubernetes.io/docs/concepts/configuration
 in the `elastic-agent-managed-kubernetes.yaml` manifest. Container resource usage depends on the number of datastreams
 and the environment size.
 
-{agent}s should be enrolled to Fleet and users should be able to deploy the Kubernetes package accordingly.
-This can be confirmed in {kib} under Fleet  / Agents section.
+{agent}s should be enrolled to {fleet} and users should be able to deploy the Kubernetes package accordingly.
+This can be confirmed in {kib} under {fleet}  / Agents section.
 
 
 [discrete]

--- a/docs/en/ingest-management/elastic-agent/running-on-kubernetes-standalone.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/running-on-kubernetes-standalone.asciidoc
@@ -50,7 +50,7 @@ the Pod's log collection using <<kubernetes-provider,dynamic inputs and kubernet
 [discrete]
 == Settings
 
-Set the Elasticsearch settings before deploying the manifest:
+Set the {es} settings before deploying the manifest:
 
 [source,yaml]
 ------------------------------------------------

--- a/docs/en/ingest-management/elastic-agent/uninstall-elastic-agent.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/uninstall-elastic-agent.asciidoc
@@ -43,7 +43,7 @@ TIP: Search for these processes and stop them if they're still running:
 running {agent} on macOS, delete `/Library/Elastic/Agent/*`. Not sure where the
 files are installed? Refer to <<installation-layout>>.
 
-. If you've configured the Elastic Endpoint integration, also remove the files
+. If you've configured the {elastic-endpoint} integration, also remove the files
 installed for endpoint protection. The directory structure is similar to {agent},
 for example, `/Library/Elastic/Endpoint/*`.
 +

--- a/docs/en/ingest-management/fleet-agent-proxy-support.asciidoc
+++ b/docs/en/ingest-management/fleet-agent-proxy-support.asciidoc
@@ -34,11 +34,11 @@ upgrades
 
 image::images/agent-proxy-server.png[Image showing connections between {agent}, {fleet-server}, and {es}]
 
-If {fleet} is unable to access the Elastic Package Registry because {kib} is
+If {fleet} is unable to access the {package-registry} because {kib} is
 behind a proxy server, you may also need to set the registry proxy URL
 in the {kib} configuration.
 
-image::images/fleet-epr-proxy.png[Image showing connections between {fleet} and the Elastic Package Registry]
+image::images/fleet-epr-proxy.png[Image showing connections between {fleet} and the {package-registry}]
 
 [discrete]
 [[host-proxy-env-vars]]
@@ -75,6 +75,7 @@ based on the system manager you're using. Here are some examples to get you
 started. For more information about setting environment variables, refer to the
 documentation for your operating system.
 
+// lint ignore agent
 * For Windows services, set environment variables for the service in
 the Windows registry.
 +
@@ -137,7 +138,7 @@ After adding environment variables, restart the service.
 
 Proxy settings in the {agent} policy override proxy settings specified by
 environment variables. This means you can specify proxy settings for {agent}
-that are different from host or system-level environment settings. Currently, we only offer a way to modify these for standalone agents. The ability to set these for Fleet-managed agents is https://github.com/elastic/elastic-agent/issues/96[under consideration]. 
+that are different from host or system-level environment settings. Currently, we only offer a way to modify these for standalone agents. The ability to set these for {fleet}-managed agents is https://github.com/elastic/elastic-agent/issues/96[under consideration]. 
 
 The following proxy settings are valid in the agent policy:
 
@@ -272,13 +273,13 @@ fleet:
 
 [discrete]
 [[epr-proxy-setting]]
-== Set the proxy URL of the Elastic Package Registry
+== Set the proxy URL of the {package-registry}
 
-{fleet} might be unable to access the Elastic Package Registry because {kib} is
+{fleet} might be unable to access the {package-registry} because {kib} is
 behind a proxy server.
 
 Also your organization might have network traffic restrictions that prevent {kib}
-from reaching the public Elastic Package Registry endpoints, like
+from reaching the public {package-registry} endpoints, like
 https://epr.elastic.co/[epr.elastic.co], to download package metadata and
 content. You can route traffic to the public endpoint of EPR through a network
 gateway, then configure proxy settings in the

--- a/docs/en/ingest-management/fleet/elastic-agent-logging.asciidoc
+++ b/docs/en/ingest-management/fleet/elastic-agent-logging.asciidoc
@@ -39,7 +39,7 @@ The *Logs* page for each agent enables you to monitor all of the log events flow
 from your agents and integrations in a centralized view.
 
 To help you get started with your analysis faster, you can use the search bar to create
-structured queries using {kibana-ref}/kuery-query.html[Kibana Query Language]. Along with
+structured queries using {kibana-ref}/kuery-query.html[{kib} Query Language]. Along with
 the power of search, you also have the option to view historical logs from a
 specified time range.
 

--- a/docs/en/ingest-management/fleet/fleet-manage-agents.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-manage-agents.asciidoc
@@ -12,13 +12,13 @@
 ****
 {agent} is a single, unified agent that you deploy to hosts or containers to
 collect data and send it to the {stack}. Behind the scenes, {agent} runs the
-{beats} shippers or Elastic Endpoint required for your configuration.
+{beats} shippers or {elastic-endpoint} required for your configuration.
 
 To learn how to add {agent}s to {fleet}, see
 <<install-fleet-managed-elastic-agent>>.
 ****
 
-To manage your {agent}s, go to *Management > Fleet > Agents* in {kib}. On the
+To manage your {agent}s, go to *Management > {fleet} > Agents* in {kib}. On the
 *Agents* tab, you can perform the following actions:
 
 

--- a/docs/en/ingest-management/fleet/fleet-server-monitoring.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-server-monitoring.asciidoc
@@ -41,6 +41,7 @@ image::images/dashboard-with-namespace-showing.png[Namespace]
 [role="screenshot"]
 image::images/datastream-namespace.png[Datastream]
 
+// lint ignore elastic-agent
 In {kib}, go to *Analytics > Dashboard* and search for the predefined dashboard
 called *[Elastic Agent] Agent metrics*. Choose this dashboard, and run a query
 based on the `fleetserver` namespace.

--- a/docs/en/ingest-management/fleet/fleet-server-scaling.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-server-scaling.asciidoc
@@ -27,7 +27,7 @@ image::images/fleet-server-hosted-container.png[{fleet-server} hosted agent]
 
 Next modify the {fleet-server} configuration by editing the agent policy: 
 
-. In *Fleet*, click *Agent Policies*. Click on the *{ecloud} agent policy* to
+. In *{fleet}*, click *Agent Policies*. Click on the *{ecloud} agent policy* to
 edit it.
 
 . Open the *Actions* menu and select *Edit integration*.
@@ -121,7 +121,7 @@ on the number of agents required by your deployment:
 * <<recommend-settings-scaling-agents>>
 
 // TODO: Confirm that these recommendations are current. The values don't match
-// the drop-down lists in the latest version of Elastic Cloud. 
+// the drop-down lists in the latest version of {ecloud}. 
 
 [discrete]
 [[resource-requirements-by-number-agents]]

--- a/docs/en/ingest-management/fleet/fleet-server.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-server.asciidoc
@@ -25,7 +25,7 @@ to {es}.
 . When a policy is updated, {fleet-server} retrieves the updated policy from
 {es} and sends it to the connected {agent}s.
 
-image:images/fleet-server-communication.png[Fleet Server handles communication between {agent}, {fleet}, {es}, and {kib}]
+image:images/fleet-server-communication.png[{fleet-server} handles communication between {agent}, {fleet}, {es}, and {kib}]
 
 {fleet-server} runs as a subprocess inside an {agent}. The agent uses a special
 policy that describes the {fleet-server} configuration. In large scale

--- a/docs/en/ingest-management/fleet/fleet-settings.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-settings.asciidoc
@@ -5,6 +5,7 @@ NOTE: The settings described here are configurable through the {fleet} UI. Refer
 {kibana-ref}/fleet-settings-kb.html[{fleet} settings in {kib}] for a list of
 settings that you can configure in the `kibana.yml` configuration file.
 
+// lint ignore fleet
 On the *Settings* tab in *Fleet*, you can configure global settings available
 to all {agent}s enrolled in {fleet}. This includes {fleet-server} hosts and
 output settings.
@@ -61,9 +62,10 @@ are updated automatically.
 Add or edit output settings to specify where {agent}s send data. {agent}s
 use the default output if you don't select an output in the agent policy.
 
-NOTE: The Elastic Cloud internal output is locked and cannot be edited. This
+
+NOTE: The {ecloud} internal output is locked and cannot be edited. This
 output is used for internal routing to reduce external network charges when
-using the Elastic Cloud agent policy. It also provides visibility for
+using the {ecloud} agent policy. It also provides visibility for
 troubleshooting on {ece}.
 
 To add or edit an output:

--- a/docs/en/ingest-management/fleet/set-elastic-agent-enrollment-timeout.asciidoc
+++ b/docs/en/ingest-management/fleet/set-elastic-agent-enrollment-timeout.asciidoc
@@ -15,7 +15,7 @@ containers, which can disappear at any time.
 
 To set the unenrollment timeout:
 
-. In *Fleet*, select *Agent policies*.
+. In *{fleet}*, select *Agent policies*.
 
 . Click the policy name, then click *Settings*.
 
@@ -46,7 +46,7 @@ To avoid this problem, set the unenrollment timeout in the agent policy for
 The agent's ID and logs will be preserved in {es}, but container logs will be
 lost.
 
-NOTE: The Elastic Cloud Agent Policy, which is used by {fleet-server} in
+NOTE: The {ecloud} agent policy, which is used by {fleet-server} in
 {ecloud}, already has an unenrollment timeout specified. You cannot change this
 setting.
 

--- a/docs/en/ingest-management/fleet/view-elastic-agent-status.asciidoc
+++ b/docs/en/ingest-management/fleet/view-elastic-agent-status.asciidoc
@@ -1,8 +1,7 @@
 [[view-elastic-agent-status]]
 = View {agent} status
 
-To view the status of your {fleet}-managed agents, go to
-*Management > Fleet > Agents*.
+To view the status of your {fleet}-managed agents, go to *Management > {fleet} > Agents*.
 
 [role="screenshot"]
 image::images/agent-status.png[Agents tab showing status of each {agent}]
@@ -38,7 +37,7 @@ one or more statuses.
 image::images/agent-status-filter.png[Agent Status dropdown with multiple statuses selected]
 
 For advanced filtering, use the search bar to create structured queries
-using {kibana-ref}/kuery-query.html[Kibana Query Language]. For example, enter
+using {kibana-ref}/kuery-query.html[{kib} Query Language]. For example, enter
 `local_metadata.os.family : "darwin"` to see only agents running on macOS.
 
 [discrete]

--- a/docs/en/ingest-management/index.asciidoc
+++ b/docs/en/ingest-management/index.asciidoc
@@ -25,7 +25,7 @@ include::{docs-root}/shared/attributes.asciidoc[]
 :apm-go-ref-v:         https://www.elastic.co/guide/en/apm/agent/go/{apm-go-branch}
 :apm-dotnet-ref-v:     https://www.elastic.co/guide/en/apm/agent/dotnet/{apm-dotnet-branch}
 
-= Fleet and Elastic Agent Guide
+= {fleet} and {agent} Guide
 
 include::overview.asciidoc[leveloffset=+1]
 

--- a/docs/en/ingest-management/integrations/add-integration-to-policy.asciidoc
+++ b/docs/en/ingest-management/integrations/add-integration-to-policy.asciidoc
@@ -9,6 +9,7 @@ policy:
 Notice that the Integrations page shows {agent} integrations along with other
 types, such as {beats}.
 
+// lint ignore elastic-agent
 . Scroll down and select *Elastic Agent only* so the view shows
 integrations that work with {agent}.
 +

--- a/docs/en/ingest-management/integrations/integrations.asciidoc
+++ b/docs/en/ingest-management/integrations/integrations.asciidoc
@@ -10,7 +10,7 @@ in {kib}, or visit {integrations-docs}[Elastic Integrations].
 apps and services, and protect systems from security threats.
 
 Each integration comes pre-packaged with assets that support all of your
-Observability needs:
+observability needs:
 
 * Data ingestion, storage, and transformation rules
 * Configuration options

--- a/docs/en/ingest-management/integrations/upgrade-integration.asciidoc
+++ b/docs/en/ingest-management/integrations/upgrade-integration.asciidoc
@@ -2,10 +2,10 @@
 = Upgrade an {agent} integration
 
 IMPORTANT: By default, {kib} requires an internet connection to download
-integration packages from the Elastic Package Registry. Make sure the {kib}
+integration packages from the {package-registry}. Make sure the {kib}
 server can connect to `https://epr.elastic.co` on port `443`. If network
-restrictions prevent {kib} from reaching the public Elastic Package Registry,
-you can use a proxy server or host your own Elastic Package Registry. To learn
+restrictions prevent {kib} from reaching the public {package-registry},
+you can use a proxy server or host your own {package-registry}. To learn
 more, refer to <<air-gapped>>. 
 
 Elastic releases {agent} integration updates periodically. To use new features

--- a/docs/en/ingest-management/migrate-beats-to-agent.asciidoc
+++ b/docs/en/ingest-management/migrate-beats-to-agent.asciidoc
@@ -162,7 +162,7 @@ be able to see the data streams for various logs and metrics from the host. This
 is out-of-the-box without any extra configuration or dashboard creation:
 +
 [role="screenshot"]
-image::images/migration-agent-data-streams.png[Screen showing data streams created by the Elastic Agent]
+image::images/migration-agent-data-streams.png[Screen showing data streams created by the {agent}]
 
 . Go to *Analytics > Discover* and examine the data streams. Note that documents
 indexed by {agent} match these patterns:
@@ -383,28 +383,28 @@ For more information, see the {ref}/aliases.html[Aliases documentation].
 [discrete]
 == Migrate index lifecycle policies
 
-Index lifecycle management (ILM) policies in {es} enable you to manage indices
+{ilm-cap} ({ilm}) policies in {es} enable you to manage indices
 according to your performance, resiliency, and retention requirements. To learn
-more about ILM, refer to the
-{ref}/index-lifecycle-management.html[ILM documentation].
+more about {ilm}, refer to the
+{ref}/index-lifecycle-management.html[{ilm} documentation].
 
-ILM is configured by default in {beats} (version 7.0 and later) and in {agent}
+{ilm} is configured by default in {beats} (version 7.0 and later) and in {agent}
 (all versions). To view the index lifecycle policies defined in {es}, go to
 *Management > Index Lifecycle Policies*.
 
 [role="screenshot"]
 image::images/migration-index-lifecycle-policies.png[Screen showing how to add a processor to an integration policy]
 
-If you used ILM with {beats}, you'll see index lifecycle policies like
+If you used {ilm} with {beats}, you'll see index lifecycle policies like
 *filebeat* and *metricbeat* in the list. After migrating to {agent}, you'll see
-polices named *logs* and *metrics*, which encapsulate the ILM policies for all
+polices named *logs* and *metrics*, which encapsulate the {ilm} policies for all
 `logs-*` and `metrics-*` index templates.
 
 When you migrate from {beats} to {agent}, you have a couple of options for
 migrating index policy settings:
 
 * *Modify the newly created index lifecycle policies (recommended).* As
-mentioned earlier, ILM is enabled by default when the {agent} is installed.
+mentioned earlier, {ilm} is enabled by default when the {agent} is installed.
 Index lifecycle policies are created and added to the index templates for
 data streams created by integrations.
 +
@@ -413,7 +413,7 @@ recommended that you modify the lifecycle policies for {agent} to match your
 previous policy. To do this:
 +
 --
-. In {kib}, go to *Stack Management > Index Lifecycle Policies* and search for a
+. In {kib}, go to *{stack-manage-app} > Index Lifecycle Policies* and search for a
 {beats} policy, for example, *filebeat*. Under *Linked indices*, notice you can
 view indices linked to the policy. Click the policy name to see the settings.
 
@@ -446,9 +446,9 @@ policy.
 index templates.
 --
 
-.What if you're not using ILM with {beats}?
+.What if you're not using {ilm} with {beats}?
 ****
-You can begin to use ILM now with {agent}. Under *Index lifecycle policies*,
+You can begin to use {ilm} now with {agent}. Under *Index lifecycle policies*,
 click the policy name and edit the settings to meet your requirements.
 ****
 
@@ -462,7 +462,7 @@ duplicated data until you remove {beats}.
 When you're satisfied with your {agent} deployment, remove {beats} from your
 hosts. All the data collected before installing the {agent} will still be
 available in {es} until you delete the data or it's removed according to the
-data retention policies you've specified for ILM.
+data retention policies you've specified for {ilm}.
 
 To remove {beats} from your host:
 

--- a/docs/en/ingest-management/overview.asciidoc
+++ b/docs/en/ingest-management/overview.asciidoc
@@ -152,6 +152,6 @@ more information, refer to
 == Data streams make index management easier
 
 The data collected by {agent} is stored in indices that are more granular than
-you'd get by default with the Beats shippers or APM Server. This gives you more visibility into the
+you'd get by default with the {beats} shippers or APM Server. This gives you more visibility into the
 sources of data volume, and control over lifecycle management policies and index
 permissions. These indices are called <<data-streams,_data streams_>>.

--- a/docs/en/ingest-management/release-notes/release-notes-7.13.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-7.13.asciidoc
@@ -90,14 +90,14 @@ impact to your application.
 
 [discrete]
 [[breaking-97206]]
-.Remove Elastic Agent routes and related services from {kib} and implement them in {fleet-server}
+.Remove {agent} routes and related services from {kib} and implement them in {fleet-server}
 [%collapsible]
 ====
 *Details* +
-Elastic Agents now use the Fleet Server to enroll agents, get agent policies, collect status information, and more. For more information, refer to {kibana-pull}97206[#97206].
+{agents} now use the {fleet-server} to enroll agents, get agent policies, collect status information, and more. For more information, refer to {kibana-pull}97206[#97206].
 
 *Impact* +
-To run and manage Elastic Agents, use the Fleet Server instead of {kib}. For more information, refer to {fleet-guide}/fleet-server.html[Fleet Server].
+To run and manage {agents}, use the {fleet-server} instead of {kib}. For more information, refer to {fleet-guide}/fleet-server.html[{fleet-server}].
 ====
       
 [discrete]
@@ -106,7 +106,7 @@ To run and manage Elastic Agents, use the Fleet Server instead of {kib}. For mor
 [%collapsible]
 ====
 *Details* +
-The existing agents in {kib} are not migrated as part of the migration to Fleet. For more information, refer to {kibana-pull}95789[#95789].
+The existing agents in {kib} are not migrated as part of the migration to {fleet}. For more information, refer to {kibana-pull}95789[#95789].
 
 *Impact* +
 The existing agent API keys are invalidated and display as `Inactive` on the *Agents* page.
@@ -180,10 +180,10 @@ or unenrollment hangs indefinitely. {fleet-server-issue}380[#380]
 === Enhancements
 
 {fleet}::
-* Hide Fleet Server policies in standalone agent instructions {kibana-pull}98787[#98787]
+* Hide {fleet-server} policies in standalone agent instructions {kibana-pull}98787[#98787]
 * Adds troubleshooting link to setup instructions {kibana-pull}98531[#98531]
 * Adds ability to specify which integration variables should be configurable {kibana-pull}97163[#97163]
-* Configure Fleet packages and integrations through endpoint {kibana-pull}94509[#94509]
+* Configure {fleet} packages and integrations through endpoint {kibana-pull}94509[#94509]
 * Adds submitOnBlur functionality to QueryStringInput {kibana-pull}93819[#93819]
 
 //{agent}::

--- a/docs/en/ingest-management/release-notes/release-notes-7.14.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-7.14.asciidoc
@@ -123,7 +123,7 @@ To fix this problem:
 
 . Delete the default {fleet-server} policy saved object:
 
-.. In {kib}, open the main menu, then go to **Management > Dev Tools > Console**.
+.. In {kib}, open the main menu, then go to **Management > {dev-tools-app} > Console**.
 
 .. In the Console, send the following requests:
 +
@@ -191,7 +191,7 @@ The 7.14.0 release adds the following new and notable features.
 //<Describe new behavior.> For more information, refer to {kibana-pull}PR[#PR].
 
 //*Impact* +
-//<Describe how users should mitigate the change.> For more information, refer to {fleet-guide}/fleet-server.html[Fleet Server].
+//<Describe how users should mitigate the change.> For more information, refer to {fleet-guide}/fleet-server.html[{fleet-server}].
 //====
 
 //[discrete]

--- a/docs/en/ingest-management/release-notes/release-notes-7.15.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-7.15.asciidoc
@@ -36,7 +36,7 @@ Review important information about the {fleet} and {agent} 7.15.1 releases.
 * Fixes policy upgrades for packages with multiple policy templates
 {kib-pull}114011[#114011]
 * Fixes Step 1 in policy editor not loading when agent policy already contains an
-integration that can only be added once (such as Endpoint Security) {kib-pull}113883[#113883]
+integration that can only be added once (such as {endpoint-sec}) {kib-pull}113883[#113883]
 * Sets code editor height to solve an overlap in default policy settings
 {kib-pull}113763[#113763]
 * Fixes issue where some variables from `xpack.fleet.agentPolicies` were not
@@ -86,7 +86,7 @@ To upgrade, refer to <<upgrade-elastic-agent>>.
 === Bug fixes
 
 {fleet}::
-* Fixes Fleet settings and HostInput error handling {kib-pull}109418[#109418]
+* Fixes {fleet} settings and HostInput error handling {kib-pull}109418[#109418]
 * Fixes Agent policy search to support simple text filters
 {kib-pull}107306[#107306]
 
@@ -136,7 +136,7 @@ To upgrade, refer to <<upgrade-elastic-agent>>.
 //<Describe new behavior.> For more information, refer to {kibana-pull}PR[#PR].
 
 //*Impact* +
-//<Describe how users should mitigate the change.> For more information, refer to {fleet-guide}/fleet-server.html[Fleet Server].
+//<Describe how users should mitigate the change.> For more information, refer to {fleet-guide}/fleet-server.html[{fleet-server}].
 //====
 
 //[discrete]

--- a/docs/en/ingest-management/release-notes/release-notes-7.16.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-7.16.asciidoc
@@ -104,7 +104,7 @@ Review important information about the {fleet} and {agent} 7.16.0 releases.
 [[enhancements-7.16.0]]
 === Enhancements
 
-Fleet::
+{fleet}::
 * Adds prompt for users to add an agent if they add an integration to an agent policy with no agents {kib-pull}114830[#114830]
 * Allow users with read access to view Integrations app {kib-pull}113925[#113925]
 * Removes enterprise license requirement for custom registry URL {kib-pull}113858[#113858]
@@ -122,7 +122,7 @@ Fleet::
 [[bug-fixes-7.16.0]]
 === Bug fixes
 
-Fleet::
+{fleet}::
 * Link to the installed version of an integration from global search {kib-pull}115736[#115736]
 * Fixes agent count in update modal {kib-pull}114622[#114622]
 * Shows security requirements page when {es} security is not enabled {kib-pull}114583[#114583]
@@ -217,7 +217,7 @@ upgrade integrations.
 //<Describe new behavior.> For more information, refer to {kibana-pull}PR[#PR].
 
 //*Impact* +
-//<Describe how users should mitigate the change.> For more information, refer to {fleet-guide}/fleet-server.html[Fleet Server].
+//<Describe how users should mitigate the change.> For more information, refer to {fleet-guide}/fleet-server.html[{fleet-server}].
 //====
 
 //[discrete]

--- a/docs/en/ingest-management/release-notes/release-notes-7.17.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-7.17.asciidoc
@@ -66,7 +66,7 @@ The Docker base image has changed from CentOS 7 to Ubuntu 20.04. {agent-issue}29
 //<Describe new behavior.> For more information, refer to {kibana-pull}PR[#PR].
 
 //*Impact* +
-//<Describe how users should mitigate the change.> For more information, refer to {fleet-guide}/fleet-server.html[Fleet Server].
+//<Describe how users should mitigate the change.> For more information, refer to {fleet-guide}/fleet-server.html[{fleet-server}].
 //====
 
 //[discrete]

--- a/docs/en/ingest-management/release-notes/release-notes-8.0.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.0.asciidoc
@@ -136,11 +136,11 @@ upgrade.
 {fleet}::
 [discrete]
 [[deprecation-119494]]
-.Updates Fleet API to improve consistency
+.Updates {fleet} API to improve consistency
 [%collapsible]
 ====
 *Details* +
-The Fleet API has been updated to improve consistency:
+The {fleet} API has been updated to improve consistency:
 
 * Hyphens are changed to underscores in some names.
 * The `pkgkey` path parameter in the packages endpoint is split.
@@ -200,7 +200,7 @@ The 8.0.0 release adds the following new and notable features.
 * Add `--fleet-server-es-ca-trusted-fingerprint` flag to allow {agent} and
 {fleet-server} to work with {es} clusters using self-signed certs.
 {agent-pull}29128[#29128]
-* Set `agent.id` to the Fleet Agent ID in events published from inputs backed
+* Set `agent.id` to the {fleet} Agent ID in events published from inputs backed
 by {beats}. {agent-issue}21121[#21121] {agent-pull}26394[#26394] {agent-pull}26548[#26548]
 
 [discrete]
@@ -255,7 +255,7 @@ by {beats}. {agent-issue}21121[#21121] {agent-pull}26394[#26394] {agent-pull}265
 //<Describe new behavior.> For more information, refer to {kibana-pull}PR[#PR].
 
 //*Impact* +
-//<Describe how users should mitigate the change.> For more information, refer to {fleet-guide}/fleet-server.html[Fleet Server].
+//<Describe how users should mitigate the change.> For more information, refer to {fleet-guide}/fleet-server.html[{fleet-server}].
 //====
 
 //[discrete]

--- a/docs/en/ingest-management/release-notes/release-notes-8.1.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.1.asciidoc
@@ -36,7 +36,7 @@ Review important information about the {fleet} and {agent} 8.1.2 release.
 * There are no bug fixes for {fleet} in this release.
 
 {agent}::
-* Propagate input ID from the Agent policy into the Filebeat configuration. Note
+* Propagate input ID from the Agent policy into the {filebeat} configuration. Note
 that no validation is performed on this field. {agent-pull}30386[#30386]
 
 // end 8.1.2 relnotes
@@ -61,7 +61,7 @@ Review important information about the {fleet} and {agent} 8.1.1 release.
 
 {agent}::
 * Fix issue where a failing artifact verification does not remove the bad artifact. {agent-pull}30281[#30281]
-* Fix the start sequence of Beats that was non-deterministic, making Beats missing their
+* Fix the start sequence of {beats} that was non-deterministic, making {beats} missing their
 configuration from Agent and not sending events. {agent-pull}30694[#30694]
 
 // end 8.1.1 relnotes
@@ -113,7 +113,7 @@ In prior releases, we provided a default {fleet-server} policy. Starting in
 8.1.0, the default {fleet-server} policy is no longer created automatically for
 self-managed deployments; instead, you need to create it explicitly.
 
-The Elastic Cloud agent policy is not changed; it is still available by default
+The {ecloud} agent policy is not changed; it is still available by default
 when using our hosted {ess} on {ecloud}.
 
 *Impact* +
@@ -146,7 +146,7 @@ folder `{path.config}/inputs.d`. {agent-pull}30087[#30087]
 
 {fleet}::
 * Add shipper label. {kib-pull}122491[#122491]
-* Add support for non-superuser access to *Fleet* and *Integrations*. {kib-pull}122347[#122347]
+* Add support for non-superuser access to *{fleet}* and *Integrations*. {kib-pull}122347[#122347]
 * Add support for bundling packages as zip archives with {kib} source. {kib-pull}122297[#122297]
 * Make the default integration install explicit. {kib-pull}121628[#121628]
 
@@ -204,7 +204,7 @@ folder `{path.config}/inputs.d`. {agent-pull}30087[#30087]
 //<Describe new behavior.> For more information, refer to {kibana-pull}PR[#PR].
 
 //*Impact* +
-//<Describe how users should mitigate the change.> For more information, refer to {fleet-guide}/fleet-server.html[Fleet Server].
+//<Describe how users should mitigate the change.> For more information, refer to {fleet-guide}/fleet-server.html[{fleet-server}].
 //====
 
 //[discrete]

--- a/docs/en/ingest-management/release-notes/release-notes-8.2.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.2.asciidoc
@@ -55,7 +55,7 @@ because they are no longer used.
 
 To find and delete legacy component templates:
 
-. In {kib}, go to *Stack Management > Index Management* and click
+. In {kib}, go to *{stack-manage-app} > Index Management* and click
 *Component Templates*.
 
 . Click `Not in use` to filter out component templates that are still in use.

--- a/docs/en/ingest-management/security/certificates.asciidoc
+++ b/docs/en/ingest-management/security/certificates.asciidoc
@@ -139,6 +139,7 @@ the *Action* column.
 .. Specify either a CA certificate or CA fingerprint to connect securely
 {es}:
 
+// lint ignore elasticsearch
 * If you have a CA trusted fingerprint, specify it in the
 *Elasticsearch CA trusted fingerprint* field. To learn more, refer to the
 {ref}/configuring-stack-security.html[{es} security documentation].
@@ -275,7 +276,7 @@ sudo elastic-agent install -f --url=https://192.0.2.1:8220 \
 Where:
 
 `url`::
-Fleet Server URL to use to enroll the {agent} into {fleet}.
+{fleet-server} URL to use to enroll the {agent} into {fleet}.
 `enrollment-token`::
 The enrollment token for the policy that will be applied to the {agent}.
 `certificate-authorities`::
@@ -283,11 +284,12 @@ CA certificate to use to connect to {fleet-server}. This is the
 CA used to <<generate-fleet-server-certs,generate a certificate and key>>
 for {fleet-server}.
 
-Don't have an enrollment token? On the *Agents* tab in Fleet, click *Add agent*.
+// lint ignore elastic-agent
+Don't have an enrollment token? On the *Agents* tab in {fleet}, click *Add agent*.
 Under *Enroll and start the Elastic Agent*, follow the in-product installation steps, making sure
 that you add the `--certificate-authorities` option before you run the command.
 --
 
 // TODO: Add reference docs about SSL settings and point to the content from
-// this topics. Before I can do this, I need to know which settings from Beats
+// this topics. Before I can do this, I need to know which settings from {beats}
 // are supported for Elastic Agent.

--- a/docs/en/ingest-management/security/logstash-certificates.asciidoc
+++ b/docs/en/ingest-management/security/logstash-certificates.asciidoc
@@ -15,7 +15,7 @@ to trusted {ls} servers, and that your {ls} servers receive data from trusted
 * Make sure your https://www.elastic.co/subscriptions[subscription level]
 supports output to {ls}.
 
-* On Windows, add port 8220 for {fleet-server} and 5044 for Logstash to the
+* On Windows, add port 8220 for {fleet-server} and 5044 for {ls} to the
 inbound port rules in Windows Advanced Firewall.
 
 * If you are connecting to a self-managed {es} cluster, you need the CA
@@ -109,7 +109,7 @@ TIP: If you've already created the {ls} `elastic-agent-pipeline.conf` pipeline
 and added it to `pipelines.yml`, skip to the example configurations and modify
 your pipeline configuration as needed.
 
-In your Logstash configuration directory, open the `pipelines.yml` file and
+In your {ls} configuration directory, open the `pipelines.yml` file and
 add the following configuration. Replace the path to your file.
 
 [source,yaml]
@@ -196,11 +196,12 @@ bin/logstash
 [[add-ls-output]]
 == Add a {ls} output to {fleet}
 
-This section describes how to add a Logstash output and configure SSL settings
+This section describes how to add a {ls} output and configure SSL settings
 in {fleet}. If you're running {agent} standalone, refer to the
-<<logstash-output,Logstash output>> configuration docs.
+<<logstash-output,{ls} output>> configuration docs.
 
-. In {kib}, go to *Fleet > Settings*.
+// lint disable logstash
+. In {kib}, go to *{fleet} > Settings*.
 
 . Under *Outputs*, click *Add output*. If you've been following the {ls} steps
 in {fleet}, you might already be on this page.
@@ -223,6 +224,7 @@ contents of the `ca.crt` file you <<generate-logstash-certs,generated earlier>>.
 
 [role="screenshot"]
 image::images/add-logstash-output.png[Screen capture of a folder called logstash that contains two files: logstash.crt and logstash.key]
+// lint enable logstash
 
 When you're done, save and apply the settings.
 
@@ -234,7 +236,7 @@ When you're done, save and apply the settings.
 {es} yet. You need to select the {ls} output in an agent policy. You can edit
 an existing policy or create a new one:
 
-. In {kib}, go to *Fleet > Agent policies* and either create a new agent policy
+. In {kib}, go to *{fleet} > Agent policies* and either create a new agent policy
 or click an existing policy to edit it:
 +
 * To change the output settings in a new policy, click *Create agent policy*
@@ -247,7 +249,7 @@ to use the {ls} output you created earlier. You might need to scroll down to see
 these options
 +
 [role="screenshot"]
-image::images/agent-output-settings.png[Screen capture showing the Logstash output policy selected in an agent policy]
+image::images/agent-output-settings.png[Screen capture showing the {ls} output policy selected in an agent policy]
 
 . Save your changes.
 
@@ -273,7 +275,7 @@ curl -XGET localhost:9600/_node/stats/events
 The request should return stats on the number of events in and out. If these
 values are 0, check the {agent} logs for problems.
  
-When data is streaming to {es}, go to *Observability* and click
+When data is streaming to {es}, go to *{observability}* and click
 *Metrics* to view metrics about your system.
 
 //TODO: WE should add some troubleshooting advice like what to do if the

--- a/docs/en/ingest-management/tab-widgets/add-fleet-server/content.asciidoc
+++ b/docs/en/ingest-management/tab-widgets/add-fleet-server/content.asciidoc
@@ -7,7 +7,7 @@ deployment.
 To confirm that an {integrations-server} is available in your deployment:
 
 . In {kib}, open the main menu, and go to *Management > {fleet}*.
-. On the *Agents* tab, look for the *Elastic Cloud agent policy*. This policy is
+. On the *Agents* tab, look for the *{ecloud} agent policy*. This policy is
 managed by {ecloud}, and contains a {fleet-server} integration and an Elastic
 APM integration. You cannot modify the policy. Confirm that the agent status is
 *Healthy*.
@@ -32,6 +32,7 @@ agent policy containing the {fleet-server} integration.
 information about these settings, see
 {fleet-guide}/fleet-settings.html[{fleet} settings].
 
+// lint ignore fleet-server
 . Under *Fleet Server hosts*, click *Edit hosts* and specify one or more host
 URLs your {agent}s will use to connect to {fleet-server}. For example,
 `https://192.0.2.1:8220`, where `192.0.2.1` is the host IP where you will
@@ -105,6 +106,6 @@ If installation is successful, you'll see the {fleet-server} {agent} on the
 *Agents* tab in *{fleet}*.
 +
 [role="screenshot"]
-image::images/agents-tab-fleet-server.png[Agent tab showing a healthy agent enrolled in the Default Fleet Server policy]
+image::images/agents-tab-fleet-server.png[Agent tab showing a healthy agent enrolled in the Default {fleet-server} policy]
 
 // end::self-managed[]

--- a/docs/en/ingest-management/tab-widgets/upgrade-fleet.asciidoc
+++ b/docs/en/ingest-management/tab-widgets/upgrade-fleet.asciidoc
@@ -4,7 +4,8 @@
 
 To confirm that {fleet-server} is available in your deployment:
 
-. Log in to {kib} and go to *Management > {fleet}*, and click the *Agents* tab.
+// lint ignore fleet
+. Log in to {kib} and go to *Management > Fleet*, and click the *Agents* tab.
 . The following message is displayed. Please note that your {agent}s have now
 been unenrolled and have stopped sending data. 
 +
@@ -13,7 +14,7 @@ Select *Do not show this message again*, and then click *Close and get started*.
 [role="screenshot"]
 image::images/fleet-server-prompt.png[Add {fleet-server} prompt]
 +
-If your previous deployment did not include an APM node, you are prompted to enable *APM & {fleet}*,
+If your previous deployment did not include an APM node, you are prompted to enable *APM & Fleet*,
 required for using {fleet-server}.
 +
 Click *Edit deployment* and add an *{integrations-server}* node to your deployment.
@@ -22,7 +23,7 @@ Click *Edit deployment* and add an *{integrations-server}* node to your deployme
 image::images/apm-fleet-prompt.png[Add {integrations-server} node prompt]
 +
 . To confirm that {fleet-server} is available in your deployment, click the *Agents* tab.
-. Under *Policies*, select the *Elastic Cloud agent policy* to confirm that {fleet-server}
+. Under *Policies*, select the *{ecloud} agent policy* to confirm that {fleet-server}
 is listed. This policy is managed by {ecloud} and can not be modified.
 +
 You are now able to install and enroll subsequent {agent}s with {fleet-server}.

--- a/docs/en/ingest-management/troubleshooting/faq.asciidoc
+++ b/docs/en/ingest-management/troubleshooting/faq.asciidoc
@@ -93,7 +93,7 @@ If {elastic-agent} is set up and running, but you don't see data in {kib}:
 
 
 
-. Go to **Management > Dev Tools** in {kib}, and in the Console, search your
+. Go to **Management > {dev-tools-app}** in {kib}, and in the Console, search your
 index for data. For example:
 +
 [source,console]
@@ -156,9 +156,9 @@ that you no longer have to run a manual setup command to load integrations as
 you did previously with {beats} modules.
 
 By default, {kib} requires an internet connection to download integration
-packages from the Elastic Package Registry. If network restrictions prevent
-{kib} from reaching the public Elastic Package Registry, you can use a proxy
-server or host your own Elastic Package Registry. To learn more, refer to
+packages from the {package-registry}. If network restrictions prevent
+{kib} from reaching the public {package-registry}, you can use a proxy
+server or host your own {package-registry}. To learn more, refer to
 <<air-gapped>>.
 
 [discrete]
@@ -171,7 +171,7 @@ download site.  However, if it is in use, the {elastic-endpoint-integration} pro
 is instructed to attempt to download newer released versions of the integration specific 
 artifacts it uses.  Some of those are, for example, the malware model, trusted apps artifact, 
 exceptions list artifact, and others.  For more information, see the 
-{security-guide}/index.html[Elastic Security solution documentation].
+{security-guide}/index.html[{elastic-sec} solution documentation].
 
 * {agent} requires internet access to download artifacts for binary upgrades.
 

--- a/docs/en/ingest-management/troubleshooting/troubleshooting.asciidoc
+++ b/docs/en/ingest-management/troubleshooting/troubleshooting.asciidoc
@@ -23,17 +23,17 @@ Have a question? Read our <<fleet-faq,FAQ>>, or contact us in the
 Running {agent} standalone? Also refer to <<debug-standalone-agents>>.
 
 //TODO: Improve how content is organized in this section, perhaps by breaking
-//it down into sections like Agent, Fleet Server, etc.
+//it down into sections like Agent, {fleet-server}, etc.
 
 [discrete]
 [[agents-in-cloud-stuck-at-updating]]
 == {agent}s hosted on {ecloud} are stuck in `Updating` or `Offline`
 
 In {ecloud}, after <<upgrade-integration,upgrading>> {fleet-server} and its
-integration policies, agents enrolled in the Elastic Cloud agent policy
+integration policies, agents enrolled in the {ecloud} agent policy
 may experience issues updating. To resolve this problem:
 
-. In a terminal window, run the following `cURL` request, providing your {kib} superuser credentials to reset the Elastic Cloud agent policy.
+. In a terminal window, run the following `cURL` request, providing your {kib} superuser credentials to reset the {ecloud} agent policy.
 
 +
 [source,shell]
@@ -46,7 +46,7 @@ curl -u <username>:<password> --request POST \
 
 . Force unenroll the agent stuck in `Updating`:
 
-.. To find agent's ID, go to *Fleet > Agents* and click the agent to see its
+.. To find agent's ID, go to *{fleet} > Agents* and click the agent to see its
 details. Copy the Agent ID.
 
 .. In a terminal window, run:
@@ -274,7 +274,7 @@ For example, if you want to include system data, make sure the *System* integrat
 .. In {fleet}, click **Agents**, and then select the {agent} policy.
 .. Select the *Settings* tab. If you want to collect agent logs or metrics, select these options.
 +
-IMPORTANT: The *Elastic Cloud agent policy* is created only in {ecloud} deployments and, by default,
+IMPORTANT: The *{ecloud} agent policy* is created only in {ecloud} deployments and, by default,
 does not include the collection of logs of metrics.
 
 You can collect other files to assess and pass to the Elastic team for review for some more advanced debugging cases.
@@ -573,9 +573,9 @@ To scale the {fleet-server} deployment, {ecloud} starts new containers or shuts 
 
 [discrete]
 [[hosted-agent-8-x-upgrade-fail]]
-== APM & Fleet fails to upgrade to 8.x on {ecloud}
+== APM & {fleet} fails to upgrade to 8.x on {ecloud}
 
-In some scenarios, upgrading APM & Fleet to 8.x may fail if the Elastic Cloud agent policy was modified manually. The {fleet} app in {kib} may show a message like:
+In some scenarios, upgrading APM & {fleet} to 8.x may fail if the {ecloud} agent policy was modified manually. The {fleet} app in {kib} may show a message like:
 
 [source,sh]
 ----

--- a/docs/en/integrations/build-integration.asciidoc
+++ b/docs/en/integrations/build-integration.asciidoc
@@ -374,7 +374,7 @@ Descriptions are shown in the {kib} UI, so try and keep them clean and consisten
 These descriptions are visualized in the {kib} UI. It would be better experience to have them clean and consistent.
 
 * Bad candidate: filebeat running on ec2 machine
-* Good candidates: Filebeat running on AWS EC2 machine
+* Good candidates: {filebeat} running on AWS EC2 machine
 
 [discrete]
 == Exporting
@@ -480,9 +480,10 @@ instance of the {agent}, proceed with steps 4 and 5:
 
 . (Optional) Download the https://www.elastic.co/downloads/elastic-agent[{agent}].
 
+// lint ignore fleet ingest-manager
 . (Optional) Enroll the {agent} and start it:
 +
-Use the "Enroll new agent" option in the Kibana UI (Ingest Manager -> Fleet -> Create user and enable Fleet) and run a similar command:
+Use the "Enroll new agent" option in the {kib} UI (Ingest Manager -> Fleet -> Create user and enable Fleet) and run a similar command:
 +
 [source,terminal]
 ----
@@ -496,9 +497,9 @@ The `elastic-agent` starts two other processes: `metricbeat` and `filebeat`.
 
 . Install package.
 +
-Click out the configuration in the Kibana UI, deploy it and wait for the agent to pick out the updated configuration.
+Click out the configuration in the {kib} UI, deploy it and wait for the agent to pick out the updated configuration.
 
-. Navigate with Kibana UI to freshly installed dashboards, verify the metrics/logs flow.
+. Navigate with {kib} UI to freshly installed dashboards, verify the metrics/logs flow.
 
 === Use test runners
 
@@ -569,7 +570,7 @@ To see how to use template functions, for example {{fields "data-stream-name"}},
 
 === Define variable properties
 
-The variable properties customize visualization of configuration options in the Kibana UI. Make sure they're defined in all manifest files.
+The variable properties customize visualization of configuration options in the {kib} UI. Make sure they're defined in all manifest files.
 
 [source,yaml]
 ----

--- a/docs/en/integrations/dashboards.asciidoc
+++ b/docs/en/integrations/dashboards.asciidoc
@@ -1,4 +1,4 @@
-= Create Kibana Dashboards
+= Create {kib} Dashboards
 
 THIS FILE HAS BEEN REPLACED
 

--- a/docs/en/integrations/elastic-package.asciidoc
+++ b/docs/en/integrations/elastic-package.asciidoc
@@ -68,7 +68,7 @@ Use this command to build a package. Currently, it supports only the "integratio
 
 Built packages are stored in the "build/" folder located at the root folder of the local Git repository checkout that contains your package folder. The command will also render the README file in your package folder if a corresponding template file present in "_dev/build/docs/README.md". All "_dev" directories under your package will be omitted.
 
-Built packages are served up by the Elastic Package Registry running locally (see "elastic-package stack"). Therefore, if you want a local package to be served up by the local Elastic Package Registry, make sure to build that package first using "elastic-package build".
+Built packages are served up by the {package-registry} running locally (see "elastic-package stack"). Therefore, if you want a local package to be served up by the local {package-registry}, make sure to build that package first using "elastic-package build".
 
 You can also publish built packages to the global package registry service.
 
@@ -106,7 +106,7 @@ For details on creating a new package, review the https://github.com/elastic/ela
 
 _Context: package_
 
-Use this command to export assets relevant for the package, e.g. Kibana dashboards.
+Use this command to export assets relevant for the package, e.g. {kib} dashboards.
 
 [discrete]
 === `elastic-package format`
@@ -204,7 +204,7 @@ Use this command to run tests on a package. Currently, the following types of te
 
 [discrete]
 ==== Asset Loading Tests
-These tests ensure that all the Elasticsearch and Kibana assets defined by your package get loaded up as expected.
+These tests ensure that all the {es} and {kib} assets defined by your package get loaded up as expected.
 
 For details on running asset loading tests for a package, see the https://github.com/elastic/elastic-package/blob/main/docs/howto/asset_testing.md[HOWTO guide].
 

--- a/docs/en/integrations/index.asciidoc
+++ b/docs/en/integrations/index.asciidoc
@@ -44,4 +44,4 @@ include::package-spec.asciidoc[leveloffset=+1]
 // == Community integrations
 
 // Should we have a community integrations page?
-// Similar to what exists in the Beats developer guide: https://www.elastic.co/guide/en/beats/devguide/current/community-beats.html
+// Similar to what exists in the {beats} developer guide: https://www.elastic.co/guide/en/beats/devguide/current/community-beats.html

--- a/docs/en/integrations/integration-example.asciidoc
+++ b/docs/en/integrations/integration-example.asciidoc
@@ -43,7 +43,7 @@ Let's choose one of these data streams to dig into: access logs.
 [[apache-ingest-pipelines]]
 == Ingest pipelines
 
-Access logs (or any logs) should be parsed into structured data prior to ingesting them into Elasticsearch.
+Access logs (or any logs) should be parsed into structured data prior to ingesting them into {es}.
 To do this, integrations use **ingest pipelines**
 
 ****
@@ -161,9 +161,9 @@ stuff
 
 [discrete]
 [[apache-kibana-assets]]
-== Kibana assets
+== {kib} assets
 
-Something about Kibana dashboards or visualizations
+Something about {kib} dashboards or visualizations
 
 [discrete]
 [[apache-everything-else]]

--- a/docs/en/integrations/package-spec.asciidoc
+++ b/docs/en/integrations/package-spec.asciidoc
@@ -13,7 +13,7 @@ The package specification describes:
 
 In general, assets within a package are organized by `<elastic-stack-component>/<asset-type>`.
 For example, ingest pipelines are stored in the `elasticsearch/ingest-pipeline` folder.
-This logic applies to all Elasticsearch, Kibana, and Agent assets.
+This logic applies to all {es}, {kib}, and Agent assets.
 
 Top-level assets are picked up as JSON documents and pushed to the corresponding {es} and {kib} APIs.
 
@@ -26,10 +26,10 @@ Each data stream should have its folder of assets within this folder,
 and the names of these data streams must follow the data stream naming scheme.
 
 The contents of these folders follow the `<elastic-stack-component>/<asset-type>` structure.
-During installation, Fleet enforces data stream naming rules.
+During installation, {fleet} enforces data stream naming rules.
 All assets in this folder belong directly or indirectly to data streams.
 
-In most scenarios, only data stream assets are needed. However, there are exceptions where global assets are required to get more flexibility. For example, an ILM policy that applies to all data streams.
+In most scenarios, only data stream assets are needed. However, there are exceptions where global assets are required to get more flexibility. For example, an {ilm-init} policy that applies to all data streams.
 
 [discrete]
 [[supported-assets]]
@@ -46,7 +46,7 @@ The following assets are typically found in an Elastic package:
 ** Dashboards
 ** Visualization
 ** {data-sources-cap}
-** ML Modules
+** {ml-init} Modules
 ** Map
 ** Search
 ** Security rules

--- a/docs/en/integrations/pipeline-testing.asciidoc
+++ b/docs/en/integrations/pipeline-testing.asciidoc
@@ -19,8 +19,8 @@ Conceptually, running a pipeline test involves the following steps:
 == Limitations
 
 At the moment, pipeline tests have limitations. The main ones are:
-* As you're only testing the ingest pipeline, you can prepare mocked documents with imaginary fields, different from ones collected in Beats. Also, the other way round, you can skip most of the example fields and use tiny documents with a minimal set of fields just to satisfy the pipeline validation.
-* There might be integrations that transform data mainly using Beats processors instead of ingest pipelines. In such cases, ingest pipelines are rather plain.
+* As you're only testing the ingest pipeline, you can prepare mocked documents with imaginary fields, different from ones collected in {beats}. Also, the other way round, you can skip most of the example fields and use tiny documents with a minimal set of fields just to satisfy the pipeline validation.
+* There might be integrations that transform data mainly using {beats} processors instead of ingest pipelines. In such cases, ingest pipelines are rather plain.
 
 [discrete]
 [[pipeline-defining-test]]
@@ -204,7 +204,7 @@ If you want to run pipeline tests for **specific data streams** in a package, na
 elastic-package test pipeline --data-streams <data stream 1>[,<data stream 2>,...]
 ----
 
-Finally, when you are done running all pipeline tests, bring down the Elastic Stack. This corresponds to step 4 as described in the <<pipeline-concepts,Conceptual-process>> section.
+Finally, when you are done running all pipeline tests, bring down the {stack}. This corresponds to step 4 as described in the <<pipeline-concepts,Conceptual-process>> section.
 
 [source,terminal]
 ----

--- a/docs/en/integrations/publish-integration.asciidoc
+++ b/docs/en/integrations/publish-integration.asciidoc
@@ -21,7 +21,7 @@ CI will kick off a build job for the main branch, which can release your integra
 [discrete]
 == Promote
 
-Now that you've tested your integration with Kibana, it's time to promote it to staging or production.
+Now that you've tested your integration with {kib}, it's time to promote it to staging or production.
 Run:
 
 [source,terminal]

--- a/docs/en/integrations/system-testing.asciidoc
+++ b/docs/en/integrations/system-testing.asciidoc
@@ -15,13 +15,13 @@ Conceptually, running a system test involves the following steps:
 . Create a test policy that configures a single data stream for a single package.
 . Assign the test policy to the enrolled Agent.
 . Wait a reasonable amount of time for the Agent to collect data from the
-   integration service and index it into the correct Elasticsearch data stream.
+   integration service and index it into the correct {es} data stream.
 . Query the first 500 documents based on `@timestamp` for validation.
 . Validate mappings are defined for the fields contained in the indexed documents.
 . Validate that the JSON data types contained `_source` are compatible with
    mappings declared for the field.
 . Delete test artifacts and tear down the instance of the package's integration service.
-. Once all desired data streams have been system tested, tear down the Elastic Stack.
+. Once all desired data streams have been system tested, tear down the {stack}.
 
 [discrete]
 [[system-test-limitations]]
@@ -152,8 +152,8 @@ The Kubernetes service deployer needs [kind](https://kind.sigs.k8s.io/) to be in
 wget -qO-  https://raw.githubusercontent.com/elastic/elastic-package/main/scripts/kind-config.yaml | kind create cluster --config -
 ----
 
-Before executing system tests, the service deployer applies once the deployment of the Elastic Agent to the cluster and links
-the kind cluster with the Elastic stack network - applications running in the kind cluster can reach Elasticsearch and Kibana instances.
+Before executing system tests, the service deployer applies once the deployment of the {agent} to the cluster and links
+the kind cluster with the Elastic stack network - applications running in the kind cluster can reach {es} and {kib} instances.
 The {agent}'s deployment is not deleted after tests to shorten the total test execution time, but it can be reused.
 
 See how to execute system tests for the Kubernetes integration (`pod` data stream):
@@ -271,7 +271,7 @@ elastic-package stack down
 === Generating sample events
 
 As the system tests exercise an integration end-to-end from running the integration's service all the way
-to indexing generated data from the integration's data streams into Elasticsearch, it is possible to generate
+to indexing generated data from the integration's data streams into {es}, it is possible to generate
 `sample_event.json` files for each of the integration's data streams while running these tests.
 
 [source,terminal]

--- a/docs/en/integrations/what-is-an-integration.asciidoc
+++ b/docs/en/integrations/what-is-an-integration.asciidoc
@@ -52,4 +52,4 @@ those will intercept the data and transform it before it is indexed.
 . Visualize the results
 +
 Integrations can and should ship with custom dashboards and visualizations that are installed with the integration.
-Use these for a tailored view of your Observability data.
+Use these for a tailored view of your {observability} data.

--- a/docs/en/observability/analyze-metrics.asciidoc
+++ b/docs/en/observability/analyze-metrics.asciidoc
@@ -36,5 +36,5 @@ endif::[]
 
 ifeval::["{is-current-version}"=="false"]
 [role="screenshot"]
-image::images/metrics-app.png[Metrics app in Kibana]
+image::images/metrics-app.png[{metrics-app} in {kib}]
 endif::[]

--- a/docs/en/observability/analyze-monitors.asciidoc
+++ b/docs/en/observability/analyze-monitors.asciidoc
@@ -1,7 +1,7 @@
 [[analyze-monitors]]
 = Analyze monitors
 
-To access this page, go to *Observability > Uptime > Monitors*. Click on a listed monitor
+To access this page, go to *{observability} > Uptime > Monitors*. Click on a listed monitor
 to view more details and analyze further.
 
 The monitor detail screen displays several panels of information.
@@ -34,7 +34,7 @@ The *Monitor duration* chart displays the timing for each check that was perform
 helps you to gain insights into how quickly requests resolve by the targeted endpoint and give you a
 sense of how frequently a host or endpoint was down in your selected timespan.
 
-Included on this chart is the anomaly detection ({ml}) integration. For more information, see
+Included on this chart is the {anomaly-detect} ({ml}) integration. For more information, see
 <<inspect-uptime-duration-anomalies,Inspect Uptime duration anomalies>>.
 
 [role="screenshot"]

--- a/docs/en/observability/apm.asciidoc
+++ b/docs/en/observability/apm.asciidoc
@@ -1,7 +1,7 @@
 [[apm]]
 = Application performance monitoring (APM)
 
-Elastic APM is an application performance monitoring system built on the Elastic Stack.
+Elastic APM is an application performance monitoring system built on the {stack}.
 It allows you to monitor software services and applications in real time, by
 collecting detailed performance information on response time for incoming requests,
 database queries, calls to caches, external HTTP requests, and more.
@@ -26,7 +26,7 @@ endif::[]
 
 ifeval::["{is-current-version}"=="false"]
 [role="screenshot"]
-image::images/apm-app-landing.png[APM app in Kibana]
+image::images/apm-app-landing.png[{apm-app} in {kib}]
 endif::[]
 
 To learn more, see {apm-guide-ref}/index.html[APM Overview].

--- a/docs/en/observability/categorize-logs.asciidoc
+++ b/docs/en/observability/categorize-logs.asciidoc
@@ -23,6 +23,7 @@ high message counts in the categories.
 [role="screenshot"]
 image::images/log-create-categorization-job.jpg[Configure log categorization job]
 
+// lint ignore ml
 1. Select *Categories*, and you are prompted to use {ml} to create 
    log rate categorizations.
 2. Choose a time range for the {ml} analysis. By default, the {ml} job analyzes 

--- a/docs/en/observability/ci-cd-observability.asciidoc
+++ b/docs/en/observability/ci-cd-observability.asciidoc
@@ -1,9 +1,9 @@
 [[ci-cd-observability]]
-= CI/CD Observability
+= CI/CD observability
 :figure-caption!:
 
 To help administrators monitor and troubleshoot their CI/CD platform and help developers
-increase the speed and reliability of their CI/CD pipelines, Elastic Observability
+increase the speed and reliability of their CI/CD pipelines, Elastic {observability}
 provides visibility in Continuous Integration and Continuous Delivery (CI/CD) processes.
 
 To provide monitoring dashboards, alerting, and root cause analysis on pipelines, Elastic
@@ -14,10 +14,10 @@ OpenTelemetry.
 [[ci-cd-architecture]]
 == CI/CD observability architectures
 
-Using the APM Server, connect all your OpenTelemetry native CI/CD tools directly to Elastic Observability.
+Using the APM Server, connect all your OpenTelemetry native CI/CD tools directly to Elastic {observability}.
 
-.Architecture of CI/CD Observability with Elastic
-image::images/simple-arch-observability.png[Simple architecture of CI/CD Observability with Elastic]
+.Architecture of CI/CD observability with Elastic
+image::images/simple-arch-observability.png[Simple architecture of CI/CD observability with Elastic]
 
 A more advanced CI/CD observability architecture includes an OpenTelemetry Collector
 deployed on the edge, next to the CI/CD tools. This architecture provides the following:
@@ -25,38 +25,39 @@ deployed on the edge, next to the CI/CD tools. This architecture provides the fo
 * Low latency between the CI/CD tools and the collector is particularly beneficial to
 ephemeral tools like the otel-cli.
 * The ability to route the observability signals to multiple backends in addition to
-Elastic Observability.
+Elastic {observability}.
 
-.Advanced architecture of CI/CD Observability with Elastic
-image::images/advanced-arch-observability.png[Advanced architecture of CI/CD Observability with Elastic]
+.Advanced architecture of CI/CD observability with Elastic
+image::images/advanced-arch-observability.png[Advanced architecture of CI/CD observability with Elastic]
 
 [discrete]
 [[ci-cd-administrators]]
+// lint ignore observability
 == Observability for CI/CD administrators
 
-Elastic Observability allows CI/CD administrators to monitor and troubleshoot CI/CD
+Elastic {observability} allows CI/CD administrators to monitor and troubleshoot CI/CD
 platforms and detect anomalies.
 
 [discrete]
 [[ci-cd-monitoring]]
 === CI/CD platform monitoring and alerting
 
-Elastic Observability helps CI/CD administrators monitor their platform by providing KPI dashboards
+Elastic {observability} helps CI/CD administrators monitor their platform by providing KPI dashboards
 of CI systems.
 
 The Jenkins health dashboards provide insights on the build executions, the failures, the
 provisioning of build agents, the active and idle workers, or the JVM health.
 
 [role="screenshot"]
-.Jenkins KPIs in Elastic Observability
+.Jenkins KPIs in Elastic {observability}
 image::images/ci-cd-overview.png[CI/CD overview]
 
 [role="screenshot"]
-.Jenkins Provisioning KPIs in Elastic Observability
+.Jenkins Provisioning KPIs in Elastic {observability}
 image::images/jenkins-kpis.png[Jenkins KPIs]
 
 [role="screenshot"]
-.Jenkins JVM health indicators in Elastic Observability
+.Jenkins JVM health indicators in Elastic {observability}
 image::images/jenkins-jvm-indicators.png[Jenkins JVM health indicators]
 
 [discrete]
@@ -66,7 +67,7 @@ image::images/jenkins-jvm-indicators.png[Jenkins JVM health indicators]
 CI/CD administrators need to assess the impact of anomalies when troubleshooting platform problems quickly,
 whether troubleshooting just one pipeline to much broader outages impacting many pipelines or the entire CI/CD platform.
 
-Elastic Observability enables troubleshooting CI platform outages by providing visualizations of pipeline
+Elastic {observability} enables troubleshooting CI platform outages by providing visualizations of pipeline
 executions as distributed traces, along with the capability to slice and dice pipeline executions in any dimension
 to assess the nature and the impact of the outage.
 
@@ -75,7 +76,7 @@ Select any of those errors to view the specific information. In this case, it's 
 the CI agent that stopped.
 
 [role="screenshot"]
-.Jenkins pipeline build error in Elastic Observability
+.Jenkins pipeline build error in Elastic {observability}
 image::images/jenkins-pipeline-build.png[Jenkins pipeline builds]
 
 The Errors overview screen provides a high-level view of the exceptions that CI builds catch.
@@ -83,36 +84,37 @@ Similar errors are grouped to quickly see which ones are affecting your services
 and allow you to take action to rectify them.
 
 [role="screenshot"]
-.Jenkins jobs and pipelines errors in Elastic Observability
+.Jenkins jobs and pipelines errors in Elastic {observability}
 image::images/jenkins-pipeline-errors.png[Jenkins pipeline build errors]
 
 [role="screenshot"]
-.Concourse CI pipeline execution as a trace in Elastic Observability
+.Concourse CI pipeline execution as a trace in Elastic {observability}
 image::images/concourse-ci-traces.png[Concourse CI traces view]
 
 [discrete]
 [[ci-cd-developers]]
+// lint ignore observability
 == Observability for developers
 
 Development teams need to continuously optimize their ever-changing CI/CD pipelines to improve
 their reliability while chasing faster pipelines. Visualizations of pipelines as distributed
 traces help to document what’s happening and improve performance and reliability (flaky tests and pipelines).
 
-Integrating with many popular CI/CD and DevOps tools like Maven or Ansible using OpenTelemetry, Elastic Observability
+Integrating with many popular CI/CD and DevOps tools like Maven or Ansible using OpenTelemetry, Elastic {observability}
 solves these problems by providing deep insights into the execution of CI/CD pipelines.
 
 [discrete]
 [[ci-cd-visibility]]
 === CI/CD pipeline visibility
 
-The visualization of CI/CD pipelines as distributed traces in Elastic Observability provides
+The visualization of CI/CD pipelines as distributed traces in Elastic {observability} provides
 documentation and health indicators of all your pipelines.
 
-The APM Service view in Elastic Observability provides a view of all your instrumented CI/CD
+The APM Service view in Elastic {observability} provides a view of all your instrumented CI/CD
 servers with insights on their KPIs.
 
 [role="screenshot"]
-.Jenkins servers in Elastic Observability
+.Jenkins servers in Elastic {observability}
 image::images/jenkins-servers.png[Jenkins servers view]
 
 The Service page provides more granular insights into your CI/CD workflows by breaking down health
@@ -120,7 +122,7 @@ and performance metrics by pipeline. To quickly view which pipelines experience 
 most frequently executed, or are the slowest, you can sort and filter the list.
 
 [role="screenshot"]
-.A Jenkins server in Elastic Observability
+.A Jenkins server in Elastic {observability}
 image::images/jenkins-server.png[Jenkins server view]
 
 [discrete]
@@ -132,7 +134,7 @@ information about its performance over time. The pipeline summary shows a breakd
 failure rates across the pipeline’s individual builds and jobs to spot slowdowns or failures.
 
 [role="screenshot"]
-.Performance overview of a Jenkins pipeline in Elastic Observability
+.Performance overview of a Jenkins pipeline in Elastic {observability}
 image::images/jenkins-pipeline-overview.png[Jenkins pipeline overview]
 
 The pipelines and traditional jobs are instrumented automatically. If you spot a slow or failing
@@ -141,13 +143,13 @@ for the high duration or errorful jobs. You can then dig into the details to und
 source of the error.
 
 [role="screenshot"]
-.A Jenkins pipeline build as a trace in Elastic Observability
+.A Jenkins pipeline build as a trace in Elastic {observability}
 image::images/jenkins-pipeline-trace.png[Trace of a Jenkins pipeline build]
 
 To investigate further, you can view the details of the build captured as labels.
 
 [role="screenshot"]
-.Contextual attributes of a Jenkins pipeline execution in Elastic Observability
+.Contextual attributes of a Jenkins pipeline execution in Elastic {observability}
 image::images/jenkins-pipeline-context.png[Attributes of a Jenkins pipeline execution]
 
 [discrete]
@@ -180,6 +182,7 @@ in addition to the traces and metrics pipelines.
 
 To store pipeline logs in Elastic:
 
+// lint ignore observability
 1. Navigate to the _OpenTelemetry_ section of the Jenkins configuration screen.
 2. Set the _OTLP Endpoint_.
 3. Use the _Add Visualisation Observability Backend_ drop-down to select the *Elastic {observability}* option.
@@ -276,10 +279,11 @@ image::images/configure-otel-plugin.png[Configure OTEL plugin]
 ** Header name: `"Authorization"`
 ** Header value: a secret text credential with the value of `"ApiKey an_api_key"` (`an_api_key` is the value of the secret key)
 
+// lint ignore observability
 . Go to *Add Visualisation Observability Backend* and define the URL for your {kib} server.
 +
 [role="screenshot"]
-image::images/kibana-url.png[Define Kibana URL]
+image::images/kibana-url.png[Define {kib} URL]
 +
 . Finally, there are additional settings to configure:
 
@@ -292,7 +296,7 @@ WARNING: You can export the OpenTelemetry configuration as environment variables
 Ansible Otel plugin, and so on. If you enable this option, consider that you can potentially expose the credentials in
 the console output.
 
-To learn more about the integration of Jenkins with Elastic Observability, see https://plugins.jenkins.io/opentelemetry/[OpenTelemetry].
+To learn more about the integration of Jenkins with Elastic {observability}, see https://plugins.jenkins.io/opentelemetry/[OpenTelemetry].
 
 [discrete]
 [[ci-cd-jenkins-dashbaords]]
@@ -306,20 +310,20 @@ that are compatible with version 7.12 or higher.
 
 For instance, you can follow the below steps:
 
-* Import the dashboard in the Kibana UI
+* Import the dashboard in the {kib} UI
 
 [role="screenshot"]
-.Import dashboard in Kibana
-image::images/jenkins-dashboard-import.png[Import kibana dashboard]
+.Import dashboard in {kib}
+image::images/jenkins-dashboard-import.png[Import {kib} dashboard]
 
 * The new dashboard is now ready to be used:
 
 [role="screenshot"]
-.Jenkins dashboard in Kibana is ready
-image::images/jenkins-dashboard-ready.png[Jenkins dashboard in Kibana]
+.Jenkins dashboard in {kib} is ready
+image::images/jenkins-dashboard-ready.png[Jenkins dashboard in {kib}]
 
 [role="screenshot"]
-.Jenkins dashboard in Kibana
+.Jenkins dashboard in {kib}
 image::images/jenkins-dashboard.png[Jenkins dashboard]
 
 [discrete]
@@ -353,7 +357,7 @@ For example, you can add the following snippet to your pom.xml file:
 </project>
 ----
 
-You can now trigger to send the Maven build reporting performance data to Elastic Observability by
+You can now trigger to send the Maven build reporting performance data to Elastic {observability} by
 passing the configuration details as environment variables:
 
 [source,bash]
@@ -378,7 +382,7 @@ mvn -Dmaven.ext.class.path=path/to/opentelemetry-maven-extension.jar verify
 ----
 
 You can also trigger your Maven builds from the CI platform and visualize the end-to-end
-pipeline execution in Elastic Observability, including the detailed steps of your CI
+pipeline execution in Elastic {observability}, including the detailed steps of your CI
 pipeline and the Maven build.
 
 When invoking Maven builds with Jenkins, it’s unnecessary to use environment variables
@@ -389,7 +393,7 @@ to inject OpenTelemetry configuration as environment variables. For more details
 .A Jenkins pipeline executing Maven builds
 image::images/jenkins-maven-pipeline.png[Maven builds in Jenkins]
 
-To learn more, see the https://github.com/open-telemetry/opentelemetry-java-contrib/tree/main/maven-extension[integration of Maven builds with Elastic Observability].
+To learn more, see the https://github.com/open-telemetry/opentelemetry-java-contrib/tree/main/maven-extension[integration of Maven builds with Elastic {observability}].
 
 [discrete]
 [[ci-cd-ansible]]
@@ -472,7 +476,7 @@ make login build push
 ----
 
 [role="screenshot"]
-.A Jenkins build executing a Makefile instrumented with the otel-cli in Elastic Observability
+.A Jenkins build executing a Makefile instrumented with the otel-cli in Elastic {observability}
 image::images/jenkins-makefile.png[Jenkins build executing an instrumented Makefile]
 
 [role="screenshot"]
@@ -519,10 +523,10 @@ CONCOURSE_TRACING_OTLP_HEADERS=Authorization=Bearer your-secret-token
 Context propagation is supported; therefore, you can benefit from the integrations described above.
 
 Once Concourse CI tracing is configured, Concourse CI pipeline executions are
-reported in Elastic Observability.
+reported in Elastic {observability}.
 
 [role="screenshot"]
-.A Concourse CI pipeline execution in Elastic Observability
+.A Concourse CI pipeline execution in Elastic {observability}
 image::images/jenkins-concourse.png[Concourse CI pipeline execution]
 
 The Concourse CI doesn’t report health metrics through OpenTelemetry. However, you can use the
@@ -538,7 +542,7 @@ of pipelines.
 
 Integrating automated service health checks in deployment pipelines is critical for end-to-end deployment automation, which crucially enables deployment frequency to be increased.
 
-Elastic Observability exposes HTTP APIs to check the health of services. You can integrate these APIs in deployment pipelines to verify the behaviour of newly deployed instances, and either automatically continue the deployments or roll back according to the health status.
+Elastic {observability} exposes HTTP APIs to check the health of services. You can integrate these APIs in deployment pipelines to verify the behaviour of newly deployed instances, and either automatically continue the deployments or roll back according to the health status.
 
 The following example shows a canary deployment pipeline that leverages Elastic health check HTTP APIs to automate the quality check before rolling out the deployment from the canary to the entire set of instances:
 

--- a/docs/en/observability/configure-logs-sources.asciidoc
+++ b/docs/en/observability/configure-logs-sources.asciidoc
@@ -3,7 +3,7 @@
 
 Specify the source configuration for logs in the
 {kibana-ref}/logs-ui-settings-kb.html[{logs-app} settings] in the
-{kibana-ref}/settings.html[Kibana configuration file].
+{kibana-ref}/settings.html[{kib} configuration file].
 By default, the configuration uses the `filebeat-*` index pattern to query the data.
 The configuration also defines field settings for things like timestamps
 and container names, and the default columns displayed in the logs stream.
@@ -16,7 +16,7 @@ default configuration settings.
 [[edit-config-settings]]
 == Edit configuration settings
 
-. To access this page, go to *Observability > Logs*.
+. To access this page, go to *{observability} > Logs*.
 +
 . Click *Settings*.
 +
@@ -24,7 +24,7 @@ default configuration settings.
 
 | *Name* | Name of the source configuration. 
 
-| *Index pattern* | {kib} index patterns or index name patterns in the {es} indices
+| *{ipm-cap}* | {kib} index patterns or index name patterns in the {es} indices
 to read log data from.
 
 Each log source now integrates with {kib} index patterns which support creating and
@@ -41,7 +41,7 @@ instead of index pattern. The Logs UI can now integrate with {data-sources} to
 configure the used indices by clicking *Use {data-sources}*.
 
 | *Fields* | Configuring fields input has been deprecated. You should adjust your indexing using the
-<<logs-app-fields,Logs app fields>>, which use the {ecs-ref}/index.html[Elastic Common Schema (ECS) specification].
+<<logs-app-fields,{logs-app} fields>>, which use the {ecs-ref}/index.html[Elastic Common Schema (ECS) specification].
 
 | *Log columns* | Columns that are displayed in the logs *Stream* page.
 
@@ -55,7 +55,7 @@ configure the used indices by clicking *Use {data-sources}*.
 
 [TIP]
 ===============================
-If {kibana-ref}/xpack-spaces.html[Spaces] are enabled in your Kibana instance,
+If {kibana-ref}/xpack-spaces.html[Spaces] are enabled in your {kib} instance,
 any configuration changes you make here are specific to the current space.
 You can make different subsets of data available by creating multiple spaces
 with other data source configurations.
@@ -81,4 +81,4 @@ To filter the field list by that name, you can start typing a field name in the 
 4. When you have completed your changes, click *Apply*.
 
 If the fields are greyed out and cannot be edited, you may not have sufficient privileges
-to modify the source configuration. For more information, see {kibana-ref}/xpack-security-authorization.html[Granting access to Kibana].
+to modify the source configuration. For more information, see {kibana-ref}/xpack-security-authorization.html[Granting access to {kib}].

--- a/docs/en/observability/configure-metrics-sources.asciidoc
+++ b/docs/en/observability/configure-metrics-sources.asciidoc
@@ -10,7 +10,7 @@ and container names.
 [[metrics-config-settings]]
 == Override configuration settings
 
-. To access this page, go to *Observability > Metrics*.
+. To access this page, go to *{observability} > Metrics*.
 +
 . Click *Settings*.
 +
@@ -20,10 +20,10 @@ You can override the following configuration settings.
 
 | *Name* | Name of the source configuration. 
 
-| *Indices* | Index pattern or patterns in the {es} indices to read metrics data from.
+| *Indices* | {ipm-cap} or patterns in the {es} indices to read metrics data from.
 
 | *Fields* | Configuring fields input has been deprecated. You should adjust your indexing using the
-<<metrics-app-fields,Metrics app fields>>, which use the {ecs-ref}/index.html[Elastic Common Schema (ECS) specification].
+<<metrics-app-fields,{metrics-app} fields>>, which use the {ecs-ref}/index.html[Elastic Common Schema (ECS) specification].
 
 | *{ml-cap}* | Specify the minimum severity score required to display anomalies in the {metrics-app}.
 
@@ -32,10 +32,10 @@ You can override the following configuration settings.
 . When you have completed your changes, click *Apply*.
 +
 If the fields are greyed out and cannot be edited, you may not have sufficient privileges to change the source configuration.
-For more information see {kibana-ref}/xpack-security-authorization.html[Granting access to Kibana].
+For more information see {kibana-ref}/xpack-security-authorization.html[Granting access to {kib}].
 +
 [TIP]
 ===============================
-If {kibana-ref}/xpack-spaces.html[Spaces] are enabled in your Kibana instance, any configuration changes you make here are specific to the current space.
+If {kibana-ref}/xpack-spaces.html[Spaces] are enabled in your {kib} instance, any configuration changes you make here are specific to the current space.
 You can make different subsets of data available by creating multiple spaces with different data source configurations.
 ===============================

--- a/docs/en/observability/configure-uptime-settings.asciidoc
+++ b/docs/en/observability/configure-uptime-settings.asciidoc
@@ -8,7 +8,7 @@ for TLS certificates.
 Uptime settings apply to the current space only. To segment
 different uptime use cases and domains, use different settings in other spaces.
 
-. To access this page, go to *Observability > Uptime*.
+. To access this page, go to *{observability} > Uptime*.
 . At the top of the page, click *Settings*.
 +
 [IMPORTANT]
@@ -30,7 +30,7 @@ data outside of this pattern.
 =====
 
 [role="screenshot"]
-image::images/heartbeat-indices.png[Heartbeat indices]
+image::images/heartbeat-indices.png[{heartbeat} indices]
 
 [discrete]
 [[configure-uptime-alert-connectors]]

--- a/docs/en/observability/create-alerts.asciidoc
+++ b/docs/en/observability/create-alerts.asciidoc
@@ -38,7 +38,7 @@ NOTE: The {observability} Rules page allows you to set a rule to be "Snoozed ind
 To snooze a rule for a specific time period, you must use the centralized {kibana-ref}/create-and-manage-rules.html[{rules-ui} page].
 
 Extend your rules by connecting them to actions that use built-in *connectors* for email,
-IBM Resilient, Index, JIRA, Microsoft Teams, PagerDuty, Server log, {sn} ITSM, and Slack.
+{ibm-r}, Index, JIRA, Microsoft Teams, PagerDuty, Server log, {sn} ITSM, and Slack.
 Also supported is a powerful webhook output letting you tie into other third-party systems.
 Connectors allow actions to talk to these services and integrations.
 

--- a/docs/en/observability/create-observability-connectors.asciidoc
+++ b/docs/en/observability/create-observability-connectors.asciidoc
@@ -3,10 +3,10 @@
 
 You can send cases to these third-party systems:
 
-* ServiceNow ITSM
-* ServiceNow SecOps
-* Jira (including Jira Service Desk)
-* IBM Resilient
+* {sn-itsm}
+* {sn-sir}
+* {jira} (including {jira} Service Desk)
+* {ibm-r}
 * {swimlane}
 
 IMPORTANT: To send cases to external systems, you need the appropriate license, and your role must
@@ -27,7 +27,7 @@ automatically close when they are sent to an external system.
 [role="screenshot"]
 image::images/add-case-connector.png[]
 . From the *Incident management system* list, select *Add new connector*.
-. Select the system to send cases to: *ServiceNow*, *Jira*, *IBM Resilient*, or *{swimlane}*.
+. Select the system to send cases to: *{sn}*, *{jira}*, *{ibm-r}*, or *{swimlane}*.
 
 . Enter your required settings.
 +
@@ -37,26 +37,26 @@ image::images/add-case-connector.png[]
 
 | *URL* | The URL of the external system to which you want to send cases.
 
-| *API URL* |  ({swimlane} only) The URL of the Swimlane instance to which you want to send cases.
+| *API URL* |  ({swimlane} only) The URL of the {swimlane} instance to which you want to send cases.
 
-| *Organization ID* | (IBM Resilient only) Your organization’s IBM Resilient ID number.
+| *Organization ID* | ({ibm-r} only) Your organization’s {ibm-r} ID number.
 
 | *Application ID* | ({swimlane} only) The application ID of your {swimlane} application. From {swimlane}, you can find the application
 ID by checking your application’s settings or at the end of your application’s URL after you’ve opened it.
 
-| *Username* | (ServiceNow only) The username of the ServiceNow account is used to access the ServiceNow instance.
+| *Username* | ({sn} only) The username of the {sn} account is used to access the {sn} instance.
 
-| *Password* | (ServiceNow only) The password of the ServiceNow account is used to access the ServiceNow instance.
+| *Password* | ({sn} only) The password of the {sn} account is used to access the {sn} instance.
 
-| *Project key* | (Jira only) The key of the Jira project to which you are sending cases.
+| *Project key* | ({jira} only) The key of the {jira} project to which you are sending cases.
 
-| *Email or Username* | (Jira only) The Jira account username or email.
+| *Email or Username* | ({jira} only) The {jira} account username or email.
 
-| *API token or Password* | (Jira only) The API token or password is used to authenticate Jira updates.
+| *API token or Password* | ({jira} only) The API token or password is used to authenticate {jira} updates.
 
-| *API key ID* | (IBM Resilient only) The API key is used to authenticate IBM Resilient updates.
+| *API key ID* | ({ibm-r} only) The API key is used to authenticate {ibm-r} updates.
 
-| *API key secret* | (IBM Resilient only) The API key secret is used to authenticate IBM Resilient updates.
+| *API key secret* | ({ibm-r} only) The API key secret is used to authenticate {ibm-r} updates.
 
 | *API token* | ({swimlane} only) The {swimlane} API authentication token is used for HTTP Basic authentication.
 This is the personal access token for your user role.

--- a/docs/en/observability/exploratory-data-visualizations.asciidoc
+++ b/docs/en/observability/exploratory-data-visualizations.asciidoc
@@ -1,6 +1,7 @@
 [[exploratory-data-visualizations]]
 = Explore data
 
+// lint ignore data-view
 The *Explore data* view in {kib} enables you to select and filter result data in any dimension, and look
  for the cause or impact of performance problems.
 
@@ -10,13 +11,13 @@ Based on your synthetic monitoring, infra metrics, user experience, and mobile
   of your web applications.
 
 [role="screenshot"]
-image::images/exploratory-view.png[Explore data view for Monitor duration]
+image::images/exploratory-view.png[Explore {data-source} for Monitor duration]
 
 [discrete]
 [[explore-data-view]]
-== Explore data view
+== Explore {data-source}
 
-You can use the Explore data view to filter your data and build multi-series
+You can use the Explore {data-source} to filter your data and build multi-series
 visualizations that help you clarify what's essential, and examine the cause or
 impact of performance difficulties. You can compare different time periods,
 different cohorts, and even different data types.
@@ -70,18 +71,18 @@ your visualization, click *Remove series* and then *Add series*.
 [[create-multi-series-visualizations]]
 == Create multi-series visualizations
 
-The Explore data view is currently enabled for the following apps:
+The Explore {data-source} is currently enabled for the following apps:
 
 * Metrics
 * Uptime
-* User Experience
+* {user-experience}
 
 To create a multi-series visualization:
 
 . Click *Explore data* from a compatible app.
 * The report type will default to the most appropriate for the app, but you can
 edit the series or add more series to the visualization. For example, if you
-click *Explore Data* from the Uptime app, the `Synthetics monitoring`
+click *Explore Data* from the {uptime-app}, the `Synthetics monitoring`
  data type and `Monitor duration` report metric will be preselected.
 . Click *Add series* to define an additional series for the visualization.
 . Click *Select data type* and choose from the following options:
@@ -137,14 +138,14 @@ and give you a sense of how frequently a host or endpoint was down in your selec
 
 [discrete]
 [[explore-data-user-experience]]
-== User Experience
+== {user-experience}
 
 Based on the {user-experience} data from your instrumented applications, you can create
 detailed visualizations for performance distributions, key performance indicators (KPI) over time,
 and for core web vitals of your web applications.
 
 [role="screenshot"]
-image::images/exploratory-view-ux-page-load-time.png[Explore data for User Experience (page load time)]
+image::images/exploratory-view-ux-page-load-time.png[Explore data for {user-experience} (page load time)]
 
 |===
 

--- a/docs/en/observability/explore-metrics.asciidoc
+++ b/docs/en/observability/explore-metrics.asciidoc
@@ -9,7 +9,7 @@ for one or more resources that you are monitoring.
 Additionally, for detailed analyses of your metrics, you can annotate and save visualizations for
 your custom dashboards by using the {kibana-ref}/tsvb.html[Time Series Visual Builder (TSVB)] within {kib}.
 
-To access this page, go to *Observability > Metrics*, and then click *Metrics Explorer*.
+To access this page, go to *{observability} > Metrics*, and then click *Metrics Explorer*.
 
 By default, the Metrics Explorer page displays the CPU usage for hosts, Kubernetes pods, and Docker containers.
 The initial configuration has the *Average* aggregation selected, the *of* field is populated with the default metrics,
@@ -33,7 +33,7 @@ image::images/metrics-explorer-filter.png[Metrics explorer query]
 +
 3. Select *Actions* in the top right-hand corner of one of the graphs and then click *Add filter*. 
 +
-This graph now displays the metrics only for that host. The filter has added a {kibana-ref}/kuery-query.html[Kibana Query Language] filter for `host.name`
+This graph now displays the metrics only for that host. The filter has added a {kibana-ref}/kuery-query.html[{kib} Query Language] filter for `host.name`
 in the second row of the Metrics Explorer configuration.
 +
 4. Let's analyze some host-specific metrics. In the *of* field, delete each one of the system load metrics.

--- a/docs/en/observability/gcp-dataflow.asciidoc
+++ b/docs/en/observability/gcp-dataflow.asciidoc
@@ -2,8 +2,7 @@
 === GCP Dataflow templates 
 
 In this tutorial, you'll learn how to ship logs directly from the Google Cloud
-Console with the Dataflow template for analyzing GCP Audit Logs in the Elastic
-Stack.
+Console with the Dataflow template for analyzing GCP Audit Logs in the {stack}.
 
 [discrete]
 ==== What you'll learn
@@ -20,7 +19,7 @@ view those logs in {kib}.
 Create a deployment using our hosted {ess} on {ess-trial}[{ecloud}].
 The deployment includes an {es} cluster for storing and searching your data,
 and {kib} for visualizing and managing your data.
-For more information, see <<spin-up-stack,Spin up the Elastic Stack>>.
+For more information, see <<spin-up-stack,Spin up the {stack}>>.
 
 [discrete]
 ==== Step 1: Install the GCP integration 
@@ -79,7 +78,7 @@ To create a job, click *Create Job From Template*.
 Set *Job name* as `auditlogs-stream` and select `Pub/Sub to Elasticsearch` from
 the *Dataflow template* dropdown menu:
 
-image::monitor-gcp-dataflow-pub-sub-elasticsearch.png[GCP Dataflow Pub/Sub to Elasticsearch]
+image::monitor-gcp-dataflow-pub-sub-elasticsearch.png[GCP Dataflow Pub/Sub to {es}]
 
 Before running the job, fill in required parameters:
 

--- a/docs/en/observability/grant-cases-access.asciidoc
+++ b/docs/en/observability/grant-cases-access.asciidoc
@@ -1,11 +1,13 @@
 [[grant-cases-access]]
 = Configure access to cases
 
+// lint ignore observability
 To access and send cases to external systems, you need the https://www.elastic.co/subscriptions[appropriate license],
 and your role must have the *Cases* {kib} privilege as a user for the *Observability* feature.
 
 Here are the minimum required privileges:
 
+// lint disable observability
 [options="header"]
 |=== 
 
@@ -22,6 +24,7 @@ NOTE: Roles without `All` *Actions and Connectors* feature privileges cannot cre
 | Revoke all access to cases | `None` for the *Cases* feature under *Observability*.
 
 |=== 
+// lint enable observability
 
 For more details, refer to {kibana-ref}/xpack-spaces.html#spaces-control-user-access[feature access based on user privileges].
 

--- a/docs/en/observability/infrastructure-threshold-alert.asciidoc
+++ b/docs/en/observability/infrastructure-threshold-alert.asciidoc
@@ -8,7 +8,7 @@ resource or a group of resources within your infrastructure.
 Additionally, each rule can be defined using multiple
 conditions that combine metrics and thresholds to create precise notifications and reduce false positives.
 
-. To access this page, go to *Observability > Metrics*.
+. To access this page, go to *{observability} > Metrics*.
 . On the *Inventory* page or the *Metrics Explorer* page, click *Alerts > Infrastructure*.
 . Select *Create inventory alert*.
 

--- a/docs/en/observability/ingest-logs-metrics-uptime.asciidoc
+++ b/docs/en/observability/ingest-logs-metrics-uptime.asciidoc
@@ -195,18 +195,18 @@ For detailed information about HTTP options, refer to our
 By default, the hostname and port are required.
 
 For detailed information about TCP options, refer to our
-{heartbeat-ref}/monitor-tcp-options.html[Heartbeat] documentation.
+{heartbeat-ref}/monitor-tcp-options.html[{heartbeat}] documentation.
 
 | **ICMP** | Uses an ICMP `v4` and `v6` Echo Request to ping the configured hosts. By default,
 the host name is required.
 
 For detailed information about ICMP options, refer to our
-{heartbeat-ref}/monitor-icmp-options.html[Heartbeat] documentation.
+{heartbeat-ref}/monitor-icmp-options.html[{heartbeat}] documentation.
 
 | **Browser** a| Runs automated tests using a real Chromium browser via the synthetics agent.
 
 For detailed information about browser options, refer to our
-{heartbeat-ref}/monitor-browser-options.html[Heartbeat] documentation.
+{heartbeat-ref}/monitor-browser-options.html[{heartbeat}] documentation.
 
 NOTE: To create a **browser** monitor, you must use the elastic-agent-complete Docker container as this contains the dependencies necessary to run browser monitors. To learn more, refer to <<uptime-set-up>>.
 
@@ -239,8 +239,8 @@ image::images/kibana-fleet-policies-default-with-synthetics.png[{fleet} showing 
 +
 All {agent}s that use this policy will collect logs, metrics, and uptime data from the host.
 
-. To view the data in the {observability-guide}/view-monitor-status.html[Uptime app], go to
-**Observability > Uptime** in the main menu.
+. To view the data in the {observability-guide}/view-monitor-status.html[{uptime-app}], go to
+**{observability} > Uptime** in the main menu.
 
 [discrete]
 [[add-nginx-integration]]
@@ -303,7 +303,7 @@ just another integration that you add to the agent policy!
 {observability-guide}/create-alerts.html[Create alerts] and find out about
 problems while sipping your favorite beverage poolside.
 
-* Want Elastic to do the heavy lifting? Use machine learning to
+* Want Elastic to do the heavy lifting? Use {ml} to
 {observability-guide}/inspect-log-anomalies.html[detect anomalies].
 
 * Got everything working like you want it? Roll out your agent policies to

--- a/docs/en/observability/ingest-logs.asciidoc
+++ b/docs/en/observability/ingest-logs.asciidoc
@@ -64,7 +64,7 @@ To learn more about required roles and privileges, see {filebeat-ref}/feature-ro
 [NOTE]
 =====
 
-You can send data to other {filebeat-ref}/configuring-output.html[outputs], such as Logstash,
+You can send data to other {filebeat-ref}/configuring-output.html[outputs], such as {ls},
 but that requires additional configuration and setup.
 
 =====
@@ -155,7 +155,7 @@ A connection to {es} (or {ess}) is required to set up the initial
 environment. If you're using a different output, such as {ls}, see:
 
 * {filebeat-ref}/filebeat-template.html#load-template-manually[Load the index template manually]
-* {filebeat-ref}/load-kibana-dashboards.html[Load Kibana dashboards]
+* {filebeat-ref}/load-kibana-dashboards.html[Load {kib} dashboards]
 * {filebeat-ref}/load-ingest-pipelines.html[Load ingest pipelines]
 =====
 
@@ -200,7 +200,7 @@ a time-based index, and no data displays, you might need to increase the time ra
 You can now search your log messages, filter your search results, add or remove fields,
 examine the document contents in either table or JSON format, and view a document in context.
 
-Now let's have a look at the <<monitor-logs,Logs app>>.
+Now let's have a look at the <<monitor-logs,{logs-app}>>.
 
 :!beatname_uc:
 :!beatname_lc:

--- a/docs/en/observability/ingest-metrics.asciidoc
+++ b/docs/en/observability/ingest-metrics.asciidoc
@@ -85,7 +85,7 @@ include::{beats-repo-dir}/tab-widgets/enable-modules-widget.asciidoc[]
 +
 See the {metricbeat-ref}/command-line-options.html#modules-command[modules command]
 to learn more about this command. If you are using a Docker image,
-see {metricbeat-ref}/running-on-docker.html[Run Metricbeat on Docker].
+see {metricbeat-ref}/running-on-docker.html[Run {metricbeat} on Docker].
 
 . In the module config under `modules.d`, change the module settings to match your environment.
 See {metricbeat-ref}/configuration-metricbeat.html#module-config-options[Standard config options]
@@ -125,9 +125,9 @@ This step loads the recommended {ref}/indices-templates.html[index template]
 for writing to {es} and deploys the sample dashboards for visualizing the data in {kib}.
 
 TIP: A connection to {es} (or {ess}) is required to set up the initial environment.
-If you’re using a different output, such as Logstash, see
+If you’re using a different output, such as {ls}, see
 {metricbeat-ref}/metricbeat-template.html#load-template-manually[Load the index template manually]
-and {metricbeat-ref}/load-kibana-dashboards.html[Load Kibana dashboards].
+and {metricbeat-ref}/load-kibana-dashboards.html[Load {kib} dashboards].
 
 [discrete]
 [[start-metricbeat]]
@@ -164,7 +164,7 @@ include::{beats-repo-dir}/tab-widgets/open-kibana-widget.asciidoc[]
 Each document in the index that matches the `metricbeat-*` {data-source}
 is displayed. By default, *Discover* shows data for the last 15 minutes.
 
-Now let's have a look at the <<analyze-metrics,Metrics app>>.
+Now let's have a look at the <<analyze-metrics,{metrics-app}>>.
 
 :!beatname_uc:
 :!beatname_lc:

--- a/docs/en/observability/ingest-splunk.asciidoc
+++ b/docs/en/observability/ingest-splunk.asciidoc
@@ -11,7 +11,7 @@
 If you haven't already, you need to install {es} for storing and
 searching your data, and {kib} for visualizing and managing it. For
 more information, see <<spin-up-stack>>.
-After {es} and {kib} are installed, Fleet must be enabled; see the
+After {es} and {kib} are installed, {fleet} must be enabled; see the
 <<ingest-logs-metrics-uptime>>.
 
 
@@ -21,7 +21,7 @@ Apache, AWS Cloudtrail, Nginx, and Zeek integrations offer the ability
 to seamlessly ingest data from a Splunk Enterprise instance.  Data
 will be automatically mapped to the Elastic Common Schema, making it
 available for rapid analysis in Elastic solutions, including Security
-and Observability.
+and {observability}.
 
 These integrations work by using the `httpjson` input in {agent} to
 run a Splunk search via the Splunk REST API and then extract the raw

--- a/docs/en/observability/ingest-traces.asciidoc
+++ b/docs/en/observability/ingest-traces.asciidoc
@@ -90,7 +90,7 @@ APM agents are written in the same language as your service.
 To monitor a new service, you must install the agent and configure it with a service name,
 APM Server host, and Secret token.
 
-* **Service name**: The APM integration maps an instrumented service's name–defined in each APM agent's configuration–
+* **Service name**: The APM integration maps an instrumented service's name–defined in each {apm-agent}'s configuration–
 to the index that its data is stored in {es}.
 Service names are case-insensitive and must be unique.
 For example, you cannot have a service named `Foo` and another named `foo`.
@@ -99,7 +99,7 @@ Special characters will be removed from service names and replaced with undersco
 * **APM Server URL**: The host and port that APM Server listens for events on.
 This should match the host and port defined when setting up the APM integration.
 
-* **Secret token**: Authentication method for APM agent and APM Server communication.
+* **Secret token**: Authentication method for {apm-agent} and APM Server communication.
 This should match the secret token defined when setting up the APM integration.
 
 TIP: You can edit your APM integration settings if you need to change the APM Server URL
@@ -120,7 +120,7 @@ endif::[]
 [[view-apm-integration-data]]
 == Step 5: View your data
 
-Back in {kib}, under Observability, select APM.
+Back in {kib}, under {observability}, select APM.
 You should see application performance monitoring data flowing into the {stack}!
 
 NOTE: The built-in `apm_user` role is not compatible with the APM integration
@@ -129,7 +129,7 @@ For a list of indices users need access to, refer to
 {apm-guide-ref}/apm-data-streams.html[APM data streams]
 
 [role="screenshot"]
-image::images/kibana-apm-sample-data.png[APM app with data]
+image::images/kibana-apm-sample-data.png[{apm-app} with data]
 
 [discrete]
 == What's next?
@@ -146,7 +146,7 @@ just another integration that you add to the agent policy!
 {observability-guide}/create-alerts.html[Create alerts] and find out about
 problems while sipping your favorite beverage poolside.
 
-* Want Elastic to do the heavy lifting? Use machine learning to
+* Want Elastic to do the heavy lifting? Use {ml} to
 {observability-guide}/inspect-log-anomalies.html[detect anomalies].
 
 * Got everything working like you want it? Roll out your agent policies to

--- a/docs/en/observability/ingest-uptime.asciidoc
+++ b/docs/en/observability/ingest-uptime.asciidoc
@@ -29,7 +29,7 @@ and possibly even outside of the network where the services that you want to mon
 [[deployment-considerations]]
 == Deployment considerations
 
-There are multiple ways to deploy Uptime and Heartbeat. A guiding principle is that when
+There are multiple ways to deploy Uptime and {heartbeat}. A guiding principle is that when
 an outage takes down the service being monitored, it should not take down {heartbeat}.
 
 {heartbeat} is commonly run as a centralized service within a data center.
@@ -94,7 +94,7 @@ include::{beats-repo-dir}/tab-widgets/set-connection-widget.asciidoc[]
 [NOTE]
 =====
 
-You can send data to other {heartbeat-ref}/configuring-output.html[outputs], such as Logstash,
+You can send data to other {heartbeat-ref}/configuring-output.html[outputs], such as {ls},
 but that requires additional configuration and setup.
 
 =====
@@ -158,7 +158,7 @@ reference configuration file shows all non-deprecated options. You’ll find it 
 {beatname_uc} can be deployed in multiple locations so that you can detect
 differences in availability and response times across those locations.
 Configure the {beatname_uc} location to allow {kib} to display location-specific
-information on Uptime maps and perform Uptime anomaly detection based
+information on Uptime maps and perform Uptime {anomaly-detect} based
 on location.
 
 To configure the location of a {beatname_uc} instance, modify the
@@ -180,7 +180,7 @@ processors:
         #location: "37.926868, -78.024902" <3>
 ----------------------------------------------------------------------
 <1> Uncomment the `geo` setting.
-<2> Uncomment `name` and assign the name of the location of the Heartbeat server.
+<2> Uncomment `name` and assign the name of the location of the {heartbeat} server.
 <3> Optionally uncomment `location` and assign the latitude and longitude.
 
 [TIP]
@@ -253,9 +253,9 @@ Let's confirm your data is correctly ingested to your cluster.
 include::{beats-repo-dir}/tab-widgets/open-kibana-widget.asciidoc[]
 --
 
-. In the side navigation, click *Observability > Uptime*.
+. In the side navigation, click *{observability} > Uptime*.
 
-Now let's have a look at the <<monitor-uptime-synthetics,Uptime app>>.
+Now let's have a look at the <<monitor-uptime-synthetics,{uptime-app}>>.
 
 :!beatname_uc:
 :!beatname_lc:

--- a/docs/en/observability/inspect-log-anomalies.asciidoc
+++ b/docs/en/observability/inspect-log-anomalies.asciidoc
@@ -17,18 +17,18 @@ and thus we're serving fewer requests.
 * A spike in the log rate could denote a DDoS attack.
 This may lead to an investigation of IP addresses from incoming requests.
 
-You can also view log anomalies directly in the {kibana-ref}/xpack-ml-anomalies.html[Machine Learning app].
+You can also view log anomalies directly in the {kibana-ref}/xpack-ml-anomalies.html[{ml-app} app].
 
 [discrete]
 [[enable-anomaly-detection]]
-== Enable log rate analysis and anomaly detection
+== Enable log rate analysis and {anomaly-detect}
 
-Create a machine learning job to detect anomalous log entry rates automatically.
+Create a {ml} job to detect anomalous log entry rates automatically.
 
-1. Select *Anomalies*, and you'll be prompted to create a machine learning job which will carry out the log rate analysis.
-2. Choose a time range for the machine learning analysis.
+1. Select *Anomalies*, and you'll be prompted to create a {ml} job which will carry out the log rate analysis.
+2. Choose a time range for the {ml} analysis.
 3. Add the Indices that contain the logs you want to analyze.
-4. Click *Create ML job*.
+4. Click *Create {ml-init} job*.
 5. You're now ready to explore your log partitions.
 
 [discrete]
@@ -52,7 +52,7 @@ The chart shows the time range where anomalies were detected.
 The typical rate values are shown in grey, while the anomalous regions are color-coded and superimposed on top.
 
 When a time range is flagged as anomalous,
-the machine learning algorithms have detected unusual log rate activity.
+the {ml} algorithms have detected unusual log rate activity.
 This might be because:
 
 * The log rate is significantly higher than usual.
@@ -67,5 +67,5 @@ To help you further drill down into a potential anomaly,
 you can view an anomaly chart for each partition. Anomaly scores range from 0
 (no anomalies) to 100 (critical).
 
-To analyze the anomalies in more detail, click *View anomaly in machine learning*, which opens the
-{ml-docs}/ml-gs-results.html[Anomaly Explorer in Machine Learning].
+To analyze the anomalies in more detail, click *View anomaly in {ml}*, which opens the
+{ml-docs}/ml-gs-results.html[Anomaly Explorer in {ml-app}].

--- a/docs/en/observability/inspect-metric-anomalies.asciidoc
+++ b/docs/en/observability/inspect-metric-anomalies.asciidoc
@@ -19,12 +19,13 @@ automatically.
 Once you create {ml} jobs, you can not change the settings. You can 
 recreate these jobs later. However, you will remove any previously detected anomalies.
 
+// lint ignore anomaly-detection observability
 1. In the side navigation, click *Observability > Metrics > Anomaly detection*.
-2. You’ll be prompted to create a machine learning job for *Hosts* or 
+2. You’ll be prompted to create a {ml} job for *Hosts* or 
 *Kubernetes Pods*. Click *Enable*.
-3. Choose a start date for the machine learning analysis.
+3. Choose a start date for the {ml} analysis.
 +
-Machine learning jobs analyze the last four weeks of data and continue to run 
+{ml-cap} jobs analyze the last four weeks of data and continue to run 
 indefinitely.
 +
 4. Select a partition field.
@@ -42,14 +43,14 @@ equally across groups.
 5. By default, {ml} jobs analyze all of your metric data, and the results are listed under
 the *Anomalies* tab. You can filter this list to view only the jobs or metrics that
 you are interested in. For example, you can filter by job name and node name to view
-specific anomaly detection jobs for that host.
+specific {anomaly-detect} jobs for that host.
 6. Click *Enable jobs*.
 7. You're now ready to explore your metric anomalies. Click *Anomalies*.
 +
 [role="screenshot"]
-image::images/metrics-ml-jobs.png[Metrics Machine Learning anomalies]
+image::images/metrics-ml-jobs.png[Metrics {ml-app} anomalies]
 +
-The *Anomalies* table displays a list of each single metric anomaly detection job
+The *Anomalies* table displays a list of each single metric {anomaly-detect} job
 for the specific host or Kubernetes pod. By default, anomaly jobs are sorted by
 time to show the most recent job.
 +
@@ -60,7 +61,7 @@ increase between the actual value and the expected ("typical") value of the metr
 the anomaly record result.
 +
 To drill down and analyze the metric anomaly, select *Actions > Open in Anomaly Explorer*
-to view the {ml-docs}/ml-gs-results.html[Anomaly Explorer in Machine Learning]. You can
+to view the {ml-docs}/ml-gs-results.html[Anomaly Explorer in {ml-app}]. You can
 also select *Actions > Show in Inventory* to view the host or Kubernetes pods Inventory
 page, filtered by the specific metric.
 +

--- a/docs/en/observability/inspect-uptime-duration-anomalies.asciidoc
+++ b/docs/en/observability/inspect-uptime-duration-anomalies.asciidoc
@@ -7,22 +7,24 @@ on the *Monitor duration* chart.
 
 [discrete]
 [[uptime-anomaly-detection]]
-== Enable uptime duration anomaly detection
+== Enable uptime duration {anomaly-detect}
 
-Create a machine learning job to detect anomalous monitor duration rates automatically.
+Create a {ml} job to detect anomalous monitor duration rates automatically.
 
+// lint disable observability anomaly-detection
 1. To access this page, go to *Observability > Uptime > Monitors*, and then click a monitor to view its the details.
 2. In the *Monitor duration* panel, click *Enable anomaly detection*.
 +
 [NOTE]
 =====
-If anomaly detection is already enabled, click *Anomaly detection* and select to view duration anomalies directly in the
-{ml-docs}/ml-gs-results.html[Machine Learning app], enable an <<duration-anomaly-alert,anomaly rule>>,
-or disable the anomaly detection.
+If {anomaly-detect} is already enabled, click *Anomaly detection* and select to view duration anomalies directly in the
+{ml-docs}/ml-gs-results.html[{ml-app} app], enable an <<duration-anomaly-alert,anomaly rule>>,
+or disable the {anomaly-detect}.
 =====
 +
-3. You are prompted to create a <<duration-anomaly-alert,response duration anomaly rule>> for the machine learning job which will carry
+3. You are prompted to create a <<duration-anomaly-alert,response duration anomaly rule>> for the {ml} job which will carry
 out the analysis, and you can configure which severity level to create the rule for.
+// lint enable observability anomaly-detection
 
 When an anomaly is detected, the duration is displayed on the *Monitor duration*
 chart, along with the duration times. The colors represent the criticality of the anomaly: red

--- a/docs/en/observability/inspect.asciidoc
+++ b/docs/en/observability/inspect.asciidoc
@@ -23,6 +23,7 @@ Inspecting requests is available for the following apps:
 
 To enable inspect across apps:
 
+// lint ignore observability
 . Go to {kib}'s {kibana-ref}/advanced-options.html[Advanced Settings].
 . Find the *Observability* section.
 . Turn on the *Inspect ES queries* option.

--- a/docs/en/observability/instrument-apps.asciidoc
+++ b/docs/en/observability/instrument-apps.asciidoc
@@ -49,7 +49,7 @@ include::{apm-repo-dir}/legacy/tab-widgets/configure-server-widget.asciidoc[]
 [[view-apm-data]]
 == Step 3: View your data in {kib}
 
-To view the <<observability-ui,Observability Overview>> page:
+To view the <<observability-ui,{observability} Overview>> page:
 
 . Launch {kib}:
 +
@@ -57,7 +57,7 @@ To view the <<observability-ui,Observability Overview>> page:
 include::{beats-repo-dir}/tab-widgets/open-kibana-widget.asciidoc[]
 --
 
-. In the side navigation, select *Observability*, and click *Overview*.
+. In the side navigation, select *{observability}*, and click *Overview*.
 
 :!beatname_uc:
 :!beatname_lc:

--- a/docs/en/observability/logs-app-fields.asciidoc
+++ b/docs/en/observability/logs-app-fields.asciidoc
@@ -1,5 +1,5 @@
 [[logs-app-fields]]
-= Logs app fields
+= {logs-app} fields
 
 This section lists the required fields the {logs-app} uses to display data.
 Please note that some of the fields listed are not https://www.elastic.co/guide/en/ecs/current/ecs-reference.html#_what_is_ecs[ECS fields].

--- a/docs/en/observability/logs-threshold-alert.asciidoc
+++ b/docs/en/observability/logs-threshold-alert.asciidoc
@@ -1,7 +1,7 @@
 [[logs-threshold-alert]]
 = Create a logs threshold rule
 
-. To access this page, go to *Observability > Logs*.
+. To access this page, go to *{observability} > Logs*.
 . Click *Alerts > Create alert*.
 
 [role="screenshot"]
@@ -123,14 +123,14 @@ When setting a *group by*, we recommend using the *more than* comparator for you
 
 [discrete]
 [[es-queries]]
-=== Elasticsearch queries (advanced)
+=== {es} queries (advanced)
 
 When a rule check is performed, a query is built based on the configuration of the rule. For the vast majority of cases it
 shouldn't be necessary to know what these queries are. However, to determine an optimal configuration or to aid with
 debugging, it might be useful to see the structure of these queries. Below is an example {es} query for the following configuration:
 
 [role="screenshot"]
-image::images/log-threshold-alert-es-query-ungrouped.png[Log threshold ungrouped Elasticsearch query example]
+image::images/log-threshold-alert-es-query-ungrouped.png[Log threshold ungrouped {es} query example]
 
 .Without group by
 [source,json]
@@ -180,7 +180,7 @@ image::images/log-threshold-alert-es-query-ungrouped.png[Log threshold ungrouped
 <2> Taken from the *Timestamp* setting
 
 [role="screenshot"]
-image::images/log-threshold-alert-es-query-grouped.png[Log threshold grouped Elasticsearch query example]
+image::images/log-threshold-alert-es-query-grouped.png[Log threshold grouped {es} query example]
 
 .With group by
 [source,json]

--- a/docs/en/observability/metrics-app-fields.asciidoc
+++ b/docs/en/observability/metrics-app-fields.asciidoc
@@ -1,5 +1,5 @@
 [[metrics-app-fields]]
-= Metrics app fields
+= {metrics-app} fields
 
 This section lists the required fields the {metrics-app} uses to display data.
 Please note that some of the fields listed are not https://www.elastic.co/guide/en/ecs/current/ecs-reference.html#_what_is_ecs[ECS fields].
@@ -8,7 +8,7 @@ Please note that some of the fields listed are not https://www.elastic.co/guide/
 == Additional field details
 
 The `event.dataset` field is required to display data properly in some views. This field
-is a combination of `metricset.module`, which is the Metricbeat module name, and `metricset.name`,
+is a combination of `metricset.module`, which is the {metricbeat} module name, and `metricset.name`,
 which is the metricset name.
 
 To determine each metric's optimal time interval, all charts use `metricset.period`.
@@ -348,7 +348,7 @@ The type of the service data is collected from.
 +
 The type can be used to group and correlate logs and metrics from one service type.
 +
-Example: If metrics are collected from Elasticsearch, service.type would be elasticsearch.
+Example: If metrics are collected from {es}, service.type would be `elasticsearch`.
 +
 type: keyword
 +

--- a/docs/en/observability/metrics-threshold-alert.asciidoc
+++ b/docs/en/observability/metrics-threshold-alert.asciidoc
@@ -8,7 +8,7 @@ time period.
 Additionally, each rule can be defined using multiple
 conditions that combine metrics and thresholds to create precise notifications.
 
-. To access this page, go to *Observability > Metrics*.
+. To access this page, go to *{observability} > Metrics*.
 . On the *Inventory* page or the *Metrics Explorer* page, click *Alerts > Metrics*.
 . Select *Create threshold alert*.
 

--- a/docs/en/observability/monitor-aws.asciidoc
+++ b/docs/en/observability/monitor-aws.asciidoc
@@ -5,7 +5,7 @@
 == Monitor Amazon Web Services ({aws})
 
 In this tutorial, you’ll learn how to monitor your {aws} infrastructure using
-Elastic Observability: Logs and Metrics.
+Elastic {observability}: Logs and Metrics.
 
 [discrete]
 [[aws-what-you-learn]]
@@ -15,7 +15,7 @@ You'll learn how to:
 
 - Create and configure an S3 bucket
 - Create and configure an SQS queue.
-- Install and configure Filebeat and Metricbeat to collect Logs and Metrics
+- Install and configure {filebeat} and {metricbeat} to collect Logs and Metrics
 - Collect logs from S3
 - Collect metrics from Amazon CloudWatch
 
@@ -27,11 +27,11 @@ You'll learn how to:
 Create a deployment using our hosted {ess} on {ess-trial}[{ecloud}].
 The deployment includes an {es} cluster for storing and searching your data,
 and {kib} for visualizing and managing your data.
-To learn more, see <<spin-up-stack,Spin up the Elastic Stack>>.
+To learn more, see <<spin-up-stack,Spin up the {stack}>>.
 
 With this tutorial, we assume that your logs and your infrastructure
 data are already shipped to CloudWatch. We are going to show you how you can
-stream your data from CloudWatch to Elasticsearch. If you don’t know how to put
+stream your data from CloudWatch to {es}. If you don’t know how to put
 your {aws} logs and infrastructure data in CloudWatch, Amazon provides a lot of
 documentation around this specific topic:
 
@@ -43,8 +43,8 @@ documentation around this specific topic:
 [[aws-step-one]]
 === Step 1:  Create an S3 Bucket
 
-To centralize your logs in Elasticsearch, you need to have an S3 bucket.
-Filebeat, the agent you'll use to collect logs, has an input for S3.
+To centralize your logs in {es}, you need to have an S3 bucket.
+{filebeat}, the agent you'll use to collect logs, has an input for S3.
 
 In the https://s3.console.aws.amazon.com/s3[{aws} S3 console], click on *Create
 bucket*. Give the bucket a *name* and specify the *region* in which you want it
@@ -60,10 +60,10 @@ You should now have an S3 bucket in which you can export your logs, but you will
 also need an SQS queue. To avoid significant lagging with polling all
 log files from each S3 bucket, we will use Amazon Simple Queue Service (SQS).
 This will provide us with an Amazon S3 notification when a new S3 object is
-created. The {filebeat-ref}/filebeat-input-aws-s3.html[Filebeat S3 input]
+created. The {filebeat-ref}/filebeat-input-aws-s3.html[{filebeat} S3 input]
 checks SQS for new messages regarding the new object created in S3 and uses the
 information in these messages to retrieve logs from S3 buckets. With this setup,
-periodic polling from each S3 bucket is not needed. Instead, the Filebeat S3
+periodic polling from each S3 bucket is not needed. Instead, the {filebeat} S3
 input guarantees near real-time data collection from S3 buckets with both speed
 and reliability.
 
@@ -274,8 +274,8 @@ the following configurations.
 <3> Add the URL to the queue containing notifications around the bucket containing the EC2 logs
 <4> Add the URL to the queue containing notifications around the bucket containing the S3 access logs
 
-Once you have edited the config file, you need to restart filebeat. To stop
-flebeat, you can press CTRL + C in the terminal. Now let's restart filebeat by
+Once you have edited the config file, you need to restart {filebeat}. To stop
+flebeat, you can press CTRL + C in the terminal. Now let's restart {filebeat} by
 running the following command:
 
 [source,bash]
@@ -287,14 +287,15 @@ running the following command:
 [[aws-step-six]]
 === Step 6: Visualize Logs
 
-Now that the logs are being shipped to Elasticsearch we can visualize them in
-Kibana. To see the raw logs, open the main menu in Kibana, then click
+Now that the logs are being shipped to {es} we can visualize them in
+{kib}. To see the raw logs, open the main menu in {kib}, then click
 **Logs**:
 
 image::EC2-logs.png[EC2 logs in the Logs UI]
 
+// lint ignore filebeat
 The filesets we used in the previous steps also come with prebuilt dashboards
-that you can use to visualize the data. In Kibana, open the main menu and click
+that you can use to visualize the data. In {kib}, open the main menu and click
 **Dashboard**. Search for S3 and select the dashboard called:
 **[Filebeat AWS] S3 Server Access Log Overview**:
 
@@ -308,7 +309,7 @@ This gives you an overview of how your S3 buckets are being accessed.
 
 To monitor your {aws} infrastructure you will need to first make sure your
 infrastructure data are being shipped to CloudWatch. To ship the data to
-Elasticsearch we are going to use the {aws} module from Metricbeat. This module
+{es} we are going to use the {aws} module from {metricbeat}. This module
 periodically fetches monitoring metrics from AWS CloudWatch using
 **GetMetricData** API for {aws} services.
 
@@ -402,7 +403,7 @@ least the following permissions attached to it:
 }
 ----
 
-You can now start Metricbeat:
+You can now start {metricbeat}:
 
 [source,bash]
 ----
@@ -413,19 +414,21 @@ You can now start Metricbeat:
 [[aws-step-ten]]
 === Step 10: Visualize metrics
 
-Now that the metrics are being streamed to Elasticsearch we can visualize them in
-Kibana. In Kibana, open the main menu and click
+Now that the metrics are being streamed to {es} we can visualize them in
+{kib}. In {kib}, open the main menu and click
 **Metrics**. Make sure to show the **{aws}** source and the **EC2 Instances**:
 
 image::EC2-instances.png[Your EC2 Infrastructure]
 
+// lint ignore metricbeat
 The metricsets we used in the previous steps also comes with prebuilt dashboard
-that you can use to visualize the data. In Kibana, open the main menu and click
+that you can use to visualize the data. In {kib}, open the main menu and click
 **Dashboard**. Search for EC2 and select the dashboard called: **[Metricbeat
 AWS] EC2 Overview**:
 
 image::ec2-dashboard.png[EC2 Overview]
 
+// lint ignore metricbeat
 If you want to track your billings on {aws}, you can also check the
 **[Metricbeat AWS] Billing Overview** dashboard:
 

--- a/docs/en/observability/monitor-azure.asciidoc
+++ b/docs/en/observability/monitor-azure.asciidoc
@@ -4,7 +4,7 @@
 == Monitor Microsoft Azure
 
 In this {tutorial}, you'll learn how to monitor your Microsoft Azure deployments
-using Elastic Observability: Logs and Metrics.
+using Elastic {observability}: Logs and Metrics.
 
 [discrete]
 [[azure-what-you-learn]]
@@ -14,9 +14,9 @@ You'll learn how to:
 
 - Create an {es} resource in the Azure portal.
 - Ingest Azure platform logs using the native integration and view those logs
-in Kibana.
+in {kib}.
 - Ingest logs and metrics from your virtual machines and view those logs and
-metrics in Kibana.
+metrics in {kib}.
 - Ingest other metrics (such as billing) using the
 {metricbeat-ref}/metricbeat-module-azure.html[{metricbeat} Azure module] and
 view those metrics in {kib}.
@@ -30,7 +30,7 @@ within the Azure portal.
 The Microsoft Azure portal integration makes it faster and easier for you to
 experience the value of Elastic in your Azure environment.
 Behind the scenes, this process will provision a marketplace subscription with
-Elastic Cloud.
+{ecloud}.
 
 [discrete]
 ==== Create an {es} resource
@@ -71,14 +71,14 @@ To access the cluster, click *{kib}*.
 [role="screenshot"]
 image:monitor-azure-elastic-deployment.png[Elastic resource]
 
+// lint ignore observability
 . To single sign-on directly
 into Elastic, select your Azure account.
-
 . To see if there is any available data, click *Observability*.
 There should be no data yet, but next, you will ingest logs.
 +
 [role="screenshot"]
-image:monitor-azure-kibana-observability-page-empty.png[{kib} observability
+image:monitor-azure-kibana-observability-page-empty.png[{kib} {observability}
 page (no data)]
 
 [discrete]
@@ -113,19 +113,19 @@ Native metrics collection is not fully supported yet and is discussed
 later.
 ====
 
-. Within {kib}, click *Observability* until you
+. Within {kib}, click *{observability}* until you
 see some data.
 This may take a few minutes.
 +
 [role="screenshot"]
-image:monitor-azure-kibana-observability-page-data.png[{kib} observability page
+image:monitor-azure-kibana-observability-page-data.png[{kib} {observability} page
 (with data)]
 
-. To access the Logs app and analyze all your subscription
+. To access the {logs-app} and analyze all your subscription
 and resource logs, click *View in app*.
 +
 [role="screenshot"]
-image:monitor-azure-kibana-logs-app.png[{kib} Logs app]
+image:monitor-azure-kibana-logs-app.png[{kib} {logs-app}]
 
 [discrete]
 [[azure-step-three]]
@@ -144,10 +144,10 @@ image:monitor-azure-elastic-vms.png[Select VMs to collect logs and metrics from]
 
 . Wait until it is installed and sending data (if the list
 does not update, click *Refresh* ).
-To see the logs from the VM in the Logs app, click  *Logs*.
+To see the logs from the VM in the {logs-app}, click  *Logs*.
 +
 [role="screenshot"]
-image:monitor-azure-kibana-vms-logs.png[VMs logs in the Logs app]
+image:monitor-azure-kibana-vms-logs.png[VMs logs in the {logs-app}]
 +
 To see the VM metrics dashboard, click *Metrics*.
 +
@@ -247,7 +247,7 @@ To configure {metricbeat} you need the {es} cluster
 details.
 
 . On the {es} resource page, click *Manage changes in
-Elastic Cloud*.
+{ecloud}*.
 +
 [role="screenshot"]
 image:monitor-azure-elastic-deployment.png[Elastic resource]
@@ -255,13 +255,13 @@ image:monitor-azure-elastic-deployment.png[Elastic resource]
 . Copy the *Cloud ID* and keep it safe. You will use it later.
 +
 [role="screenshot"]
-image:monitor-azure-kibana-deployment.png[Elastic Cloud deployment]
+image:monitor-azure-kibana-deployment.png[{ecloud} deployment]
 
 . Click *Security* and then click *Reset password*. Confirm, and copy the
 password. Keep it safe as you will use it later.
 +
 [role="screenshot"]
-image:monitor-azure-kibana-security.png[Elastic Cloud security]
+image:monitor-azure-kibana-security.png[{ecloud} security]
 
 You can run {metricbeat} on any machine. This {tutorial} uses a small
 Azure VM, *B2s* (2 vCPUs, 4 GB memory), with an Ubuntu distribution.

--- a/docs/en/observability/monitor-gcp.asciidoc
+++ b/docs/en/observability/monitor-gcp.asciidoc
@@ -5,7 +5,7 @@
 == Monitor Google Cloud Platform
 
 In this tutorial, you'll learn how to monitor your Google Cloud Platform ({gcp})
-deployments using Elastic Observability: Logs and Metrics.
+deployments using Elastic {observability}: Logs and Metrics.
 
 [NOTE]
 ====
@@ -33,7 +33,7 @@ Google Cloud module] and view those logs in {kib}.
 Create a deployment using our hosted {ess} on {ess-trial}[{ecloud}].
 The deployment includes an {es} cluster for storing and searching your data,
 and {kib} for visualizing and managing your data.
-For more information, see <<spin-up-stack,Spin up the Elastic Stack>>.
+For more information, see <<spin-up-stack,Spin up the {stack}>>.
 
 [discrete]
 === Step 1: Setup a Service Account
@@ -52,7 +52,7 @@ image::monitor-gcp-service-account-menu.png[Service account menu]
 
 Next, click *Create Service Account*. Define the new service account
 name (for example, "gcp-monitor") and the description (for example, "Service
-account to monitor {gcp} services using the Elastic Stack").
+account to monitor {gcp} services using the {stack}").
 
 image::monitor-gcp-service-account-name.png[Service account name]
 

--- a/docs/en/observability/monitor-java-app.asciidoc
+++ b/docs/en/observability/monitor-java-app.asciidoc
@@ -2,7 +2,7 @@
 == Monitor a Java application
 
 In this tutorial, you'll learn how to monitor a Java application using Elastic
-Observability: Logs, Metrics, APM, and Uptime.
+{observability}: Logs, Metrics, APM, and Uptime.
 
 [discrete]
 === What you'll learn
@@ -22,7 +22,7 @@ Java agent].
 
 Create a deployment using our hosted {ess} on {ess-trial}[{ecloud}]. The deployment includes
 an {es} cluster for storing and searching your data, {kib} for visualizing and managing
-your data, and an APM server. For more information, see <<spin-up-stack,Spin up the Elastic Stack>>.
+your data, and an APM server. For more information, see <<spin-up-stack,Spin up the {stack}>>.
 If you do not want to follow all those steps listed here and take a look at
 the final java code, check out the
 https://github.com/elastic/observability-contrib/tree/main/monitor-java-app[observability-contrib
@@ -438,8 +438,8 @@ echo -n "<Your Cloud ID>" | ./filebeat keystore add CLOUD_ID --stdin
 +
 To store logs in {es} with minimal permissions, create an API key to send data from {filebeat} to {ess}.
 +
-. Log into Kibana user (you can do so from the Cloud Console without typing
-in any permissions) and select *Management* -> *Dev Tools*. Send the
+. Log into {kib} user (you can do so from the Cloud Console without typing
+in any permissions) and select *Management* -> *{dev-tools-app}*. Send the
 following request:
 +
 [source,console]
@@ -536,14 +536,14 @@ This command results in roughly 8k requests per
 second, and the equivalent number of log lines are also written.
 
 [discrete]
-=== Step 3: View logs in Kibana
+=== Step 3: View logs in {kib}
 
-. Log into Kibana and select the *Discover* app.
+. Log into {kib} and select the *Discover* app.
 +
 There is a summary of the documents at the top, but let’s take a look at a single document.
 +
 [role="screenshot"]
-image:./images/monitor-java-app-kibana-single-document.png[Kibana single document view]
+image:./images/monitor-java-app-kibana-single-document.png[{kib} single document view]
 +
 You can see that a lot more data is indexed than just the event. There is information about
 the offset in the file, information about the component shipping the logs, the name of the shipper's
@@ -578,7 +578,7 @@ static Handler mainHandler() {
 }
 ----
 +
-. Now let's have a look at the Logs app in {kib}. Select *Observability* -> *Logs*.
+. Now let's have a look at the {logs-app} in {kib}. Select *{observability}* -> *Logs*.
 +
 If you want to see the streaming feature at work, run the following curl request in
 a loop while sleeping.
@@ -592,7 +592,7 @@ while $(sleep 0.7) ; do curl localhost:7000 ; done
 highlight specific terms, as shown here.
 +
 [role="screenshot"]
-image:./images/monitor-java-app-kibana-streaming.png[Kibana Logs UI Streaming]
+image:./images/monitor-java-app-kibana-streaming.png[{kib} Logs UI Streaming]
 +
 Looking at one of the documents being indexed, you can see that the log message
 is contained in a single field. Verify this by looking at one of those documents.
@@ -920,7 +920,7 @@ One of the most helpful parts of the ingest pipeline is the ability to debug by 
 the {ref}/simulate-pipeline-api.html[Simulate Pipeline API].
 
 . Let’s write a pipeline that is similar to our {filebeat} processors using
-the Dev Tools panel in Kibana, run the following:
+the {dev-tools-app} panel in {kib}, run the following:
 +
 [source,console]
 ----
@@ -1359,7 +1359,7 @@ GET metricbeat-*/_search
 ----
 
 Visualize the number of log messages over time, split by the
-log level. Since the Elastic Stack 7.7, there is a new way of creating a
+log level. Since the {stack} 7.7, there is a new way of creating a
 visualization called `Lens`.
 
 . Log into {kib} and select *Visualize* -> *Create Visualization*.
@@ -1486,7 +1486,7 @@ stable, but the maximum value of the documents in the buckets. Click on the righ
 the field name on the y-axis and select `Max`. This gives you a similar
 visualization than shown, with a peak where you ran the `wrk` command above.
 +
-. Now let's have a look at the {metrics-app} in {kib}. Select *Observability* -> *Metrics*.
+. Now let's have a look at the {metrics-app} in {kib}. Select *{observability}* -> *Metrics*.
 +
 You will only see data from a single shipper. Still, the moment
 you are running several services and the ability to group this per
@@ -1512,7 +1512,7 @@ often better to log the `rate` instead of the `counter` field.
 [discrete]
 == Step 7: Instrument the application
 
-The third piece of Observability is Application Performance Management (APM).
+The third piece of {observability} is Application Performance Management (APM).
 An APM setup consists of an APM server which accepts the data (and is
 already running within our {ecloud} setup) and an agent delivering
 the data to the server.
@@ -1538,7 +1538,7 @@ similar. The two most important terms are *Spans* and
 
 A transaction encapsulates a series of spans, which contain
 information about the execution of a piece of code. Let’s take a look at
-this screenshot from the Kibana APM app.
+this screenshot from the {kib} {apm-app}.
 
 [role="screenshot"]
 image:./images/monitor-java-app-apm-transactions.png[A transaction with spans]
@@ -1550,7 +1550,7 @@ transaction. There are two spans within. First, a request is sent to
 response is rendered using Thymeleaf. The request to {es} is faster than the
 rendering in this case.
 
-The Java APM agent can instrument specific frameworks
+The Java {apm-agent} can instrument specific frameworks
 automatically. Spring and Spring Boot are supported well, and the
 above data was created by adding the agent to the Spring Boot
 application; there is no configuration necessary.
@@ -1561,7 +1561,7 @@ keep getting added so you may want to check the
 documentation].
 
 [discrete]
-==== Add the APM agent to your code
+==== Add the {apm-agent} to your code
 
 You have two options to add Java agent instrumentation to your
 application.
@@ -1582,7 +1582,7 @@ wget https://repo1.maven.org/maven2/co/elastic/apm/elastic-apm-agent/1.17.0/elas
 
 Specify the agent on startup as well as the configuration
 parameters of where to send the APM data to. Before starting the Java application,
-let’s get an API key for our APM server running in Elastic Cloud.
+let’s get an API key for our APM server running in {ecloud}.
 
 When you check your deployment in {ecloud} and click on `APM` on
 the left, you will see the `APM Server Secret Token`, which you can use.
@@ -1639,7 +1639,7 @@ This above message will return something like this:
 
 [source,text]
 ----
-2020-07-10 15:04:48.144  INFO Attaching the Elastic APM agent to 30730
+2020-07-10 15:04:48.144  INFO Attaching the Elastic {apm-agent} to 30730
 2020-07-10 15:04:49.649  INFO Done
 ----
 
@@ -1647,7 +1647,7 @@ So now the agent was attached to a running application with a special
 configuration.
 
 While both of the first two possibilities work, you can also use the third
-one: using the APM agent as a direct dependency. This allows you to write
+one: using the {apm-agent} as a direct dependency. This allows you to write
 custom spans and transactions within our application.
 
 [discrete]
@@ -1727,7 +1727,7 @@ java -jar build/libs/javalin-app-all.jar
 If you want to run this in your IDE, you can either set the environment
 variables manually or search for a plugin that supports `.env` files.
 +
-Wait a few minutes and let’s finally take a look at the APM app.
+Wait a few minutes and let’s finally take a look at the {apm-app}.
 +
 [role="screenshot"]
 image:./images/monitor-java-app-apm-ui-javalin-app.png[Javalin App APM UI]
@@ -2065,8 +2065,8 @@ processors:
 
 include::{beats-repo-dir}/tab-widgets/start-widget-heartbeat.asciidoc[]
 
-To view the Uptime app,
-select *Observability* -> *Uptime*. The overview looks
+To view the {uptime-app},
+select *{observability}* -> *Uptime*. The overview looks
 like this.
 
 [role="screenshot"]
@@ -2101,4 +2101,4 @@ the time.
 === What's next?
 
 For more information about using  Elastic
-Observability, see the <<observability-introduction,Observability documentation>>.
+{observability}, see the <<observability-introduction,{observability} documentation>>.

--- a/docs/en/observability/monitor-k8s/monitor-k8s-application-performance.asciidoc
+++ b/docs/en/observability/monitor-k8s/monitor-k8s-application-performance.asciidoc
@@ -23,7 +23,7 @@ If you want to manage APM Server yourself, there are a few alternative options:
 [%collapsible]
 .Expand alternatives
 ====
-* {eck-ref}/[Elastic Cloud on Kubernetes (ECK)] -- The Elastic recommended approach for managing
+* {eck-ref}/[{ecloud} on Kubernetes (ECK)] -- The Elastic recommended approach for managing
 APM Server deployed with Kubernetes.
 Built on the Kubernetes Operator pattern, ECK extends basic Kubernetes orchestration capabilities
 to support the setup and management of APM Server on Kubernetes.
@@ -201,16 +201,16 @@ kubectl apply -f demo.yml
 ----
 
 [discrete]
-=== View your traces in Kibana
+=== View your traces in {kib}
 
-To view your application's trace data, open Kibana and go to *Observability* *>* *APM*.
+To view your application's trace data, open {kib} and go to *{observability} > APM*.
 
-The APM app allows you to monitor your software services and applications in real-time:
+The {apm-app} allows you to monitor your software services and applications in real-time:
 visualize detailed performance information on your services, identify and analyze errors,
 and monitor host-level and agent-specific metrics like JVM and Go runtime metrics.
 
 [screenshot]
-image::images/spring-apm-app-2.png[APM app kubernetes]
+image::images/spring-apm-app-2.png[{apm-app} kubernetes]
 
 Having access to application-level insights with just a few clicks can drastically decrease the time you spend debugging errors, slow response times, and crashes.
 
@@ -218,4 +218,4 @@ Best of all, because Kubernetes environment variables have been mapped to APM me
 you can filter your trace data by Kubernetes `namespace`, `node.name`, `pod.name`, and `pod.uid`.
 
 [screenshot]
-image::images/apm-app-kubernetes-filter.png[APM app kubernetes]
+image::images/apm-app-kubernetes-filter.png[{apm-app} kubernetes]

--- a/docs/en/observability/monitor-k8s/monitor-k8s-logs.asciidoc
+++ b/docs/en/observability/monitor-k8s/monitor-k8s-logs.asciidoc
@@ -324,17 +324,17 @@ don't run this command, the default node selector will skip master nodes.
 === View logs in {kib}
 
 To view the log data collected by {filebeat}, open {kib} and go to
-**Observability > Logs**.
+**{observability} > Logs**.
 
-The https://www.elastic.co/log-monitoring[Logs app] in {kib} allows you to
+The https://www.elastic.co/log-monitoring[{logs-app}] in {kib} allows you to
 search, filter, and tail all the logs collected into the {stack}. Instead of
 having to ssh into different servers and tail individual files, all the logs are
-available in one tool under the Logs app.
+available in one tool under the {logs-app}.
 
 [role="screenshot"]
-image::images/log-stream.png[Logs app streaming messages collected by {filebeat}]
+image::images/log-stream.png[{logs-app} streaming messages collected by {filebeat}]
 
-Explore the Logs app:
+Explore the {logs-app}:
 
 * Enter a keyword or text string in the search field to filter logs. 
 * Use the time picker or timeline view on the side to move forward and back in

--- a/docs/en/observability/monitor-k8s/monitor-k8s-metrics.asciidoc
+++ b/docs/en/observability/monitor-k8s/monitor-k8s-metrics.asciidoc
@@ -430,7 +430,7 @@ don't run this command, the default node selector will skip master nodes.
 === View performance and health metrics
 
 To view the performance and health metrics collected by {metricbeat}, open
-{kib} and go to **Observability > Metrics**.
+{kib} and go to **{observability} > Metrics**.
 
 On the **Inventory** page, you can switch between different views to see an
 overview of the containers and pods running on Kubernetes:

--- a/docs/en/observability/monitor-k8s/monitor-k8s-network.asciidoc
+++ b/docs/en/observability/monitor-k8s/monitor-k8s-network.asciidoc
@@ -9,7 +9,7 @@ TODO: provide a brief intro.
 [discrete]
 === Deploy {packetbeat} to capture network traffic data
 
-TODO: Describe how to configure and deploy Packetbeat as a daemonset.
+TODO: Describe how to configure and deploy {packetbeat} as a daemonset.
 
 [discrete]
 === View network traffic data

--- a/docs/en/observability/monitor-k8s/monitor-k8s-uptime.asciidoc
+++ b/docs/en/observability/monitor-k8s/monitor-k8s-uptime.asciidoc
@@ -9,9 +9,9 @@ TODO: Provide a brief intro.
 [discrete]
 === Deploy {heartbeat} to collect uptime and availability data
 
-TODO: Describe how to configure and deploy Heartbeat as a daemonset.
+TODO: Describe how to configure and deploy {heartbeat} as a daemonset.
 
 [discrete]
 === View uptime and availability in {kib}
 
-TODO: Describe how to use the Uptime app and pre-built dashboards/visualizations.
+TODO: Describe how to use the {uptime-app} and pre-built dashboards/visualizations.

--- a/docs/en/observability/monitor-k8s/monitor-k8s.asciidoc
+++ b/docs/en/observability/monitor-k8s/monitor-k8s.asciidoc
@@ -36,7 +36,7 @@ your application, including the orchestration software itself:
 
 
 This guide describes how to deploy Elastic monitoring agents as DaemonSets using
-`kubectl` and the Beats GitHub repository manifest files. For other
+`kubectl` and the {beats} GitHub repository manifest files. For other
 deployment options, see the Kubernetes operator and custom resource definitions
 from {eck-ref}/index.html[{ecloud} on Kubernetes (ECK)] or the
 https://github.com/elastic/helm-charts/blob/master/README.md[Helm charts].
@@ -66,5 +66,5 @@ just another integration that you add to the agent policy!
 {observability-guide}/create-alerts.html[Create alerts] and find out about
 problems while sipping your favorite beverage poolside.
 
-* Want Elastic to do the heavy lifting? Use machine learning to
+* Want Elastic to do the heavy lifting? Use {ml} to
 {observability-guide}/inspect-log-anomalies.html[detect anomalies].

--- a/docs/en/observability/monitor-logs.asciidoc
+++ b/docs/en/observability/monitor-logs.asciidoc
@@ -10,7 +10,7 @@ more data sources. Log events are indexed into {es} and are sorted from older to
 with infinite scrolling in both directions.
 
 There is live streaming of logs, filtering using auto-complete, and a logs histogram
-for quick navigation. You can also use machine learning to detect specific log
+for quick navigation. You can also use {ml} to detect specific log
 anomalies automatically and categorize log messages to quickly identify patterns in your
 log events.
 
@@ -34,7 +34,7 @@ endif::[]
 
 ifeval::["{is-current-version}"=="false"]
 [role="screenshot"]
-image::images/logs-app.png[Logs app in Kibana]
+image::images/logs-app.png[{logs-app} in {kib}]
 endif::[]
 
-To view the {logs-app}, go to *Observability > Logs*.
+To view the {logs-app}, go to *{observability} > Logs*.

--- a/docs/en/observability/monitor-servers.asciidoc
+++ b/docs/en/observability/monitor-servers.asciidoc
@@ -161,7 +161,7 @@ All of this information can help when investigating events—for example, filter
 [role="screenshot"]
 image::images/anomalies-overlay.png[Anomalies]
 
-The *Anomalies* table displays a list of each single metric anomaly detection job for the specific host. By default, anomaly
+The *Anomalies* table displays a list of each single metric {anomaly-detect} job for the specific host. By default, anomaly
 jobs are sorted by time to show the most recent job. 
 
 Along with the name of each anomaly job, detected anomalies with a severity score equal to 50, or higher, are listed. These
@@ -169,7 +169,7 @@ scores represent a severity of "warning" or higher in the selected time period. 
 the actual value and the expected ("typical") value of the host metric in the anomaly record result.
 
 To drill down and analyze the metric anomaly, select *Actions > Open in Anomaly Explorer* to view the
-{ml-docs}/ml-gs-results.html[Anomaly Explorer in Machine Learning]. You can also select *Actions > Show in Inventory* to view the host
+{ml-docs}/ml-gs-results.html[Anomaly Explorer in {ml-app}]. You can also select *Actions > Show in Inventory* to view the host
 Inventory page, filtered by the specific metric. 
 ====
 

--- a/docs/en/observability/monitor-status-alert.asciidoc
+++ b/docs/en/observability/monitor-status-alert.asciidoc
@@ -4,7 +4,7 @@
 Within the {uptime-app}, create a *Monitor Status* rule to receive notifications
 based on errors and outages. 
 
-. To access this page, go to *Observability > Uptime*.
+. To access this page, go to *{observability} > Uptime*.
 . At the top of the page, click *Alerts and rules > Create rule*.
 . Select *Monitor status rule*.
 

--- a/docs/en/observability/observability-introduction.asciidoc
+++ b/docs/en/observability/observability-introduction.asciidoc
@@ -1,19 +1,19 @@
 [[observability-introduction]]
 [role="xpack"]
-= What is Elastic Observability?
+= What is Elastic {observability}?
 
-Observability provides you with granular insights and context into the behavior
+{observability} provides you with granular insights and context into the behavior
 of applications running in your environments. At Elastic, we view observability as an
 attribute of any system that you build and want to monitor. Being able to detect
 and fix root cause events quickly within an observable system is what we consider
 a minimum requirement for any analyst.
 
-https://www.elastic.co/observability[Elastic Observability] provides you with a
+https://www.elastic.co/observability[Elastic {observability}] provides you with a
 single stack to unify your logs, metrics, uptime data, application traces, user experience data, and synthetics.
 Ingest your data directly to {es}, where you can further process and enhance the data,
 before visualizing it in {kib}.
 
-image::images/observability.png[Elastic Observability]
+image::images/observability.png[Elastic {observability}]
 
 Search, monitor, and apply analytics in real time to events happening across all of
 your environments. Analyze the logs for a specific transaction, monitor the performance metrics
@@ -42,13 +42,13 @@ availability zones or namespaces.
 
 To instrument your code and collect performance data and errors at runtime, install APM agents
 like Java, Go, .NET, and many more. To quickly find the APM traces for underlying services,
-drill-down into the APM app.
+drill-down into the {apm-app}.
 
 [float]
 [[uptime-overview]]
 == Uptime data
 
-Install and configure Heartbeat on your servers to monitor host availability, service
+Install and configure {heartbeat} on your servers to monitor host availability, service
 uptime, web site endpoints, and API monitoring. For detailed
 monitor summaries, with support for monitors from multiple locations, drill-down into
 the {uptime-app}.
@@ -57,7 +57,7 @@ the {uptime-app}.
 [[user-experience-overview]]
 == User experience data
 
-User Experience data, powered by the APM Real User Monitoring (RUM) agent,
+{user-experience} data, powered by the APM Real User Monitoring (RUM) agent,
 provides a way to quantify and analyze the perceived performance of your web application.
 
 [float]
@@ -73,6 +73,6 @@ The end result is rich, consistent, and repeatable data that you can trend and a
 == Alerting
 
 To help keep you aware of potential issues in your environments, the {logs-app}, {metrics-app},
-APM app, and the {uptime-app} all integrate with {kib}’s alerting
+{apm-app}, and the {uptime-app} all integrate with {kib}’s alerting
 and actions feature. It provides a set of built-in actions and specific threshold rules
 for you to use and enables central management of all rules from {kib} Management.

--- a/docs/en/observability/observability-ui.asciidoc
+++ b/docs/en/observability/observability-ui.asciidoc
@@ -19,7 +19,7 @@ and more &mdash; all from the convenience of a {kib} UI.
 * **A centralized hub for Elastic's solutions.** From log analytics to
 metrics discovery to APM, {kib} is the portal for accessing these and other capabilities.
 
-Within {kib}, the *Observability Overview* page contains a wide variety of charts
+Within {kib}, the *{observability} Overview* page contains a wide variety of charts
 displaying analytics relating to the components that help you make your systems
 observable: logs, metrics, APM, and uptime data.
 
@@ -105,9 +105,9 @@ image::images/uptime-summary.png[Summary of Monitors on the {observability} over
 
 [float]
 [[view-user-experience]]
-== User Experience
+== {user-experience}
 
-The *User Experience* chart provides a snapshot of core web vitals for the service with the most traffic.
+The *{user-experience}* chart provides a snapshot of core web vitals for the service with the most traffic.
 User experience provides a way to quantify and analyze the perceived performance of your web application.
 Unlike testing environments, {user-experience} data reflects real-world user experiences.
 Drill down further by looking at data by URL, operating system, browser, and location —
@@ -117,4 +117,4 @@ To drill down and view this {user-experience} data, click *Show dashboard*.
 For more information, see <<user-experience,{user-experience}>>.
 
 [role="screenshot"]
-image::images/obs-overview-ue.png[Summary of User Experience metrics on the {observability} overview page]
+image::images/obs-overview-ue.png[Summary of {user-experience} metrics on the {observability} overview page]

--- a/docs/en/observability/redirects.asciidoc
+++ b/docs/en/observability/redirects.asciidoc
@@ -9,7 +9,7 @@ The following pages have moved or been deleted.
 Refer to <<exploratory-data-visualizations,Explore data>>.
 
 [role="exclude",id="user-experience-visualizations"]
-=== User experience visualizations
+=== {user-experience} visualizations
 
 Refer to <<exploratory-data-visualizations,Explore data>>.
 
@@ -25,6 +25,6 @@ Refer to <<monitoring-uptime>>.
 Refer to <<uptime-set-up>>.
 
 [role="exclude",id="synthetics-quickstart-fleet"]
-=== Synthetic monitoring using Elastic Agent and Fleet
+=== Synthetic monitoring using {agent} and {fleet}
 
 Refer to <<uptime-set-up>>.

--- a/docs/en/observability/spin-up-stack.asciidoc
+++ b/docs/en/observability/spin-up-stack.asciidoc
@@ -1,7 +1,7 @@
 [[spin-up-stack]]
 = Spin up the {stack}
 
-To use Elastic Observability, you need {es} for storing and searching your
+To use Elastic {observability}, you need {es} for storing and searching your
 data, and {kib} for visualizing and managing it.
 
 You can use our

--- a/docs/en/observability/synthetic-monitoring-visualizations.asciidoc
+++ b/docs/en/observability/synthetic-monitoring-visualizations.asciidoc
@@ -9,7 +9,7 @@ relating to your monitor durations or pings over time.
 [role="screenshot"]
 image::images/synthetic-monitoring-visualization.png[Synthetic monitoring visualization]
 
-. Go to *Observability > Uptime*.
+. Go to *{observability} > Uptime*.
 . On the *Overview* page, click *Analyze data*.
 . For data type, select *Synthetic Monitoring*.
 . Under **Report**, choose the type of data you want to analyze:

--- a/docs/en/observability/synthetics-command-reference.asciidoc
+++ b/docs/en/observability/synthetics-command-reference.asciidoc
@@ -9,7 +9,7 @@
 [[elastic-synthetics-command]]
 == `elastic-synthetics`
 
-beta[] Heartbeat uses the `npx @elastic/synthetics` command to run and report synthetic tests.
+beta[] {heartbeat} uses the `npx @elastic/synthetics` command to run and report synthetic tests.
 It can also be used locally to help develop your tests.
 
 *SYNOPSIS*
@@ -22,7 +22,7 @@ npx @elastic/synthetics [options] [files] [dir]
 *FLAGS*
 
 You will not need to use most command line flags -- they have been implemented
-purely to interact with Heartbeat.
+purely to interact with {heartbeat}.
 However, there are some you may find useful.
 They are documented below.
 

--- a/docs/en/observability/synthetics-params-secrets.asciidoc
+++ b/docs/en/observability/synthetics-params-secrets.asciidoc
@@ -6,10 +6,10 @@
 ++++
 
 beta[] You may need to use dynamically defined values in your synthetic scripts, which may sometimes be sensitive. 
-For instance, you may want to test a production website with a particular demo account whose password is only known to the team administering heartbeat. 
-Another scenario might be using a different URL when running the tests under Heartbeat and then running them locally using the Synthetics agent.
+For instance, you may want to test a production website with a particular demo account whose password is only known to the team administering {heartbeat}. 
+Another scenario might be using a different URL when running the tests under {heartbeat} and then running them locally using the Synthetics agent.
 Solving these problems is where params come in. Params are variables that you can use within a synthetic suite. 
-They can be defined either in the suites config file, the synthetics agent command line, or in a Heartbeat YAML config file.
+They can be defined either in the suites config file, the synthetics agent command line, or in a {heartbeat} YAML config file.
 
 You should also note that since synthetics is a full javascript environment, it is also possible to use regular environment variables via
 the standard node `process.env` global object.
@@ -40,10 +40,10 @@ Parameter values can be declared by any of the following methods:
 
 * Declaring a default value for the parameter in a configuration file.
 * Passing the `--params` CLI argument. 
-* Specifying the parameter in the heartbeat yaml config using the `params` option.
+* Specifying the parameter in the {heartbeat} yaml config using the `params` option.
 
-The values in the configuration file are read first, then merged with either the CLI argument, or the Heartbeat
-option, with the CLI and Heartbeat options taking precedence over the configuration file.
+The values in the configuration file are read first, then merged with either the CLI argument, or the {heartbeat}
+option, with the CLI and {heartbeat} options taking precedence over the configuration file.
 
 These options are discussed in detail in the sections below.
 
@@ -70,7 +70,7 @@ export default (env) => {
 ----
 
 Note that we use the `env` variable in the above example, which corresponds to the value of the `NODE_ENV` environment variable
-, or the `environment` parameter in the `browser` monitor definition when using Heartbeat. 
+, or the `environment` parameter in the `browser` monitor definition when using {heartbeat}. 
 
 [discrete]
 [[synthetics-cli-params]]
@@ -82,9 +82,9 @@ To override the `url` parameter, you would run: `elastic-synthetics . --params '
 
 [discrete]
 [[synthetics-hb-params]]
-== Using Heartbeat options to set params
+== Using {heartbeat} options to set params
 
-When running via Heartbeat use the `params` option to set additional parameters, passed through the `--params` flag
+When running via {heartbeat} use the `params` option to set additional parameters, passed through the `--params` flag
 mentioned above and have their values merged over any default values. In the example below we run the todos app, overriding the `url`
 parameter.
 
@@ -112,7 +112,7 @@ important to remember that since synthetics scripts have no limitations, a malic
 exfiltrates `params` and other data at runtime. Therefore, it is generally best not to use truly sensitive passwords (e.g. an admin password to test an admin
 panel, or a real credit card) in *any* synthetics tools. Instead, set up limited dummy accounts, or fake credit cards with limited functionality.
 
-Use either environment variables or the Heartbeat keystore to handle any values needing encryption at rest. 
+Use either environment variables or the {heartbeat} keystore to handle any values needing encryption at rest. 
 As an example, the syntax `${URL}` for instance, to reference a variable named `URL` in either the secret store or the environment. For example: 
 
 [source,yaml]
@@ -130,4 +130,4 @@ As an example, the syntax `${URL}` for instance, to reference a variable named `
       folder: "synthetics-tests"
 ----
 
-To setup the heartbeat keystore see the https://www.elastic.co/guide/en/beats/heartbeat/current/keystore.html[Heartbeat keystore documentation]. 
+To setup the {heartbeat} keystore see the https://www.elastic.co/guide/en/beats/heartbeat/current/keystore.html[{heartbeat} keystore documentation]. 

--- a/docs/en/observability/tab-widgets/add-apm-integration/content.asciidoc
+++ b/docs/en/observability/tab-widgets/add-apm-integration/content.asciidoc
@@ -4,17 +4,17 @@
 [role="screenshot"]
 image::./images/kibana-fleet-integrations-apm.png[{fleet} showing APM integration]
 
-. Click **Manage APM integration in Fleet**.
+. Click **Manage APM integration in {fleet}**.
 +
 [role="screenshot"]
 image::./images/cloud-add-apm.png[Add APM integration]
 
-. On the **Elastic APM** page, select the **Elastic Cloud agent policy**.
+. On the **Elastic APM** page, select the **{ecloud} agent policy**.
 +
 [role="screenshot"]
 image::./images/cloud-apm-policy-view.png[Cloud APM policy view on the Elastic APM page]
 
-. As you can see, the APM integration has been added to the Elastic Cloud Agent policy.
+. As you can see, the APM integration has been added to the {ecloud} agent policy.
 This is the default policy for {agent}s hosted on {ecloud}.
 In the **Elastic APM** row of the table, in the **Actions** column, 
 select **Edit integration** to configure the APM integration.
@@ -54,7 +54,7 @@ image::./images/add-integration-apm.png[{fleet} Add APM integration page]
 
 . To see the updated policy, click the *Default policy* link.
 +
-The newly added APM integration should appear under **Fleet** > **Agent policies** > **Default policy**,
+The newly added APM integration should appear under **{fleet}** > **Agent policies** > **Default policy**,
 along with the default System integration.
 +
 [role="screenshot"]

--- a/docs/en/observability/tail-logs.asciidoc
+++ b/docs/en/observability/tail-logs.asciidoc
@@ -31,7 +31,7 @@ endif::[]
 == Filter logs
 
 To help you get started with your analysis faster and extract fields from your logs, use the search bar
-to create structured queries using {kibana-ref}/kuery-query.html[Kibana Query Language].
+to create structured queries using {kibana-ref}/kuery-query.html[{kib} Query Language].
 For example, enter `host.hostname : "host1"` to see only the information for `host1`.
 
 Additionally, click *Highlights* and enter a term you would like to locate within the log events. The Logs
@@ -75,4 +75,4 @@ To see other actions related to a log event, click *Actions* in the *Log event d
 Depending on the event and the features you have configured, you can:
 
 * Select *View status in Uptime* to <<view-monitor-status,view related uptime information>> in the {uptime-app}.
-* Select *View in APM* to {kibana-ref}/traces.html[view corresponding APM traces] in the *APM* app.
+* Select *View in APM* to {kibana-ref}/traces.html[view corresponding APM traces] in the {apm-app}.

--- a/docs/en/observability/troubleshoot-uptime-mapping-issues.asciidoc
+++ b/docs/en/observability/troubleshoot-uptime-mapping-issues.asciidoc
@@ -9,7 +9,7 @@
 
 There are situations in which {heartbeat} data can be indexed without the correct mappings applied.
 These situations cannot occur with the {elastic-agent} configured via {fleet}, only with standalone {heartbeat} or {elastic-agent} running in standalone mode.
-This can occur when the underlying `heartbeat-VERSION` ILM alias is deleted manually or when {heartbeat} writes data
+This can occur when the underlying `heartbeat-VERSION` {ilm-init} alias is deleted manually or when {heartbeat} writes data
 through an intermediary such as {ls} without the `setup` command being run. 
 When running {elastic-agent} in standalone mode this can happen if manually setup datastreams have incorrect mappings.
 
@@ -30,7 +30,7 @@ delete all the {heartbeat} indicies that match the pattern the {uptime-app} will
 There are multiple ways to achieve this.
 You can read about performing this using the {ref}/index-mgmt.html[Index Management UI] or with the {ref}/indices-delete-index.html[Delete index API].
 
-If using {elastic-agent} you will want to fix any issues with custom datastream mappings. We encourage the use of fleet to eliminate this issue.
+If using {elastic-agent} you will want to fix any issues with custom datastream mappings. We encourage the use of {fleet} to eliminate this issue.
 
 [discrete]
 === If using {heartbeat}, perform {heartbeat} setup
@@ -38,7 +38,7 @@ If using {elastic-agent} you will want to fix any issues with custom datastream 
 The below command will cause {heartbeat} to perform its setup processes and recreate the index template properly.
 
 NOTE: For more information on how to use this command, you can reference the
-{heartbeat-ref}/heartbeat-installation-configuration.html[Heartbeat quickstart guide].
+{heartbeat-ref}/heartbeat-installation-configuration.html[{heartbeat} quickstart guide].
 
 --
 include::{beats-repo-dir}/tab-widgets/setup-widget.asciidoc[]

--- a/docs/en/observability/tutorials.asciidoc
+++ b/docs/en/observability/tutorials.asciidoc
@@ -1,7 +1,7 @@
 [[observability-tutorials]]
 = Tutorials
 
-Using Elastic Observability, learn how to analyze log data,
+Using Elastic {observability}, learn how to analyze log data,
 monitor system and service metrics, instrument code and
 collect performance data, and monitor host availability and endpoints.
 

--- a/docs/en/observability/uptime-duration-anomaly-alert.asciidoc
+++ b/docs/en/observability/uptime-duration-anomaly-alert.asciidoc
@@ -6,7 +6,8 @@ based on the response durations for all of the geographic locations of each moni
 monitor runs for an unusual amount of time, at a particular time, an anomaly is recorded and
 highlighted on the <<inspect-uptime-duration-anomalies,Monitor duration>> chart.
 
-. To access this page, go to *Observability > Uptime*.
+// lint ignore anomaly-detection
+. To access this page, go to *{observability} > Uptime*.
 . On the *Monitors* page, select on a monitor, and then click *Enable anomaly detection*.
 
 [discrete]

--- a/docs/en/observability/uptime-tls-alert.asciidoc
+++ b/docs/en/observability/uptime-tls-alert.asciidoc
@@ -5,7 +5,7 @@ Within the {uptime-app}, you can create a rule that notifies
 you when one or more of your monitors has a TLS certificate expiring
 within a specified threshold, or when it exceeds an age limit.
 
-. To access this page, go to *Observability > Uptime*.
+. To access this page, go to *{observability} > Uptime*.
 . At the top of the page, click *Alerts and rules > Create rule*.
 . Select *TLS rule*.
 

--- a/docs/en/observability/user-experience-visualizations.asciidoc
+++ b/docs/en/observability/user-experience-visualizations.asciidoc
@@ -1,5 +1,5 @@
 [[user-experience-visualizations]]
-= Create user experience visualizations
+= Create {user-experience} visualizations
 
 experimental[]
 
@@ -8,9 +8,10 @@ detailed visualizations for performance distributions, key performance indicator
 and for core web vitals of your web applications.
 
 [role="screenshot"]
-image::images/user-experience-visualization.png[User experience visualization]
+image::images/user-experience-visualization.png[{user-experience} visualization]
 
-. Go to *Observability > {user-experience} > Dashboard*.
+// lint ignore user-experience
+. Go to *{observability} > User Experience > Dashboard*.
 . Click *Analyze data*.
 . For data type, select *{user-experience} (RUM)*.
 . Under **Report**, choose the type of data you want to analyze:

--- a/docs/en/observability/user-experience.asciidoc
+++ b/docs/en/observability/user-experience.asciidoc
@@ -8,8 +8,7 @@ Unlike testing environments, {user-experience} data reflects real-world user exp
 Drill down further by looking at data by URL, operating system, browser, and location --
 all of which can impact how your application performs on end-user machines.
 
-Powered by the APM Real user monitoring (RUM) agent, all it takes is a few lines of code to begin
-surfacing key user experience metrics.
+Powered by the APM Real user monitoring (RUM) agent, all it takes is a few lines of code to begin surfacing key user experience metrics.
 
 // Conditionally display a screenshot or video depending on what the
 // current documentation version is.
@@ -31,7 +30,7 @@ endif::[]
 
 ifeval::["{is-current-version}"=="false"]
 [role="screenshot"]
-image::images/user-experience-tab.png[User experience tab]
+image::images/user-experience-tab.png[{user-experience} tab]
 endif::[]
 
 [discrete]
@@ -66,7 +65,7 @@ you must have good Core Web Vitals.
 {user-experience} metrics are powered by the {apm-rum-ref}[APM Real User Monitoring (RUM) agent].
 The RUM agent uses browser timing APIs, like https://w3c.github.io/navigation-timing/[Navigation Timing],
 https://w3c.github.io/resource-timing/[Resource Timing], https://w3c.github.io/paint-timing/[Paint Timing],
-and https://w3c.github.io/user-timing/[User Timing], to capture user experience
+and https://w3c.github.io/user-timing/[User Timing], to capture {user-experience}
 metrics every time a user hits one of your pages.
 This data is stored in {es}, where it can be visualized using {kib}.
 
@@ -90,7 +89,7 @@ You won't be able to fix any problems from viewing these metrics alone,
 but you'll get a sense of the big picture as you dive deeper into your data.
 
 [role="screenshot"]
-image::images/page-load-duration.png[User experience page load duration metrics]
+image::images/page-load-duration.png[{user-experience} page load duration metrics]
 
 [discrete]
 [[user-experience-metrics]]
@@ -101,7 +100,7 @@ For example, first contentful paint is the timestamp when the browser begins ren
 In other words, it's around this time that a user first gets feedback that the page is loading.
 
 [role="screenshot"]
-image::images/user-exp-metrics.png[User experience metrics]
+image::images/user-exp-metrics.png[{user-experience} metrics]
 
 // This is collapsed by default
 [%collapsible]
@@ -193,7 +192,7 @@ Don't forget, this data also influences search engine page rankings and placemen
 without requiring the use of AMP.
 
 [role="screenshot"]
-image::images/visitor-breakdown.png[User experience visitor breakdown]
+image::images/visitor-breakdown.png[{user-experience} visitor breakdown]
 
 [discrete]
 [[user-experience-errors]]
@@ -207,7 +206,7 @@ Error monitoring removes this blindspot by surfacing JavaScript errors that are
 occurring on your website in production.
 
 [role="screenshot"]
-image::images/js-errors.png[User experience javascript errors]
+image::images/js-errors.png[{user-experience} javascript errors]
 
 Open error messages in APM for additional analysis tools,
 like occurrence rates, transaction ids, user data, and more.
@@ -217,7 +216,7 @@ like occurrence rates, transaction ids, user data, and more.
 === Feedback and troubleshooting
 
 Have a question? Want to leave feedback? Visit the
-https://discuss.elastic.co/c/observability/user-experience/87[User experience discussion forum].
+https://discuss.elastic.co/c/observability/user-experience/87[{user-experience} discussion forum].
 
 [discrete]
 [[user-experience-references]]

--- a/docs/en/observability/view-infrastructure-metrics.asciidoc
+++ b/docs/en/observability/view-infrastructure-metrics.asciidoc
@@ -6,7 +6,7 @@ the resources that you are monitoring. All monitored resources emitting
 a core set of infrastructure metrics are displayed to give you a quick view of the overall health
 of your infrastructure.
 
-To access this page, go to *Observability > Metrics*. The *Inventory* page is displayed by default.
+To access this page, go to *{observability} > Metrics*. The *Inventory* page is displayed by default.
 
 An overview of the hosts that you are monitoring and the current CPU usage
 for each host are displayed in a waffle map of one or more rectangular grids. 
@@ -32,7 +32,7 @@ of your Kubernetes pods, grouped by namespace, and sorted by the memory usage va
 [role="screenshot"]
 image::images/kubernetes-filter.png[Kubernetes pod filtering]
 
-You can also use the search bar to create structured queries using {kibana-ref}/kuery-query.html[Kibana Query Language].
+You can also use the search bar to create structured queries using {kibana-ref}/kuery-query.html[{kib} Query Language].
 For example, enter `host.hostname : "host1"`` to see only the information for `host1`.
 
 To examine the metrics for a specific time, use the time filter to select the date and time.

--- a/docs/en/observability/view-monitor-status.asciidoc
+++ b/docs/en/observability/view-monitor-status.asciidoc
@@ -5,7 +5,7 @@ The *Monitors* page provides you with a high-level view of all
 the services you are monitoring to help you quickly diagnose outages and other connectivity issues
 within your network.
 
-To access this page, go to *Observability > Uptime > Monitors*.
+To access this page, go to *{observability} > Uptime > Monitors*.
 
 [IMPORTANT]
 =====

--- a/docs/en/observability/view-observability-alerts.asciidoc
+++ b/docs/en/observability/view-observability-alerts.asciidoc
@@ -30,7 +30,7 @@ image::images/alerts-page.png[Alerts page]
 == Filter alerts
 
 To help you get started with your analysis faster, use the KQL bar to create structured queries using
-{kibana-ref}/kuery-query.html[Kibana Query Language]. For example, `kibana.alert.rule.name : <>`.
+{kibana-ref}/kuery-query.html[{kib} Query Language]. For example, `kibana.alert.rule.name : <>`.
 
 You can use the time filter to define a specific date and time range. By default, this filter is set to search
 for the last 15 minutes.

--- a/docs/en/shared/configure-apm-agents/content.asciidoc
+++ b/docs/en/shared/configure-apm-agents/content.asciidoc
@@ -1,9 +1,9 @@
 // tag::central-config[]
-Central configuration allows you to fine-tune your agent configuration from within the APM app.
+Central configuration allows you to fine-tune your agent configuration from within the {apm-app}.
 Changes are automatically propagated to your APM agents, and there’s no need to redeploy.
 
 A select number of configuration options are supported.
-See {apm-app-ref}/agent-configuration.html[Agent configuration in Kibana]
+See {apm-app-ref}/agent-configuration.html[Agent configuration in {kib}]
 for more information and a configuration reference.
 // end::central-config[]
 

--- a/docs/en/shared/configure-apm-server/content.asciidoc
+++ b/docs/en/shared/configure-apm-server/content.asciidoc
@@ -1,6 +1,6 @@
 // tag::ess[]
 
-If you're running APM Server in Elastic cloud, you can configure your own user settings right in the Elasticsearch Service Console.
+If you're running APM Server in Elastic cloud, you can configure your own user settings right in the {ess} Console.
 Any changes are automatically appended to the `apm-server.yml` configuration file for your instance.
 
 Full details are available in the {cloud}/ec-manage-apm-settings.html[APM user settings] documentation.

--- a/docs/en/shared/install-apm-agents-kube/go.asciidoc
+++ b/docs/en/shared/install-apm-agents-kube/go.asciidoc
@@ -1,6 +1,6 @@
 *Install the agent*
 
-Install the APM agent packages for Go.
+Install the {apm-agent} packages for Go.
 
 [source,go]
 ----

--- a/docs/en/shared/install-apm-agents-kube/nodejs.asciidoc
+++ b/docs/en/shared/install-apm-agents-kube/nodejs.asciidoc
@@ -1,6 +1,6 @@
-*Install the APM agent*
+*Install the {apm-agent}*
 
-Install the APM agent for Node.js as a dependency to your application.
+Install the {apm-agent} for Node.js as a dependency to your application.
 
 [source,js]
 ----

--- a/docs/en/shared/install-apm-agents-kube/python.asciidoc
+++ b/docs/en/shared/install-apm-agents-kube/python.asciidoc
@@ -1,6 +1,6 @@
-*Install the APM agent*
+*Install the {apm-agent}*
 
-Install the APM agent for Python as a dependency:
+Install the {apm-agent} for Python as a dependency:
 
 [source,python]
 ----

--- a/docs/en/shared/install-apm-agents-kube/ruby.asciidoc
+++ b/docs/en/shared/install-apm-agents-kube/ruby.asciidoc
@@ -1,4 +1,4 @@
-*Install the APM agent*
+*Install the {apm-agent}*
 
 Add the agent to your Gemfile.
 

--- a/docs/en/shared/install-apm-agents/content.asciidoc
+++ b/docs/en/shared/install-apm-agents/content.asciidoc
@@ -1,7 +1,7 @@
 // tag::go[]
 *Install the agent*
 
-Install the APM agent packages for Go.
+Install the {apm-agent} packages for Go.
 
 [source,go]
 ----
@@ -59,7 +59,7 @@ func main() {
 
 // tag::java[]
 
-*Download the APM agent*
+*Download the {apm-agent}*
 
 Download the agent jar from http://search.maven.org/#search%7Cga%7C1%7Ca%3Aelastic-apm-agent[Maven Central].
 Do not add the agent as a dependency to your application.
@@ -92,7 +92,7 @@ java -javaagent:/path/to/elastic-apm-agent-<version>.jar \
 // ***************************************************
 
 // tag::net[]
-*Download the APM agent*
+*Download the {apm-agent}*
 
 Add the agent packages from https://www.nuget.org/packages?q=Elastic.apm[NuGet] to your .NET application.
 There are multiple NuGet packages available for different use cases.
@@ -155,9 +155,9 @@ See the agent reference for more information.
 // ***************************************************
 
 // tag::node[]
-*Install the APM agent*
+*Install the {apm-agent}*
 
-Install the APM agent for Node.js as a dependency to your application.
+Install the {apm-agent} for Node.js as a dependency to your application.
 
 [source,js]
 ----
@@ -199,9 +199,9 @@ var apm = require('elastic-apm-node').start({
 // tag::python[]
 Django::
 +
-*Install the APM agent*
+*Install the {apm-agent}*
 +
-Install the APM agent for Python as a dependency.
+Install the {apm-agent} for Python as a dependency.
 +
 [source,python]
 ----
@@ -242,9 +242,9 @@ MIDDLEWARE = (
 
 Flask::
 +
-*Install the APM agent*
+*Install the {apm-agent}*
 +
-Install the APM agent for Python as a dependency.
+Install the {apm-agent} for Python as a dependency.
 +
 [source,python]
 ----
@@ -289,7 +289,7 @@ apm = ElasticAPM(app)
 // end::python[]
 
 // tag::ruby[]
-*Install the APM agent*
+*Install the {apm-agent}*
 
 Add the agent to your Gemfile.
 

--- a/docs/en/shared/install-configure-metricbeat.asciidoc
+++ b/docs/en/shared/install-configure-metricbeat.asciidoc
@@ -40,7 +40,7 @@ echo -n "<Your Deployment Cloud ID>" | ./metricbeat keystore add CLOUD_ID --stdi
 ----
 
 . To store metrics in {es} with minimal permissions, create an API key to send
-data from {metricbeat} to {ess}. Log into Kibana (you can do so from the Cloud
+data from {metricbeat} to {ess}. Log into {kib} (you can do so from the Cloud
 Console without typing in any permissions) and select *Management* -> *Dev
 Tools*. Send the following request:
 +

--- a/docs/en/shared/spin-up-the-stack/content.asciidoc
+++ b/docs/en/shared/spin-up-the-stack/content.asciidoc
@@ -9,7 +9,7 @@ supported operating systems and product compatibility. We recommend you use the 
 version of {es}, {kib}, and APM Server.
 
 . {stack-gs}/get-started-elastic-stack.html#install-elasticsearch[Install {es}]
-. {stack-gs}/get-started-elastic-stack.html#install-kibana[Install Kibana]
+. {stack-gs}/get-started-elastic-stack.html#install-kibana[Install {kib}]
 . {apm-guide-ref}/apm-quick-start.html[Install APM server]
 
 // end::self-managed[]

--- a/docs/en/templates/tutorial-template.asciidoc
+++ b/docs/en/templates/tutorial-template.asciidoc
@@ -1,4 +1,4 @@
-// Use this template to create tutorials within the Observability documentation.
+// Use this template to create tutorials within the {observability} documentation.
 // Replace the text with your own. 
 
 // To add your tutorial to the doc build, put your .asciidoc file in
@@ -15,7 +15,7 @@
 = Tutorial title
 
 Introduce the reader to what they will do in this tutorial and provide a list
-of what the reader will learn. If required, include links to topics within the Observability docs. 
+of what the reader will learn. If required, include links to topics within the {observability} docs. 
 
 In this tutorial, you learn how to:
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.2`:
 - [Lints all docs for shared attributes use (#1820)](https://github.com/elastic/observability-docs/pull/1820)

<!--- Backport version: 8.4.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)