### PR TITLE
Fix broken link to Azure Activity Logs

### DIFF
--- a/docs/en/observability/monitor-azure-agent.asciidoc
+++ b/docs/en/observability/monitor-azure-agent.asciidoc
@@ -319,7 +319,7 @@ activity logs integration to see more details about it.
 a description.
 
 . Specify values for all the required fields. For more information about these
-settings, refer to the {integrations-docs}/activitylogs[Azure activity logs]
+settings, refer to the {integrations-docs}/azure/activitylogs[Azure activity logs]
 documentation.
 +
 --


### PR DESCRIPTION
Fix a broken link to Azure Activity Logs in the "Monitor Azure with Elastic Agent" tutorial