### PR TITLE
Fix synchronization in widget tabs

### DIFF
--- a/docs/en/ingest-management/tab-widgets/add-fleet-server/widget.asciidoc
+++ b/docs/en/ingest-management/tab-widgets/add-fleet-server/widget.asciidoc
@@ -1,5 +1,5 @@
 ++++
-<div class="tabs" data-tab-group="spin-up-stack">
+<div class="tabs" data-tab-group="host">
   <div role="tablist" aria-label="Spin up">
     <button role="tab"
             aria-selected="true"

--- a/docs/en/observability/tab-widgets/add-apm-integration/widget.asciidoc
+++ b/docs/en/observability/tab-widgets/add-apm-integration/widget.asciidoc
@@ -1,5 +1,5 @@
 ++++
-<div class="tabs" data-tab-group="add-apm-integration">
+<div class="tabs" data-tab-group="host">
   <div role="tablist" aria-label="Add APM integration">
     <button role="tab"
             aria-selected="true"


### PR DESCRIPTION
Closes #1877 

The IDs used to drive the synchronization need to be the same, or the tabs will not be synced.