### PR TITLE
Update link to integrations in the Fleet/Agent overview

### DIFF
--- a/docs/en/ingest-management/overview.asciidoc
+++ b/docs/en/ingest-management/overview.asciidoc
@@ -24,7 +24,7 @@ To learn about installation options, refer to <<elastic-agent-installation>>.
 [[unified-integrations]]
 == {integrations}
 
-{integrations-docs} [Elastic integrations] provide an easy way to connect Elastic to external services and systems, and quickly get insights or take action.
+{integrations-docs}[Elastic integrations] provide an easy way to connect Elastic to external services and systems, and quickly get insights or take action.
 They can collect new sources of data, and they often ship
 with out-of-the-box assets like dashboards, visualizations, and pipelines to
 extract structured fields out of logs and events. This makes it easier to get insights

--- a/docs/en/ingest-management/overview.asciidoc
+++ b/docs/en/ingest-management/overview.asciidoc
@@ -24,7 +24,7 @@ To learn about installation options, refer to <<elastic-agent-installation>>.
 [[unified-integrations]]
 == {integrations}
 
-Our https://www.elastic.co/integrations/[integrations] provide an easy way to connect Elastic to external services and systems, and quickly get insights or take action.
+{integrations-docs} [Elastic integrations] provide an easy way to connect Elastic to external services and systems, and quickly get insights or take action.
 They can collect new sources of data, and they often ship
 with out-of-the-box assets like dashboards, visualizations, and pipelines to
 extract structured fields out of logs and events. This makes it easier to get insights
@@ -37,8 +37,6 @@ integrations.
 
 [role="screenshot"]
 image::images/integrations.png[Integrations page]
-
-See our https://www.elastic.co/integrations/data-integrations[list of integrations] to learn more about them.
 
 [discrete]
 [[configuring-integrations]]


### PR DESCRIPTION
This topic was written before we had external documentation for integrations. Let's link to the integrations documentation to avoid sending users down the rabbit hole of accidentally installing Beats.