### PR TITLE
Ensure all known issues are documented for Agent in 8.6.x

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-8.6.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.6.asciidoc
@@ -75,6 +75,27 @@ To work around this problem, uninstall the {agent} and install it again with
 {fleet-server} enabled during the bootstrap process.
 ====
 
+[[known-issue-2103-8-6-2]]
+.Installing {agent} on MacOS Ventura fails with a permissions error if Full Disk Access is not granted to the application used for installation.
+====
+
+*Details*
+
+Installing {agent} on MacOS Ventura fails with a permissions error like the one below if Full Disk Access
+permission is not granted to the application used for installation.
+
+[source,shell]
+----
+Error: failed to fix permissions: chown /Library/Elastic/Agent/data/elastic-agent-c13f91/elastic-agent.app: operation not permitted
+----
+
+For more information, refer to {agent-issue}2103[#2103].
+
+*Impact* +
+
+Ensure that the application (eg. Terminal, or a custom package) used to install {agent} has Full Disk Access before running `sudo ./elastic-agent install`.
+====
+
 [discrete]
 [[enhancements-8.6.2]]
 === Enhancements
@@ -102,6 +123,7 @@ specified as "warning" or "warn" {fleet-server-issue}2328[#2328] {fleet-server-p
 * Enable nodejs engine validation when bundling synthetics
 {agent-issue}2249[#2249] {agent-pull}2256[#2256] {agent-pull}2225[#2225]
 * Guarantee that services are stopped before they are started. Fixes occasional upgrade failures when Elastic Defend is installed {agent-pull}2226[#2226]
+* Fix an issue where inputs in {beats} started by {agent} can be incorrectly disabled. This primarily occurs when changing the log level. {agent-issue}2232[#2232] {beats-pull}34504[#34504]
 
 // end 8.6.2 relnotes
 
@@ -153,6 +175,30 @@ For more information, refer to {agent-issue}2170[#2170].
 
 To work around this problem, uninstall the {agent} and install it again with
 {fleet-server} enabled during the bootstrap process.
+====
+
+[[known-issue-2232-8-6-1]]
+.Changing the {agent} log level can incorrectly disable inputs in supervised {beats}.
+[%collapsible]
+====
+
+*Details*
+
+Data collection may be disabled when the [agent] log level is changed. Avoid changing the {agent} log level.
+
+Upgrade to 8.6.2 to fix the problem. For more information, refer to {agent-issue}2232[#2232].
+====
+
+[[known-issue-2328-8-6-1]]
+.{fleet-server} will crash when configured to use the Warning log level.
+[%collapsible]
+====
+
+*Details*
+{fleet-server} will crash when configured to use the Warning log level. Do not use the Warning log level.
+Affected {fleet-server} instances must be reinstalled to fix the problem.
+
+Upgrade to 8.6.2 to fix the problem. For more information, refer to {fleet-server-issue}2328[#2328].
 ====
 
 [discrete]

--- a/docs/en/ingest-management/release-notes/release-notes-8.6.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.6.asciidoc
@@ -36,7 +36,7 @@ Review important information about the {fleet} and {agent} 8.6.2 release.
 
 [discrete]
 [[known-issue-issue-2066-8-6-2]]
-.Osquery live query results can take up to five minutes to show up in {kib}
+.Osquery live query results can take up to five minutes to show up in {kib}.
 [%collapsible]
 ====
 *Details* +
@@ -49,7 +49,7 @@ Be aware that the live query results shown in {kib} may be delayed by up to 5 mi
 ====
 
 [[known-issue-2170-8-6-2]]
-.Adding a {fleet-server} integration to an agent results in panic if the agent was not bootstrapped with a {fleet-server}
+.Adding a {fleet-server} integration to an agent results in panic if the agent was not bootstrapped with a {fleet-server}.
 [%collapsible]
 ====
 
@@ -75,26 +75,19 @@ To work around this problem, uninstall the {agent} and install it again with
 {fleet-server} enabled during the bootstrap process.
 ====
 
-[[known-issue-2103-8-6-2]]
-.Installing {agent} on MacOS Ventura fails with a permissions error if Full Disk Access is not granted to the application used for installation.
+[[known-issue-issue-2103-8.6.2]]
+.Installating {agent} on MacOS Ventura may fail if Full Disk Access has not been granted to the application used for installation.
 [%collapsible]
 ====
-
-*Details*
-
-Installing {agent} on MacOS Ventura fails with a permissions error like the one below if Full Disk Access
-permission is not granted to the application used for installation.
-
-[source,shell]
-----
-Error: failed to fix permissions: chown /Library/Elastic/Agent/data/elastic-agent-c13f91/elastic-agent.app: operation not permitted
-----
+*Details* +
+This issue occurs on MacOS Ventura when Full Disk Access is not granted to the application that runs the installation command.
+This could be either a Terminal or any custom package that a user has built to distribute {agent}.
 
 For more information, refer to {agent-issue}2103[#2103].
 
 *Impact* +
-
-Ensure that the application (eg. Terminal, or a custom package) used to install {agent} has Full Disk Access before running `sudo ./elastic-agent install`.
+{agent} will fail to install and produce "Error: failed to fix permissions: chown elastic-agent.app: operation not permitted" message.
+Ensure that the application used to install {agent} (for example, the Terminal or custom package) has Full Disk Access before running `sudo ./elastic-agent install`.
 ====
 
 [discrete]
@@ -139,7 +132,7 @@ Review important information about the {fleet} and {agent} 8.6.1 release.
 
 [discrete]
 [[known-issue-issue-2066-8-6-1]]
-.Osquery live query results can take up to five minutes to show up in {kib}
+.Osquery live query results can take up to five minutes to show up in {kib}.
 [%collapsible]
 ====
 *Details* +
@@ -152,7 +145,7 @@ Be aware that the live query results shown in {kib} may be delayed by up to 5 mi
 ====
 
 [[known-issue-2170]]
-.Adding a {fleet-server} integration to an agent results in panic if the agent was not bootstrapped with a {fleet-server}
+.Adding a {fleet-server} integration to an agent results in panic if the agent was not bootstrapped with a {fleet-server}.
 [%collapsible]
 ====
 
@@ -179,7 +172,7 @@ To work around this problem, uninstall the {agent} and install it again with
 ====
 
 [[known-issue-2232-8-6-1]]
-.Changing the {agent} log level can incorrectly disable inputs in supervised {beats}
+.Changing the {agent} log level can incorrectly disable inputs in supervised {beats}.
 [%collapsible]
 ====
 
@@ -191,7 +184,7 @@ Upgrade to 8.6.2 to fix the problem. For more information, refer to {agent-issue
 ====
 
 [[known-issue-2328-8-6-1]]
-.{fleet-server} will crash when configured to use the Warning log level
+.{fleet-server} will crash when configured to use the Warning log level.
 [%collapsible]
 ====
 
@@ -201,6 +194,21 @@ Upgrade to 8.6.2 to fix the problem. For more information, refer to {agent-issue
 Affected {fleet-server} instances must be reinstalled to fix the problem.
 
 Upgrade to 8.6.2 to fix the problem. For more information, refer to {fleet-server-issue}2328[#2328].
+====
+
+[[known-issue-issue-2103-8.6.1]]
+.Installating {agent} on MacOS Ventura may fail if Full Disk Access has not been granted to the application used for installation.
+[%collapsible]
+====
+*Details* +
+This issue occurs on MacOS Ventura when Full Disk Access is not granted to the application that runs the installation command.
+This could be either a Terminal or any custom package that a user has built to distribute {agent}.
+
+For more information, refer to {agent-issue}2103[#2103].
+
+*Impact* +
+{agent} will fail to install and produce "Error: failed to fix permissions: chown elastic-agent.app: operation not permitted" message.
+Ensure that the application used to install {agent} (for example, the Terminal or custom package) has Full Disk Access before running `sudo ./elastic-agent install`.
 ====
 
 [discrete]
@@ -291,7 +299,7 @@ of dedoted kubernetes labels inside conditions has to be updated.
 
 [discrete]
 [[known-issue-issue-2066]]
-.Osquery live query results can take up to five minutes to show up in {kib}
+.Osquery live query results can take up to five minutes to show up in {kib}.
 [%collapsible]
 ====
 *Details* +
@@ -303,21 +311,24 @@ For more information, refer to {agent-issue}2066[#2066].
 Be aware that the live query results shown in {kib} may be delayed by up to 5 minutes.
 ====
 
-[[known-issue-issue-2103]]
-.Installation of {agent} on MacOS Ventura may fail if Full Disk Access has not been granted to the installer
+[[known-issue-issue-2103-8.6.0]]
+.Installating {agent} on MacOS Ventura may fail if Full Disk Access has not been granted to the application used for installation.
 [%collapsible]
 ====
 *Details* +
 This issue occurs on MacOS Ventura when Full Disk Access is not granted to the application that runs the installation command.
 This could be either a Terminal or any custom package that a user has built to distribute {agent}.
 
+For more information, refer to {agent-issue}2103[#2103].
+
 *Impact* +
 {agent} will fail to install and produce "Error: failed to fix permissions: chown elastic-agent.app: operation not permitted" message.
 Ensure that the application used to install {agent} (for example, the Terminal or custom package) has Full Disk Access before running `sudo ./elastic-agent install`.
 ====
 
+
 [[known-issue-issue-2086]]
-.Beats started by agent may fail with `output unit has no config` error
+.Beats started by agent may fail with `output unit has no config` error.
 [%collapsible]
 ====
 *Details* +

--- a/docs/en/ingest-management/release-notes/release-notes-8.6.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.6.asciidoc
@@ -179,7 +179,7 @@ To work around this problem, uninstall the {agent} and install it again with
 ====
 
 [[known-issue-2232-8-6-1]]
-.Changing the {agent} log level can incorrectly disable inputs in supervised {beats}.
+.Changing the {agent} log level can incorrectly disable inputs in supervised {beats}
 [%collapsible]
 ====
 

--- a/docs/en/ingest-management/release-notes/release-notes-8.6.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.6.asciidoc
@@ -76,7 +76,7 @@ To work around this problem, uninstall the {agent} and install it again with
 ====
 
 [[known-issue-issue-2103-8.6.2]]
-.Installating {agent} on MacOS Ventura may fail if Full Disk Access has not been granted to the application used for installation.
+.Installing {agent} on MacOS Ventura may fail if Full Disk Access has not been granted to the application used for installation.
 [%collapsible]
 ====
 *Details* +
@@ -197,7 +197,7 @@ Upgrade to 8.6.2 to fix the problem. For more information, refer to {fleet-serve
 ====
 
 [[known-issue-issue-2103-8.6.1]]
-.Installating {agent} on MacOS Ventura may fail if Full Disk Access has not been granted to the application used for installation.
+.Installing {agent} on MacOS Ventura may fail if Full Disk Access has not been granted to the application used for installation.
 [%collapsible]
 ====
 *Details* +
@@ -312,7 +312,7 @@ Be aware that the live query results shown in {kib} may be delayed by up to 5 mi
 ====
 
 [[known-issue-issue-2103-8.6.0]]
-.Installating {agent} on MacOS Ventura may fail if Full Disk Access has not been granted to the application used for installation.
+.Installing {agent} on MacOS Ventura may fail if Full Disk Access has not been granted to the application used for installation.
 [%collapsible]
 ====
 *Details* +

--- a/docs/en/ingest-management/release-notes/release-notes-8.6.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.6.asciidoc
@@ -191,7 +191,7 @@ Upgrade to 8.6.2 to fix the problem. For more information, refer to {agent-issue
 ====
 
 [[known-issue-2328-8-6-1]]
-.{fleet-server} will crash when configured to use the Warning log level.
+.{fleet-server} will crash when configured to use the Warning log level
 [%collapsible]
 ====
 

--- a/docs/en/ingest-management/release-notes/release-notes-8.6.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.6.asciidoc
@@ -77,6 +77,7 @@ To work around this problem, uninstall the {agent} and install it again with
 
 [[known-issue-2103-8-6-2]]
 .Installing {agent} on MacOS Ventura fails with a permissions error if Full Disk Access is not granted to the application used for installation.
+[%collapsible]
 ====
 
 *Details*
@@ -184,7 +185,7 @@ To work around this problem, uninstall the {agent} and install it again with
 
 *Details*
 
-Data collection may be disabled when the [agent] log level is changed. Avoid changing the {agent} log level.
+Data collection may be disabled when the {agent} log level is changed. Avoid changing the {agent} log level.
 
 Upgrade to 8.6.2 to fix the problem. For more information, refer to {agent-issue}2232[#2232].
 ====
@@ -195,6 +196,7 @@ Upgrade to 8.6.2 to fix the problem. For more information, refer to {agent-issue
 ====
 
 *Details*
+
 {fleet-server} will crash when configured to use the Warning log level. Do not use the Warning log level.
 Affected {fleet-server} instances must be reinstalled to fix the problem.
 


### PR DESCRIPTION
- Add two known issues for 8.6.1 that are high severity and fixed in 8.6.2.
- Copy the release notes for a fix in Beats that applies to agent in 8.6.2 since it fixes a critical issue and needs to be visible.
- Add a known issue in 8.6.2 for the agent failing to install on MacOS Ventura. This technically applies to every version of the agent.