### PR TITLE
Provide context for procedures under Fleet Settings

### DIFF
--- a/docs/en/ingest-management/fleet/fleet-settings.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-settings.asciidoc
@@ -266,7 +266,7 @@ restricted environment, refer to <<air-gapped>>.
 To add or edit the source of binary downloads:
 
 . Go to **{fleet} -> Settings**.
-. Under **Agent Ginary Download**, click **Add agent binary source** or **Edit**.
+. Under **Agent Binary Download**, click **Add agent binary source** or **Edit**.
 . Set the agent binary source name.
 . For **Host**, specify the address where you are hosting the artifacts
 repository.

--- a/docs/en/ingest-management/fleet/fleet-settings.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-settings.asciidoc
@@ -75,7 +75,9 @@ troubleshooting on {ece}.
 
 To add or edit an output:
 
-. Click **Add output** or **Edit**.
+. Go to **{fleet} -> Settings**.
+
+. Under **Outputs**, click **Add output** or **Edit**.
 
 . Set the output name and type.
 
@@ -263,7 +265,8 @@ restricted environment, refer to <<air-gapped>>.
 
 To add or edit the source of binary downloads:
 
-. Click **Add agent binary source** or **Edit**.
+. Go to **{fleet} -> Settings**.
+. Under **Agent Ginary Download**, click **Add agent binary source** or **Edit**.
 . Set the agent binary source name.
 . For **Host**, specify the address where you are hosting the artifacts
 repository.


### PR DESCRIPTION
Users who jump into this page need to scroll up to understand the context. Let's make it easier by making the context clear.