### PR TITLE
Add Fleet/Agent 8.6.1 relnotes

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-8.6.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.6.asciidoc
@@ -47,6 +47,33 @@ For more information, refer to {agent-issue}2066[#2066].
 Be aware that the live query results shown in {kib} may be delayed by up to 5 minutes.
 ====
 
+[[known-issue-2170]]
+.Adding a {fleet-server} integration to an agent results in panic if the agent was not bootstrapped with a {fleet-server}
+[%collapsible]
+====
+
+*Details*
+
+A panic occurs because the {agent} does not have a `fleet.server` in the `fleet.enc`
+configuration file. When this happens, the agent fails with a message like:
+
+[source,shell]
+----
+panic: runtime error: invalid memory address or nil pointer dereference
+[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x557b8eeafc1d]
+goroutine 86 [running]:
+github.com/elastic/elastic-agent/internal/pkg/agent/application.FleetServerComponentModifier.func1({0xc000652f00, 0xa, 0x10}, 0x557b8fa8eb92?)
+...
+----
+
+For more information, refer to {agent-issue}2170[#2170].
+
+*Impact* +
+
+To work around this problem, uninstall the {agent} and install it again with
+{fleet-server} enabled during the bootstrap process.
+====
+
 [discrete]
 [[bug-fixes-8.6.1]]
 === Bug fixes
@@ -61,8 +88,9 @@ Be aware that the live query results shown in {kib} may be delayed by up to 5 mi
 * No bug fixes in this release
 
 {agent}::
-* Fix issue where it's possible for a component to receive a unit without a
-config {agent-pull}2138[#2138] {agent-issue}2086[#2086]
+* Fix issue where {beats} started by {agent} may fail with an `output unit has no config` error {agent-pull}2138[#2138] {agent-issue}2086[#2086]
+* Fix broken deployments that use traffic filter by injecting custom headers {agent-pull}2158[#2158] {beats-issue}32993[#32993]
+* Make it easier to filter agent logs from the combined agent log file {agent-pull}2044[#2044] {agent-issue}1810[#1810]
 
 // end 8.6.1 relnotes
 

--- a/docs/en/ingest-management/release-notes/release-notes-8.6.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.6.asciidoc
@@ -79,17 +79,19 @@ To work around this problem, uninstall the {agent} and install it again with
 === Bug fixes
 
 {fleet}::
-* Fix missing policy Id in installation URL for cloud integrations {kibana-pull}149243[#149243]
+* Fix missing policy ID in installation URL for cloud integrations {kibana-pull}149243[#149243]
 * Fix package installation APIs to install packages without a version {kibana-pull}149193[#149193]
 * Fix issue where the latest GA version could not be installed if there was a newer prerelease version in the registry
 {kibana-pull}149133[#149133] {kibana-pull}149104[#149104]
 
 {fleet-server}::
-* No bug fixes in this release
+* Update the `.fleet-agent` index when acknowledging policy changes when {ls}
+is the configured output. Fixes agents always showing as Updating when using the
+{ls} output {fleet-server-pull}2119[#2119]
 
 {agent}::
 * Fix issue where {beats} started by {agent} may fail with an `output unit has no config` error {agent-pull}2138[#2138] {agent-issue}2086[#2086]
-* Fix broken deployments that use traffic filter by injecting custom headers {agent-pull}2158[#2158] {beats-issue}32993[#32993]
+* Restore the ability to set custom HTTP headers at enrollment time. Fixes traffic filters in Integrations Server cloud deployments {agent-pull}2158[#2158] {beats-issue}32993[#32993]
 * Make it easier to filter agent logs from the combined agent log file {agent-pull}2044[#2044] {agent-issue}1810[#1810]
 
 // end 8.6.1 relnotes

--- a/docs/en/ingest-management/release-notes/release-notes-8.6.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.6.asciidoc
@@ -14,12 +14,39 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-8.6.1>>
 * <<release-notes-8.6.0>>
 
 Also see:
 
 * {kibana-ref}/release-notes.html[{kib} release notes]
 * {beats-ref}/release-notes.html[{beats} release notes]
+
+// begin 8.6.1 relnotes
+
+[[release-notes-8.6.1]]
+== {fleet} and {agent} 8.6.1
+
+Review important information about the {fleet} and {agent} 8.6.1 release.
+
+[discrete]
+[[bug-fixes-8.6.1]]
+=== Bug fixes
+
+{fleet}::
+* Fix missing policy Id in installation URL for cloud integrations {kibana-pull}149243[#149243]
+* Fix package installation APIs to install packages without a version {kibana-pull}149193[#149193]
+* Fix issue where the latest GA version could not be installed if there was a newer prerelease version in the registry
+{kibana-pull}149133[#149133] and {kibana-pull}149104[#149104]
+
+{fleet-server}::
+* No bug fixes in this release
+
+{agent}::
+* Fix issue where it's possible for a component to receive a unit without a
+config {agent-pull}2138[#2138] {agent-issue}2086[#2086]
+
+// end 8.6.1 relnotes
 
 // begin 8.6.0 relnotes
 

--- a/docs/en/ingest-management/release-notes/release-notes-8.6.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.6.asciidoc
@@ -30,6 +30,24 @@ Also see:
 Review important information about the {fleet} and {agent} 8.6.1 release.
 
 [discrete]
+[[known-issues-8.6.1]]
+=== Known issues
+
+[discrete]
+[[known-issue-issue-2066-8-6-1]]
+.Osquery live query results can take up to five minutes to show up in {kib}
+[%collapsible]
+====
+*Details* +
+A known issue in {agent} may prevent live query results from being available
+in the {kib} UI even though the results have been successfully sent to {es}. 
+For more information, refer to {agent-issue}2066[#2066].
+
+*Impact* +
+Be aware that the live query results shown in {kib} may be delayed by up to 5 minutes.
+====
+
+[discrete]
 [[bug-fixes-8.6.1]]
 === Bug fixes
 
@@ -37,7 +55,7 @@ Review important information about the {fleet} and {agent} 8.6.1 release.
 * Fix missing policy Id in installation URL for cloud integrations {kibana-pull}149243[#149243]
 * Fix package installation APIs to install packages without a version {kibana-pull}149193[#149193]
 * Fix issue where the latest GA version could not be installed if there was a newer prerelease version in the registry
-{kibana-pull}149133[#149133] and {kibana-pull}149104[#149104]
+{kibana-pull}149133[#149133] {kibana-pull}149104[#149104]
 
 {fleet-server}::
 * No bug fixes in this release


### PR DESCRIPTION
Closes #2537

Adds release notes compiled manually from fleet-server changelog, Fleet section in Kibana release notes, and elastic-agent fragments.
