### PR TITLE
[DOCS] Add server.publicBaseUrl to case setup

### DIFF
--- a/docs/en/observability/grant-cases-access.asciidoc
+++ b/docs/en/observability/grant-cases-access.asciidoc
@@ -38,7 +38,7 @@ NOTE: These privileges also enable you to delete comments and alerts from a case
 // lint enable observability
 
 NOTE: If you are using an on-premises {kib} deployment and want your email
-notifications and external incident management system to contain links back
+notifications and external incident management systems to contain links back
 to {kib}, configure the 
 {kibana-ref}/settings.html#server-publicBaseUrl[server.publicBaseUrl] setting.
 

--- a/docs/en/observability/grant-cases-access.asciidoc
+++ b/docs/en/observability/grant-cases-access.asciidoc
@@ -37,9 +37,9 @@ NOTE: These privileges also enable you to delete comments and alerts from a case
 |=== 
 // lint enable observability
 
-NOTE: If you are using an on-premises {kib} deployment and you want the email
-notifications and the external incident management systems to contain links back
-to {kib}, you must configure the 
+NOTE: If you are using an on-premises {kib} deployment and want your email
+notifications and external incident management system to contain links back
+to {kib}, configure the 
 {kibana-ref}/settings.html#server-publicBaseUrl[server.publicBaseUrl] setting.
 
 For more details, refer to {kibana-ref}/xpack-spaces.html#spaces-control-user-access[feature access based on user privileges].

--- a/docs/en/observability/grant-cases-access.asciidoc
+++ b/docs/en/observability/grant-cases-access.asciidoc
@@ -37,6 +37,11 @@ NOTE: These privileges also enable you to delete comments and alerts from a case
 |=== 
 // lint enable observability
 
+NOTE: If you are using an on-premises {kib} deployment and you want the email
+notifications and the external incident management systems to contain links back
+to {kib}, you must configure the 
+<<server-publicBaseUrl,`server.publicBaseUrl`>> setting.
+
 For more details, refer to {kibana-ref}/xpack-spaces.html#spaces-control-user-access[feature access based on user privileges].
 
 [role="screenshot"]

--- a/docs/en/observability/grant-cases-access.asciidoc
+++ b/docs/en/observability/grant-cases-access.asciidoc
@@ -40,7 +40,7 @@ NOTE: These privileges also enable you to delete comments and alerts from a case
 NOTE: If you are using an on-premises {kib} deployment and you want the email
 notifications and the external incident management systems to contain links back
 to {kib}, you must configure the 
-<<server-publicBaseUrl,`server.publicBaseUrl`>> setting.
+{kibana-ref}/settings.html#server-publicBaseUrl[server.publicBaseUrl] setting.
 
 For more details, refer to {kibana-ref}/xpack-spaces.html#spaces-control-user-access[feature access based on user privileges].
 


### PR DESCRIPTION
Relates to https://github.com/elastic/kibana/issues/141059, https://github.com/elastic/kibana/issues/141061

This PR updates the documentation for the [case requirements](https://www.elastic.co/guide/en/observability/master/grant-cases-access.html) to include mention of the server.publicBaseUrl setting.