### PR TITLE
[8.5] Provider var substitution syntax (#2294)

### DIFF
--- a/docs/en/ingest-management/elastic-agent/configuration/providers/elastic-agent-providers.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/providers/elastic-agent-providers.asciidoc
@@ -7,7 +7,7 @@ of the provider in the context of the {agent}.
 
 For example, a provider named `foo` provides
 `{"key1": "value1", "key2": "value2"}`, the key-value pairs are placed in
-`{"foo" : {"key1": "value1", "key2": "value2"}}`. To reference the keys, use `{{foo.key1}}` and `{{foo.key2}}`.
+`{"foo" : {"key1": "value1", "key2": "value2"}}`. To reference the keys, use `${foo.key1}` and `${foo.key2}`.
 
 [discrete]
 == Provider configuration


### PR DESCRIPTION
# Backport

This will backport the following commits from `8.4` to `8.5`:
 - [Provider var substitution syntax (#2294)](https://github.com/elastic/observability-docs/pull/2294)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)