### PR TITLE
[DOCS] Add Webhook Case Management connector to Cases

### DIFF
--- a/docs/en/observability/create-observability-connectors.asciidoc
+++ b/docs/en/observability/create-observability-connectors.asciidoc
@@ -8,6 +8,7 @@ You can send cases to these third-party systems:
 * {jira} (including {jira} Service Desk)
 * {ibm-r}
 * {swimlane}
+* {webhook-cm}
 
 IMPORTANT: To send cases to external systems, you need the appropriate license, and your role must
 have the *Cases* {kib} privilege as a user. For more details, refer to <<grant-cases-access>>.
@@ -27,56 +28,14 @@ automatically close when they are sent to an external system.
 [role="screenshot"]
 image::images/add-case-connector.png[]
 . From the *Incident management system* list, select *Add new connector*.
-. Select the system to send cases to: *{sn}*, *{jira}*, *{ibm-r}*, or *{swimlane}*.
+. Select the system to send cases to: *{sn}*, *{jira}*, *{ibm-r}*, *{swimlane}*,
+or {webhook-cm}
 
-. Enter your required settings.
-+
-|=== 
+. Enter your required settings. Refer to <<resilient-action-type>>,
+<<jira-action-type>>, <<servicenow-action-type>>, <<servicenow-sir-action-type>>,
+or <<swimlane-action-type>> for connector configuration details.
+// or <<cases-webhook-action-type>>
 
-| *Connector name* | Name for the connector. 
-
-| *URL* | The URL of the external system to which you want to send cases.
-
-| *API URL* |  ({swimlane} only) The URL of the {swimlane} instance to which you want to send cases.
-
-| *Organization ID* | ({ibm-r} only) Your organization’s {ibm-r} ID number.
-
-| *Application ID* | ({swimlane} only) The application ID of your {swimlane} application. From {swimlane}, you can find the application
-ID by checking your application’s settings or at the end of your application’s URL after you’ve opened it.
-
-| *Username* | ({sn} only) The username of the {sn} account is used to access the {sn} instance.
-
-| *Password* | ({sn} only) The password of the {sn} account is used to access the {sn} instance.
-
-| *Project key* | ({jira} only) The key of the {jira} project to which you are sending cases.
-
-| *Email or Username* | ({jira} only) The {jira} account username or email.
-
-| *API token or Password* | ({jira} only) The API token or password is used to authenticate {jira} updates.
-
-| *API key ID* | ({ibm-r} only) The API key is used to authenticate {ibm-r} updates.
-
-| *API key secret* | ({ibm-r} only) The API key secret is used to authenticate {ibm-r} updates.
-
-| *API token* | ({swimlane} only) The {swimlane} API authentication token is used for HTTP Basic authentication.
-This is the personal access token for your user role.
-
-|===
-+
-. Choose the connector type ({swimlane} only):
-+
-|=== 
-
-| *All* | You can choose to set all or no field mappings when creating your new {swimlane} connector. However, note that if
-you don’t set field mappings now, you’ll be prompted to do so if you want to use the connector for a case or a rule. This
-is because the prompts no longer display once you set up the required mappings. 
-
-| *Alerts* | Provide an alert ID and rule name.
-
-| *Cases* | Provide a case ID, a case name, comments, and a description.
-
-|=== 
-+
 . Click *Save*.
 
 [discrete]

--- a/docs/en/observability/create-observability-connectors.asciidoc
+++ b/docs/en/observability/create-observability-connectors.asciidoc
@@ -31,10 +31,13 @@ image::images/add-case-connector.png[]
 . Select the system to send cases to: *{sn}*, *{jira}*, *{ibm-r}*, *{swimlane}*,
 or {webhook-cm}
 
-. Enter your required settings. Refer to <<resilient-action-type>>,
-<<jira-action-type>>, <<servicenow-action-type>>, <<servicenow-sir-action-type>>,
-or <<swimlane-action-type>> for connector configuration details.
-// or <<cases-webhook-action-type>>
+. Enter your required settings. For connector configuration details, refer to
+{kibana-ref}/resilient-action-type.html[{ibm-r} connector],
+{kibana-ref}/jira-action-type.html[{jira} connector],
+{kibana-ref}/servicenow-action-type.html[{sn-itsm} connector],
+{kibana-ref}/servicenow-sir-action-type.html[{sn-sir} connector],
+or {kibana-ref}/swimlane-action-type.html[{swimlane} connector].
+// or {kibana-ref}/cases-webhook-action-type.html[{webhook-cm} connector].
 
 . Click *Save*.
 

--- a/docs/en/observability/create-observability-connectors.asciidoc
+++ b/docs/en/observability/create-observability-connectors.asciidoc
@@ -36,8 +36,8 @@ or *{webhook-cm}*.
 {kibana-ref}/jira-action-type.html[{jira} connector],
 {kibana-ref}/servicenow-action-type.html[{sn-itsm} connector],
 {kibana-ref}/servicenow-sir-action-type.html[{sn-sir} connector],
-or {kibana-ref}/swimlane-action-type.html[{swimlane} connector].
-// or {kibana-ref}/cases-webhook-action-type.html[{webhook-cm} connector].
+{kibana-ref}/swimlane-action-type.html[{swimlane} connector], or
+{kibana-ref}/cases-webhook-action-type.html[{webhook-cm} connector].
 
 . Click *Save*.
 

--- a/docs/en/observability/create-observability-connectors.asciidoc
+++ b/docs/en/observability/create-observability-connectors.asciidoc
@@ -29,7 +29,7 @@ automatically close when they are sent to an external system.
 image::images/add-case-connector.png[]
 . From the *Incident management system* list, select *Add new connector*.
 . Select the system to send cases to: *{sn}*, *{jira}*, *{ibm-r}*, *{swimlane}*,
-or {webhook-cm}
+or *{webhook-cm}*.
 
 . Enter your required settings. For connector configuration details, refer to
 {kibana-ref}/resilient-action-type.html[{ibm-r} connector],


### PR DESCRIPTION
Relates to https://github.com/elastic/kibana/issues/124687

This PR updates https://www.elastic.co/guide/en/observability/master/cases-external-connectors.html with information about the new Webhook Case Management connector. It cannot link to more information until https://github.com/elastic/kibana/pull/137726 is merged.

This PR also removes the table that contains configuration details for each connector. Instead, it links to the appropriate pages in the Kibana Guide where those details are maintained.