### PR TITLE
Fix numbering problem caused by linter comment

### DIFF
--- a/docs/en/observability/ingest-logs-metrics-uptime.asciidoc
+++ b/docs/en/observability/ingest-logs-metrics-uptime.asciidoc
@@ -191,7 +191,6 @@ the agent policy you created earlier. That way, you can deploy the change to
 the agent that's already running.
 
 . When you're done, click **Save and continue**, then **Save and deploy changes**.
-
 // lint ignore nginx-1
 . To see the updated policy, click the agent policy link.
 +


### PR DESCRIPTION
Numbering restarts because the linter comment adds an extra line. This PR fixes the problem.

![image](https://user-images.githubusercontent.com/14206422/212436123-2edc2c0c-6f3a-4125-b78a-429a98393478.png)
