### PR TITLE
Clean up old TODO items in source files for Fleet/Agent docs

### DIFF
--- a/docs/en/ingest-management/agent-policies.asciidoc
+++ b/docs/en/ingest-management/agent-policies.asciidoc
@@ -223,9 +223,6 @@ Assuming your {subscriptions}[{stack} subscription level] supports per-policy
 outputs, you can change the output of a policy to send data to a different
 output.
 
-//TODO: Add link to <<output-settings>> after merging
-//https://github.com/elastic/observability-docs/pull/1807/.
-
 . In {fleet}, click *Settings* and view the list of available outputs.
 If necessary, click *Add output* to add a new output with the settings you
 require. For more information, refer to <<output-settings>>.

--- a/docs/en/ingest-management/elastic-agent/configuration/elastic-agent-configuration.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/elastic-agent-configuration.asciidoc
@@ -54,5 +54,3 @@ run an {agent} standalone. For a full reference example, refer to the
 The settings described here are available for standalone {agent}s. Settings for
 {fleet}-managed agents are specified through the UI. You do not set them
 explicitly in a policy file.
-
-//TODO: Explain the structure of the file, how it's used, etc.

--- a/docs/en/ingest-management/elastic-agent/configuration/outputs/output-elasticsearch.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/outputs/output-elasticsearch.asciidoc
@@ -20,9 +20,6 @@ Matrix].
 This example configures an {es} output called `default` in the
 `elastic-agent.yml` file:
 
-//TODO: Provide a example that shows more of the settings users are likely to
-//change.
-
 [source,yaml]
 ----
 outputs:

--- a/docs/en/ingest-management/elastic-agent/configuration/outputs/output-logstash.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/outputs/output-logstash.asciidoc
@@ -20,9 +20,6 @@ Support Matrix].
 This example configures a {ls} output called `default` in the
 `elastic-agent.yml` file:
 
-//TODO: Provide a example that shows more of the settings users are likely to
-//change.
-
 [source,yaml]
 ----
 outputs:

--- a/docs/en/ingest-management/elastic-agent/install-elastic-agent.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/install-elastic-agent.asciidoc
@@ -1,8 +1,6 @@
 [[elastic-agent-installation]]
 = Install {agent}s
 
-//TODO: Follow up with Jason to see where and what we need to say about allowlists
-//for restricting access to the file system.
 You have a few options for installing and managing an {agent}:
 
 * **Install a {fleet}-managed {agent} (recommended)**

--- a/docs/en/ingest-management/elastic-agent/install-standalone-elastic-agent.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/install-standalone-elastic-agent.asciidoc
@@ -80,14 +80,9 @@ systemd, so just enable then start the service.
 include::{tab-widgets}/run-standalone-widget.asciidoc[]
 --
 
-//TODO: Update the privileges shown above.
-
 Refer to <<installation-layout>> for the location of installed {agent} files.
 
 Because {agent} is installed as an auto-starting service, it will restart
 automatically if the system is rebooted.
 
 If you run into problems, refer to <<fleet-troubleshooting>>.
-
-//TODO: Fix link to troubleshooting when we have a topic about troubleshooting for
-//stand-alone agents.

--- a/docs/en/ingest-management/fleet/elastic-agent-logging.asciidoc
+++ b/docs/en/ingest-management/fleet/elastic-agent-logging.asciidoc
@@ -5,9 +5,6 @@
 <titleabbrev>View {agent} logs</titleabbrev>
 ++++
 
-//TODO: This topic needs to be updated with info about metrics. There's an
-//issue open for this here: https://github.com/elastic/observability-docs/issues/971
-
 Agent monitoring, which includes collecting agent logs and agent metrics,
 is enabled by default on each agent policy assigned to an agent. If
 logging for the agent is not required, you need to deselect the logging option when

--- a/docs/en/ingest-management/fleet/fleet-manage-agents.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-manage-agents.asciidoc
@@ -35,9 +35,3 @@ tags to filter the Agents list in {fleet}.
 |View {agent} logs and set the logging level.
 
 |===
-
-//TODO: Check to see if bulk operations are available for these actions.
-
-//TODO: Consider moving all the content under this section to one topic. There
-//is a lot of content in the topics, though, so I worry about the usability of
-//long scrolling topics in our current doc system.

--- a/docs/en/ingest-management/fleet/fleet-server-deployment-models.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-server-deployment-models.asciidoc
@@ -41,8 +41,6 @@ have access to a private segmented network.
 It’s recommended that the administrator provision multiple instances of the
 {fleet-server} and use a load balancer to better scale the deployment.
 
-//TODO: Replace with clean images when they are available.
-
 image::images/fleet-server-on-prem-deployment.png[{fleet-server} on-premises deployment model]
 
 [discrete]

--- a/docs/en/ingest-management/fleet/fleet-server-monitoring.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-server-monitoring.asciidoc
@@ -52,7 +52,5 @@ metric and then resize the {fleet-server}, if necessary.
 [role="screenshot"]
 image::images/dashboard-datastream.png[Dashboard Data stream]
 
-//TODO: Update dashboard when CPU usage info is displaying correctly. 
-
 Note that as an alternative to running the query, you can hide all metrics
 except `fleet_server` in the dashboard.

--- a/docs/en/ingest-management/fleet/fleet-server-scaling.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-server-scaling.asciidoc
@@ -134,9 +134,6 @@ on the number of agents required by your deployment:
 * <<resource-requirements-by-number-agents>>
 * <<recommend-settings-scaling-agents>>
 
-// TODO: Confirm that these recommendations are current. The values don't match
-// the drop-down lists in the latest version of {ecloud}. 
-
 [discrete]
 [[resource-requirements-by-number-agents]]
 === Resource requirements by number of agents

--- a/docs/en/ingest-management/fleet/upgrade-elastic-agent.asciidoc
+++ b/docs/en/ingest-management/fleet/upgrade-elastic-agent.asciidoc
@@ -131,16 +131,14 @@ image::images/upgrade-status.png[Screenshot of Agents tab showing upgrade status
 . When upgrading many agents, you can fine tune the maintenance window by
 viewing stats and metrics about the upgrade:
 +
-.. On the **Agents** tab, click the host name to view agent details.
-.. Click **View agent dashboard** to open the **[{agent}] metrics** dashboard
-//TODO: This needs more detail. I did not see any visualizations or stats
-//related to downloads. Is this capability not available yet? Should I remove
-//this steps, or is there something useful to be gleaned related to upgrades?
+.. On the **Agents** tab, click the host name to view agent details. If you
+don't see the host name, try refreshing the page.
+.. Click **View agent dashboard** to open the **[{agent}] metrics** dashboard.
 
 . If the upgrade fails, view the agent logs to find the reason:
 +
-.. On the **Agents** tab, click the host name to view agent details.
-.. Click **Logs** and search for failures.
+.. From the **Agent details** tab in {fleet}, click **Logs**.
+.. Search for failures.
 +
 [role="screenshot"]
 image::images/upgrade-failure.png[Agent logs showing upgrade failure]

--- a/docs/en/ingest-management/security/certificates.asciidoc
+++ b/docs/en/ingest-management/security/certificates.asciidoc
@@ -289,7 +289,3 @@ Don't have an enrollment token? On the *Agents* tab in {fleet}, click *Add agent
 Under *Enroll and start the Elastic Agent*, follow the in-product installation steps, making sure
 that you add the `--certificate-authorities` option before you run the command.
 --
-
-// TODO: Add reference docs about SSL settings and point to the content from
-// this topics. Before I can do this, I need to know which settings from {beats}
-// are supported for Elastic Agent.

--- a/docs/en/ingest-management/security/enrollment-tokens.asciidoc
+++ b/docs/en/ingest-management/security/enrollment-tokens.asciidoc
@@ -23,9 +23,6 @@ This API key is used to communicate with the {fleet-server}. It has only the
 permissions needed to communicate with the {fleet-server}. If the API key is
 invalid, {fleet-server} stops communicating with the {agent}.
 
-// TODO: Convert the following steps to 7.14 after this topic is merged and
-// backported to 7.13.
-
 [discrete]
 [[create-fleet-enrollment-tokens]]
 == Create enrollment tokens

--- a/docs/en/ingest-management/security/logstash-certificates.asciidoc
+++ b/docs/en/ingest-management/security/logstash-certificates.asciidoc
@@ -277,6 +277,3 @@ values are 0, check the {agent} logs for problems.
  
 When data is streaming to {es}, go to *{observability}* and click
 *Metrics* to view metrics about your system.
-
-//TODO: WE should add some troubleshooting advice like what to do if the
-//connection is refused. But maybe after beta drops.

--- a/docs/en/ingest-management/tab-widgets/upgrade-fleet.asciidoc
+++ b/docs/en/ingest-management/tab-widgets/upgrade-fleet.asciidoc
@@ -34,8 +34,6 @@ You are now able to install and enroll subsequent {agent}s with {fleet-server}.
 
 To upgrade to {fleet-server}:
 
-//TODO: Mention API for adding the token.
-
 . Log in to {kib} and go to *Management > {fleet}*.
 . Click the *Agents* tab.
 . The following message is displayed. Please note that your {agent}s have now

--- a/docs/en/ingest-management/troubleshooting/troubleshooting.asciidoc
+++ b/docs/en/ingest-management/troubleshooting/troubleshooting.asciidoc
@@ -22,9 +22,6 @@ Have a question? Read our <<fleet-faq,FAQ>>, or contact us in the
 
 Running {agent} standalone? Also refer to <<debug-standalone-agents>>.
 
-//TODO: Improve how content is organized in this section, perhaps by breaking
-//it down into sections like Agent, {fleet-server}, etc.
-
 [discrete]
 [[agents-in-cloud-stuck-at-updating]]
 == {agent}s hosted on {ecloud} are stuck in `Updating` or `Offline`


### PR DESCRIPTION
Closes https://github.com/elastic/observability-docs/issues/1619

* Removes items that are done, we don't plan to do, or are already tracked in GitHub.

I've created these issues to track remaining work:
* https://github.com/elastic/observability-docs/issues/2032
* https://github.com/elastic/observability-docs/issues/2033