### PR TITLE
Add Fleet and Elastic Agent 8.4.2 release notes

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-8.4.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.4.asciidoc
@@ -13,14 +13,32 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-8.4.2>>
 * <<release-notes-8.4.1>>
 * <<release-notes-8.4.0>>
-
 
 Also see:
 
 * {kibana-ref}/release-notes.html[{kib} release notes]
 * {beats-ref}/release-notes.html[{beats} release notes]
+
+// begin 8.4.2 relnotes
+
+[[release-notes-8.4.2]]
+== {fleet} and {agent} 8.4.2
+
+[discrete]
+[[bug-fixes-8.4.2]]
+=== Bug fixes
+
+{fleet}::
+* Apply fixes for package policy upgrade API with multiple ids {kibana-pull}140069[#140069]
+* Improve performance for many integration policies {kibana-pull}139648[#139648]
+
+{agent}::
+* No bug fixes for this release
+
+// end 8.4.2 relnotes
 
 // begin 8.4.1 relnotes
 


### PR DESCRIPTION
This is my first time doing the Fleet and Elastic Agent release notes so these might need some work, but here's what I did:

- [ ] **Elastic Agent**: Looked at the commit history for `elastic-agent` in the latest build candidate listed in the [dev tracking issue](https://github.com/elastic/dev/issues/2118). 
    - I'm not sure if [the changes in this PR](https://github.com/elastic/elastic-agent/pull/1130/files#diff-867eb8a32d99eda9bb244b7b86d7abd0031618bae71d0276fe139fe697c3063dR117) should be included.
- [x] **Fleet**: Checked the Kibana 8.4.2 [release notes PR](https://github.com/elastic/kibana/pull/140832) and found two [Fleet changes](https://github.com/elastic/kibana/pull/140832/files#diff-6eabb97e98640429cb68b61823f99438d287d604d72ecf0e93ed2e9ecbec7479R78-R80).
- [x] Add `backport-8.4` label.
- [x] Tag the Fleet and data control plane teams for a review. @dedemorton I'll let you tag in the right people once you've taken a look!

**Note:** I'm not sure if we still `credentials-error` note under "Known issues". From what I could tell it looks like it _might_ be addressed in 8.4.2 (see [the Beats release notes](https://github.com/elastic/beats/pull/33122/files#diff-cb0601935fcaac3fea29b215282428b964b8b6e1bd5a6b8c68e84d651633c9e3R13)).