### PR TITLE
Add Fleet and Elastic Agent 8.2.3 release notes

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-8.2.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.2.asciidoc
@@ -12,6 +12,7 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-8.2.3>>
 * <<release-notes-8.2.2>>
 * <<release-notes-8.2.1>>
 * <<release-notes-8.2.0>>
@@ -22,12 +23,30 @@ Also see:
 * {kibana-ref}/release-notes.html[{kib} release notes]
 * {beats-ref}/release-notes.html[{beats} release notes]
 
+// begin 8.2.3 relnotes
+
+[[release-notes-8.2.3]]
+== {fleet} and {agent} 8.2.3
+
+Review important information about the {fleet} and {agent} 8.2.3 release.
+
+[discrete]
+[[bug-fixes-8.2.3]]
+=== Bug fixes
+
+{fleet}::
+* {agent} integration now installs automatically if agent monitoring is
+turned on in the agent policy. {kib-pull}133530[#133530]
+* Removes {beats} tutorials from the Elastic Stack category. {kib-pull}132957[#132957]
+
+// end 8.2.3 relnotes
+
 // begin 8.2.2 relnotes
 
 [[release-notes-8.2.2]]
 == {fleet} and {agent} 8.2.2
 
-There are no bug fixes for Fleet or Elastic Agent in this release.
+There are no bug fixes for {fleet} or {agent} in this release.
 
 // end 8.2.2 relnotes
 


### PR DESCRIPTION
Adds 8.2.3 release notes. Do not merge yet.

Waiting for build candidate to check for Elastic Agent items.
