### PR TITLE
[Synthetics] Add cap requirements to Observability synthetics docs

### DIFF
--- a/docs/en/observability/uptime-set-up-app.asciidoc
+++ b/docs/en/observability/uptime-set-up-app.asciidoc
@@ -120,10 +120,18 @@ docker run \
   --env FLEET_ENROLL=1 \
   --env FLEET_URL={fleet-server-host-url} \
   --env FLEET_ENROLLMENT_TOKEN={enrollment-token} \
+  --cap-add=NET_RAW
+  --cap-add=SETUID
   --rm docker.elastic.co/beats/elastic-agent-complete:{version}
 ----
 
 endif::[]
+
+[IMPORTANT]
+====
+`elastic-agent-complete` Docker image requires additional capabilities to operate correctly. Ensure
+`NET_RAW` and `SETUID` are enabled on the container.
+====
 
 For more information on running {agent} with Docker, see
 {fleet-guide}/elastic-agent-container.html[Run {agent} in a container] and

--- a/docs/en/observability/uptime-set-up-heartbeat.asciidoc
+++ b/docs/en/observability/uptime-set-up-heartbeat.asciidoc
@@ -83,6 +83,7 @@ docker run \
   --name=heartbeat \
   --user=heartbeat \
   --volume="$PWD/heartbeat.yml:/usr/share/heartbeat/heartbeat.yml:ro" \
+  --cap-add=NET_RAW
   docker.elastic.co/beats/elastic-agent-complete:{version} heartbeat -e \
   -E cloud.id={cloud-id} \
   -E cloud.auth=elastic:{cloud-pass}
@@ -98,6 +99,7 @@ docker run \
   --name=heartbeat \
   --user=heartbeat \
   --volume="$PWD/heartbeat.yml:/usr/share/heartbeat/heartbeat.yml:ro" \
+  --cap-add=NET_RAW
   docker.elastic.co/beats/elastic-agent-complete:{version} heartbeat -e \
   -E output.elasticsearch.hosts=["localhost:9200"] \
   -E output.elasticsearch.username=elastic \


### PR DESCRIPTION
We've had a few instances where cap requirements are overlook at setup and it generates confusion for users and support engineers when errors happen.
This will hopefully help to identify these scenarios.

@colleenmcginnis @andrewvc I've tried to keep explanation on the lighter side, but I'm open to suggestion on a different structure/detail level.