### PR TITLE
Remove standalone-only warning for Logstash output

### DIFF
--- a/docs/en/ingest-management/elastic-agent/configuration/outputs/output-logstash.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/outputs/output-logstash.asciidoc
@@ -9,9 +9,6 @@
 
 include::{fleet-repo-dir}/standalone-note.asciidoc[]
 
-IMPORTANT: The {ls} output is currently only supported for {agent}s in
-standalone mode. {fleet}-managed agents are not supported.
-
 The {ls} output uses an internal protocol to send events directly to {ls} over
 TCP. {ls} provides additional parsing, transformation, and routing of data
 collected by {agent}.


### PR DESCRIPTION
With [8.2](https://github.com/elastic/obs-dc-team/issues/601), Fleet-managed Agent gained the ability to output data to Logstash. That rendered the warning on this page unnecessary.