### PR TITLE
remove conf `xpack.security.enabled: true`

### DIFF
--- a/docs/en/ingest-management/troubleshooting/troubleshooting.asciidoc
+++ b/docs/en/ingest-management/troubleshooting/troubleshooting.asciidoc
@@ -94,7 +94,6 @@ and specify your user credentials:
 [source,yaml]
 ----
 xpack.encryptedSavedObjects.encryptionKey: "something_at_least_32_characters"
-xpack.security.enabled: true
 elasticsearch.username: "my_username" <1>
 elasticsearch.password: "my_password"
 ----


### PR DESCRIPTION
This configuration is no longer supported in version 8+, request to remove and correct the documentation.

https://discuss.elastic.co/t/heartbeat-failed-to-activate/322415