### PR TITLE
[synthetics] Link to `request` parameter example

### DIFF
--- a/docs/en/observability/synthetics-create-test.asciidoc
+++ b/docs/en/observability/synthetics-create-test.asciidoc
@@ -207,7 +207,7 @@ with the corresponding https://playwright.dev/docs/api/class-browsercontext[`Bro
 via <<elastic-synthetics-command, `--playwright-options`>> or in the
 <<synthetics-configuration, `synthetics.config.ts` file>>.
 
-See a full example using the `request` parameter in the https://github.com/elastic/synthetics-demo/blob/main/advanced-examples/journeys/api-requests.journey.ts[Elastic Synthetics demo repository].
+For a full example that shows how to use the `request` object, refer to the https://github.com/elastic/synthetics-demo/blob/main/advanced-examples/journeys/api-requests.journey.ts[Elastic Synthetics demo repository].
 
 NOTE: The `request` parameter is not intended to be used for writing pure API tests. Instead, it is a way to support
 writing plain HTTP requests in service of a browser-based test.

--- a/docs/en/observability/synthetics-create-test.asciidoc
+++ b/docs/en/observability/synthetics-create-test.asciidoc
@@ -207,6 +207,8 @@ with the corresponding https://playwright.dev/docs/api/class-browsercontext[`Bro
 via <<elastic-synthetics-command, `--playwright-options`>> or in the
 <<synthetics-configuration, `synthetics.config.ts` file>>.
 
+See a full example using the `request` parameter in the https://github.com/elastic/synthetics-demo/blob/main/advanced-examples/journeys/api-requests.journey.ts[Elastic Synthetics demo repository].
+
 NOTE: The `request` parameter is not intended to be used for writing pure API tests. Instead, it is a way to support
 writing plain HTTP requests in service of a browser-based test.
 


### PR DESCRIPTION
Closes https://github.com/elastic/observability-docs/issues/2115

Adds a link to the [`request` parameter example](https://github.com/elastic/synthetics-demo/blob/main/advanced-examples/journeys/api-requests.journey.ts) in the [/synthetics-demo](https://github.com/elastic/synthetics-demo) repo.