### PR TITLE
Clarify that at least one fileset must be enabled in a filebeat module

### DIFF
--- a/docs/en/observability/ingest-logs.asciidoc
+++ b/docs/en/observability/ingest-logs.asciidoc
@@ -92,7 +92,8 @@ include::{beats-repo-dir}/tab-widgets/enable-modules-widget.asciidoc[]
 --
 
 . In the module config under `modules.d`, change the module settings to match
-your environment.
+your environment. You must enable at least one fileset in the module.
+**Filesets are disabled by default.** 
 +
 For example, log locations are set based on the OS. If your logs aren't in
 default locations, set the `paths` variable:
@@ -102,6 +103,7 @@ default locations, set the `paths` variable:
 ----
 - module: nginx
   access:
+    enabled: true
     var.paths: ["/var/log/nginx/access.log*"] <1>
 ----
 --


### PR DESCRIPTION
Starting with 8.0.0, Filebeat modules no longer have a default fileset (system), and users must explicitly enable the filesets they want to use. The Filebeat Reference was updated, but the observability guide was not.

File this under 101 reasons why we should avoid duplicating identical content.

Incidentally I usually argue against making random sentences bold, but this has apparently been a sticking point for a lot of users, so I've decided it's Ok as long as we don't put it in red all caps. :-P Too soon?

Related issue: https://github.com/elastic/observability-docs/issues/1043