### PR TITLE
Remove standalone-only warning for Logstash output (#1984)

### DIFF
--- a/docs/en/ingest-management/elastic-agent/configuration/outputs/output-logstash.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/outputs/output-logstash.asciidoc
@@ -9,9 +9,6 @@
 
 include::{fleet-repo-dir}/standalone-note.asciidoc[]
 
-IMPORTANT: The {ls} output is currently only supported for {agent}s in
-standalone mode. {fleet}-managed agents are not supported.
-
 The {ls} output uses an internal protocol to send events directly to {ls} over
 TCP. {ls} provides additional parsing, transformation, and routing of data
 collected by {agent}.


### PR DESCRIPTION
Forward ports #1984 to main.