### PR TITLE
Fix mini toc in level 3 topics

### DIFF
--- a/docs/en/ingest-management/data-streams.asciidoc
+++ b/docs/en/ingest-management/data-streams.asciidoc
@@ -96,7 +96,7 @@ These templates are loaded when the integration is installed, and are used to co
 
 [discrete]
 [[data-streams-ilm]]
-= {ilm} ({ilm-init})
+= Index lifecycle management ({ilm-init})
 
 Use the {ref}/index-lifecycle-management.html[index lifecycle
 management] ({ilm-init}) feature in {es} to manage your {agent} data stream indices as they age.

--- a/docs/en/ingest-management/data-streams.asciidoc
+++ b/docs/en/ingest-management/data-streams.asciidoc
@@ -21,7 +21,7 @@ makes sense to your use case or company.
 
 [discrete]
 [[data-streams-naming-scheme]]
-== Data stream naming scheme
+= Data stream naming scheme
 
 {agent} uses the Elastic data stream naming scheme to name data streams.
 The naming scheme splits data into different streams based on the following components:
@@ -78,14 +78,14 @@ All of the juicy details are available in {ref}/data-streams.html[{es} Data stre
 
 [discrete]
 [[data-streams-data-view]]
-== {data-sources-cap}
+= {data-sources-cap}
 
 When searching your data in {kib}, you can use a {kibana-ref}/data-views.html[{data-source}]
 to search across all or some of your data streams.
 
 [discrete]
 [[data-streams-index-templates]]
-== Index templates
+= Index templates
 
 An index template is a way to tell {es} how to configure an index when it is created.
 For data streams, the index template configures the stream's backing indices as they are created.
@@ -96,7 +96,7 @@ These templates are loaded when the integration is installed, and are used to co
 
 [discrete]
 [[data-streams-ilm]]
-== {ilm} ({ilm-init})
+= {ilm} ({ilm-init})
 
 Use the {ref}/index-lifecycle-management.html[index lifecycle
 management] ({ilm-init}) feature in {es} to manage your {agent} data stream indices as they age.
@@ -112,7 +112,7 @@ Want to customize your index lifecycle management? See <<data-streams-ilm-tutori
 
 [discrete]
 [[data-streams-pipelines]]
-== Ingest pipelines
+= Ingest pipelines
 
 {agent} integration data streams ship with a default {ref}/ingest.html[ingest pipeline]
 that preprocesses and enriches data before indexing.
@@ -141,7 +141,7 @@ Specifically, apply the built-in `90-days-default` {ilm-init} policy so that dat
 
 [discrete]
 [[data-streams-ilm-one]]
-=== Step 1: View data streams
+== Step 1: View data streams
 
 The **Data Streams** view in {kib} shows you the data streams,
 index templates, and {ilm-init} policies associated with a given integration.
@@ -156,7 +156,7 @@ image::images/data-stream-info.png[Data streams info]
 
 [discrete]
 [[data-streams-ilm-two]]
-=== Step 2: Create a component template
+== Step 2: Create a component template
 
 For your changes to continue to be applied in future versions,
 you must put all custom index settings into a component template.
@@ -197,7 +197,7 @@ image::images/create-component-template.png[Create component template]
 
 [discrete]
 [[data-streams-ilm-three]]
-=== Step 3: Clone and modify the existing index template
+== Step 3: Clone and modify the existing index template
 
 Now that you've created a component template,
 you need to create an index template to apply the changes to the correct data stream.
@@ -223,7 +223,7 @@ image::images/create-index-template.png[Create index template]
 
 [discrete]
 [[data-streams-ilm-four]]
-=== Step 4: Roll over the data stream (optional)
+== Step 4: Roll over the data stream (optional)
 
 To confirm that the data stream is now using the new index template and {ilm-init} policy,
 you can either repeat <<data-streams-ilm-one,step one>>, or navigate to **{dev-tools-app}** and run the following:
@@ -274,7 +274,7 @@ like adding fields, obfuscate sensitive information, and more.
 
 [discrete]
 [[data-streams-pipeline-one]]
-=== Step 1: Create a custom ingest pipeline
+== Step 1: Create a custom ingest pipeline
 
 Create a custom ingest pipeline that will be called by the default integration pipeline.
 In this tutorial, we'll create a pipeline that adds a new field to our documents.
@@ -297,13 +297,13 @@ The {ref}/set-processor.html[Set processor] sets a document field and associates
 
 [discrete]
 [[data-streams-pipeline-two]]
-=== Step 2: Apply your ingest pipeline
+== Step 2: Apply your ingest pipeline
 
 Add a custom pipeline to an integration by calling it from the default ingest pipeline.
 The custom pipeline will run after the default pipeline but before the final pipeline.
 
 [discrete]
-==== Edit integration
+=== Edit integration
 
 Add a custom pipeline to an integration from the **Edit integration** workflow.
 The integration must already be configured and installed before a custom pipeline can be added.
@@ -315,7 +315,7 @@ To enter this workflow, do the following:
 . Select **Actions** -> **Edit integration**
 
 [discrete]
-==== Select a data stream
+=== Select a data stream
 
 Most integrations write to multiple data streams.
 You'll need to add the custom pipeline to each data stream individually.
@@ -328,7 +328,7 @@ For this tutorial, find the data stream configuration titled, **Collect metrics 
 This will take you to the **Create pipeline** workflow in **Stack management**.
 
 [discrete]
-==== Add the pipeline
+=== Add the pipeline
 
 Add the pipeline you created in step one.
 
@@ -341,7 +341,7 @@ Add the pipeline you created in step one.
 . Click **Create pipeline** to return to the **Edit integration** page.
 
 [discrete]
-==== Roll over the data stream (optional)
+=== Roll over the data stream (optional)
 
 For pipeline changes to take effect immediately, you must roll over the data stream.
 If you do not, the changes will not take effect until the next scheduled roll over.
@@ -356,13 +356,13 @@ The name follows the pattern `<type>-<dataset>@custom`:
 * Custom ingest pipeline designation: `@custom`
 
 [discrete]
-==== Repeat
+=== Repeat
 
 Add the custom ingest pipeline to any other data streams you wish to update.
 
 [discrete]
 [[data-streams-pipeline-three]]
-=== Step 3: Test the ingest pipeline (optional)
+== Step 3: Test the ingest pipeline (optional)
 
 Allow time for new data to be ingested before testing your pipeline.
 In a new window, open {kib} and navigate to **{kib} Dev tools**.
@@ -390,7 +390,7 @@ If your custom pipeline is working correctly, this query will return at least on
 
 [discrete]
 [[data-streams-pipeline-four]]
-=== Step 4: Add custom mappings
+== Step 4: Add custom mappings
 
 Now that a new field is being set in your {es} documents, you'll want to assign a new mapping for that field.
 Use the `@custom` component template to apply custom mappings to an integration data stream.
@@ -412,7 +412,7 @@ In the **Edit integration** workflow, do the following:
 
 [discrete]
 [[data-streams-pipeline-five]]
-=== Step 5: Test the custom mappings (optional)
+== Step 5: Test the custom mappings (optional)
 
 Allow time for new data to be ingested before testing your mappings.
 In a new window, open {kib} and navigate to **{kib} Dev tools**.

--- a/docs/en/ingest-management/elastic-agent/configuration/env/container-envs.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/env/container-envs.asciidoc
@@ -15,7 +15,7 @@ Variables on this page are grouped by action type:
 
 [discrete]
 [[env-common-vars]]
-== Common variables
+= Common variables
 
 // forces a unique ID so that settings can be included multiple times on the same page
 :type: common
@@ -52,7 +52,7 @@ include::shared-env.asciidoc[tag=kibana-ca]
 
 [discrete]
 [[env-prepare-kibana-for-fleet]]
-== Prepare {kib} for {fleet}
+= Prepare {kib} for {fleet}
 
 // forces a unique ID so that settings can be included multiple times on the same page
 :type: fleet-kib
@@ -77,7 +77,7 @@ include::shared-env.asciidoc[tag=kibana-fleet-ca]
 
 [discrete]
 [[env-bootstrap-fleet-server]]
-== Bootstrap {fleet-server}
+= Bootstrap {fleet-server}
 
 // forces a unique ID so that settings can be included multiple times on the same page
 :type: bootstrap-fleet
@@ -115,7 +115,7 @@ include::shared-env.asciidoc[tag=fleet-server-insecure-http]
 
 [discrete]
 [[env-enroll-agent]]
-== Enroll {agent}
+= Enroll {agent}
 
 // forces a unique ID so that settings can be included multiple times on the same page
 :type: enroll

--- a/docs/en/ingest-management/elastic-agent/configuration/providers/kubernetes-provider.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/providers/kubernetes-provider.asciidoc
@@ -5,7 +5,7 @@ Provides inventory information from Kubernetes.
 
 
 [discrete]
-== Provider configuration
+= Provider configuration
 
 [source,yaml]
 ----
@@ -87,7 +87,7 @@ Example:
 
 
 [discrete]
-== Provider for Pod resources
+= Provider for Pod resources
 
 The available keys are:
 
@@ -192,7 +192,7 @@ These are the fields available within config templating. The `kubernetes.*` fiel
 Note that not all of these fields are available by default and special configuration options
 are needed in order to include them.
 
-Fox example, if the Kubernetes provider provides the following inventory:
+For example, if the Kubernetes provider provides the following inventory:
 
 [source,json]
 ----
@@ -223,7 +223,7 @@ Fox example, if the Kubernetes provider provides the following inventory:
 In addition, the Kubernetes metadata are being added to each event by default.
 
 [discrete]
-== Provider for Node resources
+= Provider for Node resources
 
 [source,yaml]
 ----
@@ -268,7 +268,7 @@ The available keys are:
 |===
 
 [discrete]
-== Provider for Service resources
+= Provider for Service resources
 
 [source,yaml]
 ----

--- a/docs/en/ingest-management/elastic-agent/configuration/providers/kubernetes_leaderelection-provider.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/providers/kubernetes_leaderelection-provider.asciidoc
@@ -43,7 +43,7 @@ The available key is:
 |===
 
 [discrete]
-== Enabling configurations only when on leadership
+= Enabling configurations only when on leadership
 
 Use conditions based on the `kubernetes_leaderelection.leader` key to leverage the leaderelection provider and enable specific inputs only when the {agent} holds the leadership lock.
 The below example enables the `state_container`

--- a/docs/en/ingest-management/elastic-agent/elastic-agent-conditions.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/elastic-agent-conditions.asciidoc
@@ -1,6 +1,6 @@
 [discrete]
 [[conditions]]
-== Conditions
+= Conditions
 
 A condition is a boolean expression that you can specify in your agent policy
 to control whether a configuration is applied to the running {agent}. You can
@@ -49,7 +49,7 @@ inputs:
 
 [discrete]
 [[condition-syntax]]
-=== Condition syntax
+== Condition syntax
 
 The conditions supported by {agent} are based on {ref}/eql-syntax.html[EQL]'s
 boolean syntax, but add support for variables from providers and functions to
@@ -81,7 +81,7 @@ manipulate the values.
 
 [discrete]
 [[condition-examples]]
-=== Condition examples
+== Condition examples
 
 Run only when a specific label is included.
 

--- a/docs/en/ingest-management/elastic-agent/elastic-agent-container.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/elastic-agent-container.asciidoc
@@ -15,7 +15,7 @@ This command allows environment variables to configure all properties, and runs 
 
 [discrete]
 [[agent-in-container-pull]]
-== Pull the image
+= Pull the image
 
 There are two images for {agent}, *elastic-agent* and *elastic-agent-complete*. The *elastic-agent* image contains all the binaries for running {beats}, while the *elastic-agent-complete* image contains these binaries plus additional dependencies to run browser monitors through Elastic Synthetics. Refer to {observability-guide}/uptime-set-up.html[Synthetic monitoring via {agent} and {fleet}] for more information.
 
@@ -35,7 +35,7 @@ docker pull docker.elastic.co/beats/elastic-agent-complete:{version}
 
 [discrete]
 [[agent-in-container-command]]
-== {agent} container command
+= {agent} container command
 
 The {agent} container command offers a wide variety of options.
 To see the full list, run:
@@ -47,7 +47,7 @@ docker run --rm docker.elastic.co/beats/elastic-agent:{version} elastic-agent co
 
 [discrete]
 [[agent-in-container-cloud]]
-== {ecloud} example
+= {ecloud} example
 
 The easiest way to get started is by using an Elastic cluster running on {ecloud}.
 
@@ -74,7 +74,7 @@ Refer to <<agent-environment-variables>> for all available options.
 
 [discrete]
 [[agent-in-container-self]]
-== Self-managed example
+= Self-managed example
 
 If you're running a self-managed cluster and want to run your own {fleet-server}, run the following command, which will spin up {agent} and {fleet-server} in a container:
 
@@ -102,7 +102,7 @@ NOTE: Replace `docker.elastic.co/beats/elastic-agent` with `docker.elastic.co/be
 
 [discrete]
 [[agent-in-container-docker]]
-== Docker compose example
+= Docker compose example
 
 {agent} can be run in docker-compose.
 The example below shows how to enroll an {agent}:
@@ -138,7 +138,7 @@ Refer to <<agent-environment-variables>> for all available options.
 
 [discrete]
 [[agent-in-container-docker-logs]]
-== Logs
+= Logs
 
 As a container supports only a single version of {agent},
 logs and state are stored a bit differently than when running an {agent} outside of a container.
@@ -158,7 +158,7 @@ Check the fleet-server subprocess logs for more information.
 
 [discrete]
 [[agent-in-container-debug]]
-== Debugging
+= Debugging
 
 A monitoring endpoint can be enabled to expose resource usage and event processing data.
 The endpoint is compatible with {agent}s running in both {fleet} mode and Standalone mode.

--- a/docs/en/ingest-management/elastic-agent/elastic-agent-variable-substitution.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/elastic-agent-variable-substitution.asciidoc
@@ -1,6 +1,6 @@
 [discrete]
 [[variable-substitution]]
-== Variable substitution
+= Variable substitution
 
 The syntax for variable substitution is `${var}`, where `var` is the name of a
 variable defined by a provider. A _provider_ defines key/value pairs that are
@@ -68,7 +68,7 @@ inputs:
 ----
 
 [discrete]
-=== Alternative variables and constants
+= Alternative variables and constants
 
 Variable substitution can also define alternative variables or a constant.
 

--- a/docs/en/ingest-management/elastic-agent/running-on-kubernetes-managed-by-fleet.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/running-on-kubernetes-managed-by-fleet.asciidoc
@@ -15,7 +15,7 @@ endif::[]
 
 
 [discrete]
-== Kubernetes deploy manifests
+= Kubernetes deploy manifests
 
 With {fleet}, each agent enrolls in a policy defined in {kib} and stored in
 {es}. The policy specifies how to collect observability data from the services
@@ -49,7 +49,7 @@ curl -L -O https://raw.githubusercontent.com/elastic/elastic-agent/{branch}/depl
 ------------------------------------------------
 
 [discrete]
-== Settings
+= Settings
 
 {agent} is enrolled to a running {fleet-server} using `FLEET_URL` parameter.
 The `FLEET_ENROLLMENT_TOKEN` parameter is used to connect {agent} to a
@@ -106,7 +106,7 @@ Refer to <<agent-environment-variables>> for all available options.
 ====
 
 [discrete]
-=== Run {agent} on master nodes
+= Run {agent} on master nodes
 
 Kubernetes master nodes can use https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/[taints]
 to limit the workloads that can run on them. The manifest for managed {agent} defines
@@ -124,7 +124,7 @@ spec:
 
 
 [discrete]
-== Deploy
+= Deploy
 
 If planning to deploy `state_*` datasets of Kubernetes package,
 https://github.com/kubernetes/kube-state-metrics#usage[kube-state-metrics] needs to be already deployed
@@ -159,7 +159,7 @@ This can be confirmed in {kib} under {fleet}  / Agents section.
 
 
 [discrete]
-== Deploying {agent} to collect cluster-level metrics in large clusters
+= Deploying {agent} to collect cluster-level metrics in large clusters
 
 The size and the number of nodes in a Kubernetes cluster can be fairly large at times,
 and in such cases the Pod that will be collecting cluster level metrics might face performance
@@ -168,7 +168,7 @@ leader election strategy and instead run a dedicated, standalone {agent} instanc
 a Deployment in addition to the DaemonSet.
 
 [discrete]
-== Deploying {agent} to managed Kubernetes environment
+= Deploying {agent} to managed Kubernetes environment
 
 On managed Kubernetes solutions, such as AKS, GKE or EKS, {agent} has no access to collect metrics from the https://kubernetes.io/docs/concepts/overview/components/#control-plane-components[Kubernetes control plane]
 components, like `kube-scheduler` and `kube-controller-manager`, that are scheduled on Kubernetes master nodes.

--- a/docs/en/ingest-management/elastic-agent/running-on-kubernetes-standalone.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/running-on-kubernetes-standalone.asciidoc
@@ -14,7 +14,7 @@ endif::[]
 
 
 [discrete]
-== Kubernetes deploy manifests
+= Kubernetes deploy manifests
 
 
 Deploy {agent} as a https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/[DaemonSet]
@@ -48,7 +48,7 @@ System integration to collect system level metrics and logs from nodes, and
 the Pod's log collection using <<kubernetes-provider,dynamic inputs and Kubernetes provider>>.
 
 [discrete]
-== Settings
+= Settings
 
 Set the {es} settings before deploying the manifest:
 
@@ -86,7 +86,7 @@ Refer to <<agent-environment-variables>> for all available options.
 ====
 
 [discrete]
-=== Run {agent} on master nodes
+== Run {agent} on master nodes
 
 Kubernetes master nodes can use https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/[taints]
 to limit the workloads that can run on them. The manifest for standalone {agent} defines
@@ -104,7 +104,7 @@ spec:
 
 
 [discrete]
-== Deploy
+= Deploy
 To deploy to Kubernetes, run:
 
 ["source", "sh", subs="attributes"]
@@ -129,7 +129,7 @@ in the `elastic-agent-standalone-kubernetes.yaml` manifest. Container resource u
 and the environment size.
 
 [discrete]
-== Red Hat OpenShift configuration
+= Red Hat OpenShift configuration
 
 If you are using Red Hat OpenShift, you need to specify additional settings in
 the manifest file and enable the container to run as privileged.
@@ -223,13 +223,13 @@ oc patch namespace kube-system -p \
 This command sets the node selector for the project to an empty string.
 
 [discrete]
-== Autodiscover targeted Pods
+= Autodiscover targeted Pods
 
 Refer to <<elastic-agent-kubernetes-autodiscovery,kubernetes autodiscovery with Elastic Agent>> for more information.
 
 
 [discrete]
-== Deploying {agent} to collect cluster-level metrics in large clusters
+= Deploying {agent} to collect cluster-level metrics in large clusters
 
 The size and the number of nodes in a Kubernetes cluster can be fairly large at times,
 and in such cases the Pod that will be collecting cluster level metrics might face performance
@@ -238,7 +238,7 @@ leader election strategy and instead run a dedicated, standalone {agent} instanc
 a Deployment in addition to the DaemonSet.
 
 [discrete]
-== Deploying {agent} to managed Kubernetes environment
+= Deploying {agent} to managed Kubernetes environment
 
 On managed Kubernetes solutions, such as AKS, GKE or EKS, {agent} has no access to collect metrics from the https://kubernetes.io/docs/concepts/overview/components/#control-plane-components[Kubernetes control plane]
 components, like `kube-scheduler` and `kube-controller-manager`, that are scheduled on Kubernetes master nodes.

--- a/docs/en/ingest-management/fleet/add-fleet-server-cloud.asciidoc
+++ b/docs/en/ingest-management/fleet/add-fleet-server-cloud.asciidoc
@@ -14,7 +14,7 @@ deployment.
 
 [discrete]
 [[fleet-server-compatibility]]
-== Compatibility and prerequisites
+= Compatibility and prerequisites
 
 {fleet-server} is compatible with the following Elastic products:
 
@@ -37,7 +37,7 @@ For more information about hosting {fleet-server} on {ece}, refer to
 
 [discrete]
 [[add-fleet-server-cloud-set-up]]
-== Setup
+= Setup
 
 To confirm that an {integrations-server} is available in your deployment:
 
@@ -58,7 +58,7 @@ image::images/integrations-server-hosted-container.png[Hosted {integrations-serv
 
 [discrete]
 [[add-fleet-server-cloud-next]]
-== Next steps
+= Next steps
 
 Now you're ready to add {agent}s to your host systems. To learn how, see
 <<install-fleet-managed-elastic-agent>>.

--- a/docs/en/ingest-management/fleet/add-fleet-server-mixed.asciidoc
+++ b/docs/en/ingest-management/fleet/add-fleet-server-mixed.asciidoc
@@ -18,7 +18,7 @@ you need to:
 
 [discrete]
 [[add-fleet-server-mixed-compatibility]]
-== Compatibility
+= Compatibility
 
 {fleet-server} is compatible with the following Elastic products:
 
@@ -41,13 +41,13 @@ For more information about hosting {fleet-server} on {ece}, refer to
 
 [discrete]
 [[add-fleet-server-mixed-prereq]]
-== Prerequisites
+= Prerequisites
 
 include::add-fleet-server-on-prem.asciidoc[tag=cert-prereq]
 
 [discrete]
 [[fleet-server-add-hosts]]
-== Add {fleet-server} hosts
+= Add {fleet-server} hosts
 
 include::add-fleet-server-on-prem.asciidoc[tag=fleet-server-host-prereq]
 
@@ -57,7 +57,7 @@ include::add-fleet-server-on-prem.asciidoc[tag=add-fleet-server-host]
 
 [discrete]
 [[fleet-server-create-policy]]
-== Create a {fleet-server} policy
+= Create a {fleet-server} policy
 
 Next, you'll create a {fleet-server} policy. The {fleet-server} policy manages
 and configures the {agent} running on the {fleet-server} host to launch a
@@ -88,7 +88,7 @@ and ensure a smooth operation in a bursty environment.
 
 [discrete]
 [[fleet-server-add-server]]
-== Add {fleet-server}s
+= Add {fleet-server}s
 
 Now that the policy exists, you can add {fleet-server}s.
 A {fleet-server} is an {agent} that is enrolled in a {fleet-server} policy.
@@ -126,7 +126,7 @@ whose life-cycle can be managed (like other agents in the deployment).
 
 [discrete]
 [[fleet-server-install-agents]]
-== Next steps
+= Next steps
 
 Now you're ready to add {agent}s to your host systems. To learn how, see
 <<install-fleet-managed-elastic-agent>>.

--- a/docs/en/ingest-management/fleet/add-fleet-server-on-prem.asciidoc
+++ b/docs/en/ingest-management/fleet/add-fleet-server-on-prem.asciidoc
@@ -20,7 +20,7 @@ containerized {fleet-server}.
 
 [discrete]
 [[add-fleet-server-on-prem-compatibility]]
-== Compatibility
+= Compatibility
 
 {fleet-server} is compatible with the following Elastic products:
 
@@ -43,7 +43,7 @@ For more information about hosting {fleet-server} on {ece}, refer to
 
 [discrete]
 [[add-fleet-server-on-prem-prereq]]
-== Prerequisites
+= Prerequisites
 
 // tag::cert-prereq[]
 Before setting up {fleet-server} using this approach, you will need a
@@ -59,7 +59,7 @@ NOTE: This is not required when testing and iterating using the *Quick start* op
 
 [discrete]
 [[add-fleet-server-on-prem-hosts]]
-== Add {fleet-server} hosts
+= Add {fleet-server} hosts
 
 // tag::fleet-server-host-prereq[]
 Start by adding one or more {fleet-server} hosts.
@@ -107,7 +107,7 @@ NOTE: Skip this step if you've started the {stack} with security enabled
 
 [discrete]
 [[add-fleet-server-on-prem-add-server]]
-== Add {fleet-server}
+= Add {fleet-server}
 
 A {fleet-server} is an {agent} that is enrolled in a {fleet-server} policy.
 The policy configures the agent to operate in a special mode to serve as a {fleet-server} in your deployment.
@@ -173,14 +173,14 @@ It's recommended you generate a unique service token for each
 
 [discrete]
 [[add-fleet-server-on-prem-troubleshoot]]
-== Troubleshooting
+= Troubleshooting
 
 If you're unable to add a {fleet}-managed agent, click the **Agents** tab
 and confirm that the agent running {fleet-server} is healthy.
 
 [discrete]
 [[add-fleet-server-on-prem-next]]
-== Next steps
+= Next steps
 
 Now you're ready to add {agent}s to your host systems. To learn how, see
 <<install-fleet-managed-elastic-agent>>.

--- a/docs/en/ingest-management/fleet/monitor-elastic-agent.asciidoc
+++ b/docs/en/ingest-management/fleet/monitor-elastic-agent.asciidoc
@@ -12,8 +12,9 @@ Agent monitoring is turned on by default in the agent policy unless you
 turn it off. Want to turn off agent monitoring to stop collecting logs and
 metrics? See <<change-agent-monitoring>>.
 
+[discrete]
 [[view-agent-status]]
-== View agent status
+= View agent status
 
 To view the status of your {fleet}-managed agents, in {kib}, go to
 **Management -> {fleet} -> Agents**.
@@ -51,8 +52,9 @@ For advanced filtering, use the search bar to create structured queries
 using {kibana-ref}/kuery-query.html[{kib} Query Language]. For example, enter
 `local_metadata.os.family : "darwin"` to see only agents running on macOS.
 
+[discrete]
 [[view-agent-logs]]
-== View agent logs
+= View agent logs
 
 When {fleet} reports an agent status like `Offline` or `Unhealthy`, you might
 want to view the agent logs to diagnose potential causes. If agent monitoring
@@ -86,8 +88,9 @@ logs? Refer to <<change-logging-level>>.
 information about logging, refer to
 {observability-guide}/tail-logs.html[Tail log files].
 
+[discrete]
 [[change-logging-level]]
-=== Change the logging level
+= Change the logging level
 
 The logging level for monitored agents is set to `info` by default. You can
 change the agent logging level, for example, to turn on debug logging remotely:
@@ -111,8 +114,9 @@ logs informational messages, warnings, errors, and critical errors.
 
 . Click **Apply changes** to apply the updated logging level to the agent.
 
+[discrete]
 [[view-agent-metrics]]
-== View {agent} metrics
+= View {agent} metrics
 
 When agent monitoring is configured to collect metrics (the default), you can
 use the **[Elastic Agent] Agent metrics** dashboard in {kib} to view details
@@ -137,8 +141,9 @@ image::images/selected-agent-metrics-dashboard.png[Screen capture showing {agent
 The dashboard uses standard {kib} visualizations that you can extend to meet
 your needs.
 
+[discrete]
 [[change-agent-monitoring]]
-== Change {agent} monitoring settings
+= Change {agent} monitoring settings
 
 Agent monitoring is turned on by default in the agent policy. To change agent
 monitoring settings for all agents enrolled in a specific agent policy:


### PR DESCRIPTION
~Removing the `[discrete]` tags allows the build to create the "On this page" links for level 3 topics in the nav, but it makes the content harder to move around. If we move the topic up a level, we'll need to add the discrete tags back in. And if we move a topic down a level, we'll need to remove the discrete tags to make sure "On this page" gets populated.~

~@gtback Is this a bug or expected behavior? I feel like we ran into this problem with other topics and fixed it, so maybe the fix just needs to be applied to level 3 topics?~

Here is an example of a level 3 topic that does not have "On this page" links: https://www.elastic.co/guide/en/fleet/current/upgrade-elastic-agent.html

To fix this problem, we have decided to bump the heading levels on affected pages instead of removing the discrete tags.

TODO: 
- [x] Remove `discrete` tags from other level 3 topics (if we decide this is expected behavior and do not plan to fix it):
  Here's the list of topics that have missing mini TOCs:
  - [x] https://observability-docs_2344.docs-preview.app.elstc.co/guide/en/fleet/master/add-fleet-server-cloud.html
  - [x] https://observability-docs_2344.docs-preview.app.elstc.co/guide/en/fleet/master/add-fleet-server-on-prem.html
  - [x] https://observability-docs_2344.docs-preview.app.elstc.co/guide/en/fleet/master/add-fleet-server-mixed.html
  - [x] https://observability-docs_2344.docs-preview.app.elstc.co/guide/en/fleet/master/elastic-agent-container.html
  - [x] https://observability-docs_2344.docs-preview.app.elstc.co/guide/en/fleet/master/running-on-kubernetes-managed-by-fleet.html
  - [x] https://observability-docs_2344.docs-preview.app.elstc.co/guide/en/fleet/master/running-on-kubernetes-standalone.html
  - [x] https://observability-docs_2344.docs-preview.app.elstc.co/guide/en/fleet/master/agent-environment-variables.html
  - [x] https://observability-docs_2344.docs-preview.app.elstc.co/guide/en/fleet/master/monitor-elastic-agent.html
  - [x] https://observability-docs_2344.docs-preview.app.elstc.co/guide/en/fleet/master/data-streams-ilm-tutorial.html
  - [x] https://observability-docs_2344.docs-preview.app.elstc.co/guide/en/fleet/master/data-streams-pipeline-tutorial.html
  - [x] https://observability-docs_2344.docs-preview.app.elstc.co/guide/en/fleet/master/dynamic-input-configuration.html
  - [x] https://observability-docs_2344.docs-preview.app.elstc.co/guide/en/fleet/master/kubernetes_leaderelection-provider.html
  - [x] https://observability-docs_2344.docs-preview.app.elstc.co/guide/en/fleet/master/kubernetes-provider.html
