### PR TITLE
Adds Fleet/Agent 8.4.3 release notes

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-8.4.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.4.asciidoc
@@ -28,21 +28,31 @@ Also see:
 [[release-notes-8.4.3]]
 == {fleet} and {agent} 8.4.3
 
-//Review important information about the {fleet} and {agent} 8.4.3 release.
+Review important information about the {fleet} and {agent} 8.4.3 release.
 
 [discrete]
 [[bug-fixes-8.4.3]]
 === Bug fixes
 
-There are no bug fixes for {fleet} or {agent} in this release.
+{fleet}::
+* No bug fixes for this release
 
-//{fleet}::
-//* TBD
-//Check https://github.com/elastic/kibana/pull/141808 for Fleet relnotes
+{agent}::
+* Use at least warning level for all status logs {agent-pull}1218[#1218]
+* Fix unintended reset of source URI when downloading components {agent-pull}1252[#1252]
+* Create separate status reporter for local only events so that degraded
+{fleet} checkins no longer affect health on successful {fleet} checkins {agent-issue}1157[#1157] {agent-pull}1285[#1285]
+* Add success log message after previous checkin failures {agent-pull}1327[#1327]
 
-//{agent}::
-//* TBD
-//Check build candidate commit history for Elastic Agent for changes.
+[discrete]
+[[enhancements-8.4.3]]
+=== Enhancements
+
+{fleet}::
+* No enhancements for this release
+
+{agent}::
+* Improve logging during upgrades {agent-pull}1287[#1287]
 
 // end 8.4.3 relnotes
 

--- a/docs/en/ingest-management/release-notes/release-notes-8.4.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.4.asciidoc
@@ -5,8 +5,8 @@
 :beats-issue: https://github.com/elastic/beats/issues/
 :agent-libs-pull: https://github.com/elastic/elastic-agent-libs/pull/
 :agent-pull: https://github.com/elastic/elastic-agent/pull/
-:fleet-server-issue: https://github.com/elastic/beats/issues/fleet-server/
-:fleet-server-pull: https://github.com/elastic/beats/pull/fleet-server/
+:fleet-server-issue: https://github.com/elastic/fleet-server/issues/
+:fleet-server-pull: https://github.com/elastic/fleet-server/pull/
 
 [[release-notes]]
 = Release notes
@@ -35,7 +35,9 @@ Review important information about the {fleet} and {agent} 8.4.3 release.
 === Bug fixes
 
 {fleet}::
-* No bug fixes for this release
+* {fleet-server} no longer silently discards user-specified values for cache and
+server limits when defaults are loaded {fleet-server-issue}1841[#1841]
+{fleet-server-pull}1912[#1912]
 
 {agent}::
 * Use at least warning level for all status logs {agent-pull}1218[#1218]

--- a/docs/en/ingest-management/release-notes/release-notes-8.4.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.4.asciidoc
@@ -43,6 +43,7 @@ Review important information about the {fleet} and {agent} 8.4.3 release.
 * Create separate status reporter for local only events so that degraded
 {fleet} checkins no longer affect health on successful {fleet} checkins {agent-issue}1157[#1157] {agent-pull}1285[#1285]
 * Add success log message after previous checkin failures {agent-pull}1327[#1327]
+* Fix Unix socket connection errors when using diagnostics command {agent-pull}2201[#2201]
 
 [discrete]
 [[enhancements-8.4.3]]

--- a/docs/en/ingest-management/release-notes/release-notes-8.4.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.4.asciidoc
@@ -13,6 +13,7 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-8.4.3>>
 * <<release-notes-8.4.2>>
 * <<release-notes-8.4.1>>
 * <<release-notes-8.4.0>>
@@ -22,10 +23,35 @@ Also see:
 * {kibana-ref}/release-notes.html[{kib} release notes]
 * {beats-ref}/release-notes.html[{beats} release notes]
 
+// begin 8.4.3 relnotes
+
+[[release-notes-8.4.3]]
+== {fleet} and {agent} 8.4.3
+
+//Review important information about the {fleet} and {agent} 8.4.3 release.
+
+[discrete]
+[[bug-fixes-8.4.3]]
+=== Bug fixes
+
+There are no bug fixes for {fleet} or {agent} in this release.
+
+//{fleet}::
+//* TBD
+//Check https://github.com/elastic/kibana/pull/141808 for Fleet relnotes
+
+//{agent}::
+//* TBD
+//Check build candidate commit history for Elastic Agent for changes.
+
+// end 8.4.3 relnotes
+
 // begin 8.4.2 relnotes
 
 [[release-notes-8.4.2]]
 == {fleet} and {agent} 8.4.2
+
+Review important information about the {fleet} and {agent} 8.4.2 release.
 
 [discrete]
 [[bug-fixes-8.4.2]]
@@ -44,6 +70,8 @@ Also see:
 
 [[release-notes-8.4.1]]
 == {fleet} and {agent} 8.4.1
+
+Review important information about the {fleet} and {agent} 8.4.1 release.
 
 [discrete]
 [[known-issues-8.4.1]]


### PR DESCRIPTION
Adds Elastic Agent release notes based on  https://github.com/elastic/elastic-agent/commits/5f09295a5dce74a20656ed5bc1d654b1fab06060 in BC2.

There are no Fleet release notes in the [Kibana relnotes PR](https://github.com/elastic/kibana/pull/141808), so I'm assuming no release notes for Fleet. Please confirm.