### PR TITLE
backport: Add 8.6 branch

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -175,3 +175,16 @@ pull_request_rules:
         labels:
           - "backport"
         title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"
+  - name: backport patches to 8.6 branch
+    conditions:
+      - merged
+      - label=backport-v8.6.0
+    actions:
+      backport:
+        assignees:
+          - "{{ author }}"
+        branches:
+          - "8.6"
+        labels:
+          - "backport"
+        title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -178,7 +178,7 @@ pull_request_rules:
   - name: backport patches to 8.6 branch
     conditions:
       - merged
-      - label=backport-v8.6.0
+      - label=backport-8.6
     actions:
       backport:
         assignees:


### PR DESCRIPTION
Merge as soon as 8.6 branch was created. Auto-merge is not yet supported, see https://github.com/Mergifyio/mergify-engine/discussions/2821