### PR TITLE
[synthetics] Standardize beta notes across synthetics docs

### DIFF
--- a/docs/en/observability/monitor-uptime-synthetics.asciidoc
+++ b/docs/en/observability/monitor-uptime-synthetics.asciidoc
@@ -41,7 +41,9 @@ To set up your first monitor, see <<uptime-set-up>>.
 [[monitoring-synthetics]]
 == Browser monitors
 
-beta[] Real browser synthetic monitoring enables you to test critical actions and requests that an end-user would make
+beta[]
+
+Real browser synthetic monitoring enables you to test critical actions and requests that an end-user would make
 on your site at predefined intervals and in a controlled environment.
 Synthetic monitoring extends traditional end-to-end testing techniques because it allows your tests to run continuously on the cloud.
 The result is rich, consistent, and repeatable data that you can trend and alert on.

--- a/docs/en/observability/synthetics-command-reference.asciidoc
+++ b/docs/en/observability/synthetics-command-reference.asciidoc
@@ -5,11 +5,13 @@
 <titleabbrev>Command reference</titleabbrev>
 ++++
 
+beta[]
+
 [discrete]
 [[elastic-synthetics-command]]
 == `elastic-synthetics`
 
-beta[] {heartbeat} uses the `npx @elastic/synthetics` command to run and report synthetic tests.
+{heartbeat} uses the `npx @elastic/synthetics` command to run and report synthetic tests.
 It can also be used locally to help develop your tests.
 
 [source,sh]

--- a/docs/en/observability/synthetics-configuration.asciidoc
+++ b/docs/en/observability/synthetics-configuration.asciidoc
@@ -7,7 +7,9 @@
 
 :synthetics_version: v1.0.0-beta.31
 
-beta[] Synthetic tests support the configuration of dynamic parameters that can be
+beta[] 
+
+Synthetic tests support the configuration of dynamic parameters that can be
 used in projects. In addition, the Synthetics agent, which is built on top
 of Playwright, supports configuring browser and context options that are available
 in Playwright-specific methods, for example, `ignoreHTTPSErrors`, `extraHTTPHeaders`, and `viewport`.

--- a/docs/en/observability/synthetics-create-test.asciidoc
+++ b/docs/en/observability/synthetics-create-test.asciidoc
@@ -1,9 +1,11 @@
 [[synthetics-create-test]]
 = Write a synthetic test
 
+beta[] 
+
 [[synthetics-syntax]]
 
-beta[] To write synthetic tests for your application, you'll need to know basic JavaScript and
+To write synthetic tests for your application, you'll need to know basic JavaScript and
 {playwright-url}[Playwright] syntax.
 
 TIP: {playwright-url}[Playwright] is a browser testing library developed by Microsoft.

--- a/docs/en/observability/synthetics-journeys.asciidoc
+++ b/docs/en/observability/synthetics-journeys.asciidoc
@@ -1,6 +1,8 @@
 [[synthetics-journeys]]
 = Use synthetic monitors
 
+beta[] 
+
 Synthetic monitoring extends traditional end-to-end testing techniques because it allows your tests to run continuously on the cloud.
 With synthetic monitoring in the {uptime-app}, you can assert that your application continues to work after a deployment by reusing
 the same journeys that you used to validate the software on your machine.

--- a/docs/en/observability/synthetics-manage-monitors.asciidoc
+++ b/docs/en/observability/synthetics-manage-monitors.asciidoc
@@ -1,6 +1,8 @@
 [[synthetics-manage-monitors]]
 = Manage synthetic monitors
 
+beta[]
+
 After you've <<synthetic-run-tests, created a synthetic monitor>>,
 you can update the contents of the tests that they run, update the monitor's configuration,
 and permanently delete monitors.

--- a/docs/en/observability/synthetics-params-secrets.asciidoc
+++ b/docs/en/observability/synthetics-params-secrets.asciidoc
@@ -6,7 +6,9 @@
 <titleabbrev>Working with parameters and secrets</titleabbrev>
 ++++
 
-beta[] You may need to use dynamically defined values in your synthetic scripts, which may sometimes be sensitive. 
+beta[]
+
+You may need to use dynamically defined values in your synthetic scripts, which may sometimes be sensitive. 
 For instance, you may want to test a production website with a particular demo account whose password is only known to the team administering {heartbeat}. 
 Another scenario might be using a different URL when running the tests under {heartbeat} and then running them locally using the Synthetics agent.
 Solving these problems is where `params` come in. `params` are variables that you can use within a synthetic project. 

--- a/docs/en/observability/synthetics-run-test.asciidoc
+++ b/docs/en/observability/synthetics-run-test.asciidoc
@@ -1,6 +1,8 @@
 [[synthetic-run-tests]]
 = Create a synthetic monitor
 
+beta[]
+
 Once you've <<synthetics-create-test, written a synthetic test>>, you can create a _monitor_ to run the test at a regular interval.
 
 [discrete]
@@ -25,8 +27,6 @@ When using this approach to create multiple monitors from a project, all monitor
 [[synthetic-monitor-choose-project]]
 === Project monitors
 
-beta[]
-
 Use the `@elastic/synthetics` library's `push` command to create monitors.
 Pushing your project creates a new browser monitor in {kib} for each journey in the project. Using the `push` command allows you to manage all browser monitors using a GitOps workflow.
 
@@ -46,8 +46,6 @@ Unlike the other approaches, this method can only be used to create _browser_ mo
 [discrete]
 [[synthetic-monitor-choose-agent]]
 === {agent}
-
-beta[]
 
 Use {agent} to configure and create browser monitors similarly to how you would set up any other type of monitor.
 

--- a/docs/en/observability/synthetics-visualize.asciidoc
+++ b/docs/en/observability/synthetics-visualize.asciidoc
@@ -5,7 +5,9 @@
 <titleabbrev>Visualize</titleabbrev>
 ++++
 
-beta[] Synthetic monitoring journeys can be visualized in the {uptime-app} side-by-side with
+beta[]
+
+Synthetic monitoring journeys can be visualized in the {uptime-app} side-by-side with
 your other Uptime monitors.
 
 [role="screenshot"]


### PR DESCRIPTION
In our last synthetics/docs sync, @paulb-elastic pointed out that we weren't consistent with beta notes across synthetics docs. This PR adds a beta note (rather than inline text with a popup) at the beginning of each page related to Elastic Synthetics and/or browser monitors.