### PR TITLE
Add Fleet and Elastic Agent 8.6.2 release notes

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-8.6.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.6.asciidoc
@@ -14,6 +14,7 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-8.6.2>>
 * <<release-notes-8.6.1>>
 * <<release-notes-8.6.0>>
 
@@ -22,7 +23,90 @@ Also see:
 * {kibana-ref}/release-notes.html[{kib} release notes]
 * {beats-ref}/release-notes.html[{beats} release notes]
 
-// begin 8.6.1 relnotes
+// begin 8.6.2 relnotes
+
+[[release-notes-8.6.2]]
+== {fleet} and {agent} 8.6.2
+
+Review important information about the {fleet} and {agent} 8.6.2 release.
+
+//REVIEWERS: Are these known issues still valid in 8.6.2. The issues are still
+//open, so I'm assuming they are.
+
+[discrete]
+[[known-issues-8.6.2]]
+=== Known issues
+
+[discrete]
+[[known-issue-issue-2066-8-6-2]]
+.Osquery live query results can take up to five minutes to show up in {kib}
+[%collapsible]
+====
+*Details* +
+A known issue in {agent} may prevent live query results from being available
+in the {kib} UI even though the results have been successfully sent to {es}. 
+For more information, refer to {agent-issue}2066[#2066].
+
+*Impact* +
+Be aware that the live query results shown in {kib} may be delayed by up to 5 minutes.
+====
+
+[[known-issue-2170-8-6-2]]
+.Adding a {fleet-server} integration to an agent results in panic if the agent was not bootstrapped with a {fleet-server}
+[%collapsible]
+====
+
+*Details*
+
+A panic occurs because the {agent} does not have a `fleet.server` in the `fleet.enc`
+configuration file. When this happens, the agent fails with a message like:
+
+[source,shell]
+----
+panic: runtime error: invalid memory address or nil pointer dereference
+[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x557b8eeafc1d]
+goroutine 86 [running]:
+github.com/elastic/elastic-agent/internal/pkg/agent/application.FleetServerComponentModifier.func1({0xc000652f00, 0xa, 0x10}, 0x557b8fa8eb92?)
+...
+----
+
+For more information, refer to {agent-issue}2170[#2170].
+
+*Impact* +
+
+To work around this problem, uninstall the {agent} and install it again with
+{fleet-server} enabled during the bootstrap process.
+====
+
+[discrete]
+[[enhancements-8.6.2]]
+=== Enhancements
+
+{fleet}::
+* Adds the ability to run agent policy schema in batches during {fleet} setup.
+Also adds `xpack.fleet.setup.agentPolicySchemaUpgradeBatchSize` config
+{kibana-pull}150688[#150688]
+
+[discrete]
+[[bug-fixes-8.6.2]]
+=== Bug fixes
+
+{fleet}::
+* Fix max 20 installed integrations returned from Fleet API {kibana-pull}150780[#150780]
+* Fix updates available when beta integrations are off {kibana-pull}149515[#149515] {kibana-pull}149486[#149486]
+
+{fleet-server}::
+* Prevent {fleet-server} from crashing by allowing the the Warn log level to be
+specified as "warning" or "warn" {fleet-server-issue}2328[#2328] {fleet-server-pull}2331[#2331]
+
+// REVIEWERS: The fleet server fragment here seems old: https://github.com/elastic/fleet-server/blob/07f924240eebed6821365c2f0ba230873a1d5726/changelog/fragments/1668434027-Accept-raw-errors-as-a-fallback-to-detailed-error-type.yaml
+// But there was an item in the changelog (#2328) ^^ that looks like it belongs in the release notes
+// Sounds like the changelog fragment process still has some hiccups? 
+
+{agent}::
+* TODO: Add items from 8.6.2.yaml when available.
+
+// end 8.6.2 relnotes
 
 [[release-notes-8.6.1]]
 == {fleet} and {agent} 8.6.1

--- a/docs/en/ingest-management/release-notes/release-notes-8.6.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.6.asciidoc
@@ -30,9 +30,6 @@ Also see:
 
 Review important information about the {fleet} and {agent} 8.6.2 release.
 
-//REVIEWERS: Are these known issues still valid in 8.6.2. The issues are still
-//open, so I'm assuming they are.
-
 [discrete]
 [[known-issues-8.6.2]]
 === Known issues
@@ -98,12 +95,6 @@ Also adds `xpack.fleet.setup.agentPolicySchemaUpgradeBatchSize` config
 {fleet-server}::
 * Prevent {fleet-server} from crashing by allowing the the Warn log level to be
 specified as "warning" or "warn" {fleet-server-issue}2328[#2328] {fleet-server-pull}2331[#2331]
-
-// REVIEWERS: The fleet server fragment that exists seems old:
-// https://github.com/elastic/fleet-server/blob/07f924240eebed6821365c2f0ba230873a1d5726/changelog/fragments/1668434027-Accept-raw-errors-as-a-fallback-to-detailed-error-type.yaml
-// But there was an item in the changelog (#2328) ^^ that looks like it belongs
-// in the release notes, so I've added it here.
-// Sounds like the changelog fragment process still has some hiccups? 
 
 {agent}::
 * Preserve component state on upgrade {agent-issue}2136[#2136] {agent-pull}2207[#2207]

--- a/docs/en/ingest-management/release-notes/release-notes-8.6.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.6.asciidoc
@@ -97,10 +97,10 @@ Also adds `xpack.fleet.setup.agentPolicySchemaUpgradeBatchSize` config
 specified as "warning" or "warn" {fleet-server-issue}2328[#2328] {fleet-server-pull}2331[#2331]
 
 {agent}::
-* Preserve component state on upgrade {agent-issue}2136[#2136] {agent-pull}2207[#2207]
+* Preserve persistent process state between upgrades. The {filebeat} registry is now correctly preserved during {agent} upgrades. {agent-issue}2136[#2136] {agent-pull}2207[#2207]
 * Enable nodejs engine validation when bundling synthetics
 {agent-issue}2249[#2249] {agent-pull}2256[#2256] {agent-pull}2225[#2225]
-* Start and stop components in a more syncronized manner {agent-pull}2226[#2226]
+* Guarantee that services are stopped before they are started. Fixes occasional upgrade failures when Elastic Defend is installed {agent-pull}2226[#2226]
 
 // end 8.6.2 relnotes
 

--- a/docs/en/ingest-management/release-notes/release-notes-8.6.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.6.asciidoc
@@ -99,12 +99,17 @@ Also adds `xpack.fleet.setup.agentPolicySchemaUpgradeBatchSize` config
 * Prevent {fleet-server} from crashing by allowing the the Warn log level to be
 specified as "warning" or "warn" {fleet-server-issue}2328[#2328] {fleet-server-pull}2331[#2331]
 
-// REVIEWERS: The fleet server fragment here seems old: https://github.com/elastic/fleet-server/blob/07f924240eebed6821365c2f0ba230873a1d5726/changelog/fragments/1668434027-Accept-raw-errors-as-a-fallback-to-detailed-error-type.yaml
-// But there was an item in the changelog (#2328) ^^ that looks like it belongs in the release notes
+// REVIEWERS: The fleet server fragment that exists seems old:
+// https://github.com/elastic/fleet-server/blob/07f924240eebed6821365c2f0ba230873a1d5726/changelog/fragments/1668434027-Accept-raw-errors-as-a-fallback-to-detailed-error-type.yaml
+// But there was an item in the changelog (#2328) ^^ that looks like it belongs
+// in the release notes, so I've added it here.
 // Sounds like the changelog fragment process still has some hiccups? 
 
 {agent}::
-* TODO: Add items from 8.6.2.yaml when available.
+* Preserve component state on upgrade {agent-issue}2136[#2136] {agent-pull}2207[#2207]
+* Enable nodejs engine validation when bundling synthetics
+{agent-issue}2249[#2249] {agent-pull}2256[#2256] {agent-pull}2225[#2225]
+* Start and stop components in a more syncronized manner {agent-pull}2226[#2226]
 
 // end 8.6.2 relnotes
 

--- a/docs/en/ingest-management/release-notes/release-notes-8.6.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.6.asciidoc
@@ -97,6 +97,7 @@ Also adds `xpack.fleet.setup.agentPolicySchemaUpgradeBatchSize` config
 specified as "warning" or "warn" {fleet-server-issue}2328[#2328] {fleet-server-pull}2331[#2331]
 
 {agent}::
+* Ignore {fleet} connectivity state when considering whether an upgrade should be rolled back. Avoids unnecessary upgrade failures due to transient network errors {agent-pull}2239[#2239]
 * Preserve persistent process state between upgrades. The {filebeat} registry is now correctly preserved during {agent} upgrades. {agent-issue}2136[#2136] {agent-pull}2207[#2207]
 * Enable nodejs engine validation when bundling synthetics
 {agent-issue}2249[#2249] {agent-pull}2256[#2256] {agent-pull}2225[#2225]


### PR DESCRIPTION
Closes #2643 

Contains the manually created relnotes for 8.6.2.

We need to revisit this process for 8.7, which IMO is a better time to change for format. We might want to consider pointing to the Kibana release notes instead of building a consolidated file that includes relnotes for Fleet, Fleet Server, and Agent.

cc'ing @karenzone 

Preview is here: https://observability-docs_2644.docs-preview.app.elstc.co/guide/en/fleet/master/release-notes-8.6.2.html

TODOs:
- [x] Add Elastic Agent items when 8.6.2.yaml is available.
- [x] Confirm that "known issues" are still valid. [marking done since reviewers did not identify these issues as fixed]