### PR TITLE
Fix docs on synthetics monitor interval

### DIFF
--- a/docs/en/observability/synthetics-configuration.asciidoc
+++ b/docs/en/observability/synthetics-configuration.asciidoc
@@ -91,7 +91,7 @@ A human readable name for the monitor.
 `tags` (`Array<string>`)::
 A list of tags that will be sent with the monitor event. Tags are displayed in the {uptime-app} and allow you to search monitors by tag.
 `schedule` (`number`)::
-The interval (in seconds) at which the monitor should run.
+The interval (in minutes) at which the monitor should run.
 `enabled` (`boolean`)::
 Enable or disable the monitor from running without deleting and recreating it.
 `locations` (https://github.com/elastic/synthetics/blob/{synthetics_version}/src/locations/public-locations.ts#L28-L37[`Array<SyntheticsLocationsType>`])::


### PR DESCRIPTION
The schedule interval in the monitor configuration is specified in minutes, so we have to fix this doc to show the proper information.