### PR TITLE
[DOCS] Notify assignees when assigned to a case

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ To build the docs:
 2. Run the `build_docs` script, passing in the path to the `index.asciidoc` and resource paths to other repos that contain source files. For example, to build the Observability Guide and open it in the browser, run:
 
 ```
-../docs/build_docs --doc ./docs/en/observability/index.asciidoc --chunk 1 --resource ../beats/libbeat/docs --resource ../apm-server/docs/guide --open
+../docs/build_docs --doc ./docs/en/observability/index.asciidoc --chunk 1 --resource ../beats/libbeat/docs --resource ../apm-server/docs/guide --resource ../kibana/docs --open
 ```
 
-The above command assumes that [elastic/docs](https://github.com/elastic/docs), [elastic/beats](https://github.com/elastic/beats) and [elastic/apm-server](https://github.com/elastic/apm-server) are checked out into the same parent directory.
+The above command assumes that [elastic/docs](https://github.com/elastic/docs), [elastic/beats](https://github.com/elastic/beats), [elastic/kibana](https://github.com/elastic/kibana), and [elastic/apm-server](https://github.com/elastic/apm-server) are checked out into the same parent directory.
 
 If you prefer to use aliases, you can load the [elastic/docs/doc_build_aliases.sh file](https://github.com/elastic/docs/blob/master/doc_build_aliases.sh), which has the resources defined for you.

--- a/docs/en/observability/index.asciidoc
+++ b/docs/en/observability/index.asciidoc
@@ -26,6 +26,7 @@ include::{docs-root}/shared/attributes.asciidoc[]
 :apm-repo-dir:         {apm-server-root}/docs
 :beats-repo-dir:       {beats-root}/libbeat/docs
 :shared:               {observability-docs-root}/docs/en/shared
+:kibana-repo-dir:      {kibana-root}/docs 
 
 :synthetics_version: v1.0.0-beta.37
 

--- a/docs/en/observability/manage-cases.asciidoc
+++ b/docs/en/observability/manage-cases.asciidoc
@@ -21,6 +21,12 @@ you've previously added one, that connector displays as the default selection. O
 default setting is `No connector selected`.
 . After you've completed all of the required fields, click *Create case*.
 
+[float]
+[[add-case-notifications]]
+== Add email notifications
+
+include::{kibana-repo-dir}/management/cases/manage-cases.asciidoc[tag=case-notifications]
+
 [discrete]
 [[manage-case-observability]]
 == Manage existing cases


### PR DESCRIPTION
Relates to https://github.com/elastic/kibana/issues/140743, https://github.com/elastic/kibana/issues/142307

This PR adds a section to https://www.elastic.co/guide/en/observability/master/manage-cases.html that describes how to set up email notifications for cases. Since the instructions are the same, the content is re-used via a [tagged region](https://docs.asciidoctor.org/asciidoc/latest/directives/include-tagged-regions/#tagging-regions).

NOTE: This PR must be merged after https://github.com/elastic/kibana/pull/147713 and https://github.com/elastic/docs/pull/2592