### PR TITLE
Add Fleet and Elastic Agent 8.3.1 release notes

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-8.3.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.3.asciidoc
@@ -1,6 +1,6 @@
 // Use these for links to issue and pulls.
 :kib-issue: https://github.com/elastic/kibana/issues/
-:kib-pull: https://github.com/elastic/kibana/pull/
+:kibana-pull: https://github.com/elastic/kibana/pull/
 :agent-issue: https://github.com/elastic/elastic-agent/issues/
 :agent-pull: https://github.com/elastic/elastic-agent/pull/
 :fleet-server-issue: https://github.com/elastic/beats/issues/fleet-server/
@@ -12,12 +12,33 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-8.3.1>>
 * <<release-notes-8.3.0>>
 
 Also see:
 
 * {kibana-ref}/release-notes.html[{kib} release notes]
 * {beats-ref}/release-notes.html[{beats} release notes]
+
+// begin 8.3.1 relnotes
+
+[[release-notes-8.3.1]]
+== {fleet} and {agent} 8.3.1
+
+Review important information about the {fleet} and {agent} 8.3.1 release.
+
+[discrete]
+[[bug-fixes-8.3.1]]
+=== Bug fixes
+
+{fleet}::
+* Fixes dropping select all {kibana-pull}135124[#135124]
+* Improves bulk actions for more than 10k agents {kibana-pull}134565[#134565]
+
+//{agent}::
+//* Add info here
+
+// end 8.3.1 relnotes
 
 // begin 8.3.0 relnotes
 
@@ -33,18 +54,18 @@ Review important information about the {fleet} and {agent} 8.3.0 release.
 The 8.3.0 release adds the following new and notable features.
 
 {fleet}::
-* Changes to agent upgrade modal to allow for rolling upgrades {kib-pull}132421[#132421]
+* Changes to agent upgrade modal to allow for rolling upgrades {kibana-pull}132421[#132421]
 
 {agent}::
-* Add ability to <<filter-agent-list-by-tags,set tags>> during {agent}
-installation and enrollment. {agent-issue}149[#149] {agent-pull}336[#336]
-* Add support for Cloudbeat. {agent-pull}179[#179]
-* Add support for Kubernetes cronjobs. {agent-pull}279[#279]
-* Increase the download artifact timeout to 10 minutes and add log download
-statistics. {agent-pull}308[#308]
-* Save the agent configuration and the state encrypted on the disk.
+* Adds ability to <<filter-agent-list-by-tags,set tags>> during {agent}
+installation and enrollment {agent-issue}149[#149] {agent-pull}336[#336]
+* Adds support for Cloudbeat {agent-pull}179[#179]
+* Adds support for Kubernetes cronjobs {agent-pull}279[#279]
+* Increases the download artifact timeout to 10 minutes and adds log download
+statistics {agent-pull}308[#308]
+* Saves the agent configuration and the state encrypted on the disk
 {agent-issue}535[#535] {agent-pull}398[#398]
-* Support scheduled actions and cancellation of pending actions.
+* Supports scheduled actions and cancellation of pending actions
 {agent-issue}393[#393] {agent-pull}419[#419]
 
 [discrete]
@@ -52,35 +73,33 @@ statistics. {agent-pull}308[#308]
 === Enhancements
 
 {fleet}::
-* Move integration labels below title and normalise styling {kib-pull}134360[#134360]
-* Adds First Integration Multi Page Steps Flow MVP (cloud only) {kib-pull}132809[#132809]
-* Optimize package installation performance, phase 2 {kib-pull}131627[#131627]
-* Adds APM instrumentation for package install process {kib-pull}131223[#131223]
-* Adds "Label" column + filter to Agent list table {kib-pull}131070[#131070]
-* Adds `cache-control` headers to key `/epm` endpoints in Fleet API {kib-pull}130921[#130921]
-* Optimize package installation performance, phase 1 {kib-pull}130906[#130906]
-* Adds experimental features (feature flags) config to fleet plugin {kib-pull}130253[#130253]
-* Adds redesigned Fleet Server flyout {kib-pull}127786[#127786]
+* Moves integration labels below title and normalizes styling {kibana-pull}134360[#134360]
+* Adds First Integration Multi Page Steps Flow MVP (cloud only) {kibana-pull}132809[#132809]
+* Optimizes package installation performance, phase 2 {kibana-pull}131627[#131627]
+* Adds APM instrumentation for package install process {kibana-pull}131223[#131223]
+* Adds "Label" column + filter to Agent list table {kibana-pull}131070[#131070]
+* Adds `cache-control` headers to key `/epm` endpoints in Fleet API {kibana-pull}130921[#130921]
+* Optimizes package installation performance, phase 1 {kibana-pull}130906[#130906]
+* Adds experimental features (feature flags) config to {fleet} plugin {kibana-pull}130253[#130253]
+* Adds redesigned {fleet-server} flyout {kibana-pull}127786[#127786]
 
 {agent}::
-* Bump `node.js` version for Heartbeat/synthetics to 16.15.0.
+* Bumps `node.js` version for Heartbeat/synthetics to 16.15.0
 {agent-pull}446[#446]
-* Add extra k8s resources in `clusterRole` to better filter objects in
-dashboards and visualizations. {agent-pull}424[#424]
-* Collect Endpoint Security logs on the `elastic-agent diagnostics collect`
-command. {agent-issue}105[#105] {agent-pull}242[#242]
-
-
+* Adds extra k8s resources in `clusterRole` to better filter objects in
+dashboards and visualizations {agent-pull}424[#424]
+* Collects Endpoint Security logs on the `elastic-agent diagnostics collect`
+command {agent-issue}105[#105] {agent-pull}242[#242]
 
 [discrete]
 [[bug-fixes-8.3.0]]
 === Bug fixes
 
 {fleet}::
-* Bulk reassign kuery optimize {kib-pull}134673[#134673]
-* Fixes flickering tabs layout in add agent flyout {kib-pull}133769[#133769]
-* Adds $ProgressPreference to windows install command in flyout {kib-pull}133756[#133756]
-* Fixes sorting by size on data streams table {kib-pull}132833[#132833]
+* Bulk reassign kuery optimize {kibana-pull}134673[#134673]
+* Fixes flickering tabs layout in add agent flyout {kibana-pull}133769[#133769]
+* Adds $ProgressPreference to Windows install command in flyout {kibana-pull}133756[#133756]
+* Fixes sorting by size on data streams table {kibana-pull}132833[#132833]
 
 {agent}::
 * {agent} now logs stdout and stderr of applications run as processes {agent-issue}88[#88]
@@ -123,7 +142,7 @@ command. {agent-issue}105[#105] {agent-pull}242[#242]
 //[%collapsible]
 //====
 //*Details* +
-//<Describe new behavior.> For more information, refer to {kib-pull}PR[#PR].
+//<Describe new behavior.> For more information, refer to {kibana-pull}PR[#PR].
 
 //*Impact* +
 //<Describe how users should mitigate the change.> For more information, refer to {fleet-guide}/fleet-server.html[Fleet Server].


### PR DESCRIPTION
Adds entries and placeholder for bug fixes in 8.3.1.

Also cleans up 8.3.0 release notes so that we are more consistent with verb tense and style used in the Kibana release notes.

TODO:

- [ ] Add Elastic Agent release notes when the BC is up and we can see the commits included