### PR TITLE
ESF: add details on using encrypted S3 buckets

### DIFF
--- a/docs/en/observability/aws-deploy-elastic-serverless-forwarder.asciidoc
+++ b/docs/en/observability/aws-deploy-elastic-serverless-forwarder.asciidoc
@@ -242,7 +242,12 @@ These parameters define the general configuration and behaviour for the forwarde
 
 - `ElasticServerlessForwarderS3ConfigFile`: Set this value to the location of your `config.yaml` in S3 URL format: `s3://bucket-name/config-file-name`. This will populate the `S3_CONFIG_FILE` environment variable for the forwarder.
 - `ElasticServerlessForwarderSSMSecrets`: Add a comma delimited list of {aws} SSM Secrets ARNs used in the `config.yml` (if any).
-- `ElasticServerlessForwarderKMSKeys`: Add a comma delimited list of {aws} KMS Keys ARNs to be used for decrypting {aws} SSM Secrets, Kinesis Data Streams, or SQS queue (if any).
+- `ElasticServerlessForwarderKMSKeys`: Add a comma delimited list of {aws} KMS Keys ARNs to be used for decrypting {aws} SSM Secrets, Kinesis Data Streams, SQS queue, or S3 buckets (if any).
+
+[NOTE]
+====
+Make sure you include all the KMS keys used to encrypt te data. For example, S3 buckets are often encrypted, so the Lambda function needs access to that key to get the object.
+====
 
 === Inputs
 These parameters define your specific <<aws-serverless-forwarder-inputs>> or 'event triggers'.

--- a/docs/en/observability/aws-deploy-elastic-serverless-forwarder.asciidoc
+++ b/docs/en/observability/aws-deploy-elastic-serverless-forwarder.asciidoc
@@ -246,7 +246,7 @@ These parameters define the general configuration and behaviour for the forwarde
 
 [NOTE]
 ====
-Make sure you include all the KMS keys used to encrypt te data. For example, S3 buckets are often encrypted, so the Lambda function needs access to that key to get the object.
+Make sure you include all the KMS keys used to encrypt the data. For example, S3 buckets are often encrypted, so the Lambda function needs access to that key to get the object.
 ====
 
 === Inputs


### PR DESCRIPTION
### Motivation
<!-- Why this pull request? -->

The current Elastic Serverless Forwarder mentions that the `ElasticServerlessForwarderKMSKeys` option is:

> a comma delimited list of AWS KMS Keys ARNs to be used for decrypting AWS SSM Secrets, Kinesis Data Streams, or SQS queue (if any)

This is correct, but we must also mention that users should add the KMS keys to encrypt the objects in the S3 bucket (if any).

### Change description
<!-- What does your code do? -->

A couple of minor updates:

- Mention user should add KMS keys used in S3 buckets.
- Add a note with an example.

### Additional Notes
<!-- Link any useful metadata: Jira task, GitHub issue, ... -->

- https://github.com/elastic/sdh-beats/issues/3071


### Reviewer checklist

* [x] PR address a single concern.
* [x] PR title and description are appropriately filled.
* [x] Changes will be merged in `main.`
