### PR TITLE
update Beats capability for DStreams

### DIFF
--- a/docs/en/ingest-management/beats-agent-comparison.asciidoc
+++ b/docs/en/ingest-management/beats-agent-comparison.asciidoc
@@ -242,10 +242,10 @@ The following table shows a comparison of capabilities supported by {beats} and 
 |{fleet} can automatically give {agent}s minimal output permissions based on the inputs running. With standalone {agent} and {beats}, users often give overly broad permissions because it's more convenient.
 
 |Data streams support
-|{n}
 |{y}
 |{y}
-|{agent}s use <<data-streams,data streams>> with easier index life cycle management and the https://www.elastic.co/blog/an-introduction-to-the-elastic-data-stream-naming-scheme[data stream naming scheme]. {beats} uses a single index with potentially thousands of fields.
+|{y}
+|Both {beats} (default as of version 8.0) and {agent}s use <<data-streams,data streams>> with easier index life cycle management and the https://www.elastic.co/blog/an-introduction-to-the-elastic-data-stream-naming-scheme[data stream naming scheme].
 
 |Variables and input conditions
 |{n}


### PR DESCRIPTION
As of Beats 8.0, data streams are the default output to Elasticsearch.  Line 245 needs change to {y} and the phrasing in Line 248 should reflect that all three options can take advantage of data streams, easier ILM, and the data stream naming scheme.

Reference: https://github.com/elastic/beats/pull/28450 linked in https://www.elastic.co/guide/en/beats/libbeat/8.0/release-notes-8.0.0.html