### PR TITLE
Add hint about standalone agents for upgrade

### DIFF
--- a/docs/en/ingest-management/fleet/air-gapped.asciidoc
+++ b/docs/en/ingest-management/fleet/air-gapped.asciidoc
@@ -141,7 +141,7 @@ NODE_EXTRA_CA_CERTS="/etc/kibana/certs/ca-cert.pem"
 [[air-gapped-limitations]]
 == Limitations for {agent} upgrades
 
-The <<upgrade-elastic-agent>> feature in technical preview does not currently support network restricted environments without access to artifacts.elastic.co.
+The <<upgrade-elastic-agent>> feature in technical preview does not currently support network restricted environments without access to artifacts.elastic.co. This should only be used with agents running in standalone mode. Agents enrolled in Fleet should be upgraded through Fleet.
 To upgrade {agent}s:
 
 1. Download the new version from the https://www.elastic.co/downloads/elastic-agent[download page]


### PR DESCRIPTION
Following the[ command reference](https://www.elastic.co/guide/en/fleet/current/elastic-agent-cmd-options.html#elastic-agent-upgrade-command
) the upgrade with --source-uri is only supported for standalone agents:
> Upgrade the currently running Elastic Agent to the specified version. This should only be used with agents running in standalone mode. Agents enrolled in Fleet should be upgraded through Fleet.


This information is missing here and will lead to frustration on the user site because the upgrade will fail with an error message when trying to upgrade fleet managed agents. Adding this information here will make clear for what use case the command is intended.