### PR TITLE
Hide topic about package signatures

### DIFF
--- a/docs/en/ingest-management/integrations/package-signatures.asciidoc
+++ b/docs/en/ingest-management/integrations/package-signatures.asciidoc
@@ -1,4 +1,4 @@
-[[package-signatures]]
+[role="exclude",id="package-signatures"]
 = Package signatures
 
 coming[8.4.0]


### PR DESCRIPTION
Closes #2051 

Any links that point directly to this topic will work, but the topic won't appear in the TOC. I'm not sure if google indexes hidden topics, but if it does, users will see that something is coming. I don't think that's a bad thing.