### PR TITLE
Add Fleet/Agent 8.5.2 release notes

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-8.5.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.5.asciidoc
@@ -35,7 +35,7 @@ Review important information about the {fleet} and {agent} 8.5.2 release.
 === Bug fixes
 
 {fleet}::
-* No bug fixes in this release
+* Always use posix paths for zip files {kib-issue}/144880[#144880] {kibana-pull}/144899[#144899]
 
 {fleet-server}::
 * Add `active: true` filter to enrollment key queries to allow {fleet-server} to handle cases where there are more than 10 inactive keys associated with a policy {fleet-server-issue}2029[#2029] {fleet-server-pull}2044[#2044]

--- a/docs/en/ingest-management/release-notes/release-notes-8.5.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.5.asciidoc
@@ -14,6 +14,7 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-8.5.2>>
 * <<release-notes-8.5.1>>
 * <<release-notes-8.5.0>>
 
@@ -21,6 +22,28 @@ Also see:
 
 * {kibana-ref}/release-notes.html[{kib} release notes]
 * {beats-ref}/release-notes.html[{beats} release notes]
+
+// begin 8.5.2 relnotes
+
+[[release-notes-8.5.2]]
+== {fleet} and {agent} 8.5.2
+
+Review important information about the {fleet} and {agent} 8.5.2 release.
+
+[discrete]
+[[bug-fixes-8.5.2]]
+=== Bug fixes
+
+{fleet}::
+* No bug fixes in this release
+
+{fleet-server}::
+* Add `active: true` filter to enrollment key queries to allow {fleet-server} to handle cases where there are more than 10 inactive keys associated with a policy {fleet-server-issue}2029[#2029] {fleet-server-pull}2044[#2044]
+
+{agent}::
+* No bug fixes in this release
+
+// end 8.5.2 relnotes
 
 // begin 8.5.1 relnotes
 

--- a/docs/en/ingest-management/release-notes/release-notes-8.5.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.5.asciidoc
@@ -35,7 +35,7 @@ Review important information about the {fleet} and {agent} 8.5.2 release.
 === Bug fixes
 
 {fleet}::
-* Always use posix paths for zip files {kib-issue}/144880[#144880] {kibana-pull}/144899[#144899]
+* Fix known issue with adding {fleet-server} integration on Windows by always using posix paths for zip files {kib-issue}/144880[#144880] {kibana-pull}/144899[#144899]
 
 {fleet-server}::
 * Add `active: true` filter to enrollment key queries to allow {fleet-server} to handle cases where there are more than 10 inactive keys associated with a policy {fleet-server-issue}2029[#2029] {fleet-server-pull}2044[#2044]


### PR DESCRIPTION
Closes #2373 

Question: Why does the [changelog fragments directory](https://github.com/elastic/elastic-agent/tree/c13f9157c438fc60cfbb822b385ea91bc91193cc/changelog/fragments) contain old entries that we documented in 8.5.1? Is this expected? Am I looking at the correct release hash?