### PR TITLE
Clarify terminology around adding an integration

### DIFF
--- a/docs/en/ingest-management/integrations/add-integration-to-policy.asciidoc
+++ b/docs/en/ingest-management/integrations/add-integration-to-policy.asciidoc
@@ -8,24 +8,29 @@
 Policies consist of one or more integrations. To add a new integration to a
 policy:
 
-. In {kib}, go to *Management > Integrations*.
+. In {kib}, go to **Management > Integrations**.
 +
 Notice that the Integrations page shows {agent} integrations along with other
 types, such as {beats}.
 // lint ignore elastic-agent
-. Scroll down and select *Elastic Agent only* so the view shows
+. Scroll down and select **Elastic Agent only** so the view shows
 integrations that work with {agent}.
 +
 [role="screenshot"]
 image::images/unified-view-selector.png[Screen capture showing options for filtering the view]
 . Search for and select an integration.
-. Click *Add <Integration>*.
-. Name the integration, and add any required configuration variables.
-. Choose the policy you want to add the integration to. You can choose an
-existing policy or create a new one.
-. Click *Save integration* to save the integration policy as a part of the
-larger {agent} {policy}. {fleet} will distribute this new policy to all {agent}s
-that are enrolled with it.
+. Click **Add <Integration>**.
+. Name the integration and add any required configuration variables.
++
+NOTE: Integration policy names must be globally unique across all agent
+policies.
+
+. Choose the agent policy you want to add the integration to. You can choose an
+existing agent policy or create a new one.
+. Click **Save integration**. This action installs the integration (if it's not
+already installed) and saves the integration policy as a part of the
+larger {agent} {policy}. {fleet} distributes this new policy to all {agent}s
+that are enrolled in the agent policy.
 
 If you haven't deployed any {agent}s yet or set up agent policies, start with
 one of our quick start guides:


### PR DESCRIPTION
Closes #1492 

This PR doesn't fix the problem with how the term "integration" is overloaded at Elastic, but hopefully it makes the terminology in this task a bit more clear.

I could have used "integration policy" in more places, but I want the steps here to match the UI (which really glosses over the distinction between an integration and integration policy).