### PR TITLE
Explain why output settings might be grayed out in Fleet

### DIFF
--- a/docs/en/ingest-management/fleet/fleet-settings.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-settings.asciidoc
@@ -84,6 +84,10 @@ To add or edit an output:
 * <<es-output-settings>>
 * <<ls-output-settings>>
 
+TIP: If the options for editing an output are grayed out, outputs
+are configured outside of {fleet}. For more information, refer to
+{kibana-ref}/fleet-settings-kb.html[{fleet} settings in {kib}].
+
 
 [discrete]
 [[es-output-settings]]


### PR DESCRIPTION
This came up in a discuss topic: https://discuss.elastic.co/t/endpoint-security-configuration/315486