### PR TITLE
Application logging docs

### DIFF
--- a/docs/en/observability/application-logs.asciidoc
+++ b/docs/en/observability/application-logs.asciidoc
@@ -1,0 +1,219 @@
+[[application-logs]]
+= Application logs
+
+Application logs provide valuable insight into events that have occurred within your services and applications.
+Correlating these logs with application traces enables you to view the context in which a log event has occurred.
+
+Structured vs unstructured logs:
+
+Structured logging is where the application writes JSON objects directly--instead of
+parsing your logs into a structured object at ingest time.
+
+Why is structure so important in logs? So you can search and aggregate on individual fields within your logs.
+
+
+[float]
+[[ingest-application-logs]]
+== Ingest application logs
+
+There are four ways to ship your application logs to the {stack}.
+Your use case will determine the method that's right for you.
+
+[float]
+=== Plaintext logs with Filebeat
+
+**Requirements**
+
+* The Elastic APM agent for your programming language.
+* Raw, plain-text application logs
+* {filebeat}, to monitor the log files or locations that you specify, collects log events, filter and correlate multi-line logs, and forwards them to {es}
+
+**Pros**
+
+* All programming languages/frameworks are supported
+
+**Cons**
+
+* Must parse application logs to be useful—meaning writing and maintaining Grok patterns and spending CPU cycles on parsing
+
+Learn more: <<plaintext-with-filebeat>>
+
+[float]
+=== ECS loggers with Filebeat
+
+Elastic Common Schema (ECS) loggers format your logs into ECS-compatible JSON,
+which removes the need to manually parse logs.
+
+**Requirements**
+
+* The Elastic APM agent for your programming language
+* The Elastic ECS logger for your language or framework
+* {filebeat}, to monitor the log files or locations that you specify, collects log events, and forwards them to {es}
+
+**Pros**
+
+* Popular logging frameworks supported
+* Simplicity: no manual parsing
+* Decently human-readable JSON structure
+* APM Log correlation
+* Resilient in case of outages
+
+**Cons**
+
+* Not all frameworks are supported
+
+Learn more: <<ecs-with-filebeat>>
+
+[float]
+=== APM agent ECS reformatting with Filebeat
+
+Elastic APM agents can automatically reformat application logs to Elastic Common Schema (ECS) format
+without needing to add an ECS logger dependency.
+
+**Requirements**
+
+* The Elastic APM agent for your programming language
+* {filebeat}, to monitor the log files or locations that you specify, collects log events, and forwards them to {es}
+
+**Pros**
+
+**Cons**
+
+**Supported APM agents/languages**
+
+* Ruby
+* Java
+
+Learn more: <<ecs-reformatting-with-filebeat>>
+
+[float]
+=== APM agent direct logs
+
+Elastic APM agents can automatically capture and send logs directly to APM Server--enabling you to
+easily ingest log events without needing a separate log shipper like {filebeat}.
+
+**Requirements**
+
+The Elastic APM agent for your programming language.
+
+**Pros**
+
+**Cons**
+
+**Supported APM agents/languages**
+
+* Java
+
+Learn more: <<apm-agent-direct>>
+
+[float]
+[[log-correlation]]
+== Log correlation
+
+Elastic APM integrates with the most popular logging frameworks in each programming language.
+These integrations inject trace, transaction, and error ID fields into your application's log records,
+allowing you correlate and easily switch between log and trace events.
+
+[float]
+=== Unstructured logs vs. ECS logs
+
+Unstructured log example:
+
+[source,log]
+----
+DEBUG:root:User 'arthur' (id: 42) successfully logged in. Session id: 91e5b9d
+DEBUG:root:User 'arthur' (id: 42) changed state to verified.
+----
+
+Structured log example:
+
+[source,log]
+----
+verified=False user='arthur' session_id='91e5b9d' id=42 event='logged_in'
+verified=True user='arthur' session_id='91e5b9d' id=42 event='changed_state'
+----
+
+ECS log example:
+
+[source,json]
+----
+{"@timestamp":"2019-08-06T12:09:12.375Z", "log.level": "INFO", "message":"Tomcat started on port(s): 8080 (http) with context path ''", "service.name":"spring-petclinic","process.thread.name":"restartedMain","log.logger":"org.springframework.boot.web.embedded.tomcat.TomcatWebServer"}
+{"@timestamp":"2019-08-06T12:09:12.379Z", "log.level": "INFO", "message":"Started PetClinicApplication in 7.095 seconds (JVM running for 9.082)", "service.name":"spring-petclinic","process.thread.name":"restartedMain","log.logger":"org.springframework.samples.petclinic.PetClinicApplication"}
+{"@timestamp":"2019-08-06T14:08:40.199Z", "log.level":"DEBUG", "message":"init find form", "service.name":"spring-petclinic","process.thread.name":"http-nio-8080-exec-8","log.logger":"org.springframework.samples.petclinic.owner.OwnerController","transaction.id":"28b7fb8d5aba51f1","trace.id":"2869b25b5469590610fea49ac04af7da"}
+----
+
+[float]
+=== Enable log correlation
+
+Log correlation is enabled in each APM agent.
+See the relevant agent documentation for more information:
+
+* {apm-go-ref}/log-correlation.html[Go]
+* {apm-java-ref}/log-correlation.html[Java]
+* {apm-dotnet-ref}/log-correlation.html[.NET]
+* {apm-node-ref}/log-correlation.html[Node.js]
+* {apm-py-ref}/log-correlation.html[Python]
+* {apm-ruby-ref}/log-correlation.html[Ruby]
+
+[[plaintext-with-filebeat]]
+== Plaintext logs with Filebeat
+
+// So before indexing, you would typically use Logstash’s amazing Grok filter to parse the application logs into a JSON object, but this means that you have to write and maintain Grok patterns and spend CPU cycles to do the parsing.
+
+Use {filebeat} to parse and ingest raw, plain-text application logs:
+
+include::./tab-widgets/filebeat-logs/widget.asciidoc[]
+
+Learn more:
+
+* {ref}/common-log-format-example.html[Example: Parse logs in the Common Log Format] -- Learn how to use the Grok processor to parse server logs before indexing.
+{filebeat-ref}/filebeat-input-filestream.html[Filestream input] -- Learn more about the Filestream {filebeat} input.
+
+[[ecs-with-filebeat]]
+== ECS logging with Filebeat
+
+The {ecs-ref}/ecs-reference.html[Elastic Common Schema (ECS)] defines a common set of fields for ingesting data into {es}.
+ECS loggers are plugins for your favorite logging library. They make it easy to format your logs into ECS-compatible JSON--letting you
+extract fields, like log level and exception stack traces.
+For example:
+
+[source,json]
+----
+{"@timestamp":"2019-08-06T12:09:12.375Z", "log.level": "INFO", "message":"Tomcat started on port(s): 8080 (http) with context path ''", "service.name":"spring-petclinic","process.thread.name":"restartedMain","log.logger":"org.springframework.boot.web.embedded.tomcat.TomcatWebServer"}
+{"@timestamp":"2019-08-06T12:09:12.379Z", "log.level": "INFO", "message":"Started PetClinicApplication in 7.095 seconds (JVM running for 9.082)", "service.name":"spring-petclinic","process.thread.name":"restartedMain","log.logger":"org.springframework.samples.petclinic.PetClinicApplication"}
+{"@timestamp":"2019-08-06T14:08:40.199Z", "log.level":"DEBUG", "message":"init find form", "service.name":"spring-petclinic","process.thread.name":"http-nio-8080-exec-8","log.logger":"org.springframework.samples.petclinic.owner.OwnerController","transaction.id":"28b7fb8d5aba51f1","trace.id":"2869b25b5469590610fea49ac04af7da"}
+----
+
+Ready to get started? See the guide for your favorite logging framework:
+
+* {ecs-logging-dotnet-ref}/setup.html[.NET]
+* Go: {ecs-logging-go-zap-ref}/setup.html[zap], {ecs-logging-go-logrus-ref}/setup.html[logrus]
+* {ecs-logging-java-ref}/setup.html[Java]
+* Node.js: {ecs-logging-nodejs-ref}/morgan.html[morgan], {ecs-logging-nodejs-ref}/pino.html[pino], {ecs-logging-nodejs-ref}/winston.html[winston]
+* {ecs-logging-php-ref}/setup.html[PHP]
+* {ecs-logging-python-ref}/installation.html[Python]
+* {ecs-logging-ruby-ref}/setup.html[Ruby]
+
+[[ecs-reformatting-with-filebeat]]
+== APM agent ECS reformatting with Filebeat
+
+Elastic APM agents can automatically reformat application logs to Elastic Common Schema (ECS) format
+without needing to add an ECS logger dependency.
+
+Enable APM agent ECS reformatting in the supported APM agent:
+
+// * {apm-java-ref}/logs.html[Java]
+// * {apm-ruby-ref}/logs.html[Ruby]
+
+Set up Filebeat:
+
+include::./tab-widgets/filebeat-logs/widget.asciidoc[]
+
+[[apm-agent-direct]]
+== APM agent direct logs
+
+Elastic APM agents can automatically capture and send logs directly to APM Server--enabling you to
+easily ingest log events without needing a separate log shipper like {filebeat}.
+
+**Supported APM agents:**
+// * {apm-java-ref}/logs.html[Java]

--- a/docs/en/observability/application-logs.asciidoc
+++ b/docs/en/observability/application-logs.asciidoc
@@ -5,7 +5,7 @@ Application logs provide valuable insight into events that have occurred within 
 
 [float]
 [[log-types]]
-=== Plaintext logs vs. ECS logs
+== Plaintext logs vs. ECS logs
 
 Logs are typically produced as either plaintext or structured.
 Plaintext logs contain only text and have no special formatting, for example:
@@ -34,7 +34,7 @@ For example, the same example shown above might look like this when structured w
 
 [float]
 [[log-correlation]]
-=== Log correlation
+== Log correlation
 
 Correlating your application logs with trace events allows you to:
 
@@ -47,21 +47,14 @@ like trace, transaction, and error ID fields into your application's logs.
 Elastic APM integrates with the most popular logging frameworks in each programming language to accomplish this automatically.
 
 Learn more about log correlation in the APM Guide: {apm-guide-ref}/log-correlation.html[log correlation]
-Or in any of the ingestion guides below.
+Or in any of the agent-specific ingestion guides:
 
-// [float]
-// === Log correlation
-
-// Log correlation is a feature provided by APM agents that allow to correlate application logs and traces.
-
-// See the relevant agent documentation for more information:
-
-// * {apm-go-ref}/log-correlation.html[Go]
-// * {apm-java-ref}/log-correlation.html[Java]
-// * {apm-dotnet-ref}/log-correlation.html[.NET]
-// * {apm-node-ref}/log-correlation.html[Node.js]
-// * {apm-py-ref}/log-correlation.html[Python]
-// * {apm-ruby-ref}/log-correlation.html[Ruby]
+* {apm-go-ref}/log-correlation.html[Go]
+* {apm-java-ref}/log-correlation.html[Java]
+* {apm-dotnet-ref}/log-correlation.html[.NET]
+* {apm-node-ref}/log-correlation.html[Node.js]
+* {apm-py-ref}/log-correlation.html[Python]
+* {apm-ruby-ref}/log-correlation.html[Ruby]
 
 [float]
 [[ingest-application-logs]]
@@ -73,7 +66,7 @@ Your use case will help determine the method that's right for you.
 * <<overview-plaintext-with-filebeat>>
 * <<overview-ecs-with-filebeat>>
 * <<overview-ecs-reformatting-with-filebeat>>
-* <<overview-apm-agent-direct>>
+* <<overview-apm-agent-log-sending>>
 
 [float]
 [[overview-plaintext-with-filebeat]]
@@ -168,10 +161,10 @@ All the benefits of using ECS logging, without having to modify the application 
 Learn more: <<ecs-reformatting-with-filebeat>>
 
 [float]
-[[overview-apm-agent-direct]]
-=== APM agent direct logs
+[[overview-apm-agent-log-sending]]
+=== APM agent log sending
 
-// tag::apm-agent-direct[]
+// tag::apm-agent-log-sending[]
 Elastic APM agents can automatically capture and send logs directly to APM Server--enabling you to
 easily ingest log events without needing a separate log shipper like {filebeat}.
 
@@ -195,9 +188,9 @@ The Elastic APM agent for your programming language.
 **Supported APM agents/languages**
 
 * Java
-// end::apm-agent-direct[]
+// end::apm-agent-log-sending[]
 
-Learn more: <<apm-agent-direct>>
+Learn more: <<apm-agent-log-sending>>
 
 [[plaintext-with-filebeat]]
 == Plaintext logs with Filebeat
@@ -266,10 +259,10 @@ Link
 include::./tab-widgets/filebeat-logs/widget.asciidoc[]
 :!ecs-logs:
 
-[[apm-agent-direct]]
-== APM agent direct logs
+[[apm-agent-log-sending]]
+== APM agent log sending
 
-include::application-logs.asciidoc[tag=apm-agent-direct]
+include::application-logs.asciidoc[tag=apm-agent-log-sending]
 
 [float]
 === Get started

--- a/docs/en/observability/application-logs.asciidoc
+++ b/docs/en/observability/application-logs.asciidoc
@@ -2,24 +2,52 @@
 = Application logs
 
 Application logs provide valuable insight into events that have occurred within your services and applications.
-Correlating these logs with application traces enables you to view the context in which a log event has occurred.
 
-Structured vs unstructured logs:
+[float]
+=== Plaintext logs vs. ECS logs
 
-Structured logging is where the application writes JSON objects directly--instead of
-parsing your logs into a structured object at ingest time.
+Logs are typically produced as either plaintext or structured.
+Plaintext logs contain only text and have no special formatting, for example:
 
-Why is structure so important in logs? So you can search and aggregate on individual fields within your logs.
+[source,log]
+----
+2019-08-06T12:09:12.375Z INFO:spring-petclinic: Tomcat started on port(s): 8080 (http) with context path, org.springframework.boot.web.embedded.tomcat.TomcatWebServer
+2019-08-06T12:09:12.379Z INFO:spring-petclinic: Started PetClinicApplication in 7.095 seconds (JVM running for 9.082), org.springframework.samples.petclinic.PetClinicApplication
+2019-08-06T14:08:40.199Z DEBUG:spring-petclinic: init find form, org.springframework.samples.petclinic.owner.OwnerController
+----
 
+Structured logs, on the other hand, follow a predefined, repeatable pattern or structure.
+This structure is applied at write time--preventing the need for parsing at ingest time.
+The Elastic Common Schema (ECS) defines a common set of fields to use when structuring logs.
+This structure allows logs to be easily ingested,
+and provides the ability to correlate, search, and aggregate on individual fields within your logs.
+
+For example, the same example shown above might look like this when structured with ECS-compatable JSON:
+
+[source,json]
+----
+{"@timestamp":"2019-08-06T12:09:12.375Z", "log.level": "INFO", "message":"Tomcat started on port(s): 8080 (http) with context path ''", "service.name":"spring-petclinic","process.thread.name":"restartedMain","log.logger":"org.springframework.boot.web.embedded.tomcat.TomcatWebServer"}
+{"@timestamp":"2019-08-06T12:09:12.379Z", "log.level": "INFO", "message":"Started PetClinicApplication in 7.095 seconds (JVM running for 9.082)", "service.name":"spring-petclinic","process.thread.name":"restartedMain","log.logger":"org.springframework.samples.petclinic.PetClinicApplication"}
+{"@timestamp":"2019-08-06T14:08:40.199Z", "log.level":"DEBUG", "message":"init find form", "service.name":"spring-petclinic","process.thread.name":"http-nio-8080-exec-8","log.logger":"org.springframework.samples.petclinic.owner.OwnerController","transaction.id":"28b7fb8d5aba51f1","trace.id":"2869b25b5469590610fea49ac04af7da"}
+----
 
 [float]
 [[ingest-application-logs]]
 == Ingest application logs
 
 There are four ways to ship your application logs to the {stack}.
-Your use case will determine the method that's right for you.
+Your use case will help determine the method that's right for you.
+
+<<overview-plaintext-with-filebeat>>
+
+<<overview-ecs-with-filebeat>>
+
+<<overview-ecs-reformatting-with-filebeat>>
+
+<<overview-apm-agent-direct>>
 
 [float]
+[[overview-plaintext-with-filebeat]]
 === Plaintext logs with Filebeat
 
 **Requirements**
@@ -39,6 +67,7 @@ Your use case will determine the method that's right for you.
 Learn more: <<plaintext-with-filebeat>>
 
 [float]
+[[overview-ecs-with-filebeat]]
 === ECS loggers with Filebeat
 
 Elastic Common Schema (ECS) loggers format your logs into ECS-compatible JSON,
@@ -65,6 +94,7 @@ which removes the need to manually parse logs.
 Learn more: <<ecs-with-filebeat>>
 
 [float]
+[[overview-ecs-reformatting-with-filebeat>>]]
 === APM agent ECS reformatting with Filebeat
 
 Elastic APM agents can automatically reformat application logs to Elastic Common Schema (ECS) format
@@ -87,6 +117,7 @@ without needing to add an ECS logger dependency.
 Learn more: <<ecs-reformatting-with-filebeat>>
 
 [float]
+[[overview-apm-agent-direct>>]]
 === APM agent direct logs
 
 Elastic APM agents can automatically capture and send logs directly to APM Server--enabling you to
@@ -114,33 +145,15 @@ Elastic APM integrates with the most popular logging frameworks in each programm
 These integrations inject trace, transaction, and error ID fields into your application's log records,
 allowing you correlate and easily switch between log and trace events.
 
-[float]
-=== Unstructured logs vs. ECS logs
 
-Unstructured log example:
 
-[source,log]
-----
-DEBUG:root:User 'arthur' (id: 42) successfully logged in. Session id: 91e5b9d
-DEBUG:root:User 'arthur' (id: 42) changed state to verified.
-----
+// Correlating these logs with application traces allows you to:
 
-Structured log example:
+// * view the context of a log and the parameters a user provided
+// * view all logs belonging to a particular trace
+// * easily move between logs and traces when debugging application issues in {kib}
 
-[source,log]
-----
-verified=False user='arthur' session_id='91e5b9d' id=42 event='logged_in'
-verified=True user='arthur' session_id='91e5b9d' id=42 event='changed_state'
-----
-
-ECS log example:
-
-[source,json]
-----
-{"@timestamp":"2019-08-06T12:09:12.375Z", "log.level": "INFO", "message":"Tomcat started on port(s): 8080 (http) with context path ''", "service.name":"spring-petclinic","process.thread.name":"restartedMain","log.logger":"org.springframework.boot.web.embedded.tomcat.TomcatWebServer"}
-{"@timestamp":"2019-08-06T12:09:12.379Z", "log.level": "INFO", "message":"Started PetClinicApplication in 7.095 seconds (JVM running for 9.082)", "service.name":"spring-petclinic","process.thread.name":"restartedMain","log.logger":"org.springframework.samples.petclinic.PetClinicApplication"}
-{"@timestamp":"2019-08-06T14:08:40.199Z", "log.level":"DEBUG", "message":"init find form", "service.name":"spring-petclinic","process.thread.name":"http-nio-8080-exec-8","log.logger":"org.springframework.samples.petclinic.owner.OwnerController","transaction.id":"28b7fb8d5aba51f1","trace.id":"2869b25b5469590610fea49ac04af7da"}
-----
+// it easier to understand _why_ something is happening
 
 [float]
 === Enable log correlation

--- a/docs/en/observability/application-logs.asciidoc
+++ b/docs/en/observability/application-logs.asciidoc
@@ -248,12 +248,12 @@ include::application-logs.asciidoc[tag=ecs-reformatting-with-filebeat]
 
 Enable APM agent ECS reformatting in the supported APM agent:
 
-Link
+_See the Ruby or Java agent docs._
 // * {apm-java-ref}/logs.html[Java]
 // * {apm-ruby-ref}/logs.html[Ruby]
 
 [float]
-=== Step 1: Set up {filebeat}
+=== Step 2: Set up {filebeat}
 
 :ecs-logs:
 include::./tab-widgets/filebeat-logs/widget.asciidoc[]
@@ -267,5 +267,6 @@ include::application-logs.asciidoc[tag=apm-agent-log-sending]
 [float]
 === Get started
 
-**Supported APM agents:**
+See the Java agent documentation to get started.
 // * {apm-java-ref}/logs.html[Java]
+// uncomment link when available

--- a/docs/en/observability/application-logs.asciidoc
+++ b/docs/en/observability/application-logs.asciidoc
@@ -46,7 +46,7 @@ To correlate your logs, you must add APM identifiers,
 like trace, transaction, and error ID fields into your application's logs.
 Elastic APM integrates with the most popular logging frameworks in each programming language to accomplish this automatically.
 
-Learn more about log correlation in the APM Guide: https://www.elastic.co/guide/en/apm/guide/8.5/log-correlation.html
+Learn more about log correlation in the APM Guide: {apm-guide-ref}/log-correlation.html[log correlation]
 Or in any of the ingestion guides below.
 
 // [float]
@@ -202,22 +202,30 @@ Learn more: <<apm-agent-direct>>
 [[plaintext-with-filebeat]]
 == Plaintext logs with Filebeat
 
-// So before indexing, you would typically use Logstash’s amazing Grok filter to parse the application logs into a JSON object, but this means that you have to write and maintain Grok patterns and spend CPU cycles to do the parsing.
-
 include::application-logs.asciidoc[tag=plaintext-with-filebeat]
 
 [float]
-=== Get started
+=== Step 1: Use {filebeat} to ingest logs
 
 :plaintext:
 include::./tab-widgets/filebeat-logs/widget.asciidoc[]
 :!plaintext:
 
 [float]
+=== Step 2: Parse logs at ingest time
+
+A downside of plaintext logs is that you can't aggregate or search on the fields within the logs.
+To enable these features, you'll need to parse the contents of your logs into ECS-compatible fields.
+
+To learn how to use the Grok processor to parse application logs before indexing,
+see {ref}/common-log-format-example.html[Example: Parse logs in the Common Log Format].
+
+[float]
 === Learn more
 
-* {ref}/common-log-format-example.html[Example: Parse logs in the Common Log Format] -- Learn how to use the Grok processor to parse server logs before indexing.
-{filebeat-ref}/filebeat-input-filestream.html[Filestream input] -- Learn more about the Filestream {filebeat} input.
+* {filebeat-ref}/filebeat-input-filestream.html[Filestream input]
+* {ref}/ingest.html[Ingest pipelines]
+* {ref}/grok-processor.html[Grok processor]
 
 [[ecs-with-filebeat]]
 == ECS logging with Filebeat
@@ -227,19 +235,7 @@ include::application-logs.asciidoc[tag=ecs-with-filebeat]
 [float]
 === Get started
 
-The {ecs-ref}/ecs-reference.html[Elastic Common Schema (ECS)] defines a common set of fields for ingesting data into {es}.
-ECS loggers are plugins for your favorite logging library. They make it easy to format your logs into ECS-compatible JSON--letting you
-extract fields, like log level and exception stack traces.
-For example:
-
-[source,json]
-----
-{"@timestamp":"2019-08-06T12:09:12.375Z", "log.level": "INFO", "message":"Tomcat started on port(s): 8080 (http) with context path ''", "service.name":"spring-petclinic","process.thread.name":"restartedMain","log.logger":"org.springframework.boot.web.embedded.tomcat.TomcatWebServer"}
-{"@timestamp":"2019-08-06T12:09:12.379Z", "log.level": "INFO", "message":"Started PetClinicApplication in 7.095 seconds (JVM running for 9.082)", "service.name":"spring-petclinic","process.thread.name":"restartedMain","log.logger":"org.springframework.samples.petclinic.PetClinicApplication"}
-{"@timestamp":"2019-08-06T14:08:40.199Z", "log.level":"DEBUG", "message":"init find form", "service.name":"spring-petclinic","process.thread.name":"http-nio-8080-exec-8","log.logger":"org.springframework.samples.petclinic.owner.OwnerController","transaction.id":"28b7fb8d5aba51f1","trace.id":"2869b25b5469590610fea49ac04af7da"}
-----
-
-Ready to get started? See the guide for your favorite logging framework:
+See the guide for your favorite logging framework:
 
 * {ecs-logging-dotnet-ref}/setup.html[.NET]
 * Go: {ecs-logging-go-zap-ref}/setup.html[zap], {ecs-logging-go-logrus-ref}/setup.html[logrus]
@@ -255,14 +251,16 @@ Ready to get started? See the guide for your favorite logging framework:
 include::application-logs.asciidoc[tag=ecs-reformatting-with-filebeat]
 
 [float]
-=== Get started
+=== Step 1: Enable APM agent reformatting
 
 Enable APM agent ECS reformatting in the supported APM agent:
 
+Link
 // * {apm-java-ref}/logs.html[Java]
 // * {apm-ruby-ref}/logs.html[Ruby]
 
-Set up Filebeat:
+[float]
+=== Step 1: Set up {filebeat}
 
 :ecs-logs:
 include::./tab-widgets/filebeat-logs/widget.asciidoc[]

--- a/docs/en/observability/application-logs.asciidoc
+++ b/docs/en/observability/application-logs.asciidoc
@@ -4,6 +4,7 @@
 Application logs provide valuable insight into events that have occurred within your services and applications.
 
 [float]
+[[log-types]]
 === Plaintext logs vs. ECS logs
 
 Logs are typically produced as either plaintext or structured.
@@ -32,102 +33,145 @@ For example, the same example shown above might look like this when structured w
 ----
 
 [float]
-[[ingest-application-logs]]
-== Ingest application logs
+[[log-correlation]]
+=== Log correlation
 
-There are four ways to ship your application logs to the {stack}.
+Correlating your application logs with trace events allows you to:
+
+* view the context of a log and the parameters a user provided
+* view all logs belonging to a particular trace
+* easily move between logs and traces when debugging application issues in {kib}
+
+To correlate your logs, you must add APM identifiers,
+like trace, transaction, and error ID fields into your application's logs.
+Elastic APM integrates with the most popular logging frameworks in each programming language to accomplish this automatically.
+
+Learn more about log correlation in the APM Guide: https://www.elastic.co/guide/en/apm/guide/8.5/log-correlation.html
+Or in any of the ingestion guides below.
+
+// [float]
+// === Log correlation
+
+// Log correlation is a feature provided by APM agents that allow to correlate application logs and traces.
+
+// See the relevant agent documentation for more information:
+
+// * {apm-go-ref}/log-correlation.html[Go]
+// * {apm-java-ref}/log-correlation.html[Java]
+// * {apm-dotnet-ref}/log-correlation.html[.NET]
+// * {apm-node-ref}/log-correlation.html[Node.js]
+// * {apm-py-ref}/log-correlation.html[Python]
+// * {apm-ruby-ref}/log-correlation.html[Ruby]
+
+[float]
+[[ingest-application-logs]]
+== How to ingest application logs
+
+There are four main ways to ingest application logs into the {stack}.
 Your use case will help determine the method that's right for you.
 
-<<overview-plaintext-with-filebeat>>
-
-<<overview-ecs-with-filebeat>>
-
-<<overview-ecs-reformatting-with-filebeat>>
-
-<<overview-apm-agent-direct>>
+* <<overview-plaintext-with-filebeat>>
+* <<overview-ecs-with-filebeat>>
+* <<overview-ecs-reformatting-with-filebeat>>
+* <<overview-apm-agent-direct>>
 
 [float]
 [[overview-plaintext-with-filebeat]]
-=== Plaintext logs with Filebeat
+=== Plaintext logs with {filebeat}
+
+// tag::plaintext-with-filebeat[]
+Use {filebeat} to parse and ingest raw, plain-text application logs.
 
 **Requirements**
 
 * (Optional) Elastic APM agent for your programming language (for log correlation)
-* Raw, plain-text application logs stored on the file-system
-* {filebeat}, configured to monitor and capture application logs
+* Raw, plain-text application logs stored on the file system
+* {filebeat} configured to monitor and capture application logs
 
 **Pros**
 
 * All programming languages/frameworks are supported
 * Existing application logs can be ingested
-* Does not require modification of the application or its configuration, unless log correlation is required.
+* Does not require modification of the application or its configuration, unless log correlation is required
 
 **Cons**
 
 * Must parse application logs to be useful—meaning writing and maintaining Grok patterns and spending CPU cycles on parsing
-* Parsing is tied to the application log format, thus it can differ per application and needs to be maintained over time
-* Log correlation requires to modify the application log format and inject IDs in log message.
+* Parsing is tied to the application log format, meaning it can differ per application and needs to be maintained over time
+* Log correlation requires modifying the application log format and inject IDs in log messages
+// end::plaintext-with-filebeat[]
 
-Learn more: <<plaintext-with-filebeat>>
+Learn more: <<plaintext-with-filebeat>>.
 
 [float]
 [[overview-ecs-with-filebeat]]
-=== ECS loggers with Filebeat
+=== ECS loggers with {filebeat}
 
+// tag::ecs-with-filebeat[]
 Elastic Common Schema (ECS) loggers format your logs into ECS-compatible JSON,
-which removes the need to manually parse logs.
+removing the need to manually parse logs.
 
 **Requirements**
 
-* (Optional) Elastic APM agent for your programming language. Allows to provide log correlation.
-
+* (Optional) Elastic APM agent for your programming language (for log correlation)
 * The Elastic ECS logger for your language or framework
-* {filebeat}, to monitor the log files or locations that you specify, collects log events, and forwards them to {es}
+* {filebeat} configured to monitor and capture application logs
 
 **Pros**
 
 * Popular logging frameworks supported
-* Simplicity: no manual parsing with filebeat, identical configuration can be reused across applications.
+* Simplicity: no manual parsing with {filebeat}, and a configuration can be reused across applications
 * Decently human-readable JSON structure
-* APM Log correlation
+* APM log correlation
 * Resilient in case of outages
 
 **Cons**
 
 * Not all frameworks are supported
 * Requires modification of the application and its log configuration
+// end::ecs-with-filebeat[]
 
 Learn more: <<ecs-with-filebeat>>
 
 [float]
-[[overview-ecs-reformatting-with-filebeat>>]]
-=== ECS reformatting with Filebeat
+[[overview-ecs-reformatting-with-filebeat]]
+=== ECS reformatting with {filebeat}
 
+// tag::ecs-reformatting-with-filebeat[]
 Elastic APM agents can automatically reformat application logs to Elastic Common Schema (ECS) format
-without needing to add an ECS logger dependency or modifying the application.
+without needing to add an ECS logger dependency or modify the application.
 
 **Requirements**
 
 * The Elastic APM agent for your programming language
-* {filebeat}, to monitor the log files or locations that you specify, collects log events, and forwards them to {es}
+* {filebeat} configured to monitor and capture application logs
 
 **Pros**
-* all the benefits of using ECS logging, without having to modify the application or its configuration.
+
+All the benefits of using ECS logging, without having to modify the application or its configuration:
+
+* Simplicity: no manual parsing with {filebeat}, and a configuration can be reused across applications
+* Decently human-readable JSON structure
+* APM log correlation
+
 **Cons**
-* Requires to use the APM agent
+
+* Requires an Elastic APM agent
 * Not all APM agents support this feature
 
 **Supported APM agents/languages**
 
 * Ruby
 * Java
+// end::ecs-reformatting-with-filebeat[]
 
 Learn more: <<ecs-reformatting-with-filebeat>>
 
 [float]
-[[overview-apm-agent-direct>>]]
+[[overview-apm-agent-direct]]
 === APM agent direct logs
 
+// tag::apm-agent-direct[]
 Elastic APM agents can automatically capture and send logs directly to APM Server--enabling you to
 easily ingest log events without needing a separate log shipper like {filebeat}.
 
@@ -136,70 +180,52 @@ easily ingest log events without needing a separate log shipper like {filebeat}.
 The Elastic APM agent for your programming language.
 
 **Pros**
-* Simple to setup as it only relies on the APM agent
+
+* Simple to set up as it only relies on the APM agent
 * No modification of the application required
 * No need to deploy {filebeat}
-* No need to store log files in filesystem.
+* No need to store log files in the file system.
 
 **Cons**
+
 * Experimental feature
-* Only supported in Java APM agent for now
-* Log messages are not persistent and can be dropped when buffered in the agent and in apm-server or in case of outage.
+* Limited APM agent support
+* Not resilient to outages: Log messages can be dropped when buffered in the agent or in APM Server
 
 **Supported APM agents/languages**
 
 * Java
+// end::apm-agent-direct[]
 
 Learn more: <<apm-agent-direct>>
-
-[float]
-[[log-correlation]]
-== Log correlation
-
-Elastic APM integrates with the most popular logging frameworks in each programming language.
-These integrations inject trace, transaction, and error ID fields into your application's log records,
-allowing you correlate and easily switch between log and trace events.
-
-
-
-// Correlating these logs with application traces allows you to:
-
-// * view the context of a log and the parameters a user provided
-// * view all logs belonging to a particular trace
-// * easily move between logs and traces when debugging application issues in {kib}
-
-// it easier to understand _why_ something is happening
-
-[float]
-=== Log correlation
-
-Log correlation is a feature provided by APM agents that allow to correlate application logs and traces.
-
-See the relevant agent documentation for more information:
-
-* {apm-go-ref}/log-correlation.html[Go]
-* {apm-java-ref}/log-correlation.html[Java]
-* {apm-dotnet-ref}/log-correlation.html[.NET]
-* {apm-node-ref}/log-correlation.html[Node.js]
-* {apm-py-ref}/log-correlation.html[Python]
-* {apm-ruby-ref}/log-correlation.html[Ruby]
 
 [[plaintext-with-filebeat]]
 == Plaintext logs with Filebeat
 
 // So before indexing, you would typically use Logstash’s amazing Grok filter to parse the application logs into a JSON object, but this means that you have to write and maintain Grok patterns and spend CPU cycles to do the parsing.
 
-Use {filebeat} to parse and ingest raw, plain-text application logs:
+include::application-logs.asciidoc[tag=plaintext-with-filebeat]
 
+[float]
+=== Get started
+
+:plaintext:
 include::./tab-widgets/filebeat-logs/widget.asciidoc[]
+:!plaintext:
 
-Learn more:
+[float]
+=== Learn more
 
 * {ref}/common-log-format-example.html[Example: Parse logs in the Common Log Format] -- Learn how to use the Grok processor to parse server logs before indexing.
 {filebeat-ref}/filebeat-input-filestream.html[Filestream input] -- Learn more about the Filestream {filebeat} input.
 
 [[ecs-with-filebeat]]
 == ECS logging with Filebeat
+
+include::application-logs.asciidoc[tag=ecs-with-filebeat]
+
+[float]
+=== Get started
 
 The {ecs-ref}/ecs-reference.html[Elastic Common Schema (ECS)] defines a common set of fields for ingesting data into {es}.
 ECS loggers are plugins for your favorite logging library. They make it easy to format your logs into ECS-compatible JSON--letting you
@@ -226,8 +252,10 @@ Ready to get started? See the guide for your favorite logging framework:
 [[ecs-reformatting-with-filebeat]]
 == APM agent ECS reformatting with Filebeat
 
-Elastic APM agents can automatically reformat application logs to Elastic Common Schema (ECS) format
-without needing to add an ECS logger dependency.
+include::application-logs.asciidoc[tag=ecs-reformatting-with-filebeat]
+
+[float]
+=== Get started
 
 Enable APM agent ECS reformatting in the supported APM agent:
 
@@ -236,13 +264,17 @@ Enable APM agent ECS reformatting in the supported APM agent:
 
 Set up Filebeat:
 
+:ecs-logs:
 include::./tab-widgets/filebeat-logs/widget.asciidoc[]
+:!ecs-logs:
 
 [[apm-agent-direct]]
 == APM agent direct logs
 
-Elastic APM agents can automatically capture and send logs directly to APM Server--enabling you to
-easily ingest log events without needing a separate log shipper like {filebeat}.
+include::application-logs.asciidoc[tag=apm-agent-direct]
+
+[float]
+=== Get started
 
 **Supported APM agents:**
 // * {apm-java-ref}/logs.html[Java]

--- a/docs/en/observability/index.asciidoc
+++ b/docs/en/observability/index.asciidoc
@@ -68,6 +68,8 @@ include::observability-ui.asciidoc[leveloffset=+1]
 include::apm.asciidoc[leveloffset=+1]
 
 // Logs
+include::application-logs.asciidoc[leveloffset=+1]
+
 include::monitor-logs.asciidoc[leveloffset=+1]
 
 include::tail-logs.asciidoc[leveloffset=+2]

--- a/docs/en/observability/tab-widgets/filebeat-logs/content.asciidoc
+++ b/docs/en/observability/tab-widgets/filebeat-logs/content.asciidoc
@@ -1,7 +1,7 @@
 // tag::logs[]
 
 . Follow the {filebeat-ref}/filebeat-installation-configuration.html[Filebeat quick start] to learn how to
-install {filebeat}, connect to the {stack}.
+install {filebeat} and connect to the {stack}.
 
 ifdef::ecs-logs[]
 . Add the following configuration to your `filebeat.yaml` file to start collecting log data.
@@ -30,9 +30,14 @@ endif::ecs-logs[]
 ifdef::plaintext[]
 . Configure filebeat.yaml file to start collecting log data.
 +
-You can't aggregate or search on the fields of unstructured logs.
-To learn how to use the Grok processor to parse server logs before indexing,
-see {ref}/common-log-format-example.html[Example: Parse logs in the Common Log Format].
+. Add the following configuration to your `filebeat.yaml` file to start collecting log data.
++
+.filebeat.yaml
+----
+filebeat.inputs:
+- type: filestream <1>
+  paths: /path/to/logs.json
+----
 endif::plaintext[]
 
 // end::logs[]
@@ -41,14 +46,13 @@ endif::plaintext[]
 // tag::kubernetes[]
 . Make sure your application logs to stdout/stderr.
 
-. Follow the {filebeat-ref}/running-on-kubernetes.html[Run Filebeat on Kubernetes] guide.
+. Follow the {filebeat-ref}/running-on-kubernetes.html[Run {filebeat} on Kubernetes] guide.
 
-. Enable https://www.elastic.co/guide/en/beats/filebeat/current/configuration-autodiscover-hints.html[hints-based autodiscover] (uncomment the corresponding section in `filebeat-kubernetes.yaml`).
+. Enable {filebeat-ref}/configuration-autodiscover-hints.html[hints-based autodiscover] (uncomment the corresponding section in `filebeat-kubernetes.yaml`).
 
 ifdef::ecs-logs[]
-. Add these annotations to your pods that log using ECS loggers.
-  This will make sure the logs are parsed appropriately.
-
+. Add these annotations to your pods that log using ECS-compatible JSON. This will make sure the logs are parsed appropriately.
++
 [source,yaml]
 ----
 annotations:
@@ -59,7 +63,6 @@ annotations:
 ----
 endif::ecs-logs[]
 ifdef::plaintext[]
-Plaintext instructions go here
 endif::plaintext[]
 // end::kubernetes[]
 
@@ -67,14 +70,13 @@ endif::plaintext[]
 // tag::docker[]
 . Make sure your application logs to stdout/stderr.
 
-. Follow the {filebeat-ref}/running-on-docker.html[Run Filebeat on Docker] guide.
+. Follow the {filebeat-ref}/running-on-docker.html[Run {filebeat} on Docker] guide.
 
-. Enable https://www.elastic.co/guide/en/beats/filebeat/current/configuration-autodiscover-hints.html[hints-based autodiscover].
+. Enable {filebeat-ref}/current/configuration-autodiscover-hints.html[hints-based autodiscover].
 
 ifdef::ecs-logs[]
-. Add these labels to your containers that log using ECS loggers.
-  This will make sure the logs are parsed appropriately.
-
+. Add these labels to your containers that log using ECS-compatible JSON. This will make sure the logs are parsed appropriately.
++
 [source,yaml]
 .docker-compose.yml
 ----
@@ -86,6 +88,5 @@ labels:
 ----
 endif::ecs-logs[]
 ifdef::plaintext[]
-Plaintext instructions go here
 endif::plaintext[]
 // end::docker[]

--- a/docs/en/observability/tab-widgets/filebeat-logs/content.asciidoc
+++ b/docs/en/observability/tab-widgets/filebeat-logs/content.asciidoc
@@ -3,9 +3,8 @@
 . Follow the {filebeat-ref}/filebeat-installation-configuration.html[Filebeat quick start] to learn how to
 install {filebeat}, connect to the {stack}.
 
+ifdef::ecs-logs[]
 . Add the following configuration to your `filebeat.yaml` file to start collecting log data.
-+
-**structured logs**
 +
 [source,yaml]
 .filebeat.yaml
@@ -27,21 +26,26 @@ processors:
   - add_kubernetes_metadata: ~
 ----
 <1> Use the filestream input to read lines from active log files.
-+
-**unstructured logs**
+endif::ecs-logs[]
+ifdef::plaintext[]
+. Configure filebeat.yaml file to start collecting log data.
 +
 You can't aggregate or search on the fields of unstructured logs.
 To learn how to use the Grok processor to parse server logs before indexing,
 see {ref}/common-log-format-example.html[Example: Parse logs in the Common Log Format].
-// TODO: Hide this section from the ECS reformatting page
+endif::plaintext[]
 
 // end::logs[]
 
 
 // tag::kubernetes[]
 . Make sure your application logs to stdout/stderr.
+
 . Follow the {filebeat-ref}/running-on-kubernetes.html[Run Filebeat on Kubernetes] guide.
+
 . Enable https://www.elastic.co/guide/en/beats/filebeat/current/configuration-autodiscover-hints.html[hints-based autodiscover] (uncomment the corresponding section in `filebeat-kubernetes.yaml`).
+
+ifdef::ecs-logs[]
 . Add these annotations to your pods that log using ECS loggers.
   This will make sure the logs are parsed appropriately.
 
@@ -53,13 +57,21 @@ annotations:
   co.elastic.logs/json.add_error_key: true
   co.elastic.logs/json.expand_keys: true
 ----
+endif::ecs-logs[]
+ifdef::plaintext[]
+Plaintext instructions go here
+endif::plaintext[]
 // end::kubernetes[]
 
 
 // tag::docker[]
 . Make sure your application logs to stdout/stderr.
+
 . Follow the {filebeat-ref}/running-on-docker.html[Run Filebeat on Docker] guide.
+
 . Enable https://www.elastic.co/guide/en/beats/filebeat/current/configuration-autodiscover-hints.html[hints-based autodiscover].
+
+ifdef::ecs-logs[]
 . Add these labels to your containers that log using ECS loggers.
   This will make sure the logs are parsed appropriately.
 
@@ -72,4 +84,8 @@ labels:
   co.elastic.logs/json.add_error_key: true
   co.elastic.logs/json.expand_keys: true
 ----
+endif::ecs-logs[]
+ifdef::plaintext[]
+Plaintext instructions go here
+endif::plaintext[]
 // end::docker[]

--- a/docs/en/observability/tab-widgets/filebeat-logs/content.asciidoc
+++ b/docs/en/observability/tab-widgets/filebeat-logs/content.asciidoc
@@ -32,6 +32,7 @@ ifdef::plaintext[]
 +
 . Add the following configuration to your `filebeat.yaml` file to start collecting log data.
 +
+[source,yaml]
 .filebeat.yaml
 ----
 filebeat.inputs:
@@ -72,7 +73,7 @@ endif::plaintext[]
 
 . Follow the {filebeat-ref}/running-on-docker.html[Run {filebeat} on Docker] guide.
 
-. Enable {filebeat-ref}/current/configuration-autodiscover-hints.html[hints-based autodiscover].
+. Enable {filebeat-ref}/configuration-autodiscover-hints.html[hints-based autodiscover].
 
 ifdef::ecs-logs[]
 . Add these labels to your containers that log using ECS-compatible JSON. This will make sure the logs are parsed appropriately.

--- a/docs/en/observability/tab-widgets/filebeat-logs/content.asciidoc
+++ b/docs/en/observability/tab-widgets/filebeat-logs/content.asciidoc
@@ -1,0 +1,75 @@
+// tag::logs[]
+
+. Follow the {filebeat-ref}/filebeat-installation-configuration.html[Filebeat quick start] to learn how to
+install {filebeat}, connect to the {stack}.
+
+. Add the following configuration to your `filebeat.yaml` file to start collecting log data.
++
+**structured logs**
++
+[source,yaml]
+.filebeat.yaml
+----
+filebeat.inputs:
+- type: filestream <1>
+  paths: /path/to/logs.json
+  parsers:
+    - ndjson:
+        keys_under_root: true
+        overwrite_keys: true
+        add_error_key: true
+        expand_keys: true
+
+processors:
+  - add_host_metadata: ~
+  - add_cloud_metadata: ~
+  - add_docker_metadata: ~
+  - add_kubernetes_metadata: ~
+----
+<1> Use the filestream input to read lines from active log files.
++
+**unstructured logs**
++
+You can't aggregate or search on the fields of unstructured logs.
+To learn how to use the Grok processor to parse server logs before indexing,
+see {ref}/common-log-format-example.html[Example: Parse logs in the Common Log Format].
+// TODO: Hide this section from the ECS reformatting page
+
+// end::logs[]
+
+
+// tag::kubernetes[]
+. Make sure your application logs to stdout/stderr.
+. Follow the {filebeat-ref}/running-on-kubernetes.html[Run Filebeat on Kubernetes] guide.
+. Enable https://www.elastic.co/guide/en/beats/filebeat/current/configuration-autodiscover-hints.html[hints-based autodiscover] (uncomment the corresponding section in `filebeat-kubernetes.yaml`).
+. Add these annotations to your pods that log using ECS loggers.
+  This will make sure the logs are parsed appropriately.
+
+[source,yaml]
+----
+annotations:
+  co.elastic.logs/json.keys_under_root: true
+  co.elastic.logs/json.overwrite_keys: true
+  co.elastic.logs/json.add_error_key: true
+  co.elastic.logs/json.expand_keys: true
+----
+// end::kubernetes[]
+
+
+// tag::docker[]
+. Make sure your application logs to stdout/stderr.
+. Follow the {filebeat-ref}/running-on-docker.html[Run Filebeat on Docker] guide.
+. Enable https://www.elastic.co/guide/en/beats/filebeat/current/configuration-autodiscover-hints.html[hints-based autodiscover].
+. Add these labels to your containers that log using ECS loggers.
+  This will make sure the logs are parsed appropriately.
+
+[source,yaml]
+.docker-compose.yml
+----
+labels:
+  co.elastic.logs/json.keys_under_root: true
+  co.elastic.logs/json.overwrite_keys: true
+  co.elastic.logs/json.add_error_key: true
+  co.elastic.logs/json.expand_keys: true
+----
+// end::docker[]

--- a/docs/en/observability/tab-widgets/filebeat-logs/widget.asciidoc
+++ b/docs/en/observability/tab-widgets/filebeat-logs/widget.asciidoc
@@ -1,0 +1,56 @@
+++++
+<div class="tabs" data-tab-group="fb">
+  <div role="tablist" aria-label="filebeat">
+    <button role="tab"
+            aria-selected="true"
+            aria-controls="logs-tab-install"
+            id="logs-install">
+      Log file
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="kubernetes-tab-install"
+            id="kubernetes-install">
+      Kubernetes
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="docker-tab-install"
+            id="docker-install">
+      Docker
+    </button>
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="logs-tab-install"
+       aria-labelledby="logs-install">
+++++
+
+include::content.asciidoc[tag=logs]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="kubernetes-tab-install"
+       aria-labelledby="kubernetes-install"
+       hidden="">
+++++
+
+include::content.asciidoc[tag=kubernetes]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="docker-tab-install"
+       aria-labelledby="docker-install"
+       hidden="">
+++++
+
+include::content.asciidoc[tag=docker]
+
+++++
+  </div>
+</div>
+++++


### PR DESCRIPTION
### Summary

cc @SylvainJuge 

[**Link to preview**](https://observability-docs_2452.docs-preview.app.elstc.co/guide/en/observability/master/application-logs.html)

### Related issues

- Replaces https://github.com/elastic/apm-server/pull/9751
- Related https://github.com/elastic/apm-agent-java/pull/2916
- Closes https://github.com/elastic/observability-docs/issues/1295
- Related https://github.com/elastic/observability-docs/issues/2362

### Related links

- https://github.com/elastic/apm/blob/main/specs/agents/log-sending.md
- https://www.elastic.co/guide/en/apm/guide/8.5/log-correlation.html
- https://www.elastic.co/guide/en/apm/agent/java/current/log-correlation.html
- https://www.elastic.co/guide/en/apm/agent/dotnet/current/log-correlation.html
- https://www.elastic.co/guide/en/apm/agent/python/current/log-correlation.html
- https://www.elastic.co/guide/en/apm/agent/nodejs/current/log-correlation.html
- https://www.elastic.co/guide/en/apm/agent/ruby/current/log-correlation.html
- https://www.elastic.co/guide/en/ecs-logging/overview/master/intro.html

### To do in a future PR:

* Add a step 3 to all methods
* Change imports to ECS logging book
* Fix filebeat.yaml sample files: some config options are out of date and others aren't explained well
* Update links to Java and Ruby agents
* 