### PR TITLE
Add known issue and workaround for enroll command failing on deb/rpm

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-8.3.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.3.asciidoc
@@ -31,6 +31,33 @@ Also see:
 Review important information about the {fleet} and {agent} 8.3.3 release.
 
 [discrete]
+[[known-issues-8.3.3]]
+=== Known issues
+
+[[known-issue-803]]
+.Enroll command fails with "no such file or directory" error on DEB and RPM
+[%collapsible]
+====
+
+*Details*
+
+An error in a post-install script in version 8.3.3 prevents DEB and RPM
+distributions from enrolling.
+
+*Impact* +
+
+To resolve this problem, run the following command. Replace the elastic-agent
+data path with the correct path for your system:
+
+[source,sh]
+----
+sudo unlink /usr/share/elastic-agent/bin/elastic-agent
+sudo ln -s /var/lib/elastic-agent/data/elastic-agent-<hash>/elastic-agent /usr/share/elastic-agent/bin/elastic-agent
+----
+
+====
+
+[discrete]
 [[bug-fixes-8.3.3]]
 === Bug fixes
 


### PR DESCRIPTION
Closes #2054. Preview is [here](https://observability-docs_2055.docs-preview.app.elstc.co/guide/en/fleet/master/release-notes-8.3.3.html).

I am using the command shown in https://github.com/elastic/elastic-agent/issues/803. I have not tested this command myself. I need reviewers to confirm that the details here are correct and that the command is valid.