### PR TITLE
Explain why the edit hosts button in Fleet may be grayed out

### DIFF
--- a/docs/en/ingest-management/fleet/fleet-settings.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-settings.asciidoc
@@ -6,7 +6,7 @@ NOTE: The settings described here are configurable through the {fleet} UI. Refer
 settings that you can configure in the `kibana.yml` configuration file.
 
 // lint ignore fleet
-On the *Settings* tab in *Fleet*, you can configure global settings available
+On the **Settings** tab in **Fleet**, you can configure global settings available
 to all {agent}s enrolled in {fleet}. This includes {fleet-server} hosts and
 output settings.
 
@@ -14,17 +14,22 @@ output settings.
 [[fleet-server-hosts-setting]]
 == {fleet-server} host settings
 
-Click *Edit hosts* and specify the host URLs your {agent}s will use to connect
-to a {fleet-server}. This setting is required. On self-managed clusters, you
-must specify one or more URLs.
+Click **Edit hosts** and specify the host URLs your {agent}s will use to connect
+to a {fleet-server}.
+
+TIP: If the **Edit hosts** option is grayed out, {fleet-server} hosts
+are configured outside of {fleet}. For more information, refer to
+{kibana-ref}/fleet-settings-kb.html[{fleet} settings in {kib}].
 
 Not sure if {fleet-server} is running? Refer to <<add-a-fleet-server>>.
 
+On self-managed clusters, you must specify one or more URLs.
+
 On {ecloud}, this field is populated automatically. If you are using
-Azure Private Link, GCP Private Service Connect, or AWS PrivateLink
-and enrolling the {agent} with a private link URL,
-ensure that this setting is configured. Otherwise, {agent} will
-reset to use a default address instead of the private link URL.
+Azure Private Link, GCP Private Service Connect, or AWS PrivateLink and
+enrolling the {agent} with a private link URL, ensure that this setting is
+configured. Otherwise, {agent} will reset to use a default address instead of
+the private link URL.
 
 NOTE: If a URL is specified without a port, {kib} sets the port to `80` (http)
 or `443` (https).
@@ -35,13 +40,13 @@ By default, {fleet-server} is typically exposed on the following ports:
 Default {fleet-server} port for self-managed clusters
 
 `443` or `9243`::
-Default {fleet-server} port for {ecloud}. View the {fleet} *Settings* tab
+Default {fleet-server} port for {ecloud}. View the {fleet} **Settings** tab
 to find the actual port that's used.
 
 IMPORTANT: The exposed ports must be open for ingress and egress in the firewall and
 networking rules on the host to allow {agent}s to communicate with {fleet-server}.
 
-Specify multiple URLs (click *Add row*) to scale out your deployment and provide
+Specify multiple URLs (click **Add row**) to scale out your deployment and provide
 automatic failover. If multiple URLs exist, {fleet} shows the first provided URL
 for enrollment purposes. Enrolled {agent}s will connect to the URLs in round
 robin order until they connect successfully. 
@@ -49,7 +54,7 @@ robin order until they connect successfully.
 When a {fleet-server} is added or removed from the list, all agent policies
 are updated automatically.
 
-*Examples:*
+**Examples:**
 
 * `https://192.0.2.1:8220`
 * `https://abae718c1276457893b1096929e0f557.fleet.eu-west-1.aws.qa.cld.elstc.co:443`
@@ -70,7 +75,7 @@ troubleshooting on {ece}.
 
 To add or edit an output:
 
-. Click *Add output* or *Edit*.
+. Click **Add output** or **Edit**.
 
 . Set the output name and type.
 
@@ -90,7 +95,7 @@ Specify these settings to send data over a secure connection to {es}.
 |===
 |
 [id="es-output-hosts-setting"]
-*Hosts*
+**Hosts**
 
 | The {es} URLs where {agent}s will send data. By default, {es} is exposed
 on the following ports:
@@ -101,7 +106,7 @@ Default {es} port for self-managed clusters
 `443`::
 Default {es} port for {ecloud}
 
-*Examples:*
+**Examples:**
 
 * `https://192.0.2.0:9200`
 * `https://1d7a52f5eb344de18ea04411fe09e564.fleet.eu-west-1.aws.qa.cld.elstc.co:443`
@@ -111,7 +116,7 @@ Default {es} port for {ecloud}
 
 |
 [id="es-trusted-fingerprint-yaml-setting"]
-*{es} CA trusted fingerprint*
+**{es} CA trusted fingerprint**
 
 | HEX encoded SHA-256 of a CA certificate. If this certificate is
 present in the chain during the handshake, it will be added to the
@@ -123,7 +128,7 @@ normally. To learn more about trusted fingerprints, refer to the
 
 |
 [id="es-output-advanced-yaml-setting"]
-*Advanced YAML configuration*
+**Advanced YAML configuration**
 
 | YAML settings that will be added to the {es} output section of each policy
 that uses this output. Make sure you specify valid YAML. The UI does not
@@ -133,7 +138,7 @@ currently provide validation.
 
 |
 [id="es-agent-integrations-output"]
-*Make this output the default for agent integrations*
+**Make this output the default for agent integrations**
 
 | When this setting is on, {agent}s use this output to send data if no other
 output is set in the agent policy.
@@ -142,7 +147,7 @@ output is set in the agent policy.
 
 |
 [id="es-agent-monitoring-output"]
-*Make this output the default for agent monitoring*
+**Make this output the default for agent monitoring**
 
 | When this setting is on, {agent}s use this output to send agent monitoring
 data if no other output is set in the agent policy.
@@ -164,12 +169,12 @@ To learn how to generate certificates, refer to <<secure-logstash-connections>>.
 |===
 |
 [id="ls-logstash-hosts"]
-*{ls} hosts*
+**{ls} hosts**
 
 | The addresses your {agent}s will use to connect to {ls}. Use the format
-`host:port`. Click *add* row to specify additional {ls} addresses.
+`host:port`. Click **add** row to specify additional {ls} addresses.
 
-*Examples:*
+**Examples:**
 
 * `192.0.2.0:5044`
 * `mylogstashhost:5044`
@@ -178,7 +183,7 @@ To learn how to generate certificates, refer to <<secure-logstash-connections>>.
 
 |
 [id="ls-server-ssl-certificate-authorities-setting"]
-*Server SSL certificate authorities*
+**Server SSL certificate authorities**
 
 | The CA certificate to use to connect to {ls}. This is the CA used to generate
 the certificate and key for {ls}. Copy and paste in the full contents for the CA
@@ -190,7 +195,7 @@ This setting is optional.
 
 |
 [id="ls-client-ssl-certificate-setting"]
-*Client SSL certificate*
+**Client SSL certificate**
 
 | The certificate generated for the client. Copy and paste in the full contents
 of the certificate.
@@ -199,7 +204,7 @@ of the certificate.
 
 |
 [id="ls-client-ssl-certificate-key-setting"]
-*Client SSL certificate key*
+**Client SSL certificate key**
 
 | The private key generated for the client. This must be in PKCS 8 key.
 Copy and paste in the full contents of the certificate key.
@@ -208,7 +213,7 @@ Copy and paste in the full contents of the certificate key.
 
 |
 [id="ls-output-advanced-yaml-setting"]
-*Advanced YAML configuration*
+**Advanced YAML configuration**
 
 | YAML settings that will be added to the {ls} output section of each policy
 that uses this output. Make sure you specify valid YAML. The UI does not
@@ -218,7 +223,7 @@ currently provide validation.
 
 |
 [id="ls-agent-integrations-output"]
-*Make this output the default for agent integrations*
+**Make this output the default for agent integrations**
 
 | When this setting is on, {agent}s use this output to send data if no other
 output is set in the agent policy.
@@ -227,7 +232,7 @@ output is set in the agent policy.
 
 |
 [id="ls-agent-monitoring-output"]
-*Make this output the default for agent monitoring*
+**Make this output the default for agent monitoring**
 
 | When this setting is on, {agent}s use this output to send agent monitoring
 data if no other output is set in the agent policy.

--- a/docs/en/ingest-management/tab-widgets/add-fleet-server/content.asciidoc
+++ b/docs/en/ingest-management/tab-widgets/add-fleet-server/content.asciidoc
@@ -39,6 +39,10 @@ about these settings, see {fleet-guide}/fleet-settings.html[{fleet} settings].
 URLs your {agent}s will use to connect to {fleet-server}. For example,
 `https://192.0.2.1:8220`, where `192.0.2.1` is the host IP where you will
 install {fleet-server}. Save and apply your settings.
++
+TIP: If the **Edit hosts** option is grayed out, {fleet-server} hosts
+are configured outside of {fleet}. For more information, refer to
+{kibana-ref}/fleet-settings-kb.html[{fleet} settings in {kib}].
 
 . In the **{es} hosts** field, specify the {es} URLs where {agent}s will send data.
 For example, `https://192.0.2.0:9200`. Skip this step if you've started the


### PR DESCRIPTION
Closes #1986 

Also adds minor cleanup of asciidoc bold formatting.