### PR TITLE
adjust for removed kibana security settings

### DIFF
--- a/docs/en/ingest-management/tab-widgets/prereq.asciidoc
+++ b/docs/en/ingest-management/tab-widgets/prereq.asciidoc
@@ -60,7 +60,6 @@ kibana.yml example:
 [source,yaml]
 ----
 elasticsearch.username: "kibana_system" <1>
-xpack.security.enabled: true
 xpack.encryptedSavedObjects.encryptionKey: "something_at_least_32_characters"
 ----
 <1> The password should be stored in the {kib} keystore as described in the


### PR DESCRIPTION
The setting `xpack.security.enabled` [has been removed since 8.0.0](https://github.com/elastic/kibana/pull/111681) so following these instructions will result in errors from the Kibana side. This file needs to be adjusted for versions of 8.0.0 and upwards