### PR TITLE
docs: add `0.0.0.0` tip

### DIFF
--- a/docs/en/observability/ingest-traces.asciidoc
+++ b/docs/en/observability/ingest-traces.asciidoc
@@ -130,6 +130,8 @@ For a list of indices users need access to, refer to
 [role="screenshot"]
 image::images/kibana-apm-sample-data.png[{apm-app} with data]
 
+Not seeing any data? Review our list of {apm-guide-ref}/common-problems.html[common problems] for helpful tips.
+
 [discrete]
 == What's next?
 

--- a/docs/en/observability/tab-widgets/add-apm-integration/content.asciidoc
+++ b/docs/en/observability/tab-widgets/add-apm-integration/content.asciidoc
@@ -31,6 +31,9 @@ image::./images/kibana-fleet-integrations-apm-overview.png[{fleet} showing APM i
 . On the **Add Elastic APM integration** page,
 define the host and port where APM Server will listen.
 Make a note of this value--you'll need it later.
++
+TIP: Using Docker or Kubernetes?
+Set the host to `0.0.0.0` to bind to all interfaces.
 
 . Click **Save and continue**.
 This step takes a minute or two to complete. When it's done,


### PR DESCRIPTION
### Summary

This PR updates the APM quick start to:
* Include a tip explaining the port Kubernetes and Docker users should use when setting up the APM integration.
* Links to the common problems section from the bottom of the quick start guide for users who aren't seeing any data flowing into the APM app.

Unfortunately, I think this is the best we can do until https://github.com/elastic/apm-server/issues/2107 lands and provides a nice home for this information. The `0.0.0.0` tip has existed in our [common problems](https://www.elastic.co/guide/en/apm/guide/current/common-problems.html#no-data-indexed) guide since 2018, but clearly, people aren't looking for it there. Hopefully this helps.

* Closes https://github.com/elastic/apm-server/issues/9214