### PR TITLE
Update kubernetes provider documentation and 8.6 release notes

### DIFF
--- a/docs/en/ingest-management/elastic-agent/configuration/autodiscovery/kubernetes-conditions-autodiscover.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/autodiscovery/kubernetes-conditions-autodiscover.asciidoc
@@ -37,7 +37,9 @@ To automatically identify a Redis Pod and monitor it with the Redis integration,
 The condition `${kubernetes.labels.app} == 'redis'` will make the {agent} look for a Pod with the  label `app:redis` within the scope defined in its manifest.
 
 For a list of provider fields that you can use in conditions, refer to <<kubernetes-provider>>.
+
 Some examples of conditions usage are:
+
 1. For a pod with label `app.kubernetes.io/name=ingress-nginx` the condition should be `condition: ${kubernetes.labels.app.kubernetes.io/name} == "ingress-nginx"`.
 2. For a pod with annotation `prometheus.io/scrape: "true"` the condition should be `${kubernetes.annotations.prometheus.io/scrape} == "true"`.
 3. For a pod with name `kube-scheduler-kind-control-plane` the condition should be `${kubernetes.pod.name == "kube-scheduler-kind-control-plane"`.

--- a/docs/en/ingest-management/elastic-agent/configuration/autodiscovery/kubernetes-conditions-autodiscover.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/autodiscovery/kubernetes-conditions-autodiscover.asciidoc
@@ -38,9 +38,9 @@ The condition `${kubernetes.labels.app} == 'redis'` will make the {agent} look f
 
 For a list of provider fields that you can use in conditions, refer to <<kubernetes-provider>>.
 Some examples of conditions usage are:
-1. For a pod with label `app.kubernetes.io/name=ingress-nginx` the condition should be `condition: ${kubernetes.labels.app.kubernetes.io/name} == "ingress-nginx"`
-2. For a pod with annotation `prometheus.io/scrape: "true"` the condition should be `${kubernetes.annotations.prometheus.io/scrape} == "true"`
-3. For a pod with name `kube-scheduler-kind-control-plane` the condition should be `${kubernetes.pod.name == "kube-scheduler-kind-control-plane"`
+1. For a pod with label `app.kubernetes.io/name=ingress-nginx` the condition should be `condition: ${kubernetes.labels.app.kubernetes.io/name} == "ingress-nginx"`.
+2. For a pod with annotation `prometheus.io/scrape: "true"` the condition should be `${kubernetes.annotations.prometheus.io/scrape} == "true"`.
+3. For a pod with name `kube-scheduler-kind-control-plane` the condition should be `${kubernetes.pod.name == "kube-scheduler-kind-control-plane"`.
 
 
 The `redis` input defined in the {agent} manifest only specifies the`info` metricset. To learn about other available metricsets and their configuration settings, refer to the {metricbeat-ref}/metricbeat-module-redis.html[Redis module page].

--- a/docs/en/ingest-management/elastic-agent/configuration/autodiscovery/kubernetes-conditions-autodiscover.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/autodiscovery/kubernetes-conditions-autodiscover.asciidoc
@@ -86,8 +86,6 @@ The following configuration will enable `kubernetes.scheduler` dataset only for 
   condition: ${kubernetes.labels.component} == 'kube-scheduler'
 ----
 
-WARNING: In some "As a Service" Kubernetes implementations, like GKE, the control plane nodes or even the Pods running on them won’t be visible. In these cases, it won’t be possible to use scheduler metricsets, necessary for this example. Refer https://www.elastic.co/guide/en/beats/metricbeat/current/metricbeat-module-kubernetes.html#_scheduler_and_controllermanager[scheduler and controller manager] to find more information.
-
 NOTE: Pods labels and annotations can be used in autodiscover conditions. In the case of labels or annotations that include dots(`.`), they can be used in conditions exactly as
 they are defined in the pods. For example `condition: ${kubernetes.labels.app.kubernetes.io/name} == 'ingress-nginx'`. This should not be mistaken with optional dedoted labels and annotations
 stored into Elasticsearch(<<kubernetes-provider>>).
@@ -95,6 +93,7 @@ stored into Elasticsearch(<<kubernetes-provider>>).
 WARNING: Before 8.6 release, labels used in autodiscover conditions were dedoted in case `labels.dedot` parameter was set to `true` in Kubernetes Provider 
 configuration. The same did not apply for annotations. This was fixed in 8.6 release. Refer to <<release-notes-8.6.0>>.
 
+WARNING: In some "As a Service" Kubernetes implementations, like GKE, the control plane nodes or even the Pods running on them won’t be visible. In these cases, it won’t be possible to use scheduler metricsets, necessary for this example. Refer https://www.elastic.co/guide/en/beats/metricbeat/current/metricbeat-module-kubernetes.html#_scheduler_and_controllermanager[scheduler and controller manager] to find more information.
 
 Following the Redis example, if you deploy another Redis Pod with a different port, it should be detected. To check this, go, for example, to the field `service.address` under `metrics-redis.info-default`. It should be displaying two different services.
 

--- a/docs/en/ingest-management/elastic-agent/configuration/autodiscovery/kubernetes-conditions-autodiscover.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/autodiscovery/kubernetes-conditions-autodiscover.asciidoc
@@ -37,6 +37,10 @@ To automatically identify a Redis Pod and monitor it with the Redis integration,
 The condition `${kubernetes.labels.app} == 'redis'` will make the {agent} look for a Pod with the  label `app:redis` within the scope defined in its manifest.
 
 For a list of provider fields that you can use in conditions, refer to <<kubernetes-provider>>.
+Some examples of conditions usage are:
+1. For a pod with label `app.kubernetes.io/name=ingress-nginx` the condition should be `condition: ${kubernetes.labels.app.kubernetes.io/name} == "ingress-nginx"`
+2. For a pod with annotation `prometheus.io/scrape: "true"` the condition should be `${kubernetes.annotations.prometheus.io/scrape} == "true"`
+3. For a pod with name `kube-scheduler-kind-control-plane` the condition should be `${kubernetes.pod.name == "kube-scheduler-kind-control-plane"`
 
 
 The `redis` input defined in the {agent} manifest only specifies the`info` metricset. To learn about other available metricsets and their configuration settings, refer to the {metricbeat-ref}/metricbeat-module-redis.html[Redis module page].

--- a/docs/en/ingest-management/elastic-agent/configuration/autodiscovery/kubernetes-conditions-autodiscover.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/autodiscovery/kubernetes-conditions-autodiscover.asciidoc
@@ -91,7 +91,7 @@ they are defined in the pods. For example `condition: ${kubernetes.labels.app.ku
 stored into Elasticsearch(<<kubernetes-provider>>).
 
 WARNING: Before 8.6 release, labels used in autodiscover conditions were dedoted in case `labels.dedot` parameter was set to `true` in Kubernetes Provider 
-configuration. The same did not apply for annotations. This was fixed in 8.6 release. Refer to <<release-notes-8.6.0>>.
+configuration (by default `true`). The same did not apply for annotations. This was fixed in 8.6 release. Refer to <<release-notes-8.6.0>>.
 
 WARNING: In some "As a Service" Kubernetes implementations, like GKE, the control plane nodes or even the Pods running on them won’t be visible. In these cases, it won’t be possible to use scheduler metricsets, necessary for this example. Refer https://www.elastic.co/guide/en/beats/metricbeat/current/metricbeat-module-kubernetes.html#_scheduler_and_controllermanager[scheduler and controller manager] to find more information.
 

--- a/docs/en/ingest-management/elastic-agent/configuration/autodiscovery/kubernetes-conditions-autodiscover.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/autodiscovery/kubernetes-conditions-autodiscover.asciidoc
@@ -87,7 +87,7 @@ The following configuration will enable `kubernetes.scheduler` dataset only for 
 ----
 
 NOTE: Pods' labels and annotations can be used in autodiscover conditions. In the case of labels or annotations that include dots(`.`), they can be used in conditions exactly as
-they are defined in the pods. For example `condition: ${kubernetes.labels.app.kubernetes.io/name} == 'ingress-nginx'`. This should not be mistaken with optional dedoted labels and annotations
+they are defined in the pods. For example `condition: ${kubernetes.labels.app.kubernetes.io/name} == 'ingress-nginx'`. This should not be confused with the dedoted (by default) labels and annotations
 stored into Elasticsearch(<<kubernetes-provider>>).
 
 WARNING: Before 8.6 release, labels used in autodiscover conditions were dedoted in case `labels.dedot` parameter was set to `true` in Kubernetes Provider 

--- a/docs/en/ingest-management/elastic-agent/configuration/autodiscovery/kubernetes-conditions-autodiscover.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/autodiscovery/kubernetes-conditions-autodiscover.asciidoc
@@ -67,7 +67,9 @@ You should now be able to see Redis data flowing in on index `metrics-redis.info
 
 NOTE: All assets (dashboards, ingest pipelines, and so on) related to the Redis integration are not installed. You need to explicitly <<install-uninstall-integration-assets,install them through {kib}>>.
 
-To set the target host dynamically for a targeted Pod based on its labels, use a variable in the {agent} policy to return path information from the provider:
+Conditions can also be used in `Kubernetes` input in order to set the target host dynamically for a targeted Pod based on its labels.
+This is useful for datasets that target specific pods like `kube-scheduler` or `kube-controller-manager`.
+The following configuration will enable `kubernetes.scheduler` dataset only for pods which have the label `component=kube-scheduler` defined.
 
 [source,yaml]
 ----
@@ -85,6 +87,14 @@ To set the target host dynamically for a targeted Pod based on its labels, use a
 ----
 
 WARNING: In some "As a Service" Kubernetes implementations, like GKE, the control plane nodes or even the Pods running on them won’t be visible. In these cases, it won’t be possible to use scheduler metricsets, necessary for this example. Refer https://www.elastic.co/guide/en/beats/metricbeat/current/metricbeat-module-kubernetes.html#_scheduler_and_controllermanager[scheduler and controller manager] to find more information.
+
+NOTE: Pods labels and annotations can be used in autodiscover conditions. In the case of labels or annotations that include dots(`.`), they can be used in conditions exactly as
+they are defined in the pods. For example `condition: ${kubernetes.labels.app.kubernetes.io/name} == 'ingress-nginx'`. This should not be mistaken with optional dedoted labels and annotations
+stored into Elasticsearch(<<kubernetes-provider>>).
+
+WARNING: Before 8.6 release, labels used in autodiscover conditions were dedoted in case `labels.dedot` parameter was set to `true` in Kubernetes Provider 
+configuration. The same did not apply for annotations. This was fixed in 8.6 release. Refer to <<release-notes-8.6.0>>.
+
 
 Following the Redis example, if you deploy another Redis Pod with a different port, it should be detected. To check this, go, for example, to the field `service.address` under `metrics-redis.info-default`. It should be displaying two different services.
 

--- a/docs/en/ingest-management/elastic-agent/configuration/autodiscovery/kubernetes-conditions-autodiscover.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/autodiscovery/kubernetes-conditions-autodiscover.asciidoc
@@ -86,7 +86,7 @@ The following configuration will enable `kubernetes.scheduler` dataset only for 
   condition: ${kubernetes.labels.component} == 'kube-scheduler'
 ----
 
-NOTE: Pods labels and annotations can be used in autodiscover conditions. In the case of labels or annotations that include dots(`.`), they can be used in conditions exactly as
+NOTE: Pods' labels and annotations can be used in autodiscover conditions. In the case of labels or annotations that include dots(`.`), they can be used in conditions exactly as
 they are defined in the pods. For example `condition: ${kubernetes.labels.app.kubernetes.io/name} == 'ingress-nginx'`. This should not be mistaken with optional dedoted labels and annotations
 stored into Elasticsearch(<<kubernetes-provider>>).
 

--- a/docs/en/ingest-management/elastic-agent/configuration/autodiscovery/kubernetes-conditions-autodiscover.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/autodiscovery/kubernetes-conditions-autodiscover.asciidoc
@@ -72,7 +72,7 @@ You should now be able to see Redis data flowing in on index `metrics-redis.info
 
 NOTE: All assets (dashboards, ingest pipelines, and so on) related to the Redis integration are not installed. You need to explicitly <<install-uninstall-integration-assets,install them through {kib}>>.
 
-Conditions can also be used in the `Kubernetes` package in order to set the target host dynamically for a targeted Pod based on its labels.
+Conditions can also be used in inputs configuration in order to set the target host dynamically for a targeted Pod based on its labels.
 This is useful for datasets that target specific pods like `kube-scheduler` or `kube-controller-manager`.
 The following configuration will enable `kubernetes.scheduler` dataset only for pods which have the label `component=kube-scheduler` defined.
 

--- a/docs/en/ingest-management/elastic-agent/configuration/autodiscovery/kubernetes-conditions-autodiscover.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/autodiscovery/kubernetes-conditions-autodiscover.asciidoc
@@ -67,7 +67,7 @@ You should now be able to see Redis data flowing in on index `metrics-redis.info
 
 NOTE: All assets (dashboards, ingest pipelines, and so on) related to the Redis integration are not installed. You need to explicitly <<install-uninstall-integration-assets,install them through {kib}>>.
 
-Conditions can also be used in `Kubernetes` input in order to set the target host dynamically for a targeted Pod based on its labels.
+Conditions can also be used in the `Kubernetes` package in order to set the target host dynamically for a targeted Pod based on its labels.
 This is useful for datasets that target specific pods like `kube-scheduler` or `kube-controller-manager`.
 The following configuration will enable `kubernetes.scheduler` dataset only for pods which have the label `component=kube-scheduler` defined.
 

--- a/docs/en/ingest-management/elastic-agent/configuration/autodiscovery/kubernetes-conditions-autodiscover.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/autodiscovery/kubernetes-conditions-autodiscover.asciidoc
@@ -37,7 +37,6 @@ To automatically identify a Redis Pod and monitor it with the Redis integration,
 The condition `${kubernetes.labels.app} == 'redis'` will make the {agent} look for a Pod with the  label `app:redis` within the scope defined in its manifest.
 
 For a list of provider fields that you can use in conditions, refer to <<kubernetes-provider>>.
-
 Some examples of conditions usage are:
 
 1. For a pod with label `app.kubernetes.io/name=ingress-nginx` the condition should be `condition: ${kubernetes.labels.app.kubernetes.io/name} == "ingress-nginx"`.

--- a/docs/en/ingest-management/elastic-agent/configuration/providers/kubernetes-provider.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/providers/kubernetes-provider.asciidoc
@@ -190,7 +190,7 @@ The available keys are:
 
 These are the fields available within config templating. The `kubernetes.*` fields will be available on each emitted event.
 `kubernetes.labels.*` and `kubernetes.annotations.*` used in config templating are not dedoted and should not be confused with
-optional dedoted labels and annotations added in the event. For examples refer to <<conditions-based-autodiscover>>.
+labels and annotations added in the final Elasticsearch document and which are dedoted by default. For examples refer to <<conditions-based-autodiscover>>.
 
 Note that not all of these fields are available by default and special configuration options
 are needed in order to include them.

--- a/docs/en/ingest-management/elastic-agent/configuration/providers/kubernetes-provider.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/providers/kubernetes-provider.asciidoc
@@ -189,7 +189,8 @@ The available keys are:
 
 
 These are the fields available within config templating. The `kubernetes.*` fields will be available on each emitted event.
-`kubernetes.labels.*` and `kubernetes.annotations.*` used in config templating are not dedoted and should not be confused with
+
+NOTE: `kubernetes.labels.*` and `kubernetes.annotations.*` used in config templating are not dedoted and should not be confused with
 labels and annotations added in the final Elasticsearch document and which are dedoted by default. For examples refer to <<conditions-based-autodiscover>>.
 
 Note that not all of these fields are available by default and special configuration options

--- a/docs/en/ingest-management/elastic-agent/configuration/providers/kubernetes-provider.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/providers/kubernetes-provider.asciidoc
@@ -189,6 +189,9 @@ The available keys are:
 
 
 These are the fields available within config templating. The `kubernetes.*` fields will be available on each emitted event.
+`kubernetes.labels.*` and `kubernetes.annotations.*` used in config templating are not dedoted and should not be mistaken with
+optional dedoted labels and annotations added in the event. For examples refer to <<conditions-based-autodiscover>>.
+
 Note that not all of these fields are available by default and special configuration options
 are needed in order to include them.
 

--- a/docs/en/ingest-management/elastic-agent/configuration/providers/kubernetes-provider.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/providers/kubernetes-provider.asciidoc
@@ -189,7 +189,7 @@ The available keys are:
 
 
 These are the fields available within config templating. The `kubernetes.*` fields will be available on each emitted event.
-`kubernetes.labels.*` and `kubernetes.annotations.*` used in config templating are not dedoted and should not be mistaken with
+`kubernetes.labels.*` and `kubernetes.annotations.*` used in config templating are not dedoted and should not be confused with
 optional dedoted labels and annotations added in the event. For examples refer to <<conditions-based-autodiscover>>.
 
 Note that not all of these fields are available by default and special configuration options

--- a/docs/en/ingest-management/release-notes/release-notes-8.6.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.6.asciidoc
@@ -68,7 +68,7 @@ Remove the `--pprof` argument from any scripts or commands you use.
 
 [discrete]
 [[breaking-1398]]
-.Not dedoted Kubernetes pod labes to be used for autodiscover conditions
+.Not dedoted Kubernetes pod labels to be used for autodiscover conditions
 [%collapsible]
 ====
 *Details* +

--- a/docs/en/ingest-management/release-notes/release-notes-8.6.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.6.asciidoc
@@ -67,6 +67,21 @@ Remove the `--pprof` argument from any scripts or commands you use.
 ====
 
 [discrete]
+[[breaking-1398]]
+.Not dedoted Kubernetes pod labes to be used for autodiscover conditions
+[%collapsible]
+====
+*Details* +
+Kubernetes pod labels used in autodiscover conditions are not dedoted anymore. This means that
+`.` are not replaced with `_` in labels like `app.kubernetes.io/component=controller`.
+This follows the same approach as kubernetes annotations. For more information refer to <<kubernetes-provider>>.
+
+*Impact* +
+Any template used for standalone elastic agent or installed integration that makes use
+of dedoted kubernetes labels inside conditions has to be updated.
+====
+
+[discrete]
 [[known-issues-8.6.0]]
 === Known issues
 


### PR DESCRIPTION
Update  kubernetes provider documentation to clearly state the correct usage of kubernetes labels in autodiscover conditions and 8.6 release notes with a breaking change.

This is due to changes done in https://github.com/elastic/elastic-agent/pull/1398 effective in 8.6 release onwards.

Release notes have been updated, because even if this is considered a bug fix, there may be clients that have already set some templates in standalone agent or conditions in packages (the few that support it).
If in those conditions they make use of dedoted labels then when upgrading to agent 8.6,  the data sets affected won't collect logs/metrics as the conditions won't match.
They need to manually update their configuration.


Updates of this PR can be found in https://github.com/elastic/observability-docs/pull/2552#issuecomment-1405078643 `Fleet and Elastic Agent Guide` in three pages.

1. Release notes
2. Configure standalone Elastic Agents -->  Providers --> Kubernetes Provider
3. Configure standalone Elastic Agents -->  Kubernetes autodiscovery with Elastic Agent --> Conditions based autodiscover 