### PR TITLE
[synthetics] Add information about the `push` command's `--yes` option

### DIFF
--- a/docs/en/observability/index.asciidoc
+++ b/docs/en/observability/index.asciidoc
@@ -27,7 +27,7 @@ include::{docs-root}/shared/attributes.asciidoc[]
 :beats-repo-dir:       {beats-root}/libbeat/docs
 :shared:               {observability-docs-root}/docs/en/shared
 
-:synthetics_version: v1.0.0-beta.32
+:synthetics_version: v1.0.0-beta.37
 
 // What is Observability?
 include::observability-introduction.asciidoc[leveloffset=+1]

--- a/docs/en/observability/synthetics-command-reference.asciidoc
+++ b/docs/en/observability/synthetics-command-reference.asciidoc
@@ -86,9 +86,9 @@ npx @elastic/synthetics push --auth <api-key> --url <kibana-url> --project <id|n
 The `push` command includes interactive prompts to prevent you from accidentally deleting or duplicating monitors.
 You will see a prompt when:
 
-* You `push` a project that used to contain one or more monitors but
-no longer contains any monitors. Select `yes` to delete them all.
-* You `push` a project that's already been pushed using one ID and then try to `push`
+* You `push` a project that used to contain one or more monitors but no longer contains any monitors.
+Select `yes` to delete all monitors associated with the project ID being pushed.
+* You `push` a project that's already been pushed using one project ID and then try to `push`
 it using a _different_ ID. Select `yes` to create duplicates of all monitors in the project.
 ====
 
@@ -117,9 +117,9 @@ The `push` command includes interactive prompts to prevent you from accidentally
 If running the CLI non-interactively, you can override these prompts using the `--yes` option.
 When the `--yes` option is passed to `push`:
 +
-* If you `push` a project that used to contain one or more monitors but
-no longer contains any monitors, all monitors will be deleted.
-* If you  `push` a project that's already been pushed using one ID and then try to `push`
+* If you `push` a project that used to contain one or more monitors but no longer contains any monitors,
+all monitors associated with the project ID being pushed will be deleted.
+* If you `push` a project that's already been pushed using one project ID and then try to `push`
 it using a _different_ ID, it will create duplicates of all monitors in the project.
 
 [discrete]

--- a/docs/en/observability/synthetics-command-reference.asciidoc
+++ b/docs/en/observability/synthetics-command-reference.asciidoc
@@ -119,8 +119,8 @@ When the `--yes` option is passed to `push`:
 +
 * If you `push` a project that used to contain one or more monitors but
 no longer contains any monitors, all monitors will be deleted.
-* If you `push` a project with that's already been pushed using an ID and then try to `push`
-it to a _different_ ID, it will create duplicates of all monitors in the project.
+* If you  `push` a project that's already been pushed using one ID and then try to `push`
+it using a _different_ ID, it will create duplicates of all monitors in the project.
 
 [discrete]
 [[elastic-synthetics-locations-command]]

--- a/docs/en/observability/synthetics-command-reference.asciidoc
+++ b/docs/en/observability/synthetics-command-reference.asciidoc
@@ -81,6 +81,17 @@ Create monitors in {kib} by using your local journeys.
 npx @elastic/synthetics push --auth <api-key> --url <kibana-url> --project <id|name>
 ----
 
+[NOTE]
+====
+The `push` command includes interactive prompts to prevent you from accidentally deleting or duplicating monitors.
+You will see a prompt when:
+
+* You `push` a project that used to contain one or more monitors but
+no longer contains any monitors. Select `yes` to delete them all.
+* You `push` a project that's already been pushed using one ID and then try to `push`
+it using a _different_ ID. Select `yes` to create duplicates of all monitors in the project.
+====
+
 `--auth`::
 API key used for {kibana-ref}/api-keys.html[{kib} authentication].
 +
@@ -93,7 +104,6 @@ To create an API key, you must be logged into {kib} as a user with the following
 ** _If using one or more public locations_: `All` for *Synthetics and Uptime* in the *Observability* section.
 ** _If using one or more private locations_: `All` for both *Fleet* and *Integrations* in the *Management* section.
 
-
 `--url`::
 The {kib} URL for the deployment to which you want to upload the monitors.
 
@@ -101,6 +111,16 @@ The {kib} URL for the deployment to which you want to upload the monitors.
 A unique id associated with your project.
 It will be used for logically grouping monitors.
 If you used <<elastic-synthetics-init-command, `init` to create a project>>, this is the `<name-of-project>` you specified.
+
+`--yes`::
+The `push` command includes interactive prompts to prevent you from accidentally deleting or duplicating monitors.
+If running the CLI non-interactively, you can override these prompts using the `--yes` option.
+When the `--yes` option is passed to `push`:
++
+* If you `push` a project that used to contain one or more monitors but
+no longer contains any monitors, all monitors will be deleted.
+* If you `push` a project with that's already been pushed using an ID and then try to `push`
+it to a _different_ ID, it will create duplicates of all monitors in the project.
 
 [discrete]
 [[elastic-synthetics-locations-command]]


### PR DESCRIPTION
Closes #2220 

## Overview

Updates [Synthetics command reference](https://observability-docs_2246.docs-preview.app.elstc.co/guide/en/observability/master/synthetics-command-reference.html) with changes to the Elastic Synthetics CLI:

* Adds a note letting the reader know that there are interactive prompts, why they are there, and when they should expect to see them. (Note: I'm not sure if this is necessary.)
* Adds a `--yes` option and explains how it works for both deleting all monitors and duplicating monitors to a new ID.

Note: The `locations` command was documented in https://github.com/elastic/observability-docs/pull/2116. Let me know if there are any updates to make to the existing language!

## For the reviewer

I'm very open to suggestions about the language used here! 