### PR TITLE
Provider var substitution syntax

### DIFF
--- a/docs/en/ingest-management/elastic-agent/configuration/providers/elastic-agent-providers.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/providers/elastic-agent-providers.asciidoc
@@ -7,7 +7,7 @@ of the provider in the context of the {agent}.
 
 For example, a provider named `foo` provides
 `{"key1": "value1", "key2": "value2"}`, the key-value pairs are placed in
-`{"foo" : {"key1": "value1", "key2": "value2"}}`. To reference the keys, use `{{foo.key1}}` and `{{foo.key2}}`.
+`{"foo" : {"key1": "value1", "key2": "value2"}}`. To reference the keys, use `${foo.key1}` and `${foo.key2}`.
 
 [discrete]
 == Provider configuration


### PR DESCRIPTION
The provider var substitution syntax in the rest of the docs is `${ provider.var }` while the example on this particular page uses double curly brace syntax `{{ provider.var }}`. Proposing this change to avoid confusion.

Apologies if i'm missing some part of the process. Just clicked the "Edit" button on the docs page :)