### PR TITLE
Make location of Fleet UI more explicit

### DIFF
--- a/docs/en/ingest-management/tab-widgets/add-fleet-server/content.asciidoc
+++ b/docs/en/ingest-management/tab-widgets/add-fleet-server/content.asciidoc
@@ -6,7 +6,7 @@ deployment.
 
 To confirm that an {integrations-server} is available in your deployment:
 
-. In {kib}, go to **Management > {fleet}**.
+. In {kib} sidebar, go to **Management > {fleet}**.
 . On the **Agents** tab, look for the **{ecloud} agent policy**. This policy is
 managed by {ecloud}, and contains a {fleet-server} integration and an Elastic
 APM integration. You cannot modify the policy. Confirm that the agent status is
@@ -32,7 +32,7 @@ NOTE: You can install only a single {agent} per host, which means you cannot run
 {fleet-server} and another {agent} on the same host unless you deploy a
 containerized {fleet-server}.
 
-. In {kib}, go to **Management > {fleet} > Settings**. For more information
+. In {kib} sidebar, go to **Management > {fleet} > Settings**. For more information
 about these settings, see {fleet-guide}/fleet-settings.html[{fleet} settings].
 // lint ignore fleet-server
 . Under **Fleet Server hosts**, click **Edit hosts** and specify one or more host


### PR DESCRIPTION
### Context
New users could be confused between the Management section in Kibana's sidebar and the Management section in the homepage.

### Change
Replace "In Kibana" with "In Kibana sidebar" for `Elasticsearch Service` and `Self-managed` tabs.

### Screenshot
![image](https://user-images.githubusercontent.com/23701614/215736341-6d44990b-01cb-4528-9ce1-810e1f690232.png)