### PR TITLE
Add subsection for custom CA in air-gapped environments

### DIFF
--- a/docs/en/ingest-management/fleet/air-gapped.asciidoc
+++ b/docs/en/ingest-management/fleet/air-gapped.asciidoc
@@ -143,17 +143,6 @@ defining the `NODE_EXTRA_CA_CERTS` environment variable:
 NODE_EXTRA_CA_CERTS="/etc/kibana/certs/ca-cert.pem"
 ----
 
-An example to run Kibana in a container with this environment variable:
-
-["source", "sh", subs="attributes"]
-----
-docker run -it -p 5601:5601 \
-  -v $(pwd)/ca-certs.pem:/etc/kibana/certs/ca-cert.pem \
-  -e NODE_EXTRA_CA_CERTS=/etc/kibana/certs/ca-cert.pem \
-  docker.elastic.co/elastic/kibana:{version}
-----
-
-
 [discrete]
 [[air-gapped-limitations]]
 == Limitations for {agent} upgrades

--- a/docs/en/ingest-management/fleet/air-gapped.asciidoc
+++ b/docs/en/ingest-management/fleet/air-gapped.asciidoc
@@ -128,15 +128,9 @@ docker run -it -p 443:443 \
 
 ==== Using custom CA certificates
 
-In scenarios where you are using a custom Certificate Authority (CA), you can see errors like this:
-
-[source,json]
----
-{"type":"log","@timestamp":"2022-03-02T09:58:36-05:00","tags":["error","plugins","fleet"],"pid":58716,"message":"Error connecting to package registry: request to https://customer.server.name:8443/categories?experimental=true&include_policy_templates=true&kibana.version=7.17.0 failed, reason: self signed certificate in certificate chain"}
----
-
-This can be addressed by adding your CA certificate file path to the Kibana startup files by
-defining the `NODE_EXTRA_CA_CERTS` environment variable:
+In air-gapped environments, it is likely that you need to use custom Certificate Authority (CA) certificates.
+If that is the case, you need to set the file path to your CA in the `NODE_EXTRA_CA_CERTS` environment
+variable in the {kib} startup files.
 
 [source,text]
 ----

--- a/docs/en/ingest-management/fleet/air-gapped.asciidoc
+++ b/docs/en/ingest-management/fleet/air-gapped.asciidoc
@@ -126,6 +126,7 @@ docker run -it -p 443:443 \
   docker.elastic.co/package-registry/distribution:{version}
 ----
 
+[discrete]
 ==== Using custom CA certificates
 
 If you are using self-signed certificates or certificates issued by a custom Certificate Authority (CA), you need to set the file path to your CA in the `NODE_EXTRA_CA_CERTS` environment

--- a/docs/en/ingest-management/fleet/air-gapped.asciidoc
+++ b/docs/en/ingest-management/fleet/air-gapped.asciidoc
@@ -126,6 +126,34 @@ docker run -it -p 443:443 \
   docker.elastic.co/package-registry/distribution:{version}
 ----
 
+==== Using custom CA certificates
+
+In scenarios where you are using a custom Certificate Authority (CA), you can see errors like this:
+
+[source,json]
+---
+{"type":"log","@timestamp":"2022-03-02T09:58:36-05:00","tags":["error","plugins","fleet"],"pid":58716,"message":"Error connecting to package registry: request to https://customer.server.name:8443/categories?experimental=true&include_policy_templates=true&kibana.version=7.17.0 failed, reason: self signed certificate in certificate chain"}
+---
+
+This can be addressed by adding your CA certificate file path to the Kibana startup files by
+defining the `NODE_EXTRA_CA_CERTS` environment variable:
+
+[source,text]
+----
+NODE_EXTRA_CA_CERTS="/etc/kibana/certs/ca-cert.pem"
+----
+
+An example to run Kibana in a container with this environment variable:
+
+["source", "sh", subs="attributes"]
+----
+docker run -it -p 5601:5601 \
+  -v $(pwd)/ca-certs.pem:/etc/kibana/certs/ca-cert.pem \
+  -e NODE_EXTRA_CA_CERTS=/etc/kibana/certs/ca-cert.pem \
+  docker.elastic.co/elastic/kibana:{version}
+----
+
+
 [discrete]
 [[air-gapped-limitations]]
 == Limitations for {agent} upgrades

--- a/docs/en/ingest-management/fleet/air-gapped.asciidoc
+++ b/docs/en/ingest-management/fleet/air-gapped.asciidoc
@@ -128,8 +128,7 @@ docker run -it -p 443:443 \
 
 ==== Using custom CA certificates
 
-In air-gapped environments, it is likely that you need to use custom Certificate Authority (CA) certificates.
-If that is the case, you need to set the file path to your CA in the `NODE_EXTRA_CA_CERTS` environment
+If you are using self-signed certificates or certificates issued by a custom Certificate Authority (CA), you need to set the file path to your CA in the `NODE_EXTRA_CA_CERTS` environment
 variable in the {kib} startup files.
 
 [source,text]

--- a/docs/en/ingest-management/troubleshooting/troubleshooting.asciidoc
+++ b/docs/en/ingest-management/troubleshooting/troubleshooting.asciidoc
@@ -135,7 +135,8 @@ In air-gapped environments, you may encounter the following error if you're usin
 ---
 
 To fix this problem, add your CA certificate file path to the {kib} startup
-file by defining the `NODE_EXTRA_CA_CERTS` environment variable.
+file by defining the `NODE_EXTRA_CA_CERTS` environment variable. More information
+about this in <<air-gapped-tls>> section.
 
 
 [discrete]

--- a/docs/en/ingest-management/troubleshooting/troubleshooting.asciidoc
+++ b/docs/en/ingest-management/troubleshooting/troubleshooting.asciidoc
@@ -124,6 +124,22 @@ an external service called the {package-registry}.
 For this to work, the {kib} server must connect to `https://epr.elastic.co` on port `443`.
 
 [discrete]
+[[fleet-errors-tls]]
+== {kib} cannot connect to {package-registry} in air-gapped environments
+
+In air-gapped environments where custom Certificater Authorities (CA) are used, if the custom
+CA is not available for {kib}, you can see error like this one:
+
+[source,json]
+---
+{"type":"log","@timestamp":"2022-03-02T09:58:36-05:00","tags":["error","plugins","fleet"],"pid":58716,"message":"Error connecting to package registry: request to https://customer.server.name:8443/categories?experimental=true&include_policy_templates=true&kibana.version=7.17.0 failed, reason: self signed certificate in certificate chain"}
+---
+
+This can be addressed by adding your CA certificate file path to the {kib} startup
+file by defining the `NODE_EXTRA_CA_CERTS` environment variable.
+
+
+[discrete]
 [[fleet-app-crashes]]
 == {fleet} in {kib} crashes
 

--- a/docs/en/ingest-management/troubleshooting/troubleshooting.asciidoc
+++ b/docs/en/ingest-management/troubleshooting/troubleshooting.asciidoc
@@ -127,15 +127,14 @@ For this to work, the {kib} server must connect to `https://epr.elastic.co` on p
 [[fleet-errors-tls]]
 == {kib} cannot connect to {package-registry} in air-gapped environments
 
-In air-gapped environments where custom Certificater Authorities (CA) are used, if the custom
-CA is not available for {kib}, you can see error like this one:
+In air-gapped environments, you may encounter the following error if you're using a custom Certificate Authority (CA) that is not available to {kib}:
 
 [source,json]
 ---
 {"type":"log","@timestamp":"2022-03-02T09:58:36-05:00","tags":["error","plugins","fleet"],"pid":58716,"message":"Error connecting to package registry: request to https://customer.server.name:8443/categories?experimental=true&include_policy_templates=true&kibana.version=7.17.0 failed, reason: self signed certificate in certificate chain"}
 ---
 
-This can be addressed by adding your CA certificate file path to the {kib} startup
+To fix this problem, add your CA certificate file path to the {kib} startup
 file by defining the `NODE_EXTRA_CA_CERTS` environment variable.
 
 

--- a/docs/en/ingest-management/troubleshooting/troubleshooting.asciidoc
+++ b/docs/en/ingest-management/troubleshooting/troubleshooting.asciidoc
@@ -130,9 +130,9 @@ For this to work, the {kib} server must connect to `https://epr.elastic.co` on p
 In air-gapped environments, you may encounter the following error if you're using a custom Certificate Authority (CA) that is not available to {kib}:
 
 [source,json]
----
+----
 {"type":"log","@timestamp":"2022-03-02T09:58:36-05:00","tags":["error","plugins","fleet"],"pid":58716,"message":"Error connecting to package registry: request to https://customer.server.name:8443/categories?experimental=true&include_policy_templates=true&kibana.version=7.17.0 failed, reason: self signed certificate in certificate chain"}
----
+----
 
 To fix this problem, add your CA certificate file path to the {kib} startup
 file by defining the `NODE_EXTRA_CA_CERTS` environment variable. More information


### PR DESCRIPTION
This PR adds a subsection to include information when the Elastic stack and EPR are deployed in air-gapped environments and custom CA are used.

Closes https://github.com/elastic/package-registry/issues/808
Closes https://github.com/elastic/observability-docs/issues/1629


Regarding backporting this PR to other branches, what labels should I add in this PR ? backport-7.17, backport-8.3 ? any other ?