### PR TITLE
Add agent upgrade retry doc

### DIFF
--- a/docs/en/ingest-management/fleet/upgrade-elastic-agent.asciidoc
+++ b/docs/en/ingest-management/fleet/upgrade-elastic-agent.asciidoc
@@ -14,6 +14,11 @@ maintenance window during which the upgrades will occur. If your {stack}
 subscription level supports it, you can schedule upgrades to occur at a specific
 date and time.
 
+In most failure cases the {agent} may retry an upgrade after a short wait. The
+wait durations betweem retries are: 1m, 5m,  10m, 15m, 30m, 1h. During this
+time, the {agent} may show up as "retrying" in the {fleet} UI. Note that an
+{agent} that is being retried, the upgrade may be aborted as detailed below.
+
 This approach simplifies the process of keeping your agents up to date. It also
 saves you time because you don’t need third-party tools or processes to
 manage upgrades.
@@ -87,7 +92,7 @@ image::images/rolling-agent-upgrade.png[Menu for bulk upgrading {agent}s]
 
 . Select the amount of time available for the maintenance window. The upgrades
 are spread out uniformly across this maintenance window to avoid exhausting
-network resources. 
+network resources.
 +
 To force selected agents to upgrade immediately when the upgrade is
 triggered, select **Immediately**. Avoid using this setting for batches of more


### PR DESCRIPTION
Add some documentation to fleet upgrades that state that the agent may retry the upgrade.

- Relates https://github.com/elastic/elastic-agent/issues/778