### PR TITLE
Add Fleet/Agent release notes for 8.5

### DIFF
--- a/docs/en/ingest-management/index.asciidoc
+++ b/docs/en/ingest-management/index.asciidoc
@@ -159,7 +159,7 @@ include::troubleshooting/troubleshooting.asciidoc[leveloffset=+2]
 
 include::troubleshooting/faq.asciidoc[leveloffset=+2]
 
-include::release-notes/release-notes-8.4.asciidoc[leveloffset=+1]
+include::release-notes/release-notes-8.5.asciidoc[leveloffset=+1]
 
 include::elastic-agent/install-fleet-managed-agent.asciidoc[leveloffset=+2]
 

--- a/docs/en/ingest-management/release-notes/release-notes-8.5.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.5.asciidoc
@@ -111,6 +111,7 @@ goroutine for the coordinator monitor {fleet-server-issue}1738[#1738]
 * Create separate status reporter for local-only events so that degraded {fleet} check-ins no longer affect health of successful {fleet} check-ins {agent-issue}1157[#1157] {agent-pull}1285[#1285]
 * Add success log message after previous check-in failures {agent-pull}1327[#1327]
 * Fix docker provider `add_fields` processors {agent-pull}1420[#1420]
+* Fix admin permission check on localized windows {agent-pull}1552[#1552]
 
 // end 8.5.0 relnotes
 

--- a/docs/en/ingest-management/release-notes/release-notes-8.5.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.5.asciidoc
@@ -101,7 +101,7 @@ goroutine for the coordinator monitor {fleet-server-issue}1738[#1738]
 * Fix issue where errors were ignored when written to {es} {fleet-server-pull}1896[#1896]
 * Update `apikey.cache_hit` log field name to match convention {fleet-server-pull}1900[#1900]
 * Custom server limits are no longer ignored when default limits are loaded {fleet-server-issue}1841[#1841] {fleet-server-pull}1912[#1912]
-* Use separate rate limiters for internal and external API listeners {fleet-server-issue}1859[#1859] {fleet-server-pull}1904[#1904]
+* Use separate rate limiters for internal and external API listeners to prevent {fleet-server} from shutting down under load {fleet-server-issue}1859[#1859] {fleet-server-pull}1904[#1904]
 * Fix `fleet.migration.total` log key overlap {fleet-server-pull}1951[#1951]
 
 {agent}::

--- a/docs/en/ingest-management/release-notes/release-notes-8.5.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.5.asciidoc
@@ -1,0 +1,239 @@
+// Use these for links to issue and pulls.
+:kib-issue: https://github.com/elastic/kibana/issues/
+:kibana-pull: https://github.com/elastic/kibana/pull/
+:agent-issue: https://github.com/elastic/elastic-agent/issues/
+:beats-issue: https://github.com/elastic/beats/issues/
+:agent-libs-pull: https://github.com/elastic/elastic-agent-libs/pull/
+:agent-pull: https://github.com/elastic/elastic-agent/pull/
+:fleet-server-issue: https://github.com/elastic/fleet-server/issues/
+:fleet-server-pull: https://github.com/elastic/fleet-server/pull/
+
+[[release-notes]]
+= Release notes
+
+This section summarizes the changes in each release.
+
+* <<release-notes-8.5.0>>
+
+Also see:
+
+* {kibana-ref}/release-notes.html[{kib} release notes]
+* {beats-ref}/release-notes.html[{beats} release notes]
+
+// begin 8.5.0 relnotes
+
+[[release-notes-8.5.0]]
+== {fleet} and {agent} 8.5.0
+
+Review important information about the {fleet} and {agent} 8.5.0 release.
+
+//TODO: Add Fleet release note items from https://github.com/elastic/kibana/pull/143134.
+
+//TODO: Add "generated" Agent release notes.
+
+//[discrete]
+//[[security-updates-8.5.0]]
+//=== Security updates
+
+//{fleet}::
+//* add info
+
+//{agent}::
+//* add info
+
+//[discrete]
+//[[breaking-changes-8.5.0]]
+//=== Breaking changes
+
+//Breaking changes can prevent your application from optimal operation and
+//performance. Before you upgrade, review the breaking changes, then mitigate the
+//impact to your application.
+
+//[discrete]
+//[[breaking-PR#]]
+//.Short description
+//[%collapsible]
+//====
+//*Details* +
+//<Describe new behavior.> For more information, refer to {kibana-pull}PR[#PR].
+
+//*Impact* +
+//<Describe how users should mitigate the change.> For more information, refer to {fleet-guide}/fleet-server.html[Fleet Server].
+//====
+
+//[discrete]
+//[[known-issues-8.5.0]]
+//=== Known issues
+
+//[[known-issue-issue#]]
+//.Short description
+//[%collapsible]
+//====
+
+//*Details*
+
+//<Describe known issue.>
+
+//*Impact* +
+
+//<Describe impact or workaround.>
+
+//====
+
+//[discrete]
+//[[deprecations-8.5.0]]
+//=== Deprecations
+
+//The following functionality is deprecated in 8.5.0, and will be removed in
+//8.5.0. Deprecated functionality does not have an immediate impact on your
+//application, but we strongly recommend you make the necessary updates after you
+//upgrade to 8.5.0.
+
+//{fleet}::
+//* add info
+
+//{agent}::
+//* add info
+
+//[discrete]
+//[[new-features-8.5.0]]
+//=== New features
+
+//The 8.5.0 release adds the following new and notable features.
+
+//{fleet}::
+//* add info
+
+//{agent}::
+//* add info
+
+//[discrete]
+//[[enhancements-8.5.0]]
+//=== Enhancements
+
+//{fleet}::
+//* add info
+
+//{agent}::
+//* add info
+
+//[discrete]
+//[[bug-fixes-8.5.0]]
+//=== Bug fixes
+
+//{fleet}::
+//* add info
+
+//{agent}::
+//* add info
+
+// end 8.5.0 relnotes
+
+// ---------------------
+//TEMPLATE
+//Use the following text as a template. Remember to replace the version info.
+
+// begin 8.5.x relnotes
+
+//[[release-notes-8.5.x]]
+//== {fleet} and {agent} 8.5.x
+
+//Review important information about the {fleet} and {agent} 8.5.x release.
+
+//[discrete]
+//[[security-updates-8.5.x]]
+//=== Security updates
+
+//{fleet}::
+//* add info
+
+//{agent}::
+//* add info
+
+//[discrete]
+//[[breaking-changes-8.5.x]]
+//=== Breaking changes
+
+//Breaking changes can prevent your application from optimal operation and
+//performance. Before you upgrade, review the breaking changes, then mitigate the
+//impact to your application.
+
+//[discrete]
+//[[breaking-PR#]]
+//.Short description
+//[%collapsible]
+//====
+//*Details* +
+//<Describe new behavior.> For more information, refer to {kibana-pull}PR[#PR].
+
+//*Impact* +
+//<Describe how users should mitigate the change.> For more information, refer to {fleet-guide}/fleet-server.html[Fleet Server].
+//====
+
+//[discrete]
+//[[known-issues-8.5.x]]
+//=== Known issues
+
+//[[known-issue-issue#]]
+//.Short description
+//[%collapsible]
+//====
+
+//*Details*
+
+//<Describe known issue.>
+
+//*Impact* +
+
+//<Describe impact or workaround.>
+
+//====
+
+//[discrete]
+//[[deprecations-8.5.x]]
+//=== Deprecations
+
+//The following functionality is deprecated in 8.5.x, and will be removed in
+//8.5.x. Deprecated functionality does not have an immediate impact on your
+//application, but we strongly recommend you make the necessary updates after you
+//upgrade to 8.5.x.
+
+//{fleet}::
+//* add info
+
+//{agent}::
+//* add info
+
+//[discrete]
+//[[new-features-8.5.x]]
+//=== New features
+
+//The 8.5.x release adds the following new and notable features.
+
+//{fleet}::
+//* add info
+
+//{agent}::
+//* add info
+
+//[discrete]
+//[[enhancements-8.5.x]]
+//=== Enhancements
+
+//{fleet}::
+//* add info
+
+//{agent}::
+//* add info
+
+//[discrete]
+//[[bug-fixes-8.5.x]]
+//=== Bug fixes
+
+//{fleet}::
+//* add info
+
+//{agent}::
+//* add info
+
+// end 8.5.x relnotes

--- a/docs/en/ingest-management/release-notes/release-notes-8.5.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.5.asciidoc
@@ -57,29 +57,31 @@ with SHA-1, update them now.
 The 8.5.0 release adds the following new and notable features.
 
 {fleet}::
-* Adds agent activity flyout {kibana-pull}140510[#140510]
-* Adds a new event toggle to capture terminal output in endpoint {kibana-pull}139421[#139421]
-* Makes batch actions asynchronous {kibana-pull}138870[#138870]
-* Adds ability to tag integration assets {kibana-pull}137184[#137184]
-* Adds support for input only packages {kibana-pull}140035[#140035]
+* Add agent activity flyout {kibana-pull}140510[#140510]
+* Add a new event toggle to capture terminal output in endpoint {kibana-pull}139421[#139421]
+* Make batch actions asynchronous {kibana-pull}138870[#138870]
+* Add ability to tag integration assets {kibana-pull}137184[#137184]
+* Add support for input-only packages {kibana-pull}140035[#140035]
 
 {fleet-server}::
 * Log redacted config when config updates {fleet-server-issue}1626[#1626] {fleet-server-pull}1671[#1671]
 
-//{agent}::
-//* add info
+{agent}::
+* Add `lumberjack` input type to the {filebeat} spec {agent-pull}959[#959]
+* Add support for hints-based autodiscovery in Kubernetes provider {agent-pull}698[#698]
+* Improve logging during upgrades {agent-pull}1287[#1287]
 
 [discrete]
 [[enhancements-8.5.0]]
 === Enhancements
 
 {fleet}::
-* Adds toggle for experimental synthetic `_source` support in {fleet} data streams {kibana-pull}140132[#140132]
-* Enhances the package policy API to create or update a package policy API with a simplified way to define inputs {kibana-pull}139420[#139420]
+* Add toggle for experimental synthetic `_source` support in {fleet} data streams {kibana-pull}140132[#140132]
+* Enhance the package policy API to create or update a package policy API with a simplified way to define inputs {kibana-pull}139420[#139420]
 * Support new subscription and license fields {kibana-pull}137799[#137799]
 
-//{agent}::
-//* add info
+{agent}::
+* Improve logging of {fleet} check-in errors and only report the local state as degraded after two consecutive failed check-ins {agent-issue}1154[#1154] {agent-pull}1477[#1477]
 
 [discrete]
 [[bug-fixes-8.5.0]]
@@ -88,24 +90,27 @@ The 8.5.0 release adds the following new and notable features.
 {fleet}::
 * Refresh search results when clearing category filter {kibana-pull}142853[#142853]
 * Respect `default_field: false` when generating index settings {kibana-pull}142277[#142277]
-* Fixes repeated debug logs when bundled package directory does not exist {kibana-pull}141660[#141660]
+* Fix repeated debug logs when bundled package directory does not exist {kibana-pull}141660[#141660]
 
 {fleet-server}::
-* Fixes a race condition between the unenroller goroutine and the main
+* Fix a race condition between the unenroller goroutine and the main
 goroutine for the coordinator monitor {fleet-server-issue}1738[#1738]
-* Removes events from agent checkin body {fleet-server-issue}1774[#1774]
-* Improves authc debug logging {fleet-server-pull}1870[#1870]
-* Adds error detail to catch-all HTTP error response {fleet-server-pull}1854[#1854]
-* Fixes issue where errors were ignored when written to {es} {fleet-server-pull}1896[#1896]
-* Updates `apikey.cache_hit` log field name to match convention {fleet-server-pull}1900[#1900]
+* Remove events from agent check-in body {fleet-server-issue}1774[#1774]
+* Improve authc debug logging {fleet-server-pull}1870[#1870]
+* Add error detail to catch-all HTTP error response {fleet-server-pull}1854[#1854]
+* Fix issue where errors were ignored when written to {es} {fleet-server-pull}1896[#1896]
+* Update `apikey.cache_hit` log field name to match convention {fleet-server-pull}1900[#1900]
 * Custom server limits are no longer ignored when default limits are loaded {fleet-server-issue}1841[#1841] {fleet-server-pull}1912[#1912]
-//REVIEWERS: Is this correct? ^^ Was "LoadServerLimits will not overwrite specified limits when loading default/agent number specified values" which makes no sense to me.
 * Use separate rate limiters for internal and external API listeners {fleet-server-issue}1859[#1859] {fleet-server-pull}1904[#1904]
-//REVIEWERS: This ^^ description does not explain why this is important to users. Can we say something like: "Use separate rate limiters for internal and external API listeners to prevent Fleet Server from shutting down under load."
-* Fixes `fleet.migration.total` log key overlap {fleet-server-pull}1951[#1951]
+* Fix `fleet.migration.total` log key overlap {fleet-server-pull}1951[#1951]
 
-//{agent}::
-//* add info
+{agent}::
+* Fix a panic caused by a race condition when installing the {agent} {agent-issue}806[#806] {agent-pull}823[#823]
+* Use the {agent} configuration directory as the root of the `inputs.d` folder {agent-issue}663[#663] {agent-pull}840[#840]
+* Fix unintended reset of source URI when downloading components {agent-pull}1252[#1252]
+* Create separate status reporter for local-only events so that degraded {fleet} check-ins no longer affect health of successful {fleet} check-ins {agent-issue}1157[#1157] {agent-pull}1285[#1285]
+* Add success log message after previous check-in failures {agent-pull}1327[#1327]
+* Fix docker provider `add_fields` processors {agent-pull}1420[#1420]
 
 // end 8.5.0 relnotes
 

--- a/docs/en/ingest-management/release-notes/release-notes-8.5.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.5.asciidoc
@@ -27,20 +27,6 @@ Also see:
 
 Review important information about the {fleet} and {agent} 8.5.0 release.
 
-//TODO: Add Fleet release note items from https://github.com/elastic/kibana/pull/143134.
-
-//TODO: Add "generated" Agent release notes.
-
-//[discrete]
-//[[security-updates-8.5.0]]
-//=== Security updates
-
-//{fleet}::
-//* add info
-
-//{agent}::
-//* add info
-
 [discrete]
 [[breaking-changes-8.5.0]]
 === Breaking changes
@@ -63,40 +49,6 @@ https://tip.golang.org/doc/go1.18#sha1[release notes].
 Do not sign certificates with SHA-1. If you are using old certificates signed
 with SHA-1, update them now.
 ====
-
-//[discrete]
-//[[known-issues-8.5.0]]
-//=== Known issues
-
-//[[known-issue-issue#]]
-//.Short description
-//[%collapsible]
-//====
-
-//*Details*
-
-//<Describe known issue.>
-
-//*Impact* +
-
-//<Describe impact or workaround.>
-
-//====
-
-//[discrete]
-//[[deprecations-8.5.0]]
-//=== Deprecations
-
-//The following functionality is deprecated in 8.5.0, and will be removed in
-//8.5.0. Deprecated functionality does not have an immediate impact on your
-//application, but we strongly recommend you make the necessary updates after you
-//upgrade to 8.5.0.
-
-//{fleet}::
-//* add info
-
-//{agent}::
-//* add info
 
 [discrete]
 [[new-features-8.5.0]]

--- a/docs/en/ingest-management/release-notes/release-notes-8.5.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.5.asciidoc
@@ -41,25 +41,28 @@ Review important information about the {fleet} and {agent} 8.5.0 release.
 //{agent}::
 //* add info
 
-//[discrete]
-//[[breaking-changes-8.5.0]]
-//=== Breaking changes
+[discrete]
+[[breaking-changes-8.5.0]]
+=== Breaking changes
 
-//Breaking changes can prevent your application from optimal operation and
-//performance. Before you upgrade, review the breaking changes, then mitigate the
-//impact to your application.
+Breaking changes can prevent your application from optimal operation and
+performance. Before you upgrade, review the breaking changes, then mitigate the
+impact to your application.
 
-//[discrete]
-//[[breaking-PR#]]
-//.Short description
-//[%collapsible]
-//====
-//*Details* +
-//<Describe new behavior.> For more information, refer to {kibana-pull}PR[#PR].
+[discrete]
+[[breaking-PR1709]]
+.{fleet-server} now rejects certificates signed with SHA-1
+[%collapsible]
+====
+*Details* +
+With the upgrade to Go 1.18, {fleet-server} now rejects certificates signed with
+SHA-1. For more information, refer to the Go 1.18
+https://tip.golang.org/doc/go1.18#sha1[release notes].
 
-//*Impact* +
-//<Describe how users should mitigate the change.> For more information, refer to {fleet-guide}/fleet-server.html[Fleet Server].
-//====
+*Impact* +
+Do not sign certificates with SHA-1. If you are using old certificates signed
+with SHA-1, update them now.
+====
 
 //[discrete]
 //[[known-issues-8.5.0]]
@@ -95,34 +98,59 @@ Review important information about the {fleet} and {agent} 8.5.0 release.
 //{agent}::
 //* add info
 
-//[discrete]
-//[[new-features-8.5.0]]
-//=== New features
+[discrete]
+[[new-features-8.5.0]]
+=== New features
 
-//The 8.5.0 release adds the following new and notable features.
+The 8.5.0 release adds the following new and notable features.
 
-//{fleet}::
-//* add info
+{fleet}::
+* Adds agent activity flyout {kibana-pull}140510[#140510]
+* Adds a new event toggle to capture terminal output in endpoint {kibana-pull}139421[#139421]
+* Makes batch actions asynchronous {kibana-pull}138870[#138870]
+* Adds ability to tag integration assets {kibana-pull}137184[#137184]
+* Adds support for input only packages {kibana-pull}140035[#140035]
 
-//{agent}::
-//* add info
-
-//[discrete]
-//[[enhancements-8.5.0]]
-//=== Enhancements
-
-//{fleet}::
-//* add info
+{fleet-server}::
+* Log redacted config when config updates {fleet-server-issue}1626[#1626] {fleet-server-pull}1671[#1671]
 
 //{agent}::
 //* add info
 
-//[discrete]
-//[[bug-fixes-8.5.0]]
-//=== Bug fixes
+[discrete]
+[[enhancements-8.5.0]]
+=== Enhancements
 
-//{fleet}::
+{fleet}::
+* Adds toggle for experimental synthetic `_source` support in {fleet} data streams {kibana-pull}140132[#140132]
+* Enhances the package policy API to create or update a package policy API with a simplified way to define inputs {kibana-pull}139420[#139420]
+* Support new subscription and license fields {kibana-pull}137799[#137799]
+
+//{agent}::
 //* add info
+
+[discrete]
+[[bug-fixes-8.5.0]]
+=== Bug fixes
+
+{fleet}::
+* Refresh search results when clearing category filter {kibana-pull}142853[#142853]
+* Respect `default_field: false` when generating index settings {kibana-pull}142277[#142277]
+* Fixes repeated debug logs when bundled package directory does not exist {kibana-pull}141660[#141660]
+
+{fleet-server}::
+* Fixes a race condition between the unenroller goroutine and the main
+goroutine for the coordinator monitor {fleet-server-issue}1738[#1738]
+* Removes events from agent checkin body {fleet-server-issue}1774[#1774]
+* Improves authc debug logging {fleet-server-pull}1870[#1870]
+* Adds error detail to catch-all HTTP error response {fleet-server-pull}1854[#1854]
+* Fixes issue where errors were ignored when written to {es} {fleet-server-pull}1896[#1896]
+* Updates `apikey.cache_hit` log field name to match convention {fleet-server-pull}1900[#1900]
+* Custom server limits are no longer ignored when default limits are loaded {fleet-server-issue}1841[#1841] {fleet-server-pull}1912[#1912]
+//REVIEWERS: Is this correct? ^^ Was "LoadServerLimits will not overwrite specified limits when loading default/agent number specified values" which makes no sense to me.
+* Use separate rate limiters for internal and external API listeners {fleet-server-issue}1859[#1859] {fleet-server-pull}1904[#1904]
+//REVIEWERS: This ^^ description does not explain why this is important to users. Can we say something like: "Use separate rate limiters for internal and external API listeners to prevent Fleet Server from shutting down under load."
+* Fixes `fleet.migration.total` log key overlap {fleet-server-pull}1951[#1951]
 
 //{agent}::
 //* add info

--- a/docs/en/ingest-management/release-notes/release-notes-8.5.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.5.asciidoc
@@ -37,7 +37,7 @@ impact to your application.
 
 [discrete]
 [[breaking-PR1709]]
-.{fleet-server} now rejects certificates signed with SHA-1
+.{fleet-server} and {agent} now reject certificates signed with SHA-1
 [%collapsible]
 ====
 *Details* +


### PR DESCRIPTION
Closes #2227

- [x] Add Fleet release notes. REVIEW READY
- [x] Add Fleet Server release notes. REVIEW READY
- [x] Add Elastic Agent release notes. REVIEW READY
- [x] Add `https://github.com/elastic/elastic-agent/pull/1552` if it gets into the final build.

Link to preview: https://observability-docs_2264.docs-preview.app.elstc.co/guide/en/fleet/master/release-notes-8.5.0.html

Questions for reviewers:

- [x] This changelog entry was not covered in the fragments but is in the commit history. Keep it? "Use the Elastic Agent configuration directory as the root of the inputs.d folder [#663](https://github.com/elastic/elastic-agent/issues/663) [#840](https://github.com/elastic/elastic-agent/pull/840)"
- [x] Is the edit I made here correct? "Custom server limits are no longer ignored when default limits are loaded [#1841](https://github.com/elastic/fleet-server/issues/1841) [#1912](https://github.com/elastic/fleet-server/pull/1912)" (The original changelog entry didn't make sense to me: "LoadServerLimits will not overwrite specified limits when loading default/agent number specified values")
- [x] Can we improve the following entry to explain why this change is important to users? "Use separate rate limiters for internal and external API listeners [#1859](https://github.com/elastic/fleet-server/issues/1859) [#1904](https://github.com/elastic/fleet-server/pull/1904)" How about saying this instead: "Use separate rate limiters for internal and external API listeners to prevent Fleet Server from shutting down under load."