### PR TITLE
Include backslash in docker run command

### DIFF
--- a/docs/en/observability/synthetics-private-location.asciidoc
+++ b/docs/en/observability/synthetics-private-location.asciidoc
@@ -87,8 +87,8 @@ docker run \
   --env FLEET_ENROLL=1 \
   --env FLEET_URL={fleet-server-host-url} \
   --env FLEET_ENROLLMENT_TOKEN={enrollment-token} \
-  --cap-add=NET_RAW
-  --cap-add=SETUID
+  --cap-add=NET_RAW \
+  --cap-add=SETUID \
   --rm docker.elastic.co/beats/elastic-agent-complete:{version}
 ----
 


### PR DESCRIPTION
The docker run command is missing the backslashes which leads to syntax errors when copy/pasting the command