### PR TITLE
Remove link to Elastic helm charts

### DIFF
--- a/docs/en/observability/monitor-k8s/monitor-k8s.asciidoc
+++ b/docs/en/observability/monitor-k8s/monitor-k8s.asciidoc
@@ -38,8 +38,7 @@ your application, including the orchestration software itself:
 This guide describes how to deploy Elastic monitoring agents as DaemonSets using
 `kubectl` and the {beats} GitHub repository manifest files. For other
 deployment options, see the Kubernetes operator and custom resource definitions
-from {eck-ref}/index.html[{ecloud} on Kubernetes (ECK)] or the
-https://github.com/elastic/helm-charts/blob/master/README.md[Helm charts].
+from {eck-ref}/index.html[{ecloud} on Kubernetes (ECK)].
 
 include::monitor-k8s-overview.asciidoc[]
 


### PR DESCRIPTION
As mentioned in the comment in the [readme](https://github.com/elastic/helm-charts/blob/master/README.md), we are no longer recommending Elastic helm charts, so we shouldn't link to them.