### PR TITLE
Update mergify, issue template, and codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,4 +4,4 @@
 
 /docs/ @elastic/obs-docs
 /docs/en/integrations/ @bmorelli25
-/docs/en/ingest-management/ @dedemorton
+/docs/en/ingest-management/ @elastic/ingest-docs

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,5 +3,4 @@
 # For more info, see https://help.github.com/articles/about-codeowners/
 
 /docs/ @elastic/obs-docs
-/docs/en/integrations/ @bmorelli25
 /docs/en/ingest-management/ @elastic/ingest-docs

--- a/.github/ISSUE_TEMPLATE/8.8-request.yaml
+++ b/.github/ISSUE_TEMPLATE/8.8-request.yaml
@@ -1,7 +1,7 @@
-name: "[Internal] 8.6 Documentation request"
-description: Request a documentation change or enhancement for the 8.6 release (Elastic employees).
+name: "[Internal] 8.8 Documentation request"
+description: Request a documentation change or enhancement for the 8.8 release (Elastic employees).
 title: "[REQUEST]: "
-labels: ["8.6-request", "Team:Docs"]
+labels: ["8.8-request", "Team:Docs"]
 body:
   - type: markdown
     attributes:

--- a/.github/workflows/add-pr-to-project.yml
+++ b/.github/workflows/add-pr-to-project.yml
@@ -2,6 +2,8 @@ name: Add PR to obs-docs board
 on:
   pull_request_target:
     types: [review_requested]
+    branches:
+      - 'main'
 jobs:
   specific_review_requested:
     name: Adding

--- a/.github/workflows/add-pr-to-project.yml
+++ b/.github/workflows/add-pr-to-project.yml
@@ -1,4 +1,4 @@
-name: Add PR to obs-docs board
+name: Add PR to obs-docs boar
 on:
   pull_request_target:
     types: [review_requested]

--- a/.github/workflows/add-pr-to-project.yml
+++ b/.github/workflows/add-pr-to-project.yml
@@ -1,4 +1,4 @@
-name: Add PR to obs-docs boar
+name: Add PR to obs-docs board
 on:
   pull_request_target:
     types: [review_requested]

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -188,3 +188,16 @@ pull_request_rules:
         labels:
           - "backport"
         title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"
+  - name: backport patches to 8.7 branch
+    conditions:
+      - merged
+      - label=backport-8.7
+    actions:
+      backport:
+        assignees:
+          - "{{ author }}"
+        branches:
+          - "8.7"
+        labels:
+          - "backport"
+        title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"


### PR DESCRIPTION
- [x] Tests that https://github.com/elastic/observability-docs/pull/2559 and https://github.com/elastic/observability-docs/pull/2560 worked
- [x] Swaps @dedemorton for @elastic/ingest-docs in the codeowners file
- [x] Adds 8.7 to Mergify
- [x] Updates our 8.6 issue template to 8.8
- [x] Only run `add-pr-to-project` on `main`