### PR TITLE
Add Fleet and Elastic Agent 8.4 release notes

### DIFF
--- a/docs/en/ingest-management/index.asciidoc
+++ b/docs/en/ingest-management/index.asciidoc
@@ -152,7 +152,7 @@ include::troubleshooting/troubleshooting.asciidoc[leveloffset=+2]
 
 include::troubleshooting/faq.asciidoc[leveloffset=+2]
 
-include::release-notes/release-notes-8.3.asciidoc[leveloffset=+1]
+include::release-notes/release-notes-8.4.asciidoc[leveloffset=+1]
 
 include::elastic-agent/install-fleet-managed-agent.asciidoc[leveloffset=+2]
 

--- a/docs/en/ingest-management/release-notes/release-notes-8.4.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.4.asciidoc
@@ -1,0 +1,235 @@
+// Use these for links to issue and pulls.
+:kib-issue: https://github.com/elastic/kibana/issues/
+:kibana-pull: https://github.com/elastic/kibana/pull/
+:agent-issue: https://github.com/elastic/elastic-agent/issues/
+:beats-issue: https://github.com/elastic/beats/issues/
+:agent-libs-pull: https://github.com/elastic/elastic-agent-libs/pull/
+:agent-pull: https://github.com/elastic/elastic-agent/pull/
+:fleet-server-issue: https://github.com/elastic/beats/issues/fleet-server/
+:fleet-server-pull: https://github.com/elastic/beats/pull/fleet-server/
+
+[[release-notes]]
+= Release notes
+
+This section summarizes the changes in each release.
+
+* <<release-notes-8.4.0>>
+
+
+Also see:
+
+* {kibana-ref}/release-notes.html[{kib} release notes]
+* {beats-ref}/release-notes.html[{beats} release notes]
+
+// begin 8.4.0 relnotes
+
+[[release-notes-8.4.0]]
+== {fleet} and {agent} 8.4.0
+
+Review important information about the {fleet} and {agent} 8.4.0 release.
+
+[discrete]
+[[breaking-changes-8.4.0]]
+=== Breaking changes
+
+Breaking changes can prevent your application from optimal operation and
+performance. Before you upgrade, review the breaking changes, then mitigate the
+impact to your application.
+
+[discrete]
+[[breaking-135669]]
+.xpack.agents.* are uneditable in UI when defined in kibana.yml
+[%collapsible]
+====
+*Details* +
+When you configure `setxpack.fleet.agents.fleet_server.hosts` and `xpack.fleet.agents.elasticsearch.hosts` in kibana.yml, you are unable to update the fields on the Fleet UI. 
+For more information, refer to {kibana-pull}135669[#135669].
+
+*Impact* +
+To configure `setxpack.fleet.agents.fleet_server.hosts` and `xpack.fleet.agents.elasticsearch.hosts` on the Fleet UI, avoid configuring the settings in kibana.yml.
+====
+
+[discrete]
+[[new-features-8.4.0]]
+=== New features
+
+The 8.4.0 release adds the following new and notable features. 
+ 
+{fleet}::
+* Enable package signature verification feature {kibana-pull}137239[#137239]
+* Allow user to force install an unverified package {kibana-pull}136108[#136108]
+* Display package verification status {kibana-pull}135928[#135928]
+* Add tag rename and delete feature {kibana-pull}135712[#135712]
+* Add UI to bulk update agent tags {kibana-pull}135646[#135646]
+* Add API to bulk update agent tags {kibana-pull}135520[#135520]
+* Add UI to add and remove agent tags {kibana-pull}135320[#135320]
+* Support sorting agent list {kibana-pull}135218[#135218]
+* Promote Logstash output support to GA {kibana-pull}135028[#135028]
+* Create new API to manage download_source setting for agent binary downloads
+{kibana-pull}134889[#134889]
+
+{agent}::
+* Add `@metadata.input_id` and `@metadata.stream_id` when applying the inject
+stream processor {agent-pull}527[#527]
+* Improve {agent} status reporting: add a liveness endpoint, allow the
+fleet-gateway component to report degraded state, and add the status update time
+and messages to the status output {agent-issue}390[#390] {agent-pull}569[#569]
+* Redact sensitive information collected by the
+`elastic-agent diagnostics collect` command {agent-issue}241[#241]
+{agent-pull}566[#566]
+
+[discrete]
+[[enhancements-8.4.0]]
+=== Enhancements
+
+{fleet}::
+* Remove Kubernetes package granularity {kibana-pull}136622[#136622]
+* Align {agent} manifests with the elastic-agent repo and add comments {kibana-pull}136394[#136394]
+* Configure source URI in global settings and in agent policy settings {kibana-pull}136263[#136263]
+* Add Kubernetes in platforms selection list and update managed agent installation steps {kibana-pull}136109[#136109]
+* Enable user to write custom ingest pipelines for {fleet}-installed datastreams {kibana-pull}134578[#134578]
+* Update manifests for agent on Kubernetes with new permissions {kibana-pull}133495[#133495]
+* Add support for a textarea type in integrations {kibana-pull}133070[#133070]
+
+{agent}::
+There are no enhancements beyond the new features added in this release
+
+[discrete]
+[[bug-fixes-8.4.0]]
+=== Bug fixes
+
+{fleet}::
+* Use point in time for agent status query to provide accurate reporting
+{kibana-pull}135816[#135816]
+
+{agent}::
+* Change default value of VerificationMode from empty string to `full`
+{agent-issue}184[#184] {agent-libs-pull}59[#59]
+* Add filemod times to contents of diagnostics collect command {agent-pull}570[#570]
+* Allow colon (:) characters in dynamic variables {agent-issue}624[#624] {agent-pull}680[#680]
+* Allow dash (`-`) characters in variable names in EQL expressions
+{agent-issue}709[#709] {agent-pull}710[#710]
+* Allow slash (`/`) characters in variable names in EQL and transpiler
+{agent-issue}715[#715] {agent-pull}718[#718]
+* Fix problem with {agent} incorrectly creating a {filebeat} `redis` input when
+a policy contains a {packetbeat} `redis` input {agent-issue}427[#427]
+{agent-pull}700[#700]
+* Fix data duplication for standalone {agent} on Kubernetes using the default
+manifest {beats-issue}31512[#31512] {agent-pull}742[#742]
+* {agent} upgrades now clean up unneeded artifacts {agent-issue}693[#693]
+{agent-issue}694[#694] {agent-pull}752[#752]
+* Fix a panic caused by a race condition when installing the {agent}
+{agent-issue}806[#806] {agent-pull}823[#823]
+
+// end 8.4.0 relnotes
+
+
+
+// ---------------------
+//TEMPLATE
+//Use the following text as a template. Remember to replace the version info.
+
+// begin 8.4.x relnotes
+
+//[[release-notes-8.4.x]]
+//== {fleet} and {agent} 8.4.x
+
+//Review important information about the {fleet} and {agent} 8.4.x release.
+
+//[discrete]
+//[[security-updates-8.4.x]]
+//=== Security updates
+
+//{fleet}::
+//* add info
+
+//{agent}::
+//* add info
+
+//[discrete]
+//[[breaking-changes-8.4.x]]
+//=== Breaking changes
+
+//Breaking changes can prevent your application from optimal operation and
+//performance. Before you upgrade, review the breaking changes, then mitigate the
+//impact to your application.
+
+//[discrete]
+//[[breaking-PR#]]
+//.Short description
+//[%collapsible]
+//====
+//*Details* +
+//<Describe new behavior.> For more information, refer to {kibana-pull}PR[#PR].
+
+//*Impact* +
+//<Describe how users should mitigate the change.> For more information, refer to {fleet-guide}/fleet-server.html[Fleet Server].
+//====
+
+//[discrete]
+//[[known-issues-8.4.x]]
+//=== Known issues
+
+//[[known-issue-issue#]]
+//.Short description
+//[%collapsible]
+//====
+
+//*Details*
+
+//<Describe known issue.>
+
+//*Impact* +
+
+//<Describe impact or workaround.>
+
+//====
+
+//[discrete]
+//[[deprecations-8.4.x]]
+//=== Deprecations
+
+//The following functionality is deprecated in 8.4.x, and will be removed in
+//8.4.x. Deprecated functionality does not have an immediate impact on your
+//application, but we strongly recommend you make the necessary updates after you
+//upgrade to 8.4.x.
+
+//{fleet}::
+//* add info
+
+//{agent}::
+//* add info
+
+//[discrete]
+//[[new-features-8.4.x]]
+//=== New features
+
+//The 8.4.x release adds the following new and notable features.
+
+//{fleet}::
+//* add info
+
+//{agent}::
+//* add info
+
+//[discrete]
+//[[enhancements-8.4.x]]
+//=== Enhancements
+
+//{fleet}::
+//* add info
+
+//{agent}::
+//* add info
+
+//[discrete]
+//[[bug-fixes-8.4.x]]
+//=== Bug fixes
+
+//{fleet}::
+//* add info
+
+//{agent}::
+//* add info
+
+// end 8.4.x relnotes

--- a/docs/en/ingest-management/release-notes/release-notes-8.4.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.4.asciidoc
@@ -58,7 +58,6 @@ The 8.4.0 release adds the following new and notable features.
 {fleet}::
 * Enable package signature verification feature {kibana-pull}137239[#137239]
 * Allow user to force install an unverified package {kibana-pull}136108[#136108]
-* Display package verification status {kibana-pull}135928[#135928]
 * Add tag rename and delete feature {kibana-pull}135712[#135712]
 * Add UI to bulk update agent tags {kibana-pull}135646[#135646]
 * Add API to bulk update agent tags {kibana-pull}135520[#135520]

--- a/docs/en/ingest-management/release-notes/release-notes-8.4.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.4.asciidoc
@@ -56,7 +56,6 @@ To configure `setxpack.fleet.agents.fleet_server.hosts` and `xpack.fleet.agents.
 The 8.4.0 release adds the following new and notable features. 
  
 {fleet}::
-* Enable package signature verification feature {kibana-pull}137239[#137239]
 * Allow user to force install an unverified package {kibana-pull}136108[#136108]
 * Add tag rename and delete feature {kibana-pull}135712[#135712]
 * Add UI to bulk update agent tags {kibana-pull}135646[#135646]


### PR DESCRIPTION
Adds release notes for Elastic Agent and Fleet in 8.4 based on changelog entries.

@jen-huang 
* I've edited the list of Fleet items taken from https://github.com/elastic/kibana/pull/137621. Some entries were confusing and  inconsistent. Please review, and I will make sure the changes get back into the Kibana docs.
* "Enables package signature verification feature"  shows up in the 8.4 release notes, but I thought we were going to wait and not expose this feature in 8.4 GA.

@jlind23 

Several of the Elastic Agent bug fixes were in 8.3.3, but since they showed up in the changelog and commit history for 8.4.0, I've included them. They are the first 6 in the list. Let me know if I should keep or remove them.

We need to get this merged tomorrow. 

TODO after merging:
- [ ] Edit Kibana release notes.
- [ ] Delete 8.3 release notes file from main.
