### PR TITLE
Rectified `configuration` spelling in troubleshooting.asciidoc docume…

### DIFF
--- a/docs/en/ingest-management/troubleshooting/troubleshooting.asciidoc
+++ b/docs/en/ingest-management/troubleshooting/troubleshooting.asciidoc
@@ -346,7 +346,7 @@ This archive collects the following information:
 
 Note that the diagnostics bundle is intended for debugging purposes only, its structure may change between releases.
 
-IMPORTANT: The configration files in the archive may have credentials in *plain text*.
+IMPORTANT: The configuration files in the archive may have credentials in *plain text*.
 These will need to be manually redacted before the archive is shared.
 
 [discrete]


### PR DESCRIPTION
…ntation.

-- IMPORTANT: The configration files in the archive may have credentials in *plain text*. ++ IMPORTANT: The configuration files in the archive may have credentials in *plain text*.

`configuration` spelling was wrong.