### PR TITLE
[main] Add docker run command (#2291)

### DIFF
--- a/docs/en/ingest-management/elastic-agent/elastic-agent-container.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/elastic-agent-container.asciidoc
@@ -42,7 +42,7 @@ To see the full list, run:
 
 [source,terminal]
 ----
-elastic-agent container -h
+docker run --rm docker.elastic.co/beats/elastic-agent:{version} elastic-agent container -h
 ----
 
 [discrete]


### PR DESCRIPTION
# Backport

This will backport the following commits from `8.4` to `main`:
 - [Add docker run command (#2291)](https://github.com/elastic/observability-docs/pull/2291)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)