### PR TITLE
[main] Including backslash in docker run command (#2586)

### DIFF
--- a/docs/en/observability/synthetics-private-location.asciidoc
+++ b/docs/en/observability/synthetics-private-location.asciidoc
@@ -87,8 +87,8 @@ docker run \
   --env FLEET_ENROLL=1 \
   --env FLEET_URL={fleet-server-host-url} \
   --env FLEET_ENROLLMENT_TOKEN={enrollment-token} \
-  --cap-add=NET_RAW
-  --cap-add=SETUID
+  --cap-add=NET_RAW \
+  --cap-add=SETUID \
   --rm docker.elastic.co/beats/elastic-agent-complete:{version}
 ----
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `8.6` to `main`:
 - [Including backslash in docker run command (#2586)](https://github.com/elastic/observability-docs/pull/2586)

<!--- Backport version: 8.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)