### PR TITLE
Update synthetics-private-location.asciidoc

### DIFF
--- a/docs/en/observability/synthetics-private-location.asciidoc
+++ b/docs/en/observability/synthetics-private-location.asciidoc
@@ -27,6 +27,7 @@ refer to {fleet-guide}/agent-policy.html#create-a-policy[{agent} policy].
 [IMPORTANT]
 ====
 A private location should be set up against an agent policy that runs on a single {agent}.
+The {agent} must be **enrolled in Fleet** (Private Locations cannot be set up using **standalone** {agents}).
 Do _not_ run the same agent policy on multiple agents being used for private locations, as you may
 end up with duplicate or missing tests. Private locations do not currently load balance tests across
 multiple {agents}. See <<synthetics-private-location-scaling>> for information on increasing the capacity


### PR DESCRIPTION
Clarify that Private Locations must be on enrolled agents (not standalone)