### PR TITLE
Add Fleet/Agent 8.5.3 release notes

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-8.5.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.5.asciidoc
@@ -14,6 +14,7 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-8.5.3>>
 * <<release-notes-8.5.2>>
 * <<release-notes-8.5.1>>
 * <<release-notes-8.5.0>>
@@ -22,6 +23,28 @@ Also see:
 
 * {kibana-ref}/release-notes.html[{kib} release notes]
 * {beats-ref}/release-notes.html[{beats} release notes]
+
+// begin 8.5.3 relnotes
+
+[[release-notes-8.5.3]]
+== {fleet} and {agent} 8.5.3
+
+Review important information about the {fleet} and {agent} 8.5.3 release.
+
+[discrete]
+[[bug-fixes-8.5.3]]
+=== Bug fixes
+
+{fleet}::
+* No bug fixes in this release
+
+{fleet-server}::
+* Fix unenroll offline agents logic {fleet-server-issue}2091[#2091] {fleet-server-pull}2092[#2092]
+
+{agent}::
+* No bug fixes in this release
+
+// end 8.5.3 relnotes
 
 // begin 8.5.2 relnotes
 


### PR DESCRIPTION
Closes #2422

These release notes are based on the commits from BC1:

Elastic Agent: 
0a6c4f05e33ed054ce54409a59f6d7da52e07cd2

Fleet Server:
34f8a9419c90a409fabd60a7345d44a78f518ac2

Next week, someone in @elastic/obs-docs will need to:
- [x]  Check BC2 for additional Elastic Agent and Fleet Server changes.
- [x] Check the [Kibana relnotes](https://github.com/elastic/kibana/pull/146706) for additional Fleet changes.
- [ ] Finalize and then merge this PR when approved.