### PR TITLE
Fix broken link to data streams ILM tutorial

### DIFF
--- a/docs/en/observability/synthetics-manage-retention.asciidoc
+++ b/docs/en/observability/synthetics-manage-retention.asciidoc
@@ -47,4 +47,4 @@ To find Synthetics data streams:
 . Filter the list of data streams for those containing the term `synthetics`.
 .. In the UI there will be three types of browser data streams: `synthetics-browser-*`, `synthetics-browser.network-*`, and `synthetics-browser.screenshot-*`.
 
-Then, you can refer to https://www.elastic.co/guide/en/fleet/current/data-streams.html#data-streams-ilm-tutorial[Tutorial: Customize data retention for integrations] to learn how to apply a custom {ilm-init} policy to the browser data streams. 
+Then, you can refer to {fleet-guide}/data-streams-ilm-tutorial.html[Tutorial: Customize data retention for integrations] to learn how to apply a custom {ilm-init} policy to the browser data streams.


### PR DESCRIPTION
Trying to fix:

```
09:42:44 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/observability/8.3/synthetics-manage-retention.html contains broken links to:
09:42:44 INFO:build_docs:   - en/fleet/current/data-streams.html#data-streams-ilm-tutorial
09:42:44 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/observability/8.4/synthetics-manage-retention.html contains broken links to:
09:42:44 INFO:build_docs:   - en/fleet/current/data-streams.html#data-streams-ilm-tutorial
09:42:44 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/observability/current/synthetics-manage-retention.html contains broken links to:
09:42:44 INFO:build_docs:   - en/fleet/current/data-streams.html#data-streams-ilm-tutorial
09:42:44 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/observability/master/synthetics-manage-retention.html contains broken links to:
09:42:44 INFO:build_docs:   - en/fleet/current/data-streams.html#data-streams-ilm-tutorial
```