### PR TITLE
Add Fleet/Agent 8.6.0 release notes

### DIFF
--- a/docs/en/ingest-management/index.asciidoc
+++ b/docs/en/ingest-management/index.asciidoc
@@ -171,7 +171,7 @@ include::troubleshooting/troubleshooting.asciidoc[leveloffset=+2]
 
 include::troubleshooting/faq.asciidoc[leveloffset=+2]
 
-include::release-notes/release-notes-8.5.asciidoc[leveloffset=+1]
+include::release-notes/release-notes-8.6.asciidoc[leveloffset=+1]
 
 include::elastic-agent/install-fleet-managed-agent.asciidoc[leveloffset=+2]
 

--- a/docs/en/ingest-management/release-notes/release-notes-8.6.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.6.asciidoc
@@ -125,7 +125,7 @@ The 8.6.0 release adds the following new and notable features.
 * Fix synchronization bug in {fleet-server} that can lead to {es} being flooded by requests to `/.fleet-actions/_fleet/_fleet_search` {fleet-server-pull}2205[#2206].
 
 {agent}::
-* {agent} uses local port when running {fleet-server} {agent-pull}1867[#1867]
+* {agent} now uses the locally bound port (8221) when running {fleet-server} instead of the external port (8220 {agent-pull}1867[#1867]
 * Correctly preserve the {filebeat} registry and other persistent input states during upgrades to eliminate event duplication after upgrades {agent-pull}1701[#1701] {agent-issue}836[#836]
 // end 8.6.0 relnotes
 

--- a/docs/en/ingest-management/release-notes/release-notes-8.6.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.6.asciidoc
@@ -122,7 +122,7 @@ The 8.6.0 release adds the following new and notable features.
 
 {fleet}::
 * Only show {fleet}-managed data streams on data streams list page {kibana-pull}143300[#143300]
-* Fix synchronization bug in {fleet-server} that can lead to {es} being flooded by requests to `/.fleet-actions/_fleet/_fleet_search` {fleet-server-pull}2205[#2206].
+* Fix synchronization bug in {fleet-server} that can lead to {es} being flooded by requests to `/.fleet-actions/_fleet/_fleet_search` {fleet-server-pull}2205[#2205].
 
 {agent}::
 * {agent} now uses the locally bound port (8221) when running {fleet-server} instead of the external port (8220 {agent-pull}1867[#1867]

--- a/docs/en/ingest-management/release-notes/release-notes-8.6.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.6.asciidoc
@@ -94,34 +94,37 @@ Review important information about the {fleet} and {agent} 8.6.0 release.
 //{agent}::
 //* add info
 
-//[discrete]
-//[[new-features-8.6.0]]
-//=== New features
+[discrete]
+[[new-features-8.6.0]]
+=== New features
 
-//The 8.6.0 release adds the following new and notable features.
+The 8.6.0 release adds the following new and notable features.
 
-//{fleet}::
-//* add info
-
-//{agent}::
-//* add info
-
-//[discrete]
-//[[enhancements-8.6.0]]
-//=== Enhancements
-
-//{fleet}::
-//* add info
+{fleet}::
+* Differentiate kubernetes integration multi page experience {kibana-pull}145224[#145224]
+* Prerelease toggle {kibana-pull}143853[#143853]
+* Adds link to skip multi step add integration workflow {kibana-pull}143279[#143279]
+* Request diagnostics {kibana-pull}142369[#142369]
 
 //{agent}::
 //* add info
 
-//[discrete]
-//[[bug-fixes-8.6.0]]
-//=== Bug fixes
+[discrete]
+[[enhancements-8.6.0]]
+=== Enhancements
 
-//{fleet}::
+{fleet}::
+Adds `?full` option to get package info endpoint to return all package fields {kibana-pull}144343[#144343]
+
+//{agent}::
 //* add info
+
+[discrete]
+[[bug-fixes-8.6.0]]
+=== Bug fixes
+
+{fleet}::
+Only show {fleet}-managed data streams on data streams list page {kibana-pull}143300[#143300]
 
 //{agent}::
 //* add info

--- a/docs/en/ingest-management/release-notes/release-notes-8.6.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.6.asciidoc
@@ -125,7 +125,7 @@ The 8.6.0 release adds the following new and notable features.
 * Fix synchronization bug in {fleet-server} that can lead to {es} being flooded by requests to `/.fleet-actions/_fleet/_fleet_search` {fleet-server-pull}2205[#2205].
 
 {agent}::
-* {agent} now uses the locally bound port (8221) when running {fleet-server} instead of the external port (8220 {agent-pull}1867[#1867]
+* {agent} now uses the locally bound port (8221) when running {fleet-server} instead of the external port (8220) {agent-pull}1867[#1867]
 * Correctly preserve the {filebeat} registry and other persistent input states during upgrades to eliminate event duplication after upgrades {agent-pull}1701[#1701] {agent-issue}836[#836]
 // end 8.6.0 relnotes
 

--- a/docs/en/ingest-management/release-notes/release-notes-8.6.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.6.asciidoc
@@ -84,8 +84,6 @@ For more information, refer to {agent-issue}2066[#2066].
 Be aware that the live query results shown in {kib} may be stale.
 ====
 
-//REVIEWERS: Is this correct ^^? Changelog entries didn't sufficient detail.
-
 [discrete]
 [[new-features-8.6.0]]
 === New features
@@ -105,8 +103,8 @@ The 8.6.0 release adds the following new and notable features.
 * Remove inputs when all streams are removed {agent-pull}1869[#1869] {agent-issue}1868[#1868]
 * No longer restart {agent} on log level change {agent-pull}1914[#1914] {agent-issue}1896[#1896]
 * Add `inspect components` command to inspect the computed components/units model of the current configuration (for example, `elastic-agent inspect components`) {agent-pull}1701[#1701] {agent-issue}836[#836]
-* Add Common Expression Language input mapping to the {filebeat} spec {agent-pull}1719[#1719] 
-* Only support {es} as an output for the beta synthetics integration {agent-pull}1491[#1491] 
+* Add Common Expression Language input mapping to the {filebeat} spec {agent-pull}1719[#1719]
+* Only support {es} as an output for the beta synthetics integration {agent-pull}1491[#1491]
 
 [discrete]
 [[enhancements-8.6.0]]

--- a/docs/en/ingest-management/release-notes/release-notes-8.6.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.6.asciidoc
@@ -81,7 +81,7 @@ in the {kib} UI even though the results have been successfully sent to {es}.
 For more information, refer to {agent-issue}2066[#2066].
 
 *Impact* +
-Be aware that the live query results shown in {kib} may be stale.
+Be aware that the live query results shown in {kib} may be delayed by up to 5 minutes.
 ====
 
 [discrete]
@@ -114,7 +114,7 @@ The 8.6.0 release adds the following new and notable features.
 * Add `?full` option to get package info endpoint to return all package fields {kibana-pull}144343[#144343]
 
 {agent}::
-* Health Status: {agent} now indicates detailed status information for each component/unit {fleet-server-pull}1747[#1747] {agent-issue}100[#100]
+* Health Status: {agent} now indicates detailed status information for each sub-process and input type {fleet-server-pull}1747[#1747] {agent-issue}100[#100]
 
 [discrete]
 [[bug-fixes-8.6.0]]
@@ -122,6 +122,7 @@ The 8.6.0 release adds the following new and notable features.
 
 {fleet}::
 * Only show {fleet}-managed data streams on data streams list page {kibana-pull}143300[#143300]
+* Fix synchronization bug in {fleet-server} that can lead to {es} being flooded by requests to `/.fleet-actions/_fleet/_fleet_search` {fleet-server-pull}2205[#2206].
 
 {agent}::
 * {agent} uses local port when running {fleet-server} {agent-pull}1867[#1867]

--- a/docs/en/ingest-management/release-notes/release-notes-8.6.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.6.asciidoc
@@ -99,11 +99,11 @@ The 8.6.0 release adds the following new and notable features.
 {agent}::
 * Upgrade Node to version 18.12.0 {agent-pull}1657[#1657] 
 * Add experimental support for running the elastic-agent-shipper {agent-pull}1527[#1527] {agent-issue}219[#219]
-* Capture stdout/stderr of all subprocesses and adjust default log level to INFO for all components {agent-pull}1702[#1702] {agent-issue}221[#221]
+* Collect logs from sub-processes via stdout and stderr and write them to a single, unified Elastic Agent log file {agent-pull}1702[#1702] {agent-issue}221[#221]
 * Remove inputs when all streams are removed {agent-pull}1869[#1869] {agent-issue}1868[#1868]
 * No longer restart {agent} on log level change {agent-pull}1914[#1914] {agent-issue}1896[#1896]
 * Add `inspect components` command to inspect the computed components/units model of the current configuration (for example, `elastic-agent inspect components`) {agent-pull}1701[#1701] {agent-issue}836[#836]
-* Add Common Expression Language input mapping to the {filebeat} spec {agent-pull}1719[#1719]
+* Add support for the Common Expression Language (CEL) {filebeat} input type {agent-pull}1719[#1719]
 * Only support {es} as an output for the beta synthetics integration {agent-pull}1491[#1491]
 
 [discrete]

--- a/docs/en/ingest-management/release-notes/release-notes-8.6.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.6.asciidoc
@@ -26,73 +26,65 @@ Also see:
 [[release-notes-8.6.0]]
 == {fleet} and {agent} 8.6.0
 
-coming[8.6.0]
-
 Review important information about the {fleet} and {agent} 8.6.0 release.
 
-//[discrete]
-//[[security-updates-8.6.0]]
-//=== Security updates
+[discrete]
+[[breaking-changes-8.6.0]]
+=== Breaking changes
 
-//{fleet}::
-//* add info
+Breaking changes can prevent your application from optimal operation and
+performance. Before you upgrade, review the breaking changes, then mitigate the
+impact to your application.
 
-//{agent}::
-//* add info
+[discrete]
+[[breaking-1994]]
+.Each input in an agent policy must have a unique ID 
+[%collapsible]
+====
+*Details* +
+Each input in an agent policy must have a unique ID, like `id: my-unique-input-id`.
+This change only affects standalone agents. Unique IDs are automatically generated in
+agent policies managed by {fleet}. For more information, refer to
+{agent-pull}/1994[#1994]
 
-//[discrete]
-//[[breaking-changes-8.6.0]]
-//=== Breaking changes
+*Impact* +
+Make sure that your standalone agent policies have a unique ID.
+====
 
-//Breaking changes can prevent your application from optimal operation and
-//performance. Before you upgrade, review the breaking changes, then mitigate the
-//impact to your application.
+[discrete]
+[[breaking-1140]]
+.Diagnostics `--pprof` argument has been removed and is now always provided
+[%collapsible]
+====
+*Details* +
+The `diagnostics` command gathers diagnostic information about the {agent} and
+each component/unit it runs. Starting in 8.6.0, the `--pprof`
+argument is no longer available because `pprof` information is now always
+provided. For more information, refer to {agent-pull}1140[#1140].
 
-//[discrete]
-//[[breaking-PR#]]
-//.Short description
-//[%collapsible]
-//====
-//*Details* +
-//<Describe new behavior.> For more information, refer to {kibana-pull}PR[#PR].
+*Impact* +
+Remove the `--pprof` argument from any scripts or commands you use.
+====
 
-//*Impact* +
-//<Describe how users should mitigate the change.> For more information, refer to {fleet-guide}/fleet-server.html[Fleet Server].
-//====
+[discrete]
+[[known-issues-8.6.0]]
+=== Known issues
 
-//[discrete]
-//[[known-issues-8.6.0]]
-//=== Known issues
+[discrete]
+[[known-issue-issue-2066]]
+.Osquery live query results can take up to five minutes to show up in {kib}
+[%collapsible]
+====
+*Details* +
+A known issue in {agent} may prevent live query results from being available
+in the {kib} UI even though the results have been successfully sent to {es}. 
+For more information, refer to {agent-issue}2066[#2066].
 
-//[[known-issue-issue#]]
-//.Short description
-//[%collapsible]
-//====
+*Impact* +
+Be aware that the live query results shown in {kib} may be stale.
+====
 
-//*Details*
-
-//<Describe known issue.>
-
-//*Impact* +
-
-//<Describe impact or workaround.>
-
-//====
-
-//[discrete]
-//[[deprecations-8.6.0]]
-//=== Deprecations
-
-//The following functionality is deprecated in 8.6.0, and will be removed in
-//8.6.0. Deprecated functionality does not have an immediate impact on your
-//application, but we strongly recommend you make the necessary updates after you
-//upgrade to 8.6.0.
-
-//{fleet}::
-//* add info
-
-//{agent}::
-//* add info
+//REVIEWERS: Is this correct ^^? Changelog entries didn't sufficient detail.
 
 [discrete]
 [[new-features-8.6.0]]
@@ -101,34 +93,41 @@ Review important information about the {fleet} and {agent} 8.6.0 release.
 The 8.6.0 release adds the following new and notable features.
 
 {fleet}::
-* Differentiate kubernetes integration multi page experience {kibana-pull}145224[#145224]
-* Prerelease toggle {kibana-pull}143853[#143853]
-* Adds link to skip multi step add integration workflow {kibana-pull}143279[#143279]
-* Request diagnostics {kibana-pull}142369[#142369]
+* Differentiate kubernetes integration multipage experience {kibana-pull}145224[#145224]
+* Add prerelease toggle to Integrations list {kibana-pull}143853[#143853]
+* Add link to allow users to skip multistep add integration workflow {kibana-pull}143279[#143279]
+* Add new action for single agents to request diagnostics {kibana-pull}142369[#142369]
 
-//{agent}::
-//* add info
+{agent}::
+* Upgrade Node to version 18.12.0 {agent-pull}1657[#1657] 
+* Add experimental support for running the elastic-agent-shipper {agent-pull}1527[#1527] {agent-issue}219[#219]
+* Capture stdout/stderr of all subprocesses and adjust default log level to INFO for all components {agent-pull}1702[#1702] {agent-issue}221[#221]
+* Remove inputs when all streams are removed {agent-pull}1869[#1869] {agent-issue}1868[#1868]
+* No longer restart {agent} on log level change {agent-pull}1914[#1914] {agent-issue}1896[#1896]
+* Add `inspect components` command to inspect the computed components/units model of the current configuration (for example, `elastic-agent inspect components`) {agent-pull}1701[#1701] {agent-issue}836[#836]
+* Add Common Expression Language input mapping to the {filebeat} spec {agent-pull}1719[#1719] 
+* Only support {es} as an output for the beta synthetics integration {agent-pull}1491[#1491] 
 
 [discrete]
 [[enhancements-8.6.0]]
 === Enhancements
 
 {fleet}::
-Adds `?full` option to get package info endpoint to return all package fields {kibana-pull}144343[#144343]
+* Add `?full` option to get package info endpoint to return all package fields {kibana-pull}144343[#144343]
 
-//{agent}::
-//* add info
+{agent}::
+* Health Status: {agent} now indicates detailed status information for each component/unit {fleet-server-pull}1747[#1747] {agent-issue}100[#100]
 
 [discrete]
 [[bug-fixes-8.6.0]]
 === Bug fixes
 
 {fleet}::
-Only show {fleet}-managed data streams on data streams list page {kibana-pull}143300[#143300]
+* Only show {fleet}-managed data streams on data streams list page {kibana-pull}143300[#143300]
 
-//{agent}::
-//* add info
-
+{agent}::
+* {agent} uses local port when running {fleet-server} {agent-pull}1867[#1867]
+* Correctly preserve the {filebeat} registry and other persistent input states during upgrades to eliminate event duplication after upgrades {agent-pull}1701[#1701] {agent-issue}836[#836]
 // end 8.6.0 relnotes
 
 

--- a/docs/en/ingest-management/release-notes/release-notes-8.6.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.6.asciidoc
@@ -1,0 +1,239 @@
+// Use these for links to issue and pulls.
+:kibana-issue: https://github.com/elastic/kibana/issues/
+:kibana-pull: https://github.com/elastic/kibana/pull/
+:beats-issue: https://github.com/elastic/beats/issues/
+:beats-pull: https://github.com/elastic/beats/pull/
+:agent-libs-pull: https://github.com/elastic/elastic-agent-libs/pull/
+:agent-issue: https://github.com/elastic/elastic-agent/issues/
+:agent-pull: https://github.com/elastic/elastic-agent/pull/
+:fleet-server-issue: https://github.com/elastic/fleet-server/issues/
+:fleet-server-pull: https://github.com/elastic/fleet-server/pull/
+
+[[release-notes]]
+= Release notes
+
+This section summarizes the changes in each release.
+
+* <<release-notes-8.6.0>>
+
+Also see:
+
+* {kibana-ref}/release-notes.html[{kib} release notes]
+* {beats-ref}/release-notes.html[{beats} release notes]
+
+// begin 8.6.0 relnotes
+
+[[release-notes-8.6.0]]
+== {fleet} and {agent} 8.6.0
+
+coming[8.6.0]
+
+Review important information about the {fleet} and {agent} 8.6.0 release.
+
+//[discrete]
+//[[security-updates-8.6.0]]
+//=== Security updates
+
+//{fleet}::
+//* add info
+
+//{agent}::
+//* add info
+
+//[discrete]
+//[[breaking-changes-8.6.0]]
+//=== Breaking changes
+
+//Breaking changes can prevent your application from optimal operation and
+//performance. Before you upgrade, review the breaking changes, then mitigate the
+//impact to your application.
+
+//[discrete]
+//[[breaking-PR#]]
+//.Short description
+//[%collapsible]
+//====
+//*Details* +
+//<Describe new behavior.> For more information, refer to {kibana-pull}PR[#PR].
+
+//*Impact* +
+//<Describe how users should mitigate the change.> For more information, refer to {fleet-guide}/fleet-server.html[Fleet Server].
+//====
+
+//[discrete]
+//[[known-issues-8.6.0]]
+//=== Known issues
+
+//[[known-issue-issue#]]
+//.Short description
+//[%collapsible]
+//====
+
+//*Details*
+
+//<Describe known issue.>
+
+//*Impact* +
+
+//<Describe impact or workaround.>
+
+//====
+
+//[discrete]
+//[[deprecations-8.6.0]]
+//=== Deprecations
+
+//The following functionality is deprecated in 8.6.0, and will be removed in
+//8.6.0. Deprecated functionality does not have an immediate impact on your
+//application, but we strongly recommend you make the necessary updates after you
+//upgrade to 8.6.0.
+
+//{fleet}::
+//* add info
+
+//{agent}::
+//* add info
+
+//[discrete]
+//[[new-features-8.6.0]]
+//=== New features
+
+//The 8.6.0 release adds the following new and notable features.
+
+//{fleet}::
+//* add info
+
+//{agent}::
+//* add info
+
+//[discrete]
+//[[enhancements-8.6.0]]
+//=== Enhancements
+
+//{fleet}::
+//* add info
+
+//{agent}::
+//* add info
+
+//[discrete]
+//[[bug-fixes-8.6.0]]
+//=== Bug fixes
+
+//{fleet}::
+//* add info
+
+//{agent}::
+//* add info
+
+// end 8.6.0 relnotes
+
+
+// ---------------------
+//TEMPLATE
+//Use the following text as a template. Remember to replace the version info.
+
+// begin 8.6.x relnotes
+
+//[[release-notes-8.6.x]]
+//== {fleet} and {agent} 8.6.x
+
+//Review important information about the {fleet} and {agent} 8.6.x release.
+
+//[discrete]
+//[[security-updates-8.6.x]]
+//=== Security updates
+
+//{fleet}::
+//* add info
+
+//{agent}::
+//* add info
+
+//[discrete]
+//[[breaking-changes-8.6.x]]
+//=== Breaking changes
+
+//Breaking changes can prevent your application from optimal operation and
+//performance. Before you upgrade, review the breaking changes, then mitigate the
+//impact to your application.
+
+//[discrete]
+//[[breaking-PR#]]
+//.Short description
+//[%collapsible]
+//====
+//*Details* +
+//<Describe new behavior.> For more information, refer to {kibana-pull}PR[#PR].
+
+//*Impact* +
+//<Describe how users should mitigate the change.> For more information, refer to {fleet-guide}/fleet-server.html[Fleet Server].
+//====
+
+//[discrete]
+//[[known-issues-8.6.x]]
+//=== Known issues
+
+//[[known-issue-issue#]]
+//.Short description
+//[%collapsible]
+//====
+
+//*Details*
+
+//<Describe known issue.>
+
+//*Impact* +
+
+//<Describe impact or workaround.>
+
+//====
+
+//[discrete]
+//[[deprecations-8.6.x]]
+//=== Deprecations
+
+//The following functionality is deprecated in 8.6.x, and will be removed in
+//8.6.x. Deprecated functionality does not have an immediate impact on your
+//application, but we strongly recommend you make the necessary updates after you
+//upgrade to 8.6.x.
+
+//{fleet}::
+//* add info
+
+//{agent}::
+//* add info
+
+//[discrete]
+//[[new-features-8.6.x]]
+//=== New features
+
+//The 8.6.x release adds the following new and notable features.
+
+//{fleet}::
+//* add info
+
+//{agent}::
+//* add info
+
+//[discrete]
+//[[enhancements-8.6.x]]
+//=== Enhancements
+
+//{fleet}::
+//* add info
+
+//{agent}::
+//* add info
+
+//[discrete]
+//[[bug-fixes-8.6.x]]
+//=== Bug fixes
+
+//{fleet}::
+//* add info
+
+//{agent}::
+//* add info
+
+// end 8.6.x relnotes

--- a/docs/en/ingest-management/release-notes/release-notes-8.6.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.6.asciidoc
@@ -105,6 +105,9 @@ The 8.6.0 release adds the following new and notable features.
 * Add `inspect components` command to inspect the computed components/units model of the current configuration (for example, `elastic-agent inspect components`) {agent-pull}1701[#1701] {agent-issue}836[#836]
 * Add support for the Common Expression Language (CEL) {filebeat} input type {agent-pull}1719[#1719]
 * Only support {es} as an output for the beta synthetics integration {agent-pull}1491[#1491]
+* New control protocol between the {agent} and its subprocesses enables per integration health reporting and simplifies new input development {agent-issue}836[#836] {agent-pull}1701[#1701]
+* Change internal directory structure: add a components directory to contain binaries and associated artifacts, and remove the downloads directory {agent-issue}836[#836] {agent-pull}1701[#1701]
+* All binaries for every supported integration are now bundled in the {agent} by default {agent-issue}836[#836] {agent-pull}126[#126]
 
 [discrete]
 [[enhancements-8.6.0]]


### PR DESCRIPTION
Closes #2449

Link to preview: https://observability-docs_2450.docs-preview.app.elstc.co/guide/en/fleet/master/release-notes-8.6.0.html

Reviewers:

- [ ] Please verify the "details" and "impact" sections. Some changelog fragments didn't contain sufficient detail, so I winged it.
- [ ] There was only one changelog fragment for Fleet Server.  It's not really a feature and feels like internals, so I don't think I should add it to the release notes, but let me know if my assumption is wrong: https://github.com/elastic/fleet-server/pull/2079

# Archived notes (please ignore everything below this heading)

Notes for finalizing this PR:

* The dev team has developed a tool to make it easier to maintain changelogs and generate release notes, but it only works for Elastic Agent.
* Assuming we want to provide a single place for users to view Elastic Agent, Fleet, and Fleet Server relnotes, we still need to assemble the content manually.
* I've provided some boilerplate text to make this easier. You may need to modify the boilerplate text and/or the agent changelog entries to get them to work. I feel we can change the style in 8.6, if we want.

## Resources

The source content for the release notes will come from the following places:

- [x]  Elastic Agent changelog fragments. The dev team will generate the changelog for 8.6.0 from existing fragments. Reach out to @endorama or @cmacknz about a week before the release. Note that there is a related issue open here to add some fragments: https://github.com/elastic/elastic-agent/issues/1687
- [x]  Fleet Server changelog fragments. You'll need to look at the changelog fragments in the `fleet-server` repo and incorporate the list of changes manually. Make sure you look at the fragments for the latest BC (basically `https://github.com/elastic/fleet-server/tree/commithash/changelog/fragments` where `commithash` is the hash associated with the release artifact. (Ask dev if you're not sure.)
- [x]  Fleet release notes in Kibana (see https://github.com/elastic/kibana/pull/145768). You'll need to copy any Fleet-related content from each section for the Kibana release notes and possibly modify attribute references to make it work in the Fleet/Agent docs. (Or we could decide not to cover Fleet and tell users to refer to the Kibana docs. Might be awkward for existing users, tho.)

Here are some related PRs and resources:
* [Getting started docs about the elastic-agent-changelog-tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/getting-started.md) - you probably don't need this info if dev generates the asciidoc file
* [Discussion about 8.6.0 release notes process](https://github.com/elastic/observability-docs/issues/703)

## Reviewers
When it's ready, this PR should be reviewed by @cmacknz and @jen-huang (or someone they designate)