### PR TITLE
Add Fleet and Elastic Agent 8.4.1 release notes

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-8.4.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.4.asciidoc
@@ -29,18 +29,6 @@ Also see:
 
 There are no bug fixes for {fleet} or {agent} in this release.
 
-//Review important information about the {fleet} and {agent} 8.4.1 release.
-
-//[discrete]
-//[[bug-fixes-8.4.1]]
-//=== Bug fixes
-
-//{fleet}::
-//* add info
-
-//{agent}::
-//* add info
-
 // end 8.4.1 relnotes
 
 // begin 8.4.0 relnotes
@@ -64,7 +52,7 @@ impact to your application.
 [%collapsible]
 ====
 *Details* +
-When you configure `setxpack.fleet.agents.fleet_server.hosts` and `xpack.fleet.agents.elasticsearch.hosts` in kibana.yml, you are unable to update the fields on the Fleet UI. 
+When you configure `setxpack.fleet.agents.fleet_server.hosts` and `xpack.fleet.agents.elasticsearch.hosts` in kibana.yml, you are unable to update the fields on the Fleet UI.
 For more information, refer to {kibana-pull}135669[#135669].
 
 *Impact* +
@@ -75,8 +63,8 @@ To configure `setxpack.fleet.agents.fleet_server.hosts` and `xpack.fleet.agents.
 [[new-features-8.4.0]]
 === New features
 
-The 8.4.0 release adds the following new and notable features. 
- 
+The 8.4.0 release adds the following new and notable features.
+
 {fleet}::
 * Allow user to force install an unverified package {kibana-pull}136108[#136108]
 * Add tag rename and delete feature {kibana-pull}135712[#135712]

--- a/docs/en/ingest-management/release-notes/release-notes-8.4.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.4.asciidoc
@@ -13,6 +13,7 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-8.4.1>>
 * <<release-notes-8.4.0>>
 
 
@@ -20,6 +21,27 @@ Also see:
 
 * {kibana-ref}/release-notes.html[{kib} release notes]
 * {beats-ref}/release-notes.html[{beats} release notes]
+
+// begin 8.4.1 relnotes
+
+[[release-notes-8.4.1]]
+== {fleet} and {agent} 8.4.1
+
+There are no bug fixes for {fleet} or {agent} in this release.
+
+//Review important information about the {fleet} and {agent} 8.4.1 release.
+
+//[discrete]
+//[[bug-fixes-8.4.1]]
+//=== Bug fixes
+
+//{fleet}::
+//* add info
+
+//{agent}::
+//* add info
+
+// end 8.4.1 relnotes
 
 // begin 8.4.0 relnotes
 


### PR DESCRIPTION
Adds skeleton file for 8.4.1.

@elastic/obs-docs Someone will need to finalize this PR for the 8.4.1 release date because I'll be on PTO.

@debadair for awareness.

Before merging:

- [x] Look at the commit history for elastic-agent in the latest build candidate listed in the [dev tracking issue](https://github.com/elastic/dev/issues/2104). If there are any bug fixes committed after August 26 that include changelog entries, uncomment the 8.4.1 intro + bug fix section in this document and add the fix under {agent}. Remove the intro sentence that says, "There are no bug fixes for {fleet} or {agent} in this release."
- [x] Check the Kibana 8.4.1 [release notes PR](https://github.com/elastic/kibana/pull/139485) for Fleet changes. Same rules apply. If you find changes, add them under {fleet}. You might need to modify them to match the style of Fleet/Agent release notes.
- [x] If there are no changes for Fleet or Agent, remove the commented out intro + bug fix section. 
- [x] Tag the Fleet and data control plane teams for a review.
- [x] After merging this PR, make sure the backport PR gets merged into 8.4 (label is already there, but you'll have to merge the backport PR).

If you aren't sure what to do, just look at a previous version. :-) 
