### PR TITLE
[DOCS] Update ES & Kibana install links

### DIFF
--- a/docs/en/shared/spin-up-the-stack/content.asciidoc
+++ b/docs/en/shared/spin-up-the-stack/content.asciidoc
@@ -8,8 +8,8 @@ See the https://www.elastic.co/support/matrix[Elastic Support Matrix] for inform
 supported operating systems and product compatibility. We recommend you use the same
 version of {es}, {kib}, and APM Server.
 
-. {stack-gs}/get-started-elastic-stack.html#install-elasticsearch[Install {es}]
-. {stack-gs}/get-started-elastic-stack.html#install-kibana[Install {kib}]
+. {ref}/install-elasticsearch.html[Install {es}]
+. {kibana-ref}/install.html[Install {kib}]
 . {apm-guide-ref}/apm-quick-start.html[Install APM server]
 
 // end::self-managed[]


### PR DESCRIPTION
We've retired the Stack Getting Started Guide in favor of the new onboarding content in 8.2.