### PR TITLE
[synthetics] Add details on how to disable throttling

### DIFF
--- a/docs/en/observability/index.asciidoc
+++ b/docs/en/observability/index.asciidoc
@@ -28,7 +28,7 @@ include::{docs-root}/shared/attributes.asciidoc[]
 :shared:               {observability-docs-root}/docs/en/shared
 :kibana-repo-dir:      {kibana-root}/docs 
 
-:synthetics_version: v1.0.0-beta.37
+:synthetics_version: v1.0.0-beta.40
 
 // What is Observability?
 include::observability-introduction.asciidoc[leveloffset=+1]

--- a/docs/en/observability/synthetics-command-reference.asciidoc
+++ b/docs/en/observability/synthetics-command-reference.asciidoc
@@ -52,6 +52,9 @@ take precedence.
 *`--screenshots <on|off|only-on-failure>`*::
 Captures screenshots for every step in the journey.
 
+*`--no-throttling`*::
+Does not apply throttling.
+
 *`-h, --help`*::
 Shows help for the `npx @elastic/synthetics` command.
 

--- a/docs/en/observability/synthetics-configuration.asciidoc
+++ b/docs/en/observability/synthetics-configuration.asciidoc
@@ -114,8 +114,8 @@ with the {kib} URL for the deployment from which to fetch available locations.
 * Go to *{uptime-app}* -> *Monitor Management* and click *Add monitor*.
 Private locations will be listed in _Monitor locations_ with a "Private" badge next to their names.
 
-`throttling` (https://github.com/elastic/synthetics/blob/{synthetics_version}/src/common_types.ts#L194-L198[`ThrottlingOptions`])::
-Control the monitor's download speeds, upload speeds, and latency to simulate your application's behavior on slower or laggier networks.
+`throttling` (`boolean` | https://github.com/elastic/synthetics/blob/{synthetics_version}/src/common_types.ts#L194-L198[`ThrottlingOptions`])::
+Control the monitor's download speeds, upload speeds, and latency to simulate your application's behavior on slower or laggier networks. Set to `false` to disable throttling altogether.
 `screenshot` (https://github.com/elastic/synthetics/blob/{synthetics_version}/src/common_types.ts#L192[`ScreenshotOptions`])::
 Control whether or not to capture screenshots. Options include `'on'`, `'off'`, or `'only-on-failure'`.
 // end::monitor-config-options[]


### PR DESCRIPTION
Closes https://github.com/elastic/observability-docs/issues/2503

Adds details on how to disable throttling in the command reference and configuration docs.