### PR TITLE
[synthetics] Move Heartbeat tab to first position in all synthetics docs

### DIFF
--- a/docs/en/observability/synthetics-run-test.asciidoc
+++ b/docs/en/observability/synthetics-run-test.asciidoc
@@ -10,6 +10,18 @@ Once you've <<synthetics-create-test, written a synthetic test>>, you can create
 There are three ways to create a browser monitor: project monitors, {heartbeat}, and {agent}.
 
 [discrete]
+[[synthetic-monitor-choose-heartbeat]]
+=== {heartbeat}
+
+Use {heartbeat} to configure and create browser monitors similar to how you would set up any other type of monitor.
+
+// pros
+Read more about the benefits of this approach in <<uptime-set-up-choose-heartbeat, the setup guide's {heartbeat} section>>.
+
+// cons
+When using this approach to create multiple monitors from a project, all monitors will use a single configuration.
+
+[discrete]
 [[synthetic-monitor-choose-project]]
 === Project monitors
 
@@ -30,18 +42,6 @@ To configure default settings, you can use a global Synthetics configuration fil
 
 // cons
 Unlike the other approaches, this method can only be used to create _browser_ monitors.
-
-[discrete]
-[[synthetic-monitor-choose-heartbeat]]
-=== {heartbeat}
-
-Use {heartbeat} to configure and create browser monitors similar to how you would set up any other type of monitor.
-
-// pros
-Read more about the benefits of this approach in <<uptime-set-up-choose-heartbeat, the setup guide's {heartbeat} section>>.
-
-// cons
-When using this approach to create multiple monitors from a project, all monitors will use a single configuration.
 
 [discrete]
 [[synthetic-monitor-choose-agent]]

--- a/docs/en/observability/tab-widgets/uptime-monitoring/manage-monitors-delete-monitor-content.asciidoc
+++ b/docs/en/observability/tab-widgets/uptime-monitoring/manage-monitors-delete-monitor-content.asciidoc
@@ -1,15 +1,15 @@
+// tag::heartbeat[]
+
+To remove a monitor using {heartbeat}, delete the monitor entry in the `heartbeat.yml` file.
+
+// end::heartbeat[]
+
 // tag::managed[]
 
 Delete the journey in the test code and push the project using the `push` command.
 The monitor associated with that journey that existed in {kib} will be deleted.
 
 // end::managed[]
-
-// tag::heartbeat[]
-
-To remove a monitor using {heartbeat}, delete the monitor entry in the `heartbeat.yml` file.
-
-// end::heartbeat[]
 
 // tag::agent[]
 

--- a/docs/en/observability/tab-widgets/uptime-monitoring/manage-monitors-delete-monitor-widget.asciidoc
+++ b/docs/en/observability/tab-widgets/uptime-monitoring/manage-monitors-delete-monitor-widget.asciidoc
@@ -24,22 +24,22 @@
   </div>
   <div tabindex="0"
        role="tabpanel"
-       id="project-monitors-tab-manage-monitors-delete-monitor"
-       aria-labelledby="project-monitors-manage-monitors-delete-monitor">
+       id="heartbeat-tab-manage-monitors-delete-monitor"
+       aria-labelledby="heartbeat-manage-monitors-delete-monitor">
 ++++
 
-include::manage-monitors-delete-monitor-content.asciidoc[tag=managed]
+include::manage-monitors-delete-monitor-content.asciidoc[tag=heartbeat]
 
 ++++
   </div>
   <div tabindex="0"
        role="tabpanel"
-       id="heartbeat-tab-manage-monitors-delete-monitor"
-       aria-labelledby="heartbeat-manage-monitors-delete-monitor"
+       id="project-monitors-tab-manage-monitors-delete-monitor"
+       aria-labelledby="project-monitors-manage-monitors-delete-monitor"
        hidden="">
 ++++
 
-include::manage-monitors-delete-monitor-content.asciidoc[tag=heartbeat]
+include::manage-monitors-delete-monitor-content.asciidoc[tag=managed]
 
 ++++
   </div>

--- a/docs/en/observability/tab-widgets/uptime-monitoring/manage-monitors-delete-monitor-widget.asciidoc
+++ b/docs/en/observability/tab-widgets/uptime-monitoring/manage-monitors-delete-monitor-widget.asciidoc
@@ -1,18 +1,18 @@
 ++++
 <div class="tabs" data-tab-group="os">
   <div role="tablist" aria-label="Delete a monitor">
-    <button role="tab"
+  <button role="tab"
             aria-selected="true"
-            aria-controls="project-monitors-tab-manage-monitors-delete-monitor"
-            id="project-monitors-manage-monitors-delete-monitor">
-      Project monitors
+            aria-controls="heartbeat-tab-manage-monitors-delete-monitor"
+            id="heartbeat-manage-monitors-delete-monitor">
+      Heartbeat
     </button>
     <button role="tab"
             aria-selected="false"
-            aria-controls="heartbeat-tab-manage-monitors-delete-monitor"
-            id="heartbeat-manage-monitors-delete-monitor"
+            aria-controls="project-monitors-tab-manage-monitors-delete-monitor"
+            id="project-monitors-manage-monitors-delete-monitor"
             tabindex="-1">
-      Heartbeat
+      Project monitors
     </button>
     <button role="tab"
             aria-selected="false"

--- a/docs/en/observability/tab-widgets/uptime-monitoring/manage-monitors-update-monitor-content.asciidoc
+++ b/docs/en/observability/tab-widgets/uptime-monitoring/manage-monitors-update-monitor-content.asciidoc
@@ -1,3 +1,9 @@
+// tag::heartbeat[]
+
+Update the relevant options in the {heartbeat} configuration file, and the changes will be reflected in the monitors.
+
+// end::heartbeat[]
+
 // tag::managed[]
 
 Update the monitor configuration options used in individual journeys in the test code (or in the
@@ -5,12 +11,6 @@ Update the monitor configuration options used in individual journeys in the test
 Then run the `push` command to replace the existing monitor in {kib} with a new monitor that uses the updated configuration options.
 
 // end::managed[]
-
-// tag::heartbeat[]
-
-Update the relevant options in the {heartbeat} configuration file, and the changes will be reflected in the monitors.
-
-// end::heartbeat[]
 
 // tag::agent[]
 

--- a/docs/en/observability/tab-widgets/uptime-monitoring/manage-monitors-update-monitor-widget.asciidoc
+++ b/docs/en/observability/tab-widgets/uptime-monitoring/manage-monitors-update-monitor-widget.asciidoc
@@ -3,16 +3,16 @@
   <div role="tablist" aria-label="Update a monitor">
     <button role="tab"
             aria-selected="true"
-            aria-controls="project-monitors-tab-manage-monitors-update-monitor"
-            id="project-monitors-manage-monitors-update-monitor">
-      Project monitors
+            aria-controls="heartbeat-tab-manage-monitors-update-monitor"
+            id="heartbeat-manage-monitors-update-monitor">
+      Heartbeat
     </button>
     <button role="tab"
             aria-selected="false"
-            aria-controls="heartbeat-tab-manage-monitors-update-monitor"
-            id="heartbeat-manage-monitors-update-monitor"
+            aria-controls="project-monitors-tab-manage-monitors-update-monitor"
+            id="project-monitors-manage-monitors-update-monitor"
             tabindex="-1">
-      Heartbeat
+      Project monitors
     </button>
     <button role="tab"
             aria-selected="false"

--- a/docs/en/observability/tab-widgets/uptime-monitoring/manage-monitors-update-monitor-widget.asciidoc
+++ b/docs/en/observability/tab-widgets/uptime-monitoring/manage-monitors-update-monitor-widget.asciidoc
@@ -24,22 +24,22 @@
   </div>
   <div tabindex="0"
        role="tabpanel"
-       id="project-monitors-tab-manage-monitors-update-monitor"
-       aria-labelledby="project-monitors-manage-monitors-update-monitor">
+       id="heartbeat-tab-manage-monitors-update-monitor"
+       aria-labelledby="heartbeat-manage-monitors-update-monitor">
 ++++
 
-include::manage-monitors-update-monitor-content.asciidoc[tag=managed]
+include::manage-monitors-update-monitor-content.asciidoc[tag=heartbeat]
 
 ++++
   </div>
   <div tabindex="0"
        role="tabpanel"
-       id="heartbeat-tab-manage-monitors-update-monitor"
-       aria-labelledby="heartbeat-manage-monitors-update-monitor"
+       id="project-monitors-tab-manage-monitors-update-monitor"
+       aria-labelledby="project-monitors-manage-monitors-update-monitor"
        hidden="">
 ++++
 
-include::manage-monitors-update-monitor-content.asciidoc[tag=heartbeat]
+include::manage-monitors-update-monitor-content.asciidoc[tag=managed]
 
 ++++
   </div>

--- a/docs/en/observability/tab-widgets/uptime-monitoring/manage-monitors-update-test-content.asciidoc
+++ b/docs/en/observability/tab-widgets/uptime-monitoring/manage-monitors-update-test-content.asciidoc
@@ -1,3 +1,11 @@
+// tag::heartbeat[]
+
+Update the tests in the directory specified in the `source.zip_url` you referenced in the {heartbeat} configuration file, and the changes will be reflected in the monitors.
+
+If you're using inline monitors within your `heartbeat.yml` configuration file, update your monitors directly in that file.
+
+// end::heartbeat[]
+
 // tag::managed[]
 
 If you're using project monitors, you can update journeys directly through code.
@@ -6,14 +14,6 @@ Then run the <<elastic-synthetics-push-command, `push` command>> to replace any 
 NOTE: Updates are linked to a monitor's `id`. To update a monitor you must keep its `id` the same.
 
 // end::managed[]
-
-// tag::heartbeat[]
-
-Update the tests in the directory specified in the `source.zip_url` you referenced in the {heartbeat} configuration file, and the changes will be reflected in the monitors.
-
-If you're using inline monitors within your `heartbeat.yml` configuration file, update your monitors directly in that file.
-
-// end::heartbeat[]
 
 // tag::agent[]
 

--- a/docs/en/observability/tab-widgets/uptime-monitoring/manage-monitors-update-test-widget.asciidoc
+++ b/docs/en/observability/tab-widgets/uptime-monitoring/manage-monitors-update-test-widget.asciidoc
@@ -24,22 +24,22 @@
   </div>
   <div tabindex="0"
        role="tabpanel"
-       id="project-monitors-tab-manage-monitors-update-test"
-       aria-labelledby="project-monitors-manage-monitors-update-test">
+       id="heartbeat-tab-manage-monitors-update-test"
+       aria-labelledby="heartbeat-manage-monitors-update-test">
 ++++
 
-include::manage-monitors-update-test-content.asciidoc[tag=managed]
+include::manage-monitors-update-test-content.asciidoc[tag=heartbeat]
 
 ++++
   </div>
   <div tabindex="0"
        role="tabpanel"
-       id="heartbeat-tab-manage-monitors-update-test"
-       aria-labelledby="heartbeat-manage-monitors-update-test"
+       id="project-monitors-tab-manage-monitors-update-test"
+       aria-labelledby="project-monitors-manage-monitors-update-test"
        hidden="">
 ++++
 
-include::manage-monitors-update-test-content.asciidoc[tag=heartbeat]
+include::manage-monitors-update-test-content.asciidoc[tag=managed]
 
 ++++
   </div>

--- a/docs/en/observability/tab-widgets/uptime-monitoring/manage-monitors-update-test-widget.asciidoc
+++ b/docs/en/observability/tab-widgets/uptime-monitoring/manage-monitors-update-test-widget.asciidoc
@@ -3,16 +3,16 @@
   <div role="tablist" aria-label="Update a journey">
     <button role="tab"
             aria-selected="true"
-            aria-controls="project-monitors-tab-manage-monitors-update-test"
-            id="project-monitors-manage-monitors-update-test">
-      Project monitors
+            aria-controls="heartbeat-tab-manage-monitors-update-test"
+            id="heartbeat-manage-monitors-update-test">
+      Heartbeat
     </button>
     <button role="tab"
             aria-selected="false"
-            aria-controls="heartbeat-tab-manage-monitors-update-test"
-            id="heartbeat-manage-monitors-update-test"
+            aria-controls="project-monitors-tab-manage-monitors-update-test"
+            id="project-monitors-manage-monitors-update-test"
             tabindex="-1">
-      Heartbeat
+      Project monitors
     </button>
     <button role="tab"
             aria-selected="false"

--- a/docs/en/observability/tab-widgets/uptime-monitoring/run-test-configure-content.asciidoc
+++ b/docs/en/observability/tab-widgets/uptime-monitoring/run-test-configure-content.asciidoc
@@ -1,3 +1,33 @@
+// tag::heartbeat[]
+
+If you used {heartbeat} to <<uptime-set-up-choose, set up monitors>>, configure the monitor in `heartbeat.yml`. Use `source` to specify where to find the tests you want to run. For example:
+
+[source,yml]
+----
+- name: Todos
+  id: todos
+  type: browser
+  schedule: "@every 1m"
+  params:
+    target_url: "https://elastic.github.io/synthetics-demo/" <1>
+  source:
+    zip_url: <2>
+      url: "https://github.com/elastic/synthetics-demo/archive/refs/heads/main.zip" <3>
+      folder: "todos/synthetics-tests" <4>
+      username: "" <5>
+      password: "" 
+----
+<1> The `params` section lets you define custom parameters to use in your script. In this example the `target_url` parameter is used by the project to determine which site to test.
+<2> In this example, our library of synthetic tests is downloaded from the
+remote zip endpoint for https://github.com/elastic/synthetics-demo/tree/main/todos/synthetics-tests[our `todos` example]. 
+<3> Note that the `url` refers to the endpoint where the test project exists.
+<4> Folder refers to the relative path where the synthetic journey files are located. {heartbeat} will invoke the synthetics library on this folder.
+<5> Username and password are blank here, but if provided, will be sent as HTTP Basic Authentication headers to the remote zip endpoint.
+
+For a list of all available configuration options, see {heartbeat-ref}/monitor-browser-options.html[Browser options in the {heartbeat} documentation].
+
+// end::heartbeat[]
+
 // tag::managed[]
 
 :synthetics_version: v1.0.0-beta.29
@@ -57,36 +87,6 @@ Control the monitor's download speeds, upload speeds, and latency to simulate yo
 Control whether or not to capture screenshots. Options include `'on'`, `'off'`, or `'only-on-failure'`.
 
 // end::managed[]
-
-// tag::heartbeat[]
-
-If you used {heartbeat} to <<uptime-set-up-choose, set up monitors>>, configure the monitor in `heartbeat.yml`. Use `source` to specify where to find the tests you want to run. For example:
-
-[source,yml]
-----
-- name: Todos
-  id: todos
-  type: browser
-  schedule: "@every 1m"
-  params:
-    target_url: "https://elastic.github.io/synthetics-demo/" <1>
-  source:
-    zip_url: <2>
-      url: "https://github.com/elastic/synthetics-demo/archive/refs/heads/main.zip" <3>
-      folder: "todos/synthetics-tests" <4>
-      username: "" <5>
-      password: "" 
-----
-<1> The `params` section lets you define custom parameters to use in your script. In this example the `target_url` parameter is used by the project to determine which site to test.
-<2> In this example, our library of synthetic tests is downloaded from the
-remote zip endpoint for https://github.com/elastic/synthetics-demo/tree/main/todos/synthetics-tests[our `todos` example]. 
-<3> Note that the `url` refers to the endpoint where the test project exists.
-<4> Folder refers to the relative path where the synthetic journey files are located. {heartbeat} will invoke the synthetics library on this folder.
-<5> Username and password are blank here, but if provided, will be sent as HTTP Basic Authentication headers to the remote zip endpoint.
-
-For a list of all available configuration options, see {heartbeat-ref}/monitor-browser-options.html[Browser options in the {heartbeat} documentation].
-
-// end::heartbeat[]
 
 // tag::agent[]
 

--- a/docs/en/observability/tab-widgets/uptime-monitoring/run-test-configure-widget.asciidoc
+++ b/docs/en/observability/tab-widgets/uptime-monitoring/run-test-configure-widget.asciidoc
@@ -3,16 +3,16 @@
   <div role="tablist" aria-label="Configure monitor">
     <button role="tab"
             aria-selected="true"
-            aria-controls="managed-service-tab-run-test-configure"
-            id="managed-service-run-test-configure">
-      Project monitors
+            aria-controls="heartbeat-tab-run-test-configure"
+            id="heartbeat-run-test-configure">
+      Heartbeat
     </button>
     <button role="tab"
             aria-selected="false"
-            aria-controls="heartbeat-tab-run-test-configure"
-            id="heartbeat-run-test-configure"
+            aria-controls="managed-service-tab-run-test-configure"
+            id="managed-service-run-test-configure"
             tabindex="-1">
-      Heartbeat
+      Project monitors
     </button>
     <button role="tab"
             aria-selected="false"

--- a/docs/en/observability/tab-widgets/uptime-monitoring/run-test-configure-widget.asciidoc
+++ b/docs/en/observability/tab-widgets/uptime-monitoring/run-test-configure-widget.asciidoc
@@ -24,22 +24,22 @@
   </div>
   <div tabindex="0"
        role="tabpanel"
-       id="managed-service-tab-run-test-configure"
-       aria-labelledby="managed-service-run-test-configure">
+       id="heartbeat-tab-run-test-configure"
+       aria-labelledby="heartbeat-run-test-configure">
 ++++
 
-include::run-test-configure-content.asciidoc[tag=managed]
+include::run-test-configure-content.asciidoc[tag=heartbeat]
 
 ++++
   </div>
   <div tabindex="0"
        role="tabpanel"
-       id="heartbeat-tab-run-test-configure"
-       aria-labelledby="heartbeat-run-test-configure"
+       id="managed-service-tab-run-test-configure"
+       aria-labelledby="managed-service-run-test-configure"
        hidden="">
 ++++
 
-include::run-test-configure-content.asciidoc[tag=heartbeat]
+include::run-test-configure-content.asciidoc[tag=managed]
 
 ++++
   </div>

--- a/docs/en/observability/tab-widgets/uptime-monitoring/run-test-suite-content.asciidoc
+++ b/docs/en/observability/tab-widgets/uptime-monitoring/run-test-suite-content.asciidoc
@@ -1,3 +1,11 @@
+// tag::heartbeat[]
+
+If you used {heartbeat} to <<uptime-set-up-choose, set up monitors>>, save changes to your `heartbeat.yml` file and make sure you've completed <<uptime-set-up-connect>>.
+
+// [ One monitor will appear on the **Monitor management** page for each journey ]
+
+// end::heartbeat[]
+
 // tag::managed[]
 
 beta[] After setting configuration options, use the `push` command to create monitors.
@@ -16,14 +24,6 @@ For more details on using the `push` command, see <<elastic-synthetics-push-comm
 One monitor will appear on the **Monitor management** page for each journey.
 
 // end::managed[]
-
-// tag::heartbeat[]
-
-If you used {heartbeat} to <<uptime-set-up-choose, set up monitors>>, save changes to your `heartbeat.yml` file and make sure you've completed <<uptime-set-up-connect>>.
-
-// [ One monitor will appear on the **Monitor management** page for each journey ]
-
-// end::heartbeat[]
 
 // tag::agent[]
 

--- a/docs/en/observability/tab-widgets/uptime-monitoring/run-test-suite-widget.asciidoc
+++ b/docs/en/observability/tab-widgets/uptime-monitoring/run-test-suite-widget.asciidoc
@@ -24,22 +24,22 @@
   </div>
   <div tabindex="0"
        role="tabpanel"
-       id="managed-service-tab-run-test-suite"
-       aria-labelledby="managed-service-run-test-suite">
+       id="heartbeat-tab-run-test-suite"
+       aria-labelledby="heartbeat-run-test-suite">
 ++++
 
-include::run-test-suite-content.asciidoc[tag=managed]
+include::run-test-suite-content.asciidoc[tag=heartbeat]
 
 ++++
   </div>
   <div tabindex="0"
        role="tabpanel"
-       id="heartbeat-tab-run-test-suite"
-       aria-labelledby="heartbeat-run-test-suite"
+       id="managed-service-tab-run-test-suite"
+       aria-labelledby="managed-service-run-test-suite"
        hidden="">
 ++++
 
-include::run-test-suite-content.asciidoc[tag=heartbeat]
+include::run-test-suite-content.asciidoc[tag=managed]
 
 ++++
   </div>

--- a/docs/en/observability/tab-widgets/uptime-monitoring/run-test-suite-widget.asciidoc
+++ b/docs/en/observability/tab-widgets/uptime-monitoring/run-test-suite-widget.asciidoc
@@ -3,16 +3,16 @@
   <div role="tablist" aria-label="Run project">
     <button role="tab"
             aria-selected="true"
-            aria-controls="managed-service-tab-run-test-suite"
-            id="managed-service-run-test-suite">
-      Project monitors
+            aria-controls="heartbeat-tab-run-test-suite"
+            id="heartbeat-run-test-suite">
+      Heartbeat
     </button>
     <button role="tab"
             aria-selected="false"
-            aria-controls="heartbeat-tab-run-test-suite"
-            id="heartbeat-run-test-suite"
+            aria-controls="managed-service-tab-run-test-suite"
+            id="managed-service-run-test-suite"
             tabindex="-1">
-      Heartbeat
+      Project monitors
     </button>
     <button role="tab"
             aria-selected="false"


### PR DESCRIPTION
As discussed with @andrewvc @lucasfcosta, we should default to Heartbeat as the primary method of creating and managing monitors while other methods are still in beta. 