### PR TITLE
[synthetics] Add `push` to table of set up options

### DIFF
--- a/docs/en/observability/uptime-set-up.asciidoc
+++ b/docs/en/observability/uptime-set-up.asciidoc
@@ -8,7 +8,7 @@ After setup is complete, the data will be available in the {uptime-app} in {kib}
 [[uptime-set-up-choose]]
 == Choose an approach
 
-There are two ways to set up an uptime monitor: *{heartbeat}* or the *{uptime-app}*.
+There are three ways to set up an uptime monitor: *{heartbeat}*, the *{uptime-app}*, or *project monitors*.
 
 |===
 | **{heartbeat}** | {heartbeat} is a lightweight daemon that you install on a remote server to periodically
@@ -26,6 +26,14 @@ This approach works well if you want to configure and update monitors using a UI
 However, **this functionality is in beta and is subject to change.**
 
 Read more in <<uptime-set-up-choose-agent>>.
+| **Project monitors** | beta[] Use the `@elastic/synthetics` library's `push` command to create monitors from an external project.
+Pushing your project creates a new browser monitor in {kib} for each journey in the project.
+
+Using the `push` command allows you to manage all browser monitors using a GitOps workflow.
+However, unlike the other approaches, this method can only be used to create _browser_ monitors.
+**This functionality is in beta and is subject to change.**
+
+Read more in <<synthetic-monitor-choose-project>>.
 |===
 
 NOTE: To use the Elastic Synthetics integration, see the https://www.elastic.co/guide/en/observability/8.3/uptime-set-up.html#uptime-set-up-choose-agent[8.3 documentation]. The Elastic Synthetics integration is similar to the {uptime-app} approach described above, but contains fewer configuration options and does not allow you to run monitors against Elastic's global managed testing locations.


### PR DESCRIPTION
⚠️ Note: This is a work in progress!

Adds the Elastic Synthetics `push` command to the table of options for setting up a monitor.

# To do

- [ ] @colleenmcginnis first draft
- [ ] @colleenmcginnis + [product team] agree on the approach
- [ ] @colleenmcginnis refine language
- [ ] [product team] review complete draft
- [ ]  @colleenmcginnis clean up for publication
    - [ ]  address feedback
    - [ ] lint content
    - [ ] ensure no redirects are needed