### PR TITLE
Add GKE docs section

### DIFF
--- a/docs/en/ingest-management/elastic-agent/install-elastic-agent-in-container.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/install-elastic-agent-in-container.asciidoc
@@ -14,7 +14,7 @@ To learn how to run {agent}s in a containerized environment, see:
 
 * <<running-on-kubernetes-standalone>>
 
-* <<running-on-gke-standard-managed-by-fleet>>
+** <<running-on-gke-standard-managed-by-fleet>>
 
 * {eck-ref}/k8s-elastic-agent.html[Run {agent} on ECK] -- for {eck} users
 

--- a/docs/en/ingest-management/elastic-agent/install-elastic-agent-in-container.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/install-elastic-agent-in-container.asciidoc
@@ -14,5 +14,7 @@ To learn how to run {agent}s in a containerized environment, see:
 
 * <<running-on-kubernetes-standalone>>
 
+* <<running-on-gke-managed-by-fleet>>
+
 * {eck-ref}/k8s-elastic-agent.html[Run {agent} on ECK] -- for {eck} users
 

--- a/docs/en/ingest-management/elastic-agent/install-elastic-agent-in-container.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/install-elastic-agent-in-container.asciidoc
@@ -14,7 +14,7 @@ To learn how to run {agent}s in a containerized environment, see:
 
 * <<running-on-kubernetes-standalone>>
 
-* <<running-on-gke-managed-by-fleet>>
+* <<running-on-gke-standard-managed-by-fleet>>
 
 * {eck-ref}/k8s-elastic-agent.html[Run {agent} on ECK] -- for {eck} users
 

--- a/docs/en/ingest-management/elastic-agent/install-elastic-agent.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/install-elastic-agent.asciidoc
@@ -39,6 +39,7 @@ Refer to:
 * <<running-on-kubernetes-managed-by-fleet>>
 * <<running-on-kubernetes-standalone>>
 * {eck-ref}/k8s-elastic-agent.html[Run {agent} on ECK] -- for {eck} users
+* <<running-on-kubernetes-gke-standard-managed-by-fleet>>
 --
 
 [discrete]

--- a/docs/en/ingest-management/elastic-agent/install-elastic-agent.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/install-elastic-agent.asciidoc
@@ -40,7 +40,7 @@ Refer to:
 * <<running-on-kubernetes-standalone>>
 * <<running-on-gke-standard-managed-by-fleet>>
 * {eck-ref}/k8s-elastic-agent.html[Run {agent} on ECK] -- for {eck} users
-* <<running-on-kubernetes-gke-standard-managed-by-fleet>>
+* <<running-on-gke-standard-managed-by-fleet>>
 --
 
 [discrete]

--- a/docs/en/ingest-management/elastic-agent/install-elastic-agent.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/install-elastic-agent.asciidoc
@@ -38,6 +38,7 @@ Refer to:
 * <<elastic-agent-container>>
 * <<running-on-kubernetes-managed-by-fleet>>
 * <<running-on-kubernetes-standalone>>
+* <<running-on-gke-managed-by-fleet>>
 * {eck-ref}/k8s-elastic-agent.html[Run {agent} on ECK] -- for {eck} users
 * <<running-on-kubernetes-gke-standard-managed-by-fleet>>
 --

--- a/docs/en/ingest-management/elastic-agent/install-elastic-agent.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/install-elastic-agent.asciidoc
@@ -38,7 +38,6 @@ Refer to:
 * <<elastic-agent-container>>
 * <<running-on-kubernetes-managed-by-fleet>>
 * <<running-on-kubernetes-standalone>>
-* <<running-on-gke-standard-managed-by-fleet>>
 * {eck-ref}/k8s-elastic-agent.html[Run {agent} on ECK] -- for {eck} users
 * <<running-on-gke-standard-managed-by-fleet>>
 --

--- a/docs/en/ingest-management/elastic-agent/install-elastic-agent.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/install-elastic-agent.asciidoc
@@ -38,7 +38,7 @@ Refer to:
 * <<elastic-agent-container>>
 * <<running-on-kubernetes-managed-by-fleet>>
 * <<running-on-kubernetes-standalone>>
-* <<running-on-gke-managed-by-fleet>>
+* <<running-on-gke-standard-managed-by-fleet>>
 * {eck-ref}/k8s-elastic-agent.html[Run {agent} on ECK] -- for {eck} users
 * <<running-on-kubernetes-gke-standard-managed-by-fleet>>
 --

--- a/docs/en/ingest-management/elastic-agent/running-on-gke-standard-managed-by-fleet.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/running-on-gke-standard-managed-by-fleet.asciidoc
@@ -30,7 +30,7 @@ at the time of writing these docs.
 [discrete]
 == Prerequisites
 
-Kube-state-metrics is not deployed by default in Kubernetes GKE!
+`kube-state-metrics` is not deployed by default in Kubernetes GKE!
 
 Data_streams with the `state_` prefix require `kube-state-metrics` to be present.
 

--- a/docs/en/ingest-management/elastic-agent/running-on-gke-standard-managed-by-fleet.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/running-on-gke-standard-managed-by-fleet.asciidoc
@@ -37,7 +37,7 @@ Data_streams with the `state_` prefix require `kube-state-metrics` to be present
 In order to install kube-state-metrics follow the instructions for its deployment are available
 https://github.com/kubernetes/kube-state-metrics#kubernetes-deployment[here].
 Generally `kube-state-metrics` runs a `Deployment` and is accessible via a service called `kube-state-metrics` on
-`kube-system` namespace, which will be the service to use in our configuration of agent
+`kube-system` namespace, which will be the service to use in agent configuration
 service within the cluster.
 
 [discrete]

--- a/docs/en/ingest-management/elastic-agent/running-on-gke-standard-managed-by-fleet.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/running-on-gke-standard-managed-by-fleet.asciidoc
@@ -51,7 +51,7 @@ the https://docs.elastic.co/en/integrations/kubernetes[Kubernetes integration].
 
 
 [discrete]
-== Enroll Elastic Agent to Fleet
+== 2. Enroll Elastic Agent to Fleet
 
 With {fleet}, each agent enrolls in a policy defined in {kib} and stored in
 {es}. The policy specifies how to collect observability data from the services

--- a/docs/en/ingest-management/elastic-agent/running-on-gke-standard-managed-by-fleet.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/running-on-gke-standard-managed-by-fleet.asciidoc
@@ -102,7 +102,7 @@ Refer to <<agent-environment-variables>> for all available options.
 ====
 
 [discrete]
-== Deploy kubernetes manifests
+== 3. Deploy kubernetes manifests
 
 On Kubernetes, we suggest deploying {agent} as a https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/[DaemonSet]
 to ensure that there is a running instance on each node of the cluster.

--- a/docs/en/ingest-management/elastic-agent/running-on-gke-standard-managed-by-fleet.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/running-on-gke-standard-managed-by-fleet.asciidoc
@@ -37,8 +37,7 @@ Data_streams with the `state_` prefix require `kube-state-metrics` to be present
 In order to install `kube-state-metrics` follow the instructions for its deployment, that are available
 https://github.com/kubernetes/kube-state-metrics#kubernetes-deployment[here].
 Generally `kube-state-metrics` runs a `Deployment` and is accessible via a service called `kube-state-metrics` on
-`kube-system` namespace, which will be the service to use in agent configuration
-service within the cluster.
+`kube-system` namespace, which will be the service to use in agent configuration.
 
 [discrete]
 == 1. Configure a Fleet policy

--- a/docs/en/ingest-management/elastic-agent/running-on-gke-standard-managed-by-fleet.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/running-on-gke-standard-managed-by-fleet.asciidoc
@@ -1,4 +1,4 @@
-[[running-on-kubernetes-gke-standard-managed-by-fleet]]
+[[running-on-gke-standard-managed-by-fleet]]
 = Run {agent} on GKE standard managed by {fleet}
 
 Use {agent} https://www.docker.elastic.co/r/beats/elastic-agent[Docker images] on Kubernetes to

--- a/docs/en/ingest-management/elastic-agent/running-on-gke-standard-managed-by-fleet.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/running-on-gke-standard-managed-by-fleet.asciidoc
@@ -41,7 +41,7 @@ Generally `kube-state-metrics` runs a `Deployment` and is accessible via a servi
 service within the cluster.
 
 [discrete]
-== Configure a Fleet policy
+== 1. Configure a Fleet policy
 
 In order for the Agents to enable the proper inputs, they need to be enrolled to the proper policy.
 For achieving Kubernetes observability, one need to create a policy and enable the Kubernetes integration.

--- a/docs/en/ingest-management/elastic-agent/running-on-gke-standard-managed-by-fleet.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/running-on-gke-standard-managed-by-fleet.asciidoc
@@ -34,7 +34,7 @@ at the time of writing these docs.
 
 Data_streams with the `state_` prefix require `kube-state-metrics` to be present.
 
-In order to install kube-state-metrics follow the instructions for its deployment are available
+In order to install `kube-state-metrics` follow the instructions for its deployment, that are available
 https://github.com/kubernetes/kube-state-metrics#kubernetes-deployment[here].
 Generally `kube-state-metrics` runs a `Deployment` and is accessible via a service called `kube-state-metrics` on
 `kube-system` namespace, which will be the service to use in agent configuration

--- a/docs/en/ingest-management/elastic-agent/running-on-gke-standard-managed-by-fleet.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/running-on-gke-standard-managed-by-fleet.asciidoc
@@ -16,7 +16,7 @@ endif::[]
 [discrete]
 == Important Notes:
 
-On managed Kubernetes solutions like GKE, {agent} has no access several data sources. Find below the list of
+On managed Kubernetes solutions like GKE, {agent} has no access to several data sources. Find below the list of
 the non available data:
 
 1. Metrics from https://kubernetes.io/docs/concepts/overview/components/#control-plane-components[Kubernetes control plane]

--- a/docs/en/ingest-management/elastic-agent/running-on-gke-standard-managed-by-fleet.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/running-on-gke-standard-managed-by-fleet.asciidoc
@@ -24,7 +24,7 @@ components are not available. Consequently metrics are not available for `kube-s
 In this regard, the respective **dashboards** will not be populated with data.
 2. **Audit logs** are available only on Kubernetes master nodes as well, hence cannot be collected by {agent}.
 
-Also note that the documentation page only applies to Standard GKE and not Autopilot. Autopilot support is a work in progress
+Also note that the documentation page only applies to Standard GKE and not Autopilot. **Autopilot support** is a work in progress
 at the time of writing these docs.
 
 [discrete]

--- a/docs/en/ingest-management/elastic-agent/running-on-gke-standard-managed-by-fleet.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/running-on-gke-standard-managed-by-fleet.asciidoc
@@ -20,7 +20,8 @@ On managed Kubernetes solutions like GKE, {agent} has no access to several data 
 the non available data:
 
 1. Metrics from https://kubernetes.io/docs/concepts/overview/components/#control-plane-components[Kubernetes control plane]
-components are not available. Consequently metrics are not available for `kube-scheduler` and `kube-controller-manager`.
+components are not available. Consequently metrics are not available for `kube-scheduler` and `kube-controller-manager`
+components.
 In this regard, the respective **dashboards** will not be populated with data.
 2. **Audit logs** are available only on Kubernetes master nodes as well, hence cannot be collected by {agent}.
 

--- a/docs/en/ingest-management/elastic-agent/running-on-kubernetes-gke-standard-managed-by-fleet.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/running-on-kubernetes-gke-standard-managed-by-fleet.asciidoc
@@ -14,23 +14,31 @@ released, so no Docker image is currently available for this version.
 endif::[]
 
 [discrete]
+== Important Notes:
+
+On managed Kubernetes solutions like GKE, {agent} has no access several data sources. Find below the list of
+the non available data:
+
+1. Metrics from https://kubernetes.io/docs/concepts/overview/components/#control-plane-components[Kubernetes control plane]
+components are not available. Consequently metrics are not available for `kube-scheduler` and `kube-controller-manager`.
+In this regard, the respective dashboards will not be populated with data.
+2. Audit logs are available only on Kubernetes master nodes as well, hence cannot be collected by {agent}.
+
+Also note that the documentation page only applies to Standard GKE and not Autopilot. Autopilot support is a work in progress
+at the time of writing these docs.
+
+[discrete]
 == Prerequisites
 
 Kube-state-metrics is not deployed by default in Kubernetes GKE!
 
-Data_streams with the `state_` prefix require ` `kube-state-metrics` library to be present
+Data_streams with the `state_` prefix require `kube-state-metrics` to be present.
 
-. In order to install kube-state-metrics follow
-the instructions for its deployment are available https://github.com/kubernetes/kube-state-metrics#kubernetes-deployment[here].
+In order to install kube-state-metrics follow the instructions for its deployment are available
+https://github.com/kubernetes/kube-state-metrics#kubernetes-deployment[here].
 Generally `kube-state-metrics` runs a `Deployment` and is accessible via a service called `kube-state-metrics` on
 `kube-system` namespace, which will be the service to use in our configuration of agent
 service within the cluster.
-
-`Kube-state-metrics` is not deployed by default in Kubernetes GKE. In order to install `kube-state-metrics` follow
-the instructions for its deployment https://github.com/kubernetes/kube-state-metrics#kubernetes-deployment[here].
-Generally `kube-state-metrics` runs a `Deployment` and is accessible via a service called `kube-state-metrics` on
-`kube-system` namespace, which will be the service to use in our configuration.
-
 
 [discrete]
 == Kubernetes deploy manifests
@@ -41,9 +49,9 @@ to be monitored. The {agent} connects to a trusted {fleet-server} instance
 to retrieve the policy and report agent events.
 
 We recommend using {fleet} management because it makes the management and
-upgrade of agents considerably easier.
+upgrade of agents' integrations considerably easier.
 
-On Kubernetes, deploy {agent} as a https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/[DaemonSet]
+On Kubernetes, we suggest deploying {agent} as a https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/[DaemonSet]
 to ensure that there is a running instance on each node of the cluster.
 These instances are used to retrieve metrics from the host, such as system metrics, container stats,
 and metrics from all the services running on top of Kubernetes.
@@ -67,7 +75,17 @@ curl -L -O https://raw.githubusercontent.com/elastic/elastic-agent/{branch}/depl
 ------------------------------------------------
 
 [discrete]
-== Settings
+== Configure a Fleet policy
+
+In order for the Agents to enable the proper inputs, they need to be enrolled to the proper policy.
+For achieving Kubernetes observability, one need to create a policy and enable the Kubernetes integration.
+
+Refer to <<create-a-policy>> to learn how to enable
+the https://docs.elastic.co/en/integrations/kubernetes[Kubernetes integration].
+
+
+[discrete]
+== Enroll Elastic Agent to Fleet
 
 {agent} is enrolled to a running {fleet-server} using `FLEET_URL` parameter.
 The `FLEET_ENROLLMENT_TOKEN` parameter is used to connect {agent} to a
@@ -83,17 +101,7 @@ change the following parameters in the manifest file:
   value: "https://fleet-server_url:port"
 - name: FLEET_ENROLLMENT_TOKEN
   value: "token"
-- name: FLEET_SERVER_POLICY_ID
-  value: "fleet-server-policy" <1>
-- name: KIBANA_HOST
-  value: ""
-- name: KIBANA_FLEET_USERNAME
-  value: ""
-- name: KIBANA_FLEET_PASSWORD
-  value: ""
 ------------------------------------------------
-<1> To learn how to create a policy, refer <<create-a-policy-no-ui>>.
-
 
 // Begin collapsed section
 [%collapsible]
@@ -109,13 +117,6 @@ include::configuration/env/shared-env.asciidoc[tag=fleet-url]
 
 include::configuration/env/shared-env.asciidoc[tag=fleet-enrollment-token]
 
-include::configuration/env/shared-env.asciidoc[tag=fleet-server-policy-id]
-
-include::configuration/env/shared-env.asciidoc[tag=kibana-host]
-
-include::configuration/env/shared-env.asciidoc[tag=kibana-fleet-username]
-
-include::configuration/env/shared-env.asciidoc[tag=kibana-fleet-password]
 |===
 
 Refer to <<agent-environment-variables>> for all available options.
@@ -126,12 +127,6 @@ Refer to <<agent-environment-variables>> for all available options.
 
 [discrete]
 == Deploy
-
-If planning to deploy `state_*` datasets of Kubernetes package,
-https://github.com/kubernetes/kube-state-metrics#usage[kube-state-metrics] needs to be already deployed
-in the cluster. If `kube-state-metrics` is not already running, deploy it now (see the
-https://github.com/kubernetes/kube-state-metrics#kubernetes-deployment[Kubernetes
-deployment] docs).
 
 To deploy {agent} on Kubernetes, run:
 
@@ -155,7 +150,7 @@ NOTE: You might need to adjust https://kubernetes.io/docs/concepts/configuration
 in the `elastic-agent-managed-kubernetes.yaml` manifest. Container resource usage depends on the number of data streams
 and the environment size.
 
-{agent}s should be enrolled to {fleet} and users should be able to deploy the Kubernetes package accordingly.
+{agent}s should be enrolled to {fleet} and users should be able to see Kubernetes data flowing to Elastic accordingly.
 This can be confirmed in {kib} under {fleet}  / Agents section.
 
 
@@ -169,9 +164,7 @@ leader election strategy and instead run a dedicated, standalone {agent} instanc
 a Deployment in addition to the DaemonSet.
 
 [discrete]
-== Important Notes:
+== Verify installation
 
-On managed Kubernetes solutions like GKE, {agent} has no access to collect metrics from the https://kubernetes.io/docs/concepts/overview/components/#control-plane-components[Kubernetes control plane]
-components, like `kube-scheduler` and `kube-controller-manager`, that are scheduled on Kubernetes master nodes.
-
-Audit logs are available only on Kubernetes master nodes as well, hence cannot be collected by {agent}.
+After Agents are successfully enrolled one can navigate to the `[Metrics Kubernetes] Cluster Overview`
+dashboard and start exploring the incoming data as well build their own visualisations and dashboards.

--- a/docs/en/ingest-management/elastic-agent/running-on-kubernetes-gke-standard-managed-by-fleet.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/running-on-kubernetes-gke-standard-managed-by-fleet.asciidoc
@@ -169,7 +169,7 @@ leader election strategy and instead run a dedicated, standalone {agent} instanc
 a Deployment in addition to the DaemonSet.
 
 [discrete]
-== Not available data
+== Important Notes:
 
 On managed Kubernetes solutions like GKE, {agent} has no access to collect metrics from the https://kubernetes.io/docs/concepts/overview/components/#control-plane-components[Kubernetes control plane]
 components, like `kube-scheduler` and `kube-controller-manager`, that are scheduled on Kubernetes master nodes.

--- a/docs/en/ingest-management/elastic-agent/running-on-kubernetes-gke-standard-managed-by-fleet.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/running-on-kubernetes-gke-standard-managed-by-fleet.asciidoc
@@ -22,7 +22,7 @@ the non available data:
 1. Metrics from https://kubernetes.io/docs/concepts/overview/components/#control-plane-components[Kubernetes control plane]
 components are not available. Consequently metrics are not available for `kube-scheduler` and `kube-controller-manager`.
 In this regard, the respective dashboards will not be populated with data.
-2. Audit logs are available only on Kubernetes master nodes as well, hence cannot be collected by {agent}.
+2. **Audit logs** are available only on Kubernetes master nodes as well, hence cannot be collected by {agent}.
 
 Also note that the documentation page only applies to Standard GKE and not Autopilot. Autopilot support is a work in progress
 at the time of writing these docs.

--- a/docs/en/ingest-management/elastic-agent/running-on-kubernetes-gke-standard-managed-by-fleet.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/running-on-kubernetes-gke-standard-managed-by-fleet.asciidoc
@@ -166,5 +166,5 @@ a Deployment in addition to the DaemonSet.
 [discrete]
 == Verify installation
 
-After Agents are successfully enrolled one can navigate to the `[Metrics Kubernetes] Cluster Overview`
+After Agents are successfully enrolled one can navigate to Kibana under **Analytics** > **Dashboards** > `[Metrics Kubernetes] Cluster Overview`
 dashboard and start exploring the incoming data as well build their own visualisations and dashboards.

--- a/docs/en/ingest-management/elastic-agent/running-on-kubernetes-gke-standard-managed-by-fleet.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/running-on-kubernetes-gke-standard-managed-by-fleet.asciidoc
@@ -64,7 +64,7 @@ cluster, such as Kubernetes events or
 https://github.com/kubernetes/kube-state-metrics[kube-state-metrics].
 
 
-Everything is deployed under the `kube-system` namespace by default. To change
+Default namespace of deployment is `kube-system` . To change
 the namespace, modify the manifest file.
 
 To download the manifest file, run:

--- a/docs/en/ingest-management/elastic-agent/running-on-kubernetes-gke-standard-managed-by-fleet.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/running-on-kubernetes-gke-standard-managed-by-fleet.asciidoc
@@ -14,7 +14,7 @@ released, so no Docker image is currently available for this version.
 endif::[]
 
 [discrete]
-== Prereqiusites
+== Prerequisites
 
 All data_streams with the `state_` prefix require `hosts` field pointing to `kube-state-metrics`
 service within the cluster.

--- a/docs/en/ingest-management/elastic-agent/running-on-kubernetes-gke-standard-managed-by-fleet.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/running-on-kubernetes-gke-standard-managed-by-fleet.asciidoc
@@ -174,4 +174,4 @@ a Deployment in addition to the DaemonSet.
 On managed Kubernetes solutions like GKE, {agent} has no access to collect metrics from the https://kubernetes.io/docs/concepts/overview/components/#control-plane-components[Kubernetes control plane]
 components, like `kube-scheduler` and `kube-controller-manager`, that are scheduled on Kubernetes master nodes.
 
-Audit logs are available only on Kubernetes master nodes as well and hence cannot be collected by {agent}.
+Audit logs are available only on Kubernetes master nodes as well, hence cannot be collected by {agent}.

--- a/docs/en/ingest-management/elastic-agent/running-on-kubernetes-gke-standard-managed-by-fleet.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/running-on-kubernetes-gke-standard-managed-by-fleet.asciidoc
@@ -66,6 +66,9 @@ The `FLEET_ENROLLMENT_TOKEN` parameter is used to connect {agent} to a
 specific {agent} policy.
 To learn how to get an enrollment token from {fleet}, see <<fleet-enrollment-tokens>>.
 
+// forces a unique ID so that settings can be included multiple times on the same page
+:type: k8s-gke
+
 To specify different destination/credentials,
 change the following parameters in the manifest file:
 

--- a/docs/en/ingest-management/elastic-agent/running-on-kubernetes-gke-standard-managed-by-fleet.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/running-on-kubernetes-gke-standard-managed-by-fleet.asciidoc
@@ -16,7 +16,14 @@ endif::[]
 [discrete]
 == Prerequisites
 
-All data_streams with the `state_` prefix require `hosts` field pointing to `kube-state-metrics`
+Kube-state-metrics is not deployed by default in Kubernetes GKE!
+
+Data_streams with the `state_` prefix require ` `kube-state-metrics` library to be present
+
+. In order to install kube-state-metrics follow
+the instructions for its deployment are available https://github.com/kubernetes/kube-state-metrics#kubernetes-deployment[here].
+Generally `kube-state-metrics` runs a `Deployment` and is accessible via a service called `kube-state-metrics` on
+`kube-system` namespace, which will be the service to use in our configuration of agent
 service within the cluster.
 
 `Kube-state-metrics` is not deployed by default in Kubernetes GKE. In order to install `kube-state-metrics` follow

--- a/docs/en/ingest-management/elastic-agent/running-on-kubernetes-gke-standard-managed-by-fleet.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/running-on-kubernetes-gke-standard-managed-by-fleet.asciidoc
@@ -20,7 +20,7 @@ All data_streams with the `state_` prefix require `hosts` field pointing to `kub
 service within the cluster.
 
 `Kube-state-metrics` is not deployed by default in Kubernetes GKE. In order to install `kube-state-metrics` follow
-the instructions for its deployment are available https://github.com/kubernetes/kube-state-metrics#kubernetes-deployment[here].
+the instructions for its deployment https://github.com/kubernetes/kube-state-metrics#kubernetes-deployment[here].
 Generally `kube-state-metrics` runs a `Deployment` and is accessible via a service called `kube-state-metrics` on
 `kube-system` namespace, which will be the service to use in our configuration.
 

--- a/docs/en/ingest-management/elastic-agent/running-on-kubernetes-gke-standard-managed-by-fleet.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/running-on-kubernetes-gke-standard-managed-by-fleet.asciidoc
@@ -21,7 +21,7 @@ the non available data:
 
 1. Metrics from https://kubernetes.io/docs/concepts/overview/components/#control-plane-components[Kubernetes control plane]
 components are not available. Consequently metrics are not available for `kube-scheduler` and `kube-controller-manager`.
-In this regard, the respective dashboards will not be populated with data.
+In this regard, the respective **dashboards** will not be populated with data.
 2. **Audit logs** are available only on Kubernetes master nodes as well, hence cannot be collected by {agent}.
 
 Also note that the documentation page only applies to Standard GKE and not Autopilot. Autopilot support is a work in progress

--- a/docs/en/ingest-management/elastic-agent/running-on-kubernetes-gke-standard-managed-by-fleet.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/running-on-kubernetes-gke-standard-managed-by-fleet.asciidoc
@@ -1,0 +1,170 @@
+[[running-on-kubernetes-gke-standard-managed-by-fleet]]
+= Run {agent} on GKE standard managed by {fleet}
+
+Use {agent} https://www.docker.elastic.co/r/beats/elastic-agent[Docker images] on Kubernetes to
+retrieve cluster metrics.
+
+TIP: Running {ecloud} on Kubernetes? Refer to {eck-ref}/k8s-elastic-agent-fleet.html[Run {elastic-agent} on ECK].
+
+ifeval::["{release-state}"=="unreleased"]
+
+However, version {version} of {agent} has not yet been
+released, so no Docker image is currently available for this version.
+
+endif::[]
+
+[discrete]
+== Prereqiusites
+
+All data_streams with the `state_` prefix require `hosts` field pointing to `kube-state-metrics`
+service within the cluster.
+
+Kube-state-metrics is not deployed by default in Kubernetes GKE. In order to install kube-state-metrics follow
+the instructions for its deployment are available https://github.com/kubernetes/kube-state-metrics#kubernetes-deployment[here].
+Generally `kube-state-metrics` runs a `Deployment` and is accessible via a service called `kube-state-metrics` on
+`kube-system` namespace, which will be the service to use in our configuration.
+
+
+[discrete]
+== Kubernetes deploy manifests
+
+With {fleet}, each agent enrolls in a policy defined in {kib} and stored in
+{es}. The policy specifies how to collect observability data from the services
+to be monitored. The {agent} connects to a trusted {fleet-server} instance
+to retrieve the policy and report agent events.
+
+We recommend using {fleet} management because it makes the management and
+upgrade of agents considerably easier.
+
+On Kubernetes, deploy {agent} as a https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/[DaemonSet]
+to ensure that there is a running instance on each node of the cluster.
+These instances are used to retrieve metrics from the host, such as system metrics, container stats,
+and metrics from all the services running on top of Kubernetes.
+
+In addition, one of the Pods in the DaemonSet will constantly hold a _leader lock_ which makes it responsible for
+handling cluster-wide monitoring.
+Find more information about leader election configuration options at <<kubernetes_leaderelection-provider, leader election provider>>.
+This instance is used to retrieve metrics that are unique for the whole
+cluster, such as Kubernetes events or
+https://github.com/kubernetes/kube-state-metrics[kube-state-metrics].
+
+
+Everything is deployed under the `kube-system` namespace by default. To change
+the namespace, modify the manifest file.
+
+To download the manifest file, run:
+
+["source", "sh", subs="attributes"]
+------------------------------------------------
+curl -L -O https://raw.githubusercontent.com/elastic/elastic-agent/{branch}/deploy/kubernetes/elastic-agent-managed-kubernetes.yaml
+------------------------------------------------
+
+[discrete]
+== Settings
+
+{agent} is enrolled to a running {fleet-server} using `FLEET_URL` parameter.
+The `FLEET_ENROLLMENT_TOKEN` parameter is used to connect {agent} to a
+specific {agent} policy.
+To learn how to get an enrollment token from {fleet}, see <<fleet-enrollment-tokens>>.
+
+To specify different destination/credentials,
+change the following parameters in the manifest file:
+
+[source,yaml]
+------------------------------------------------
+- name: FLEET_URL
+  value: "https://fleet-server_url:port"
+- name: FLEET_ENROLLMENT_TOKEN
+  value: "token"
+- name: FLEET_SERVER_POLICY_ID
+  value: "fleet-server-policy" <1>
+- name: KIBANA_HOST
+  value: ""
+- name: KIBANA_FLEET_USERNAME
+  value: ""
+- name: KIBANA_FLEET_PASSWORD
+  value: ""
+------------------------------------------------
+<1> To learn how to create a policy, refer <<create-a-policy-no-ui>>.
+
+
+// Begin collapsed section
+[%collapsible]
+.Configuration details
+====
+****
+
+[cols="2*<a"]
+|===
+| Settings | Description
+
+include::configuration/env/shared-env.asciidoc[tag=fleet-url]
+
+include::configuration/env/shared-env.asciidoc[tag=fleet-enrollment-token]
+
+include::configuration/env/shared-env.asciidoc[tag=fleet-server-policy-id]
+
+include::configuration/env/shared-env.asciidoc[tag=kibana-host]
+
+include::configuration/env/shared-env.asciidoc[tag=kibana-fleet-username]
+
+include::configuration/env/shared-env.asciidoc[tag=kibana-fleet-password]
+|===
+
+Refer to <<agent-environment-variables>> for all available options.
+
+****
+====
+
+
+[discrete]
+== Deploy
+
+If planning to deploy `state_*` datasets of Kubernetes package,
+https://github.com/kubernetes/kube-state-metrics#usage[kube-state-metrics] needs to be already deployed
+in the cluster. If `kube-state-metrics` is not already running, deploy it now (see the
+https://github.com/kubernetes/kube-state-metrics#kubernetes-deployment[Kubernetes
+deployment] docs).
+
+To deploy {agent} on Kubernetes, run:
+
+["source", "sh", subs="attributes"]
+------------------------------------------------
+kubectl create -f elastic-agent-managed-kubernetes.yaml
+------------------------------------------------
+
+To check the status, run:
+
+["source", "sh", subs="attributes"]
+------------------------------------------------
+$ kubectl get pod -n kube-system -l app=elastic-agent
+
+NAME                  READY   STATUS    RESTARTS   AGE
+elastic-agent-hrjbg   1/1     Running   0          12m
+elastic-agent-olpsd   1/1     Running   0          12m
+------------------------------------------------
+
+NOTE: You might need to adjust https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/[resource limits] of the elastic-agent container
+in the `elastic-agent-managed-kubernetes.yaml` manifest. Container resource usage depends on the number of data streams
+and the environment size.
+
+{agent}s should be enrolled to {fleet} and users should be able to deploy the Kubernetes package accordingly.
+This can be confirmed in {kib} under {fleet}  / Agents section.
+
+
+[discrete]
+== Deploying {agent} to collect cluster-level metrics in large clusters
+
+The size and the number of nodes in a Kubernetes cluster can be fairly large at times,
+and in such cases the Pod that will be collecting cluster level metrics might face performance
+issues due to resources limitations. In this case users might consider to avoid using the
+leader election strategy and instead run a dedicated, standalone {agent} instance using
+a Deployment in addition to the DaemonSet.
+
+[discrete]
+== Not available data
+
+On managed Kubernetes solutions like GKE, {agent} has no access to collect metrics from the https://kubernetes.io/docs/concepts/overview/components/#control-plane-components[Kubernetes control plane]
+components, like `kube-scheduler` and `kube-controller-manager`, that are scheduled on Kubernetes master nodes.
+
+Audit logs are available only on Kubernetes master nodes as well and hence cannot be collected by {agent}.

--- a/docs/en/ingest-management/elastic-agent/running-on-kubernetes-gke-standard-managed-by-fleet.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/running-on-kubernetes-gke-standard-managed-by-fleet.asciidoc
@@ -19,7 +19,7 @@ endif::[]
 All data_streams with the `state_` prefix require `hosts` field pointing to `kube-state-metrics`
 service within the cluster.
 
-Kube-state-metrics is not deployed by default in Kubernetes GKE. In order to install kube-state-metrics follow
+`Kube-state-metrics` is not deployed by default in Kubernetes GKE. In order to install `kube-state-metrics` follow
 the instructions for its deployment are available https://github.com/kubernetes/kube-state-metrics#kubernetes-deployment[here].
 Generally `kube-state-metrics` runs a `Deployment` and is accessible via a service called `kube-state-metrics` on
 `kube-system` namespace, which will be the service to use in our configuration.

--- a/docs/en/ingest-management/elastic-agent/running-on-kubernetes-gke-standard-managed-by-fleet.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/running-on-kubernetes-gke-standard-managed-by-fleet.asciidoc
@@ -41,40 +41,6 @@ Generally `kube-state-metrics` runs a `Deployment` and is accessible via a servi
 service within the cluster.
 
 [discrete]
-== Kubernetes deploy manifests
-
-With {fleet}, each agent enrolls in a policy defined in {kib} and stored in
-{es}. The policy specifies how to collect observability data from the services
-to be monitored. The {agent} connects to a trusted {fleet-server} instance
-to retrieve the policy and report agent events.
-
-We recommend using {fleet} management because it makes the management and
-upgrade of agents' integrations considerably easier.
-
-On Kubernetes, we suggest deploying {agent} as a https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/[DaemonSet]
-to ensure that there is a running instance on each node of the cluster.
-These instances are used to retrieve metrics from the host, such as system metrics, container stats,
-and metrics from all the services running on top of Kubernetes.
-
-In addition, one of the Pods in the DaemonSet will constantly hold a _leader lock_ which makes it responsible for
-handling cluster-wide monitoring.
-Find more information about leader election configuration options at <<kubernetes_leaderelection-provider, leader election provider>>.
-This instance is used to retrieve metrics that are unique for the whole
-cluster, such as Kubernetes events or
-https://github.com/kubernetes/kube-state-metrics[kube-state-metrics].
-
-
-Default namespace of deployment is `kube-system` . To change
-the namespace, modify the manifest file.
-
-To download the manifest file, run:
-
-["source", "sh", subs="attributes"]
-------------------------------------------------
-curl -L -O https://raw.githubusercontent.com/elastic/elastic-agent/{branch}/deploy/kubernetes/elastic-agent-managed-kubernetes.yaml
-------------------------------------------------
-
-[discrete]
 == Configure a Fleet policy
 
 In order for the Agents to enable the proper inputs, they need to be enrolled to the proper policy.
@@ -86,6 +52,14 @@ the https://docs.elastic.co/en/integrations/kubernetes[Kubernetes integration].
 
 [discrete]
 == Enroll Elastic Agent to Fleet
+
+With {fleet}, each agent enrolls in a policy defined in {kib} and stored in
+{es}. The policy specifies how to collect observability data from the services
+to be monitored. The {agent} connects to a trusted {fleet-server} instance
+to retrieve the policy and report agent events.
+
+We recommend using {fleet} management because it makes the management and
+upgrade of agents' integrations considerably easier.
 
 {agent} is enrolled to a running {fleet-server} using `FLEET_URL` parameter.
 The `FLEET_ENROLLMENT_TOKEN` parameter is used to connect {agent} to a
@@ -124,9 +98,31 @@ Refer to <<agent-environment-variables>> for all available options.
 ****
 ====
 
-
 [discrete]
-== Deploy
+== Deploy kubernetes manifests
+
+On Kubernetes, we suggest deploying {agent} as a https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/[DaemonSet]
+to ensure that there is a running instance on each node of the cluster.
+These instances are used to retrieve metrics from the host, such as system metrics, container stats,
+and metrics from all the services running on top of Kubernetes.
+
+In addition, one of the Pods in the DaemonSet will constantly hold a _leader lock_ which makes it responsible for
+handling cluster-wide monitoring.
+Find more information about leader election configuration options at <<kubernetes_leaderelection-provider, leader election provider>>.
+This instance is used to retrieve metrics that are unique for the whole
+cluster, such as Kubernetes events or
+https://github.com/kubernetes/kube-state-metrics[kube-state-metrics].
+
+
+Default namespace of deployment is `kube-system` . To change
+the namespace, modify the manifest file.
+
+To download the manifest file, run:
+
+["source", "sh", subs="attributes"]
+------------------------------------------------
+curl -L -O https://raw.githubusercontent.com/elastic/elastic-agent/{branch}/deploy/kubernetes/elastic-agent-managed-kubernetes.yaml
+------------------------------------------------
 
 To deploy {agent} on Kubernetes, run:
 

--- a/docs/en/ingest-management/index.asciidoc
+++ b/docs/en/ingest-management/index.asciidoc
@@ -65,7 +65,7 @@ include::elastic-agent/elastic-agent-container.asciidoc[leveloffset=+3]
 
 include::elastic-agent/running-on-kubernetes-managed-by-fleet.asciidoc[leveloffset=+3]
 
-include::elastic-agent/running-on-kubernetes-gke-standard-managed-by-fleet.asciidoc[leveloffset=+3]
+include::elastic-agent/running-on-gke-standard-managed-by-fleet.asciidoc[leveloffset=+3]
 
 include::elastic-agent/running-on-kubernetes-standalone.asciidoc[leveloffset=+3]
 

--- a/docs/en/ingest-management/index.asciidoc
+++ b/docs/en/ingest-management/index.asciidoc
@@ -65,6 +65,8 @@ include::elastic-agent/elastic-agent-container.asciidoc[leveloffset=+3]
 
 include::elastic-agent/running-on-kubernetes-managed-by-fleet.asciidoc[leveloffset=+3]
 
+include::elastic-agent/running-on-kubernetes-gke-standard-managed-by-fleet.asciidoc[leveloffset=+3]
+
 include::elastic-agent/running-on-kubernetes-standalone.asciidoc[leveloffset=+3]
 
 include::elastic-agent/configuration/env/container-envs.asciidoc[leveloffset=+3]


### PR DESCRIPTION
Add documentation page for GKE environments.

Part of https://github.com/elastic/observability-dev/issues/2408.