### PR TITLE
[DOCS] Add notes about security for ML anomaly detection job

### DIFF
--- a/docs/en/observability/categorize-logs.asciidoc
+++ b/docs/en/observability/categorize-logs.asciidoc
@@ -10,15 +10,22 @@ your log events quickly. Instead of manually identifying similar logs, the logs
 categorization view lists log events that have been grouped based on their 
 messages and formats so that you can take action quicker.
 
+NOTE: This feature makes use of {ml} {anomaly-jobs}. To set up jobs, you must
+have `all` {kib} feature privileges for *{ml-app}*. Users that have full or
+read-only access to {ml-features} within a {kib} space can view the results of
+_all_ {anomaly-jobs} that are visible in that space, even if they do not have
+access to the source indices of those jobs. You must carefully consider who is
+given access to {ml-features}; {anomaly-job} results may propagate field values
+that contain sensitive information from the source indices to the results. For
+more details, refer to {ml-docs}/setup.html[Set up {ml-features}].
+
 [discrete]
 [[create-log-categories]]
 == Create log categories
 
-Create a 
-{ml-docs}/ml-configuring-categories.html[{ml} job to categorize log messages] 
-automatically. {ml-cap} observes the static parts of the message, clusters 
-similar messages, classifies them into message categories, and detects unusually 
-high message counts in the categories. 
+Create a {ml} job to categorize log messages automatically. {ml-cap} observes
+the static parts of the message, clusters similar messages, classifies them into
+message categories, and detects unusually high message counts in the categories. 
 
 [role="screenshot"]
 image::images/log-create-categorization-job.jpg[Configure log categorization job]
@@ -59,3 +66,6 @@ can be viewed in the corresponding log event on the *Stream* page or displayed i
 
 [role="screenshot"]
 image::images/log-opened.png[Opened log category]
+
+For more information about categorization, go to
+{ml-docs}/ml-configuring-categories.html[Detecting anomalous categories of data]. 

--- a/docs/en/observability/inspect-log-anomalies.asciidoc
+++ b/docs/en/observability/inspect-log-anomalies.asciidoc
@@ -1,23 +1,31 @@
 [[inspect-log-anomalies]]
 = Inspect log anomalies
 
-When the {anomaly-detect} features of {ml} are enabled,
-you can use the **Anomalies** page in the {logs-app} to detect and inspect log anomalies
-and the log partitions where the log anomalies occur.
-This means you can easily see anomalous behavior without significant human intervention --
-no more manually sampling log data, calculating rates, and determining if rates are expected.
+When the {anomaly-detect} features of {ml} are enabled, you can use the
+**Anomalies** page in the {logs-app} to detect and inspect log anomalies and the
+log partitions where the log anomalies occur. This means you can easily see
+anomalous behavior without significant human intervention -- no more manually
+sampling log data, calculating rates, and determining if rates are expected.
 
-*Anomalies* automatically highlight periods where the log rate is outside expected bounds
-and therefore may be anomalous.
+*Anomalies* automatically highlight periods where the log rate is outside
+expected bounds and therefore may be anomalous. For example:
 
-For example:
+* A significant drop in the log rate might suggest that a piece of infrastructure
+stopped responding, and thus we're serving fewer requests.
+* A spike in the log rate could denote a DDoS attack. This may lead to an
+investigation of IP addresses from incoming requests.
 
-* A significant drop in the log rate might suggest that a piece of infrastructure stopped responding,
-and thus we're serving fewer requests.
-* A spike in the log rate could denote a DDoS attack.
-This may lead to an investigation of IP addresses from incoming requests.
+You can also view log anomalies directly in the
+{kibana-ref}/xpack-ml-anomalies.html[{ml-app} app].
 
-You can also view log anomalies directly in the {kibana-ref}/xpack-ml-anomalies.html[{ml-app} app].
+NOTE: This feature makes use of {ml} {anomaly-jobs}. To set up jobs, you must
+have `all` {kib} feature privileges for *{ml-app}*. Users that have full or
+read-only access to {ml-features} within a {kib} space can view the results of
+_all_ {anomaly-jobs} that are visible in that space, even if they do not have
+access to the source indices of those jobs. You must carefully consider who is
+given access to {ml-features}; {anomaly-job} results may propagate field values
+that contain sensitive information from the source indices to the results. For
+more details, refer to {ml-docs}/setup.html[Set up {ml-features}].
 
 [discrete]
 [[enable-anomaly-detection]]


### PR DESCRIPTION
Relates to https://github.com/elastic/stack-docs/pull/2204

This PR adds machine learning requirements to [Inspect log anomalies](https://www.elastic.co/guide/en/observability/master/inspect-log-anomalies.html) and [Categorize log entries](https://www.elastic.co/guide/en/observability/master/categorize-logs.html) in the Observability Guide. It also moves a link from the top to the bottom of the latter page, since the target provides more advanced options than are initially required. 

The requirements text is partially borrowed from the UI text here:

![image](https://user-images.githubusercontent.com/26471269/184039991-c26bf303-f9ac-4519-bf08-3e07260d80e4.png)
