### PR TITLE
[DOCS] Add "attributes" to display {version}

### DIFF
--- a/docs/en/ingest-management/elastic-agent/elastic-agent-container.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/elastic-agent-container.asciidoc
@@ -78,7 +78,7 @@ Refer to <<agent-environment-variables>> for all available options.
 
 If you're running a self-managed cluster and want to run your own {fleet-server}, run the following command, which will spin up {agent} and {fleet-server} in a container:
 
-[source,terminal,subs="attributes"]
+[source,sh,subs="attributes"]
 ----
 docker run \
   --env FLEET_SERVER_ENABLE=true \
@@ -87,6 +87,8 @@ docker run \
   --env FLEET_SERVER_POLICY_ID=<fleet-server-policy> \ <3>
   --rm docker.elastic.co/beats/elastic-agent:{version}
 ----
+// NOTCONSOLE
+
 <1> Your cluster's {es} host URL
 <2> The {fleet} service token -- generate one in the {fleet} UI if you don't have one already
 <3> ID of the {fleet-server} policy. To learn how to create a policy, refer

--- a/docs/en/ingest-management/elastic-agent/elastic-agent-container.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/elastic-agent-container.asciidoc
@@ -78,7 +78,7 @@ Refer to <<agent-environment-variables>> for all available options.
 
 If you're running a self-managed cluster and want to run your own {fleet-server}, run the following command, which will spin up {agent} and {fleet-server} in a container:
 
-[source,terminal,subs="attributes"]
+[source,terminal]
 ----
 docker run \
   --env FLEET_SERVER_ENABLE=true \

--- a/docs/en/ingest-management/elastic-agent/elastic-agent-container.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/elastic-agent-container.asciidoc
@@ -78,7 +78,7 @@ Refer to <<agent-environment-variables>> for all available options.
 
 If you're running a self-managed cluster and want to run your own {fleet-server}, run the following command, which will spin up {agent} and {fleet-server} in a container:
 
-[source,sh,subs="attributes"]
+["source","sh",subs="attributes"]
 ----
 docker run \
   --env FLEET_SERVER_ENABLE=true \

--- a/docs/en/ingest-management/elastic-agent/elastic-agent-container.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/elastic-agent-container.asciidoc
@@ -21,14 +21,14 @@ There are two images for {agent}, *elastic-agent* and *elastic-agent-complete*. 
 
 Run the `docker pull` command against the Elastic Docker registry:
 
-[source,terminal]
+[source,terminal,subs="attributes"]
 ----
 docker pull docker.elastic.co/beats/elastic-agent:{version}
 ----
 
 If want to run synthetics tests, run the `docker pull` command to fetch the *elastic-agent-complete* image:
 
-[source,terminal]
+[source,terminal,subs="attributes"]
 ----
 docker pull docker.elastic.co/beats/elastic-agent-complete:{version}
 ----
@@ -59,7 +59,7 @@ Find the Agent policy you want to enroll {agent} into, and display and copy the 
 
 . Enroll an {agent} running in a container with the following command:
 
-[source,terminal]
+[source,terminal,subs="attributes"]
 ----
 docker run \
   --env FLEET_ENROLL=1 \
@@ -78,7 +78,7 @@ Refer to <<agent-environment-variables>> for all available options.
 
 If you're running a self-managed cluster and want to run your own {fleet-server}, run the following command, which will spin up {agent} and {fleet-server} in a container:
 
-[source,terminal]
+[source,terminal,subs="attributes"]
 ----
 docker run \
   --env FLEET_SERVER_ENABLE=true \
@@ -105,7 +105,7 @@ NOTE: Replace `docker.elastic.co/beats/elastic-agent` with `docker.elastic.co/be
 {agent} can be run in docker-compose.
 The example below shows how to enroll an {agent}:
 
-[source,yaml]
+[source,yaml,subs="attributes"]
 ----
 version: "3"
 services:

--- a/docs/en/ingest-management/elastic-agent/elastic-agent-container.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/elastic-agent-container.asciidoc
@@ -63,8 +63,8 @@ Find the Agent policy you want to enroll {agent} into, and display and copy the 
 ----
 docker run \
   --env FLEET_ENROLL=1 \
-  --env FLEET_URL={fleet-server-host-url} \
-  --env FLEET_ENROLLMENT_TOKEN={enrollment-token} \
+  --env FLEET_URL=<fleet-server-host-url> \
+  --env FLEET_ENROLLMENT_TOKEN=<enrollment-token> \
   --rm docker.elastic.co/beats/elastic-agent:{version}
 ----
 
@@ -78,13 +78,13 @@ Refer to <<agent-environment-variables>> for all available options.
 
 If you're running a self-managed cluster and want to run your own {fleet-server}, run the following command, which will spin up {agent} and {fleet-server} in a container:
 
-[source,terminal]
+[source,terminal,subs="attributes"]
 ----
 docker run \
   --env FLEET_SERVER_ENABLE=true \
-  --env FLEET_SERVER_ELASTICSEARCH_HOST={elasticsearch-host} \ <1>
-  --env FLEET_SERVER_SERVICE_TOKEN={service-token} \ <2>
-  --env FLEET_SERVER_POLICY_ID=fleet-server-policy \ <3>
+  --env FLEET_SERVER_ELASTICSEARCH_HOST=<elasticsearch-host> \ <1>
+  --env FLEET_SERVER_SERVICE_TOKEN=<service-token> \ <2>
+  --env FLEET_SERVER_POLICY_ID=<fleet-server-policy> \ <3>
   --rm docker.elastic.co/beats/elastic-agent:{version}
 ----
 <1> Your cluster's {es} host URL
@@ -115,9 +115,9 @@ services:
     restart: always
     user: root # note, synthetic browser monitors require this set to `elastic-agent`
     environment:
-      - FLEET_ENROLLMENT_TOKEN={enrollment-token}
+      - FLEET_ENROLLMENT_TOKEN=<enrollment-token>
       - FLEET_ENROLL=1
-      - FLEET_URL={fleet-server-url}
+      - FLEET_URL=<fleet-server-url>
 ----
 
 Need to run {fleet-server} as well?
@@ -126,8 +126,8 @@ Adjust the docker-compose file above by adding these environment variables:
 [source,yaml]
 ----
       - FLEET_SERVER_ENABLE=true
-      - FLEET_SERVER_ELASTICSEARCH_HOST={elasticsearch-host}
-      - FLEET_SERVER_SERVICE_TOKEN={service-token}
+      - FLEET_SERVER_ELASTICSEARCH_HOST=<elasticsearch-host>
+      - FLEET_SERVER_SERVICE_TOKEN=<service-token>
 ----
 
 NOTE: Replace `docker.elastic.co/beats/elastic-agent` with `docker.elastic.co/beats/elastic-agent-complete` and use the `elastic-agent` user instead of root to run Synthetics Browser tests. Synthetics tests cannot run under the root user. Refer to {observability-guide}/uptime-set-up.html[Synthetics {fleet} Quickstart] for more information.


### PR DESCRIPTION
An internal user indicated that the `{version}` variable isn't rendering on the page for [running an Elastic Agent in a container](https://www.elastic.co/guide/en/fleet/master/elastic-agent-container.html). This change adds the `subs="attributes"` parameter to several code examples, which allows the `{version}` variable to be substituted with the current version.