### PR TITLE
[DOCS] Remove alerts from cases

### DIFF
--- a/docs/en/observability/grant-cases-access.asciidoc
+++ b/docs/en/observability/grant-cases-access.asciidoc
@@ -29,6 +29,8 @@ least once, which creates a user profile.
 
 | Give access to view and delete cases | `Read` for the *Cases* feature under *{observability}* with the deletion sub-feature enabled.
 
+NOTE: These privileges also enable you to delete comments and alerts from a case.
+
 | Revoke all access to cases | `None` for the *Cases* feature under *{observability}*.
 
 |=== 

--- a/docs/en/observability/grant-cases-access.asciidoc
+++ b/docs/en/observability/grant-cases-access.asciidoc
@@ -27,7 +27,8 @@ least once, which creates a user profile.
 
 | Give view-only access for cases | `Read` for the *Cases* feature under *{observability}*.
 
-| Give access to view and delete cases | `Read` for the *Cases* feature under *{observability}* with the deletion sub-feature enabled.
+| Give access to view and delete cases
+a| `Read` for the *Cases* feature under *{observability}* with the deletion sub-feature enabled.
 
 NOTE: These privileges also enable you to delete comments and alerts from a case.
 

--- a/docs/en/observability/manage-cases.asciidoc
+++ b/docs/en/observability/manage-cases.asciidoc
@@ -37,6 +37,7 @@ To view a case, click on its name. You can then:
 * Edit tags.
 * Change the status.
 * Change the severity.
+* Remove an alert.
 * Refresh the case to retrieve the latest updates.
 * Close the case.
 * Reopen a closed case.


### PR DESCRIPTION
Relates to https://github.com/elastic/kibana/issues/140800

This PR updates the Observability Guide to include mention of removing alerts from cases.