### PR TITLE
Add Fleet and Elastic Agent 7.17.9 release notes

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-7.17.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-7.17.asciidoc
@@ -14,6 +14,8 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-7.17.9>>
+
 * <<release-notes-7.17.8>>
 
 * <<release-notes-7.17.7>>
@@ -36,6 +38,15 @@ Also see:
 
 * {kibana-ref}/release-notes.html[{kib} release notes]
 * {beats-ref}/release-notes.html[{beats} release notes]
+
+// begin 7.17.9 relnotes
+
+[[release-notes-7.17.9]]
+== {fleet} and {agent} 7.17.9
+
+There are no bug fixes for Fleet or Elastic Agent in this release.
+
+// end 7.17.9 relnotes
 
 // begin 7.17.8 relnotes
 

--- a/docs/en/ingest-management/release-notes/release-notes-7.17.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-7.17.asciidoc
@@ -44,7 +44,7 @@ Also see:
 [[release-notes-7.17.9]]
 == {fleet} and {agent} 7.17.9
 
-There are no bug fixes for Fleet or Elastic Agent in this release.
+There are no bug fixes for {fleet} or {agent} in this release.
 
 // end 7.17.9 relnotes
 


### PR DESCRIPTION
Closes #2554

Do we want to carry over the breaking change "Fleet Server now rejects certificates signed with SHA-1" that we included in 7.17.7 and 7.17.8?