### PR TITLE
[DOCS] Remove refs to Stack GS

### DIFF
--- a/docs/en/ingest-management/tab-widgets/prereq.asciidoc
+++ b/docs/en/ingest-management/tab-widgets/prereq.asciidoc
@@ -10,7 +10,7 @@ all spaces.
 // tag::self-managed[]
 
 * {es} cluster and {kib} (version {minor-version}) with a basic license or
-higher. {stack-gs}/get-started-elastic-stack.html[Learn how to install the
+higher. {stack-ref}/installing-elastic-stack.html[Learn how to install the
 {stack} on your own hardware].
 
 * Secure, encrypted connection between {kib} and {es}. For more information,


### PR DESCRIPTION
We're retiring the Stack GS in favor of the new onboarding content introduced in 8.2.