### PR TITLE
[synthetics] Remove remaining references to the Elastic Synthetics integration

### DIFF
--- a/docs/en/observability/ingest-logs-metrics-uptime.asciidoc
+++ b/docs/en/observability/ingest-logs-metrics-uptime.asciidoc
@@ -1,20 +1,18 @@
 [[ingest-logs-metrics-uptime]]
-= Ingest logs, metrics, and uptime data with {agent}
+= Ingest logs and metrics with {agent}
 
 ++++
-<titleabbrev>Ingest logs, metrics, and uptime data</titleabbrev>
+<titleabbrev>Ingest logs and metrics</titleabbrev>
 ++++
 
 ****
 **New to Elastic?** Follow the steps in our {estc-welcome}/getting-started-observability.html[getting started guide] instead
-of the steps described here. Skip the "tidying up" step if you plan to come back
-to <<add-synthetics-integration>>.
+of the steps described here.
 ****
 
 This guide describes how to:
 
 * Monitor logs and infrastructure metrics from systems and services across your organization
-* Monitor the availability of your HTTP, TCP, and ICMP services using the Synthetics integration
 * Monitor Nginx logs and metrics using the Nginx integration
 
 For feedback and questions, please contact us in the {forum}[discuss forum].
@@ -166,89 +164,6 @@ You can hover over any visualization to adjust its settings, or click the
 {kibana-ref}/dashboard.html[Dashboard and visualizations].
 
 [discrete]
-[[add-synthetics-integration]]
-== Step 5: Monitor services using real browsers and lightweight HTTP, TCP, and ICMP checks
-[discrete]
-
-beta[] Next, you’ll add the Elastic Synthetics integration, enabling you to monitor the
-status and response times of applications and services in real time. You can monitor
-the availability of network endpoints via HTTP, TCP, ICMP or Browser monitors.
-
-Add the Elastic Synthetics integration to your agent policy. You use policies to
-manage settings across a group of agents. An agent policy may contain any number
-of integrations for collecting observability data from the various services
-running on your host.
-
-. In {kib}, go to the **Integrations** page (click **Add integrations** in the
-home page or main menu).
-
-. In the query bar, search for **Elastic Synthetics** and select the integration
-to see more details about it.
-
-. Click **Add Elastic Synthetics**.
-
-. Configure the integration name and select your desired monitor type from the
-following monitor types:
-+
-|===
-
-| **HTTP** | Connects via HTTP and verifies that the host returns the expected response.
-
-For detailed information about HTTP options, refer to our
-{heartbeat-ref}/monitor-http-options.html[{heartbeat}] documentation.
-
-| **TCP** | Connects via TCP and verifies the endpoint by sending and receiving a custom payload.
-By default, the hostname and port are required.
-
-For detailed information about TCP options, refer to our
-{heartbeat-ref}/monitor-tcp-options.html[{heartbeat}] documentation.
-
-| **ICMP** | Uses an ICMP `v4` and `v6` Echo Request to ping the configured hosts. By default,
-the host name is required.
-
-For detailed information about ICMP options, refer to our
-{heartbeat-ref}/monitor-icmp-options.html[{heartbeat}] documentation.
-
-| **Browser** a| Runs automated tests using a real Chromium browser via the synthetics agent.
-
-For detailed information about browser options, refer to our
-{heartbeat-ref}/monitor-browser-options.html[{heartbeat}] documentation.
-
-NOTE: To create a **browser** monitor, you must use the elastic-agent-complete Docker container as this contains the dependencies necessary to run browser monitors. To learn more, refer to <<uptime-set-up>>.
-
-|===
-
-. Enter the URL you want to monitor for availability, and select a monitor interval in seconds or minutes. By default, a monitoring
-schedule of every 3 minutes is selected.
-+
-[role="screenshot"]
-image::images/add-synthetics-integration.png[{fleet} Add Synthetics integration page]
-
-. The **HTTP** and **TCP** monitor types both support TLS. Under **TLS settings**, select **Enable
-TLS configuration**. Click the down arrow next to advanced HTTP or TCP options, and then
-enter your required settings.
-
-. Under **Where to add this integration**, select *Existing hosts*, then select
-the agent policy you created earlier. That way, you can deploy the change to
-the agent that's already running.
-
-. When you're done, click **Save and continue**, then **Save and deploy changes**.
-
-. To see the updated policy, click the agent policy link, for example,
-*Agent policy 1*.
-+
-The newly added Elastic Synthetics integration should appear on the
-**Integrations** tab in the agent policy, along with the System integration.
-+
-[role="screenshot"]
-image::images/kibana-fleet-policies-default-with-synthetics.png[{fleet} showing default agent policy with synthetics-1 data source]
-+
-Any {agent}s assigned to this policy will collect logs, metrics, and uptime data from the host.
-
-. To view the data in the {observability-guide}/view-monitor-status.html[{uptime-app}], go to
-**{observability} > Uptime** in the main menu.
-
-[discrete]
 [[add-nginx-integration]]
 == Step 5: Monitor Nginx logs and metrics
 [discrete]
@@ -281,7 +196,7 @@ the agent that's already running.
 . To see the updated policy, click the agent policy link.
 +
 The newly added Nginx integration should appear on the **Integrations** tab in
-your agent policy, along with the System and Elastic Synthetics integrations.
+your agent policy.
 +
 [role="screenshot"]
 image::images/kibana-fleet-policies-default-with-nginx.png[{fleet} showing default agent policy with nginx-1 data source]
@@ -297,6 +212,9 @@ to the data stream.
 
 [discrete]
 == What's next?
+
+* Monitor the status and response times of applications and services in real time using the {uptime-app}.
+You can monitor the availability of network endpoints via HTTP, TCP, ICMP or Browser monitors. Get started in <<monitor-uptime-synthetics>>.
 
 * Now that data is streaming into the {stack}, take your investigation to a
 deeper level! Use https://www.elastic.co/observability[Elastic {observability}]

--- a/docs/en/observability/monitor-uptime-synthetics.asciidoc
+++ b/docs/en/observability/monitor-uptime-synthetics.asciidoc
@@ -8,8 +8,7 @@
 [[uptime-monitors]]
 
 The {uptime-app} uses {agent} to periodically check the status of your services and applications.
-By adding the Elastic Synthetics integration to an agent's policy, you can monitor the
-availability of network endpoints and services using the following Uptime monitors:
+Monitor the availability of network endpoints and services using the following Uptime monitors:
 
 * <<monitoring-uptime>>
 * <<monitoring-synthetics>>

--- a/docs/en/observability/synthetics-run-test.asciidoc
+++ b/docs/en/observability/synthetics-run-test.asciidoc
@@ -155,7 +155,7 @@ image::images/private-locations-monitor-locations.png[Screenshot of Monitor loca
 . Set the _Frequency_.
 +
 [role="screenshot"]
-image::images/uptime-app-add-monitor-browser.png[Synthetics integration]
+image::images/uptime-app-add-monitor-browser.png[Monitor management options when adding a new browser monitor.]
 
 . Add steps to the *Inline script* code block directly.
 The `journey` keyword isn't required, and variables like `page` and `params` will be part of your script's scope.


### PR DESCRIPTION
Related https://github.com/elastic/observability-docs/pull/2242

Preview: https://observability-docs_2331.docs-preview.app.elstc.co/guide/en/observability/master/ingest-logs-metrics-uptime.html

We no longer want to encourage new users to get started using the Elastic Synthetics integration to collect uptime/synthetics data. Instead, they can use Heartbeat (lightweight monitors only), the Uptime UI, or project monitors, and deciding which is best for them is a bit complex during this time of transition between _Uptime_ and _Synthetics_.

| Monitor type | Method | Notes |
|--------------|------------------|-----------------------|
| [Lightweight ](https://www.elastic.co/guide/en/observability/current/uptime-set-up.html)  | [Heartbeat](https://www.elastic.co/guide/en/observability/current/uptime-set-up-choose-heartbeat.html)             | GA, preferred method |
|                        | [Uptime app UI](https://www.elastic.co/guide/en/observability/current/uptime-set-up-choose-agent.html)      | Beta                              |
|                        | [Project monitors](https://www.elastic.co/guide/en/observability/current/uptime-set-up-choose-project-monitors.html)  | Beta                              |
|                        | ~~Elastic Synthetics integration~~    | Do not use!!                 |
| [Browser](https://www.elastic.co/guide/en/observability/current/synthetic-run-tests.html)         | [Project monitors](https://www.elastic.co/guide/en/observability/current/synthetic-run-tests.html#synthetic-monitor-choose-project)  | Beta, preferred method |
|                        | [Uptime app UI](https://www.elastic.co/guide/en/observability/current/synthetic-run-tests.html#synthetics-inline-journey)      | Beta, inline only           |
|                        | ~~Heartbeat~~    | Do not use!!                 |
|                        | ~~Elastic Synthetics integration~~    | Do not use!!                 |


This PR removes remaining references to the Elastic Synthetics integration, namely in [Ingest logs, metrics, and uptime data with Elastic Agent](https://www.elastic.co/guide/en/observability/current/ingest-logs-metrics-uptime.html). For now I removed all references to ingesting uptime data altogether on this page and added a link to the [Uptime and synthetic monitoring](https://www.elastic.co/guide/en/observability/current/monitor-uptime-synthetics.html) section in  "What's next" because:

* The available ways to set up monitors (project monitors, the Uptime UI, Heartbeat) don't seem to fit well with the other steps documented on this page.
* In this time of transition, the recommended way set up monitors varies between lightweight and browser monitors and has been changing with every release.

However, if @elastic/obs-docs thinks we _should_ continue to include instructions related to uptime/synthetics on this page, we _could_ instruct users to try out the process outlined in [Use the Uptime app](https://www.elastic.co/guide/en/observability/current/uptime-set-up-choose-agent.html) since it's the fastest way to set up a lightweight monitor (though still in beta).

cc @paulb-elastic @andrewvc 