### PR TITLE
Move relnotes item from features to enhancements

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-8.6.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.6.asciidoc
@@ -106,7 +106,6 @@ The 8.6.0 release adds the following new and notable features.
 * Add support for the Common Expression Language (CEL) {filebeat} input type {agent-pull}1719[#1719]
 * Only support {es} as an output for the beta synthetics integration {agent-pull}1491[#1491]
 * New control protocol between the {agent} and its subprocesses enables per integration health reporting and simplifies new input development {agent-issue}836[#836] {agent-pull}1701[#1701]
-* Change internal directory structure: add a components directory to contain binaries and associated artifacts, and remove the downloads directory {agent-issue}836[#836] {agent-pull}1701[#1701]
 * All binaries for every supported integration are now bundled in the {agent} by default {agent-issue}836[#836] {agent-pull}126[#126]
 
 [discrete]
@@ -118,6 +117,7 @@ The 8.6.0 release adds the following new and notable features.
 
 {agent}::
 * Health Status: {agent} now indicates detailed status information for each sub-process and input type {fleet-server-pull}1747[#1747] {agent-issue}100[#100]
+* Change internal directory structure: add a components directory to contain binaries and associated artifacts, and remove the downloads directory {agent-issue}836[#836] {agent-pull}1701[#1701]
 
 [discrete]
 [[bug-fixes-8.6.0]]


### PR DESCRIPTION
Changing the dir structure is not really a new feature, but also not a breaking change in this instance, so I am moving that item to appear under enhancements.

@pierrehilbert I think that takes care of work left over from https://github.com/elastic/observability-docs/pull/2450, but let me know if there's anything else you want me to change. Thanks!