### PR TITLE
[Fleet] Update logstash client certificate generation

### DIFF
--- a/docs/en/ingest-management/security/logstash-certificates.asciidoc
+++ b/docs/en/ingest-management/security/logstash-certificates.asciidoc
@@ -58,12 +58,8 @@ image::images/ca-certs.png[Screen capture of a folder called ca that contains tw
   --name client \
   --ca-cert /path/to/ca/ca.crt \
   --ca-key /path/to/ca/ca.key \
-  --dns your.host.name.here \
-  --ip 192.0.2.1 \
   --pem
 ----
-
-Where `dns` and `ip` specify the valid host names and IP addresses where the generated certificates are valid.
 
 Extract the zip file:
 


### PR DESCRIPTION
## Description

Update confusing instructions in logstash client certificate generation. 

In Fleet we force mutual TLS when using the logstash output, but the client certificate is used to verify that the agent is part of the Fleet but not to authenticate a specific agent, the client certificate is shared between all the agent using the logstash output so it should not contains IP or DNS. 

