### PR TITLE
[agent] Add documentation for Agent encryption at rest

### DIFF
--- a/docs/en/ingest-management/elastic-agent/elastic-agent-encryption.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/elastic-agent-encryption.asciidoc
@@ -1,29 +1,29 @@
 [elastic-agent-encryption]
-= Elastic Agent Configuration Encryption
+= {agent} configuration encryption
 
-It is important for users to understand the security model of Elastic Agent and how it handles sensitive values in integration configurations.
-At a high level, Elastic Agent receives configuration data from Fleet Server over an encrypted connection, persists those secrets in an encrypted form on disk.
-This persistence is necessary to allow agents to continue to operate, even in the event of a loss of connectivity to the Fleet server.
+It is important for you to understand the {agent} security model and how it handles sensitive values in integration configurations.
+At a high level, {agent} receives configuration data from {fleet-server} over an encrypted connection and persists the encrypted configuration on disk.
+This persistence allows agents to continue to operate even if they are unable to connect to the {fleet-server}.
 
-The entirety of the Fleet Agent Policy is encrypted at rest, but is recoverable if the user has access to both the encrypted configuration data and the associated key.
-The key material in stored in an OS-dependent manner as described below.
+The entire Fleet Agent Policy is encrypted at rest, but is recoverable if you have access to both the encrypted configuration data and the associated key.
+The key material is stored in an OS-dependent manner as described in the following sections.
 
-[discreet]
-== Darwin (Mac OS)
+[discrete]
+== Darwin (macOS)
 
 Key material is stored in the system keychain. The value is stored as is without any additional transformations.
 
-[discreet]
+[discrete]
 == Windows
 
 Configuration data is encrypted with https://learn.microsoft.com/en-us/dotnet/standard/security/how-to-use-data-protection[DPAPI] `CryptProtectData` with `CRYPTPROTECT_LOCAL_MACHINE``. 
 Additional entropy is derived from crypto/rand bytes stored in the `.seed` file.
-Configuration data is stored as separate files where the name of the file is SHA256 hash of the key and the content of the file is encrypted with DPAPI data.
+Configuration data is stored as separate files, where the name of the file is a SHA256 hash of the key, and the content of the file is encrypted with DPAPI data.
 The security of key data relies on file system permissions. Only the Administrator should be able to access the file.
 
-[discreet]
+[discrete]
 == Linux
 
-The encryption key is derived from crypto/rand bytes that is written to the `.seed` file after PBKDF2 transformation.
-Configuration data is stored as separate files where the name of the file is SHA256 hash of the key and the content of the file is AES256-GSM encrypted.
+The encryption key is derived from crypto/rand bytes stored in the `.seed` file after PBKDF2 transformation.
+Configuration data is stored as separate files, where the name of the file is a SHA256 hash of the key, and the content of the file is AES256-GSM encrypted.
 The security of the key material largely relies on file system permissions.

--- a/docs/en/ingest-management/elastic-agent/elastic-agent-encryption.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/elastic-agent-encryption.asciidoc
@@ -1,0 +1,29 @@
+[elastic-agent-encryption]
+= Elastic Agent Configuration Encryption
+
+It is important for users to understand the security model of Elastic Agent and how it handles sensitive values in integration configurations.
+At a high level, Elastic Agent receives configuration data from Fleet Server over an encrypted connection, persists those secrets in an encrypted form on disk.
+This persistence is necessary to allow agents to continue to operate, even in the event of a loss of connectivity to the Fleet server.
+
+The entirety of the Fleet Agent Policy is encrypted at rest, but is recoverable if the user has access to both the encrypted configuration data and the associated key.
+The key material in stored in an OS-dependent manner as described below.
+
+[discreet]
+== Darwin (Mac OS)
+
+Key material is stored in the system keychain. The value is stored as is without any additional transformations.
+
+[discreet]
+== Windows
+
+Configuration data is encrypted with https://learn.microsoft.com/en-us/dotnet/standard/security/how-to-use-data-protection[DPAPI] `CryptProtectData` with `CRYPTPROTECT_LOCAL_MACHINE``. 
+Additional entropy is derived from crypto/rand bytes stored in the `.seed` file.
+Configuration data is stored as separate files where the name of the file is SHA256 hash of the key and the content of the file is encrypted with DPAPI data.
+The security of key data relies on file system permissions. Only the Administrator should be able to access the file.
+
+[discreet]
+== Linux
+
+The encryption key is derived from crypto/rand bytes that is written to the `.seed` file after PBKDF2 transformation.
+Configuration data is stored as separate files where the name of the file is SHA256 hash of the key and the content of the file is AES256-GSM encrypted.
+The security of the key material largely relies on file system permissions.

--- a/docs/en/ingest-management/index.asciidoc
+++ b/docs/en/ingest-management/index.asciidoc
@@ -83,6 +83,8 @@ include::elastic-agent/uninstall-elastic-agent.asciidoc[leveloffset=+2]
 
 include::elastic-agent/start-stop-elastic-agent.asciidoc[leveloffset=+2]
 
+include::elastic-agent/elastic-agent-encryption.asciidoc[leveloffset=+2]
+
 include::security/generate-certificates.asciidoc[leveloffset=+1]
 
 include::security/certificates.asciidoc[leveloffset=+2]


### PR DESCRIPTION
Based on https://github.com/elastic/elastic-agent/pull/398 and a discussion with @cmacknz .

It's a somewhat common ask from synthetics users.