### PR TITLE
Add default port assignment information

### DIFF
--- a/docs/en/ingest-management/fleet/add-fleet-server-cloud.asciidoc
+++ b/docs/en/ingest-management/fleet/add-fleet-server-cloud.asciidoc
@@ -39,6 +39,8 @@ NOTE: The TLS certificates used to secure connections between {agent} and
 {fleet-server} are managed by {ecloud}. You do not need to create a private key
 or generate certificates.
 
+include::add-fleet-server-on-prem.asciidoc[tag=default-port-prereq]
+
 [discrete]
 [[add-fleet-server-cloud-set-up]]
 = Setup

--- a/docs/en/ingest-management/fleet/add-fleet-server-mixed.asciidoc
+++ b/docs/en/ingest-management/fleet/add-fleet-server-mixed.asciidoc
@@ -43,7 +43,22 @@ For more information about hosting {fleet-server} on {ece}, refer to
 [[add-fleet-server-mixed-prereq]]
 = Prerequisites
 
+Before deploying, you need to:
+
+* Obtain or generate a Cerfiticate Authority (CA) certificate.
+* Ensure components have access to the default ports needed for communication.
+
+[discrete]
+[[add-fleet-server-mixed-cert-prereq]]
+== CA certificate
+
 include::add-fleet-server-on-prem.asciidoc[tag=cert-prereq]
+
+[discrete]
+[[default-port-assignments-mixed]]
+== Default port assignments
+
+include::add-fleet-server-on-prem.asciidoc[tag=default-port-prereq]
 
 [discrete]
 [[fleet-server-add-hosts]]

--- a/docs/en/ingest-management/fleet/add-fleet-server-on-prem.asciidoc
+++ b/docs/en/ingest-management/fleet/add-fleet-server-on-prem.asciidoc
@@ -45,9 +45,19 @@ For more information about hosting {fleet-server} on {ece}, refer to
 [[add-fleet-server-on-prem-prereq]]
 = Prerequisites
 
+Before deploying, you need to:
+
+* Obtain or generate a Cerfiticate Authority (CA) certificate.
+* Ensure components have access to the ports needed for communication.
+
+[discrete]
+[[add-fleet-server-on-prem-cert-prereq]]
+== CA certificate
+
 // tag::cert-prereq[]
+
 Before setting up {fleet-server} using this approach, you will need a
-Certificate Authority (CA) certificate to configure Transport Layer Security (TLS)
+CA certificate to configure Transport Layer Security (TLS)
 to encrypt traffic between the {fleet-server}s and the {stack}.
 
 If your organization already uses the {stack}, you may already have a CA certificate. If you do not have a CA certificate, you can read more
@@ -56,6 +66,28 @@ about generating one in <<secure-connections>>.
 NOTE: This is not required when testing and iterating using the *Quick start* option, but should always be used for production deployments.
 
 // end::cert-prereq[]
+
+[discrete]
+[[default-port-assignments-on-prem]]
+== Default port assignments
+
+//tag::default-port-prereq[]
+
+When {es} or {fleet-server} are deployed, components communicate over well-defined, pre-allocated ports.
+You may need to allow access to these ports. See the following table for default port assignments:
+
+|===
+| Component communication | Default port
+
+| Elastic Agent → {fleet-server} | 8220
+| Elastic Agent → {es} | 9200
+| Elastic Agent → Logstash | 5044
+| Elastic Agent → {fleet} | 5601
+| {fleet-server} → {fleet} | 5601
+| {fleet-server} → {es} | 9200
+|===
+
+// end::default-port-prereq[]
 
 [discrete]
 [[add-fleet-server-on-prem-hosts]]


### PR DESCRIPTION
## Description

Closes [Issue 2238](https://github.com/elastic/observability-docs/issues/2238). 

Adding the default ports to the prerequisite sections of the **Add fleet server** pages. 

I also added some sections in the prereqs for clarity and introductory material for that. 

@nimarezainia you mentioned needing these prerequisites for for both on-prem and cloud deployments, so I have added the table to both pages as well as the mixed deployment page. 