### PR TITLE
Fix app log ingest doc

### DIFF
--- a/docs/en/observability/tab-widgets/filebeat-logs/content.asciidoc
+++ b/docs/en/observability/tab-widgets/filebeat-logs/content.asciidoc
@@ -14,10 +14,10 @@ filebeat.inputs:
   paths: /path/to/logs.json
   parsers:
     - ndjson:
-        keys_under_root: true
-        overwrite_keys: true
-        add_error_key: true
-        expand_keys: true
+      keys_under_root: true
+      overwrite_keys: true
+      add_error_key: true
+      expand_keys: true
 
 processors:
   - add_host_metadata: ~

--- a/docs/en/observability/tab-widgets/filebeat-logs/content.asciidoc
+++ b/docs/en/observability/tab-widgets/filebeat-logs/content.asciidoc
@@ -37,7 +37,7 @@ ifdef::plaintext[]
 ----
 filebeat.inputs:
 - type: filestream <1>
-  paths: /path/to/logs.json
+  paths: /path/to/logs.log
 ----
 endif::plaintext[]
 


### PR DESCRIPTION
- fix indent in filebeat config
- avoid .json suffix for plaintext log file
