### PR TITLE
Add Fleet/Agent 7.17.8 release notes

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-7.17.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-7.17.asciidoc
@@ -42,15 +42,30 @@ Also see:
 [[release-notes-7.17.8]]
 == {fleet} and {agent} 7.17.8
 
-There are no bug fixes for {fleet} or {agent} in this release.
+Review important information about the {fleet} and {agent} 7.17.8 release.
 
-//Review important information about the {fleet} and {agent} 7.17.8 release.
+[discrete]
+[[breaking-changes-7.17.8]]
+=== Breaking changes
 
-//{fleet}::
-//* Add items here
+Breaking changes can prevent your application from optimal operation and
+performance. Before you upgrade, review the breaking changes, then mitigate the
+impact to your application.
 
-//{agent}::
-//* Add items here.
+[discrete]
+[[breaking-PR32493]]
+.{agent} now rejects certificates signed with SHA-1
+[%collapsible]
+====
+*Details* +
+With the upgrade to Go 1.18, {fleet-server} now rejects certificates signed with
+SHA-1. For more information, refer to the Go 1.18
+https://tip.golang.org/doc/go1.18#sha1[release notes].
+
+*Impact* +
+Do not sign certificates with SHA-1. If you are using old certificates signed
+with SHA-1, update them now.
+====
 
 // end 7.17.8 relnotes
 

--- a/docs/en/ingest-management/release-notes/release-notes-7.17.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-7.17.asciidoc
@@ -14,6 +14,8 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-7.17.8>>
+
 * <<release-notes-7.17.7>>
 
 * <<release-notes-7.17.6>>
@@ -34,6 +36,23 @@ Also see:
 
 * {kibana-ref}/release-notes.html[{kib} release notes]
 * {beats-ref}/release-notes.html[{beats} release notes]
+
+// begin 7.17.8 relnotes
+
+[[release-notes-7.17.8]]
+== {fleet} and {agent} 7.17.8
+
+There are no bug fixes for {fleet} or {agent} in this release.
+
+//Review important information about the {fleet} and {agent} 7.17.8 release.
+
+//{fleet}::
+//* Add items here
+
+//{agent}::
+//* Add items here.
+
+// end 7.17.8 relnotes
 
 // begin 7.17.7 relnotes
 

--- a/docs/en/ingest-management/release-notes/release-notes-7.17.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-7.17.asciidoc
@@ -54,7 +54,7 @@ impact to your application.
 
 [discrete]
 [[breaking-PR32493]]
-.{agent} now rejects certificates signed with SHA-1
+.{fleet-server} now rejects certificates signed with SHA-1
 [%collapsible]
 ====
 *Details* +

--- a/docs/en/ingest-management/release-notes/release-notes-7.17.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-7.17.asciidoc
@@ -53,7 +53,7 @@ performance. Before you upgrade, review the breaking changes, then mitigate the
 impact to your application.
 
 [discrete]
-[[breaking-PR32493]]
+[[breaking-PR32493X]]
 .{fleet-server} now rejects certificates signed with SHA-1
 [%collapsible]
 ====


### PR DESCRIPTION
Closes #2447.

These release notes are based on BC1. For 7.17 and earlier, the Elastic Agent source code lives in the `beats` repo, so you need to look at those commits. The contents of this PR (created on 12/02) are from this commit hash: a2289487438f57f724e1d836f3738cadd62fd477

Next week, someone in https://github.com/orgs/elastic/teams/obs-docs will need to:

 - [x] Check to see if there is another BC and look for any new changes that impact Elastic Agent.
 - [x] Check the [Kibana release notes](https://github.com/elastic/kibana/pull/146705) to verify there are no Fleet changes.
 - [ ] Finalize and then merge this PR when approved.