### PR TITLE
Fix breaking link to the CICD Observability dashboards

### DIFF
--- a/docs/en/observability/ci-cd-observability.asciidoc
+++ b/docs/en/observability/ci-cd-observability.asciidoc
@@ -305,7 +305,7 @@ To learn more about the integration of Jenkins with Elastic {observability}, see
 There are out of the box {kib} dashboards that help visualize some metrics for the CI/CD platform.
 
 Using the {kibana-ref}/dashboard-import-api.html[Import API] or the {kib} UI, you
-can https://github.com/jenkinsci/opentelemetry-plugin/tree/master/docs/dashboards/elastic[install dashboards]
+can https://github.com/jenkinsci/opentelemetry-plugin/blob/master/docs/DASHBOARDS.md#elastic[install dashboards]
 that are compatible with version 7.12 or higher.
 
 For instance, you can follow the below steps:
@@ -488,7 +488,7 @@ image::images/jenkins-service-map.png[Jenkins service map view]
 === Pytest-otel
 
 https://pypi.org/project/pytest-otel/[pytest-otel] is a pytest plugin for sending Python test
-results as OpenTelemetry traces. The test traces help you understand test execution, 
+results as OpenTelemetry traces. The test traces help you understand test execution,
 detect bottlenecks, and compare test executions across time to detect misbehavior and issues.
 
 The context propagation from CI pipelines (Jenkins job or pipeline) is passed to the Maven build


### PR DESCRIPTION
https://github.com/jenkinsci/opentelemetry-plugin/blob/master/docs/DASHBOARDS.md#elastic is the new URL

while https://github.com/jenkinsci/opentelemetry-plugin/tree/master/docs/dashboards/elastic is not anymore available