### PR TITLE
Update APM Node.js setup steps and links.

### DIFF
--- a/docs/en/shared/install-apm-agents-kube/nodejs.asciidoc
+++ b/docs/en/shared/install-apm-agents-kube/nodejs.asciidoc
@@ -36,10 +36,9 @@ Configure the agent using environment variables:
 ----
 <1> Defaults to `http://localhost:8200`
 <2> Pass in `ELASTIC_APM_SECRET_TOKEN` from the `apm-secret` keystore created previously
-<3> Allowed characters: a-z, A-Z, 0-9, -, _, and space
+<3> Defaults to "name" field in package.json, if not specified. Allowed characters: a-z, A-Z, 0-9, -, _, and space
 
 *Learn more in the agent reference*
 
 * {apm-node-ref-v}/supported-technologies.html[Supported technologies]
-* {apm-node-ref-v}/advanced-setup.html[Babel/ES Modules]
-* {apm-node-ref-v}/configuring-the-agent.html[Advanced configuration]
+* {apm-node-ref-v}/advanced-setup.html[Configuring the agent]

--- a/docs/en/shared/install-apm-agents/content.asciidoc
+++ b/docs/en/shared/install-apm-agents/content.asciidoc
@@ -172,24 +172,24 @@ This agent supports a variety of frameworks but can also be used with your custo
 [source,js]
 ----
 // Add this to the VERY top of the first file loaded in your app
+// before other packages are 'require'd.
 var apm = require('elastic-apm-node').start({
-  // Override service name from package.json
-  // Allowed characters: a-z, A-Z, 0-9, -, _, and space
-  serviceName: '',
-
+  // Set custom APM Server URL (default: http://localhost:8200)
+  serverUrl: '',
   // Use if APM Server requires a token
   secretToken: '',
 
-  // Set custom APM Server URL (default: http://localhost:8200)
-  serverUrl: ''
+  // The service name for your application. This defaults to the
+  // "name" field from package.json if not specified.
+  // Allowed characters: a-z, A-Z, 0-9, -, _, and space
+  serviceName: ''
 })
 ----
 
 *Learn more in the agent reference*
 
 * {apm-node-ref-v}/supported-technologies.html[Supported technologies]
-* {apm-node-ref-v}/advanced-setup.html[Babel/ES Modules]
-* {apm-node-ref-v}/configuring-the-agent.html[Advanced configuration]
+* {apm-node-ref-v}/advanced-setup.html[Configuring the agent]
 
 // end::node[]
 


### PR DESCRIPTION
The "advanced-setup.html" ref was misnamed, and the
"configuring-the-agent.html" ref is a sublink of the "advanced-setup.html"
page, so doesn't add value.


@bmorelli25 Does this look reasonable? I'm new to this repo.