### PR TITLE
Excluding APM server from the output section of compatibility page

### DIFF
--- a/docs/en/ingest-management/beats-agent-comparison.asciidoc
+++ b/docs/en/ingest-management/beats-agent-comparison.asciidoc
@@ -67,7 +67,7 @@ To find out if an integration is GA, see the
 The following table shows the outputs supported by the {agent} in {version}:
 
 
-NOTE: {elastic-defend} has a different output matrix.
+NOTE: {elastic-defend} and APM server have a different output matrix.
 
 [options,header]
 |===

--- a/docs/en/ingest-management/beats-agent-comparison.asciidoc
+++ b/docs/en/ingest-management/beats-agent-comparison.asciidoc
@@ -67,7 +67,7 @@ To find out if an integration is GA, see the
 The following table shows the outputs supported by the {agent} in {version}:
 
 
-NOTE: {elastic-defend} and APM server have a different output matrix.
+NOTE: {elastic-defend} and APM Server have a different output matrix.
 
 [options,header]
 |===


### PR DESCRIPTION
Addressing https://github.com/elastic/observability-docs/issues/2458

@dedemorton I couldn't find a global variable for APM server (like {apm-server} ), so just called it out.