### PR TITLE
Remove beta admonition for Logstash output in Fleet

### DIFF
--- a/docs/en/ingest-management/agent-policies.asciidoc
+++ b/docs/en/ingest-management/agent-policies.asciidoc
@@ -217,8 +217,6 @@ Any agents assigned to a policy must be unenrolled or assigned to a different po
 [[change-policy-output]]
 == Change the output of a policy
 
-beta[]
-
 Assuming your {subscriptions}[{stack} subscription level] supports per-policy
 outputs, you can change the output of a policy to send data to a different
 output.

--- a/docs/en/ingest-management/beats-agent-comparison.asciidoc
+++ b/docs/en/ingest-management/beats-agent-comparison.asciidoc
@@ -85,7 +85,7 @@ NOTE: {endpoint-cloud-sec} has a different output matrix.
 
 |{ls}
 |{y}
-|{y} (public Beta)
+|{y}
 |{y}
 
 |Kafka

--- a/docs/en/ingest-management/fleet/fleet-settings.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-settings.asciidoc
@@ -152,8 +152,6 @@ data if no other output is set in the agent policy.
 [[ls-output-settings]]
 === {ls} output settings
 
-beta[]
-
 Specify these settings to send data over a secure connection to {ls}. You must
 also configure a {ls} pipeline that reads encrypted data from {agent}s and sends
 the data to {es}. Follow the in-product steps to configure the {ls} pipeline.

--- a/docs/en/ingest-management/security/logstash-certificates.asciidoc
+++ b/docs/en/ingest-management/security/logstash-certificates.asciidoc
@@ -1,8 +1,6 @@
 [[secure-logstash-connections]]
 = Configure SSL/TLS for the {ls} output
 
-beta[]
-
 To send data from {agent} to {ls} securely, you need to configure Transport
 Layer Security (TLS). Using TLS ensures that your {agent}s send encrypted data
 to trusted {ls} servers, and that your {ls} servers receive data from trusted


### PR DESCRIPTION
Closes #2001 

Reviewers: I wasn't sure about per-policy outputs. I can add the Beta admonition back in if it's still beta in 8.4.