### PR TITLE
Add docker run command

### DIFF
--- a/docs/en/ingest-management/elastic-agent/elastic-agent-container.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/elastic-agent-container.asciidoc
@@ -42,7 +42,7 @@ To see the full list, run:
 
 [source,terminal]
 ----
-elastic-agent container -h
+docker run --rm docker.elastic.co/beats/elastic-agent:{version} elastic-agent container -h
 ----
 
 [discrete]


### PR DESCRIPTION
Since these instructions are specific to docker, it makes sense and it is clear to use a full docker run command.