### PR TITLE
Update package registry distributions according to Package Storage V2

### DIFF
--- a/docs/en/ingest-management/fleet/air-gapped.asciidoc
+++ b/docs/en/ingest-management/fleet/air-gapped.asciidoc
@@ -40,10 +40,10 @@ a selection of packages.
 There are different distributions available:
 
 * {version} (recommended): +docker.elastic.co/package-registry/distribution:{version}+ - Selection of packages from the production repository released with the {version} version of the {stack}.
-* lite {version}: +docker.elastic.co/package-registry/distribution:lite-{version}+ - Subset of the most commonly used packages from the production repository released with the {version} version of the {stack}.
+* lite-{version}: +docker.elastic.co/package-registry/distribution:lite-{version}+ - Subset of the most commonly used packages from the production repository released with the {version} version of the {stack}. This image includes the commonly used packages that are needed or when running Fleet in testing air-gapped environments.
 * production: `docker.elastic.co/package-registry/distribution:production` - Packages available in the production registry (https://epr.elastic.co).
-* lite: `docker.elastic.co/package-registry/distribution:lite` - Small subset of packages available in the production registry (https://epr.elastic.co).
-This image includes only the most commonly used packages, to be used when just common packages are needed or when trying Fleet in air-gapped environments.
+* lite: `docker.elastic.co/package-registry/distribution:lite` - Subset of the most commonly used packages available in the production registry (https://epr.elastic.co).
+This image includes the commonly used packages that are needed or when running Fleet in testing air-gapped environments.
 
 ifeval::["{release-state}"=="unreleased"]
 [WARNING]

--- a/docs/en/ingest-management/fleet/air-gapped.asciidoc
+++ b/docs/en/ingest-management/fleet/air-gapped.asciidoc
@@ -41,8 +41,7 @@ There are different distributions available:
 
 * {version} (recommended): +docker.elastic.co/package-registry/distribution:{version}+ - Selection of packages from the production repository released with the {version} version of the {stack}.
 * production: `docker.elastic.co/package-registry/distribution:production` - Packages available in the production registry (https://epr.elastic.co).
-* staging: `docker.elastic.co/package-registry/distribution:staging` - Packages available in the staging registry (https://epr-staging.elastic.co). These packages may be pending of validation.
-* snapshot: `docker.elastic.co/package-registry/distribution:snapshot` - Packages under development.
+* lite: `docker.elastic.co/package-registry/distribution:lite` - Small subset of packages available in the production registry (https://epr.elastic.co).
 
 ifeval::["{release-state}"=="unreleased"]
 [WARNING]

--- a/docs/en/ingest-management/fleet/air-gapped.asciidoc
+++ b/docs/en/ingest-management/fleet/air-gapped.asciidoc
@@ -40,10 +40,9 @@ a selection of packages.
 There are different distributions available:
 
 * {version} (recommended): +docker.elastic.co/package-registry/distribution:{version}+ - Selection of packages from the production repository released with the {version} version of the {stack}.
-* lite-{version}: +docker.elastic.co/package-registry/distribution:lite-{version}+ - Subset of the most commonly used packages from the production repository released with the {version} version of the {stack}. This image includes the commonly used packages that are needed or when running Fleet in testing air-gapped environments.
+* lite-{version}: +docker.elastic.co/package-registry/distribution:lite-{version}+ - Subset of the most commonly used packages from the production repository released with the {version} version of the {stack}. This image is a good candidate to start using Fleet on air-gapped environments.
 * production: `docker.elastic.co/package-registry/distribution:production` - Packages available in the production registry (https://epr.elastic.co).
 * lite: `docker.elastic.co/package-registry/distribution:lite` - Subset of the most commonly used packages available in the production registry (https://epr.elastic.co).
-This image includes the commonly used packages that are needed or when running Fleet in testing air-gapped environments.
 
 ifeval::["{release-state}"=="unreleased"]
 [WARNING]

--- a/docs/en/ingest-management/fleet/air-gapped.asciidoc
+++ b/docs/en/ingest-management/fleet/air-gapped.asciidoc
@@ -40,7 +40,7 @@ a selection of packages.
 There are different distributions available:
 
 * {version} (recommended): +docker.elastic.co/package-registry/distribution:{version}+ - Selection of packages from the production repository released with the {version} version of the {stack}.
-* lite-{version}: +docker.elastic.co/package-registry/distribution:lite-{version}+ - Subset of the most commonly used packages from the production repository released with the {version} version of the {stack}. This image is a good candidate to start using Fleet on air-gapped environments.
+* lite-{version}: +docker.elastic.co/package-registry/distribution:lite-{version}+ - Subset of the most commonly used packages from the production repository released with {stack} {version}. This image is a good candidate to start using {fleet} in air-gapped environments.
 * production: `docker.elastic.co/package-registry/distribution:production` - Packages available in the production registry (https://epr.elastic.co).
 * lite: `docker.elastic.co/package-registry/distribution:lite` - Subset of the most commonly used packages available in the production registry (https://epr.elastic.co).
 

--- a/docs/en/ingest-management/fleet/air-gapped.asciidoc
+++ b/docs/en/ingest-management/fleet/air-gapped.asciidoc
@@ -39,7 +39,7 @@ a selection of packages.
 
 There are different distributions available:
 
-* {version} (recommended): +docker.elastic.co/package-registry/distribution:{version}+ - Selection of packages from the production repository released with the {version} version of the {stack}.
+* {version} (recommended): +docker.elastic.co/package-registry/distribution:{version}+ - Selection of packages from the production repository released with {stack} {version}.
 * lite-{version}: +docker.elastic.co/package-registry/distribution:lite-{version}+ - Subset of the most commonly used packages from the production repository released with {stack} {version}. This image is a good candidate to start using {fleet} in air-gapped environments.
 * production: `docker.elastic.co/package-registry/distribution:production` - Packages available in the production registry (https://epr.elastic.co).
 * lite: `docker.elastic.co/package-registry/distribution:lite` - Subset of the most commonly used packages available in the production registry (https://epr.elastic.co).

--- a/docs/en/ingest-management/fleet/air-gapped.asciidoc
+++ b/docs/en/ingest-management/fleet/air-gapped.asciidoc
@@ -40,8 +40,10 @@ a selection of packages.
 There are different distributions available:
 
 * {version} (recommended): +docker.elastic.co/package-registry/distribution:{version}+ - Selection of packages from the production repository released with the {version} version of the {stack}.
+* lite {version}: +docker.elastic.co/package-registry/distribution:lite-{version}+ - Subset of the most commonly used packages from the production repository released with the {version} version of the {stack}.
 * production: `docker.elastic.co/package-registry/distribution:production` - Packages available in the production registry (https://epr.elastic.co).
 * lite: `docker.elastic.co/package-registry/distribution:lite` - Small subset of packages available in the production registry (https://epr.elastic.co).
+This image includes only the most commonly used packages, to be used when just common packages are needed or when trying Fleet in air-gapped environments.
 
 ifeval::["{release-state}"=="unreleased"]
 [WARNING]


### PR DESCRIPTION
Update references about the package registry distributions available once Package Storage V2 is used.

Snapshot and staging distributions (docker images) will no longer be updated. And, there will be a new distribution named "lite" with a small subset of commonly used packages.

