### PR TITLE
[DOC] Typos

### DIFF
--- a/docs/en/ingest-management/troubleshooting/troubleshooting.asciidoc
+++ b/docs/en/ingest-management/troubleshooting/troubleshooting.asciidoc
@@ -318,8 +318,9 @@ These will need to be manually redacted before the archive is shared.
 The diagnostics command is also able to collect `pprof` data in the archive if the `--pprof` flag is added when collecting the diagnostic.
 
 To collect the `pprof` data:
-- Enable/add `agent.monitoring.pprof.enabled: true` to `elastic-agent.yml`
-- Restart the {agent}
+
+. Enable/add `agent.monitoring.pprof.enabled: true` to `elastic-agent.yml`
+. Restart the {agent}
 
 If `agent.monitoring.http.buffer.enabled` is set to `true`, the archive will also contain recent metrics from the {agent} and {beats} processes.
 


### PR DESCRIPTION
The list was not correctly rendered as this is `asciidoc`, not markdown.

<img width="883" alt="image" src="https://user-images.githubusercontent.com/87379/200651990-fa57caf9-03c6-49b5-9536-6ea680cf6526.png">

I think we should use `.` for numbered lists.