### PR TITLE
Indicate when there are no bug fixes for Agent or Fleet

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-8.3.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.3.asciidoc
@@ -35,6 +35,9 @@ Review important information about the {fleet} and {agent} 8.3.2 release.
 {fleet}::
 * Keep all agents selected in query selection mode {kibana-pull}135530[#135530]
 
+{agent}::
+* No bug fixes for this release
+
 // end 8.3.2 relnotes
 
 // begin 8.3.1 relnotes
@@ -52,8 +55,8 @@ Review important information about the {fleet} and {agent} 8.3.1 release.
 * Fixes dropping select all {kibana-pull}135124[#135124]
 * Improves bulk actions for more than 10k agents {kibana-pull}134565[#134565]
 
-//{agent}::
-//* Add info here
+{agent}::
+* No bug fixes for this release
 
 // end 8.3.1 relnotes
 


### PR DESCRIPTION
Let's be explicit in the release notes when there are no bug fixes in patch releases.