### PR TITLE
Add docs for monitoring private networks via synthetics service

### DIFF
--- a/docs/en/observability/synthetics-private-location.asciidoc
+++ b/docs/en/observability/synthetics-private-location.asciidoc
@@ -3,21 +3,21 @@
 
 To monitor resources on private networks you can either:
 
-* Allow the Synthetics service to access your private endpoints.
+* Allow Elastic's global managed infrastructure to access your private endpoints.
 * Use {agent} to create a Private Location.
 
-Private Locations via Elastic Agent require only outbound connections from your network, while allowing access to the Synthetics Service requires allowing
+Private Locations via Elastic Agent require only outbound connections from your network, while allowing Elastic's global managed infrastructure to access a private endpoint requires
 inbound access, thus posing an additional risk that users must assess.
 
 [discrete]
 [[monitor-via-access-control]]
-= Allow the synthetics service access to your private network
+= Allow access to your private network
 
-To give the Synthetics Service access to a private endpoint, use IP address filtering, HTTP authentication, or both.
+To give Elastic's global managed infrastructure access to a private endpoint, use IP address filtering, HTTP authentication, or both.
 
 To grant access via IP, use https://manifest.synthetics.elastic-cloud.com/v1/ip-ranges.json[this list of egress IPs].
 The addresses and locations on this list may change, so automating updates to
-filtering rules is recommended. IP filtering alone will allow all users of our synthetics service access to your endpoints, if this
+filtering rules is recommended. IP filtering alone will allow all users of Elastic's global managed infrastructure access to your endpoints, if this
 is a concern consider adding additional protection via user/password authentication via a proxy like nginx.
 
 [discrete]

--- a/docs/en/observability/synthetics-private-location.asciidoc
+++ b/docs/en/observability/synthetics-private-location.asciidoc
@@ -1,7 +1,11 @@
 [[synthetics-private-location]]
-= Monitor a private endpoint
+= Monitor resources on private networks
 
-To monitor resources on private networks use {{agent}} to create a Private Location, or allow access to your private endpoints to the Synthetics Service.
+To monitor resources on private networks you can either:
+
+* Allow the Synthetics service to access your private endpoints.
+* Use {agent} to create a Private Location.
+
 Private Locations via Elastic Agent require only outbound connections from your network, while allowing access to the Synthetics Service requires allowing
 inbound access, thus posing an additional risk that users must assess.
 
@@ -9,11 +13,11 @@ inbound access, thus posing an additional risk that users must assess.
 [[monitor-via-access-control]]
 = Allow the synthetics service access to your private network
 
-To grant access to a private endpoint to our Synthetics Service use one or both of IP address filtering and HTTP authentication.
+To give the Synthetics Service access to a private endpoint, use IP address filtering, HTTP authentication, or both.
 
-To grant access via IP, use the list of egress IPs maintaned at https://manifest.synthetics.elastic-cloud.com/v1/ip-ranges.json[this URL].
-Please note that the addresses and locations on this list may be updated from time to time, so automating the updating of your
-filtering rules is recommended. Note that IP filtering alone will allow all users of our synthetics service access to your endpoints, if this
+To grant access via IP, use https://manifest.synthetics.elastic-cloud.com/v1/ip-ranges.json[this list of egress IPs].
+The addresses and locations on this list may change, so automating updates to
+filtering rules is recommended. IP filtering alone will allow all users of our synthetics service access to your endpoints, if this
 is a concern consider adding additional protection via user/password authentication via a proxy like nginx.
 
 [discrete]

--- a/docs/en/observability/synthetics-private-location.asciidoc
+++ b/docs/en/observability/synthetics-private-location.asciidoc
@@ -1,5 +1,24 @@
 [[synthetics-private-location]]
-= Add a private location
+= Monitor a private endpoint
+
+To monitor resources on private networks use {{agent}} to create a Private Location, or allow access to your private endpoints to the Synthetics Service.
+Private Locations via Elastic Agent require only outbound connections from your network, while allowing access to the Synthetics Service requires allowing
+inbound access, thus posing an additional risk that users must assess.
+
+[discrete]
+[[monitor-via-access-control]]
+= Allow the synthetics service access to your private network
+
+To grant access to a private endpoint to our Synthetics Service use one or both of IP address filtering and HTTP authentication.
+
+To grant access via IP, use the list of egress IPs maintaned at https://manifest.synthetics.elastic-cloud.com/v1/ip-ranges.json[this URL].
+Please note that the addresses and locations on this list may be updated from time to time, so automating the updating of your
+filtering rules is recommended. Note that IP filtering alone will allow all users of our synthetics service access to your endpoints, if this
+is a concern consider adding additional protection via user/password authentication via a proxy like nginx.
+
+[discrete]
+[[monitor-via-private-agent]]
+= Monitor via a private agent
 
 IMPORTANT: This is only relevant to monitors created using the {uptime-app} or project monitors.
 


### PR DESCRIPTION
Users often ask us for IP ranges used by the synthetics service, as for example [here](https://elasticstack.slack.com/archives/CNRTHRCLD/p1675327330988699), to allow access into private networks for monitoring purposes. The docs here explain / document that.