### PR TITLE
Add new known issue to 8.6 agent release notes

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-8.6.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.6.asciidoc
@@ -128,7 +128,6 @@ The 8.6.0 release adds the following new and notable features.
 
 {agent}::
 * {agent} now uses the locally bound port (8221) when running {fleet-server} instead of the external port (8220) {agent-pull}1867[#1867]
-* Correctly preserve the {filebeat} registry and other persistent input states during upgrades to eliminate event duplication after upgrades {agent-pull}1701[#1701] {agent-issue}836[#836]
 // end 8.6.0 relnotes
 
 

--- a/docs/en/ingest-management/release-notes/release-notes-8.6.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.6.asciidoc
@@ -85,7 +85,7 @@ Be aware that the live query results shown in {kib} may be delayed by up to 5 mi
 ====
 
 [[known-issue-issue-2086]]
-.Beats started by agent can be configured without a valid output
+.Beats started by agent may fail with `output unit has no config` error
 [%collapsible]
 ====
 *Details* +

--- a/docs/en/ingest-management/release-notes/release-notes-8.6.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.6.asciidoc
@@ -84,6 +84,22 @@ For more information, refer to {agent-issue}2066[#2066].
 Be aware that the live query results shown in {kib} may be delayed by up to 5 minutes.
 ====
 
+[[known-issue-issue-2086]]
+.Beats started by agent can be configured without a valid output
+[%collapsible]
+====
+*Details* +
+A known issue in {agent} may lead to Beat processes being started without a
+valid output. The problem can be corrected by triggering a restart of {agent}
+or the affected Beats. Beats managed by {agent} can be restarted by changing the
+{agent} log level or the output section of the {agent} policy.
+For more information, refer to {agent-issue}2086[#2086].
+
+*Impact* +
+{agent} will appear unhealthy and the affected Beats will not be able to write
+event data to {es} or Logstash.
+====
+
 [discrete]
 [[new-features-8.6.0]]
 === New features

--- a/docs/en/ingest-management/release-notes/release-notes-8.6.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.6.asciidoc
@@ -90,8 +90,8 @@ Be aware that the live query results shown in {kib} may be delayed by up to 5 mi
 ====
 *Details* +
 A known issue in {agent} may lead to Beat processes being started without a
-valid output. The problem can be corrected by triggering a restart of {agent}
-or the affected Beats. Beats managed by {agent} can be restarted by changing the
+valid output. To correct the problem, trigger a restart of {agent}
+or the affected Beats. For Beats managed by {agent}, you can trigger a restart by changing the
 {agent} log level or the output section of the {agent} policy.
 For more information, refer to {agent-issue}2086[#2086].
 


### PR DESCRIPTION
Add https://github.com/elastic/elastic-agent/issues/2086 as a known issue in the release notes.

Also removes an entry about fixing duplicated events on upgrade that was not actually fixed in 8.6.