### PR TITLE
Update link to future package spec

### DIFF
--- a/docs/en/integrations/index.asciidoc
+++ b/docs/en/integrations/index.asciidoc
@@ -7,8 +7,7 @@ include::{docs-root}/shared/attributes.asciidoc[]
 :package-spec-repo: https://github.com/elastic/package-spec
 
 // Access package spec files with {package-spec-root}
-:package-spec-version: 1
-:package-spec: {package-spec-root}/versions/{package-spec-version}
+:package-spec: {package-spec-root}/spec
 
 // repos
 :integrations-repo-link: https://github.com/elastic/integrations


### PR DESCRIPTION
We are changing how to handle multiple versions in the package spec repository.

To be merged after https://github.com/elastic/package-spec/pull/384.