### PR TITLE
[synthetics] Document how to import NPM packages and their limitations

### DIFF
--- a/docs/en/observability/synthetics-command-reference.asciidoc
+++ b/docs/en/observability/synthetics-command-reference.asciidoc
@@ -94,9 +94,13 @@ it using a _different_ ID. Select `yes` to create duplicates of all monitors in 
 
 [NOTE]
 ====
-If the journey code in a project uses an external Node.js package,
-that package will be bundled with the journey code on `push`.
-However, you can't `push` bundles that are more than 800 Kilobytes.
+If the journey contains external NPM packages other than the `@elastic/synthetics`,
+those packages will be bundled along with the journey code when the `push` command is invoked.
+However there are some limitations when using external packages:
+	
+* Bundled journeys after compression should not be more than 800 Kilobytes.
+* Native node modules will not work as expected.
+  There will be platform inconsistency.
 ====
 
 `--auth`::

--- a/docs/en/observability/synthetics-command-reference.asciidoc
+++ b/docs/en/observability/synthetics-command-reference.asciidoc
@@ -92,6 +92,13 @@ Select `yes` to delete all monitors associated with the project ID being pushed.
 it using a _different_ ID. Select `yes` to create duplicates of all monitors in the project.
 ====
 
+[NOTE]
+====
+If the journey code in a project uses an external Node.js package,
+that package will be bundled with the journey code on `push`.
+However, you can't `push` bundles that are more than 800 Kilobytes.
+====
+
 `--auth`::
 API key used for {kibana-ref}/api-keys.html[{kib} authentication].
 +

--- a/docs/en/observability/synthetics-command-reference.asciidoc
+++ b/docs/en/observability/synthetics-command-reference.asciidoc
@@ -99,8 +99,7 @@ those packages will be bundled along with the journey code when the `push` comma
 However there are some limitations when using external packages:
 	
 * Bundled journeys after compression should not be more than 800 Kilobytes.
-* Native node modules will not work as expected.
-  There will be platform inconsistency.
+* Native node modules will not work as expected due to platform inconsistency. 
 ====
 
 `--auth`::

--- a/docs/en/observability/synthetics-create-test.asciidoc
+++ b/docs/en/observability/synthetics-create-test.asciidoc
@@ -265,14 +265,15 @@ journey('bundle test', ({ page, params }) => {
 });
 ----
 
-When you <<synthetic-run-tests,create a monitor>> from a journey that uses an
-external NPM package, Elastic Synthetics will bundle the journey file and
-the external package so the test will work wherever it is configured to run.
+When you <<synthetic-run-tests,create a monitor>> from a journey that uses
+external NPM packages, those packages will be bundled along with the
+journey code when the `push` command is invoked.
 
-However, there are a couple limitations:
-
-* You can't `push` bundles that are more than 800 Kilobytes.
-* External packages that use native bindings will not work.
+However there are some limitations when using external packages:
+	
+* Bundled journeys after compression should not be more than 800 Kilobytes.
+* Native node modules will not work as expected.
+  There will be platform inconsistency.
 
 [discrete]
 [[synthetics-sample-test]]

--- a/docs/en/observability/synthetics-create-test.asciidoc
+++ b/docs/en/observability/synthetics-create-test.asciidoc
@@ -272,8 +272,7 @@ journey code when the `push` command is invoked.
 However there are some limitations when using external packages:
 	
 * Bundled journeys after compression should not be more than 800 Kilobytes.
-* Native node modules will not work as expected.
-  There will be platform inconsistency.
+* Native node modules will not work as expected due to platform inconsistency.
 
 [discrete]
 [[synthetics-sample-test]]

--- a/docs/en/observability/synthetics-create-test.asciidoc
+++ b/docs/en/observability/synthetics-create-test.asciidoc
@@ -247,6 +247,34 @@ afterAll(({ params }) => {
 ----
 
 [discrete]
+[[synthetics-import-packages]]
+== Import NPM packages
+
+You can import and use other NPM packages inside journey code.
+Refer to the example below using the external NPM package `is-positive`:
+
+[source,js]
+----
+import { journey, step, monitor, expect } from '@elastic/synthetics';
+import isPositive from 'is-positive';
+
+journey('bundle test', ({ page, params }) => {
+  step('check if positive', () => {
+    expect(isPositive(4)).toBe(true);
+  });
+});
+----
+
+When you <<synthetic-run-tests,create a monitor>> from a journey that uses an
+external NPM package, Elastic Synthetics will bundle the journey file and
+the external package so the test will work wherever it is configured to run.
+
+However, there are a couple limitations:
+
+* You can't `push` bundles that are more than 800 Kilobytes.
+* External packages that use native bindings will not work.
+
+[discrete]
 [[synthetics-sample-test]]
 == Sample synthetic test
 


### PR DESCRIPTION
Closes https://github.com/elastic/observability-docs/issues/2219

Documents how to import and use external NPM packages in journey code and the limitations when pushing a project that uses external packages.

cc @paulb-elastic 
