### PR TITLE
[main] Need to get an emergency release note out for 8.5.1 (#2390)

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-8.5.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.5.asciidoc
@@ -30,6 +30,30 @@ Also see:
 Review important information about the {fleet} and {agent} 8.5.1 release.
 
 [discrete]
+[[known-issues-8.5.1]]
+=== Known issues
+
+[[known-issue-144880]]
+.Unable to add {fleet-server} integration on Windows
+[%collapsible]
+====
+
+*Details*
+
+We discovered a high severity issue in version 8.5.1 that only affects Windows
+users in self-managed environments. When you attempt to add a {fleet-server},
+{kib} is unable to add the {fleet-server} integration, and the {fleet-server}
+polices are created without the necessary integration. For more information,
+see {kib-issue}/144880[issue #144880].
+
+*Impact* +
+
+This issue will be resolved in version 8.5.2. We advise Windows users not to
+upgrade to version 8.5.1.
+====
+
+
+[discrete]
 [[enhancements-8.5.1]]
 === Enhancements
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `8.5` to `main`:
 - [Need to get an emergency release note out for 8.5.1 (#2390)](https://github.com/elastic/observability-docs/pull/2390)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)