### PR TITLE
Replace outdated ingest-guide attribute

### DIFF
--- a/docs/en/ingest-management/tab-widgets/run.asciidoc
+++ b/docs/en/ingest-management/tab-widgets/run.asciidoc
@@ -53,7 +53,7 @@ This command starts {agent} in the foreground. You must restart {agent}
 manually if the agent terminates or the system is rebooted.
 
 To start the agent automatically when the system is rebooted, 
-{ingest-guide}/elastic-agent-installation.html#elastic-agent-install-service-macos[Install the agent as a service].
+{fleet-guide}/elastic-agent-installation.html#elastic-agent-install-service-macos[Install the agent as a service].
 ====
 
 // end::mac[]


### PR DESCRIPTION
This pre-emptively fixes broken links that will occur when the docs shared `ingest-guide` attribute is repurposed.

```
15:24:17 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/fleet/7.9/ingest-management-getting-started.html contains broken links to:
15:24:17 INFO:build_docs:   - en/ingest/7.9/elastic-agent-installation.html
15:24:17 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/fleet/7.9/run-elastic-agent.html contains broken links to:
15:24:17 INFO:build_docs:   - en/ingest/7.9/elastic-agent-installation.html
```