### PR TITLE
[8.2] Remove old FAQ description about secure communications

### DIFF
--- a/docs/en/ingest-management/troubleshooting/faq.asciidoc
+++ b/docs/en/ingest-management/troubleshooting/faq.asciidoc
@@ -210,14 +210,6 @@ same way as other integrations. Try it out! For more information, see the
 (Windows) permissions.
 
 [discrete]
-[[how-are-agent-kibana-communications-secured]]
-== How are communications secured between {agent} and {kib}?
-
-{agent} connects to {kib} over TLS and authenticates the certificate
-presented by {kib}. The agent then provides an API key as an authentication
-token, which {kib} validates.
-
-[discrete]
 [[how-are-secrets-secured]]
 == How are secrets secured when entered into integration policies or agent policies in {kib}?
 


### PR DESCRIPTION
Manually backports relevant bits of https://github.com/elastic/observability-docs/pull/1983 to 8.2 branch.