### PR TITLE
Fix wrong config in elastic-agent-debug-input-configs.asciidoc

### DIFF
--- a/docs/en/ingest-management/elastic-agent/elastic-agent-debug-input-configs.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/elastic-agent-debug-input-configs.asciidoc
@@ -48,7 +48,7 @@ inputs:
     enabled: true
     streams:
       - paths:
-          - /var/log/{{local_dynamic.key}}
+          - /var/log/${local_dynamic.key}
 ----
 
 Then run `elastic-agent inspect` to see the generated configuration. For


### PR DESCRIPTION
Replace `{{var}}` with `${var}`.