### PR TITLE
[Synthetics] Suggest not to use browser types in 7x

### DIFF
--- a/docs/en/observability/monitor-uptime-synthetics.asciidoc
+++ b/docs/en/observability/monitor-uptime-synthetics.asciidoc
@@ -13,6 +13,12 @@ TCP, and ICMP monitors.
 [[monitoring-synthetics]]
 == Browser checks
 
+[IMPORTANT]
+====
+Browser checks are beta (and will never be GA) in version `7.x` and it has significantly changed in version `8.x`.
+We do not recommend using Browser monitors anymore in `7.x` but suggest you try it out in newer versions of `8.x` instead.
+====
+
 beta[] Real browser synthetic monitoring enables you to test critical actions and requests that an end-user would perform
 on your site at predefined intervals and in a controlled environment. You can view each synthetic monitoring journey
 in the {uptime-app} side-by-side with your other <<monitor-uptime,Uptime monitors>>. The result is rich, consistent, and repeatable

--- a/docs/en/observability/monitor-uptime-synthetics.asciidoc
+++ b/docs/en/observability/monitor-uptime-synthetics.asciidoc
@@ -13,11 +13,7 @@ TCP, and ICMP monitors.
 [[monitoring-synthetics]]
 == Browser checks
 
-[IMPORTANT]
-====
-Browser checks are beta (and will never be GA) in version `7.x` and it has significantly changed in version `8.x`.
-We do not recommend using Browser monitors anymore in `7.x` but suggest you try it out in newer versions of `8.x` instead.
-====
+include::shared/synthetics-note.asciidoc[]
 
 beta[] Real browser synthetic monitoring enables you to test critical actions and requests that an end-user would perform
 on your site at predefined intervals and in a controlled environment. You can view each synthetic monitoring journey

--- a/docs/en/observability/monitor-uptime.asciidoc
+++ b/docs/en/observability/monitor-uptime.asciidoc
@@ -23,6 +23,9 @@ status code and display the correct text.
 
 | *Browser monitor* | Using the synthetics agent, run automated synthetic monitoring test suites on a real Chromium
 browser. For more details, refer to <<synthetic-monitoring,Real browser synthetic monitoring>>. 
+**Important** Browser checks are beta (and will never be GA) in version `7.x` and it has significantly changed in version `8.x`.
+We do not recommend using Browser monitors anymore in `7.x` but suggest you try it out in newer versions of `8.x` instead.
+
 
 |===
 

--- a/docs/en/observability/monitor-uptime.asciidoc
+++ b/docs/en/observability/monitor-uptime.asciidoc
@@ -22,7 +22,8 @@ to ensure the service is accessible and running.
 status code and display the correct text.
 
 | *Browser monitor* | Using the synthetics agent, run automated synthetic monitoring test suites on a real Chromium
-browser. For more details, refer to <<synthetic-monitoring,Real browser synthetic monitoring>>. 
+browser. For more details, refer to <<synthetic-monitoring,Real browser synthetic monitoring>>.
+
 **Important** Browser checks are beta (and will never be GA) in version `7.x` and it has significantly changed in version `8.x`.
 We do not recommend using Browser monitors anymore in `7.x` but suggest you try it out in newer versions of `8.x` instead.
 

--- a/docs/en/observability/monitor-uptime.asciidoc
+++ b/docs/en/observability/monitor-uptime.asciidoc
@@ -21,12 +21,10 @@ to ensure the service is accessible and running.
 | *HTTP monitor* | Monitor your website. The HTTP monitor checks to ensure specific endpoints return the correct
 status code and display the correct text.
 
-| *Browser monitor* | Using the synthetics agent, run automated synthetic monitoring test suites on a real Chromium
+| *Browser monitor* a| Using the synthetics agent, run automated synthetic monitoring test suites on a real Chromium
 browser. For more details, refer to <<synthetic-monitoring,Real browser synthetic monitoring>>.
 
-**Important** Browser checks are beta (and will never be GA) in version `7.x` and it has significantly changed in version `8.x`.
-We do not recommend using Browser monitors anymore in `7.x` but suggest you try it out in newer versions of `8.x` instead.
-
+include::shared/synthetics-note.asciidoc[]
 
 |===
 

--- a/docs/en/observability/shared/synthetics-note.asciidoc
+++ b/docs/en/observability/shared/synthetics-note.asciidoc
@@ -1,0 +1,5 @@
+[IMPORTANT]
+====
+Browser checks are beta (and will never be GA) in version `7.x` and it has significantly changed in version `8.x`.
+We do not recommend using Browser monitors anymore in `7.x` but suggest you try it out in newer versions of `8.x` instead.
+====

--- a/docs/en/observability/shared/synthetics-note.asciidoc
+++ b/docs/en/observability/shared/synthetics-note.asciidoc
@@ -2,5 +2,5 @@
 ====
 *In version `7.x`*, browser checks are in beta and will never be made generally available in `7.x`.
 
-*If you want to use browser monitors*, we highly recommend using the latest version of browser checks available in `8.x`. This functionality has changed significantly in version `8.x`. We do _not_ recommend using browser monitors in `7.x` anymore.
+*If you want to use browser checks*, we highly recommend using the latest version of browser checks available in `8.x`. This functionality has changed significantly in version `8.x`. We do _not_ recommend using browser checks in `7.x` anymore.
 ====

--- a/docs/en/observability/shared/synthetics-note.asciidoc
+++ b/docs/en/observability/shared/synthetics-note.asciidoc
@@ -1,5 +1,6 @@
 [IMPORTANT]
 ====
-Browser checks are beta (and will never be GA) in version `7.x` and it has significantly changed in version `8.x`.
-We do not recommend using Browser monitors anymore in `7.x` but suggest you try it out in newer versions of `8.x` instead.
+*In version `7.x`*, browser checks are in beta and will never be made generally available in `7.x`.
+
+*If you want to use browser monitors*, we highly recommend using the latest version of browser checks available in `8.x`. This functionality has changed significantly in version `8.x`. We do _not_ recommend using browser monitors in `7.x` anymore.
 ====

--- a/docs/en/observability/synthetic-monitoring.asciidoc
+++ b/docs/en/observability/synthetic-monitoring.asciidoc
@@ -1,11 +1,7 @@
 [[synthetic-monitoring]]
 = Real browser synthetic monitoring
 
-[IMPORTANT]
-====
-Browser checks are beta (and will never be GA) in version `7.x` and it has significantly changed in version `8.x`.
-We do not recommend using Browser monitors anymore in `7.x` but suggest you try it out in newer versions of `8.x` instead.
-====
+include::shared/synthetics-note.asciidoc[]
 
 [role="screenshot"]
 image::images/synthetic-app-overview.png[Synthetics app overview]

--- a/docs/en/observability/synthetic-monitoring.asciidoc
+++ b/docs/en/observability/synthetic-monitoring.asciidoc
@@ -1,10 +1,10 @@
 [[synthetic-monitoring]]
 = Real browser synthetic monitoring
 
-[TIP]
+[IMPORTANT]
 ====
-Have a question? Want to leave feedback? Visit the
-https://discuss.elastic.co/tags/c/observability/uptime/75/synthetics[Synthetics discussion forum].
+Browser checks are beta (and will never be GA) in version `7.x` and it has significantly changed in version `8.x`.
+We do not recommend using Browser monitors anymore in `7.x` but suggest you try it out in newer versions of `8.x` instead.
 ====
 
 [role="screenshot"]

--- a/docs/en/observability/synthetics-command-reference.asciidoc
+++ b/docs/en/observability/synthetics-command-reference.asciidoc
@@ -5,6 +5,12 @@
 <titleabbrev>Command reference</titleabbrev>
 ++++
 
+[IMPORTANT]
+====
+Browser checks are beta (and will never be GA) in version `7.x` and it has significantly changed in version `8.x`.
+We do not recommend using Browser monitors anymore in `7.x` but suggest you try it out in newer versions of `8.x` instead.
+====
+
 [discrete]
 [[elastic-synthetics-command]]
 == `elastic-synthetics`

--- a/docs/en/observability/synthetics-command-reference.asciidoc
+++ b/docs/en/observability/synthetics-command-reference.asciidoc
@@ -5,11 +5,7 @@
 <titleabbrev>Command reference</titleabbrev>
 ++++
 
-[IMPORTANT]
-====
-Browser checks are beta (and will never be GA) in version `7.x` and it has significantly changed in version `8.x`.
-We do not recommend using Browser monitors anymore in `7.x` but suggest you try it out in newer versions of `8.x` instead.
-====
+include::shared/synthetics-note.asciidoc[]
 
 [discrete]
 [[elastic-synthetics-command]]

--- a/docs/en/observability/synthetics-configuration.asciidoc
+++ b/docs/en/observability/synthetics-configuration.asciidoc
@@ -5,6 +5,12 @@
 <titleabbrev>Synthetic tests configuration</titleabbrev>
 ++++
 
+[IMPORTANT]
+====
+Browser checks are beta (and will never be GA) in version `7.x` and it has significantly changed in version `8.x`.
+We do not recommend using Browser monitors anymore in `7.x` but suggest you try it out in newer versions of `8.x` instead.
+====
+
 beta[] Synthetic tests support the configuration of dynamic parameters that can be
 used in the suites. In addition, the Synthetics agent, which is built on top
 of Playwright, supports configuring browser and context options that are available

--- a/docs/en/observability/synthetics-configuration.asciidoc
+++ b/docs/en/observability/synthetics-configuration.asciidoc
@@ -5,11 +5,7 @@
 <titleabbrev>Synthetic tests configuration</titleabbrev>
 ++++
 
-[IMPORTANT]
-====
-Browser checks are beta (and will never be GA) in version `7.x` and it has significantly changed in version `8.x`.
-We do not recommend using Browser monitors anymore in `7.x` but suggest you try it out in newer versions of `8.x` instead.
-====
+include::shared/synthetics-note.asciidoc[]
 
 beta[] Synthetic tests support the configuration of dynamic parameters that can be
 used in the suites. In addition, the Synthetics agent, which is built on top

--- a/docs/en/observability/synthetics-create-test.asciidoc
+++ b/docs/en/observability/synthetics-create-test.asciidoc
@@ -5,6 +5,12 @@
 <titleabbrev>Create a test</titleabbrev>
 ++++
 
+[IMPORTANT]
+====
+Browser checks are beta (and will never be GA) in version `7.x` and it has significantly changed in version `8.x`.
+We do not recommend using Browser monitors anymore in `7.x` but suggest you try it out in newer versions of `8.x` instead.
+====
+
 [discrete]
 [[synthetics-syntax]]
 == Syntax

--- a/docs/en/observability/synthetics-create-test.asciidoc
+++ b/docs/en/observability/synthetics-create-test.asciidoc
@@ -5,11 +5,7 @@
 <titleabbrev>Create a test</titleabbrev>
 ++++
 
-[IMPORTANT]
-====
-Browser checks are beta (and will never be GA) in version `7.x` and it has significantly changed in version `8.x`.
-We do not recommend using Browser monitors anymore in `7.x` but suggest you try it out in newer versions of `8.x` instead.
-====
+include::shared/synthetics-note.asciidoc[]
 
 [discrete]
 [[synthetics-syntax]]

--- a/docs/en/observability/synthetics-params-secrets.asciidoc
+++ b/docs/en/observability/synthetics-params-secrets.asciidoc
@@ -5,11 +5,7 @@
 <titleabbrev>Working with parameters and secrets</titleabbrev>
 ++++
 
-[IMPORTANT]
-====
-Browser checks are beta (and will never be GA) in version `7.x` and it has significantly changed in version `8.x`.
-We do not recommend using Browser monitors anymore in `7.x` but suggest you try it out in newer versions of `8.x` instead.
-====
+include::shared/synthetics-note.asciidoc[]
 
 beta[] You may need to use dynamically defined values in your synthetic scripts, which may sometimes be sensitive. 
 For instance, you may want to test a production website with a particular demo account whose password is only known to the team administering heartbeat. 

--- a/docs/en/observability/synthetics-params-secrets.asciidoc
+++ b/docs/en/observability/synthetics-params-secrets.asciidoc
@@ -5,6 +5,12 @@
 <titleabbrev>Working with parameters and secrets</titleabbrev>
 ++++
 
+[IMPORTANT]
+====
+Browser checks are beta (and will never be GA) in version `7.x` and it has significantly changed in version `8.x`.
+We do not recommend using Browser monitors anymore in `7.x` but suggest you try it out in newer versions of `8.x` instead.
+====
+
 beta[] You may need to use dynamically defined values in your synthetic scripts, which may sometimes be sensitive. 
 For instance, you may want to test a production website with a particular demo account whose password is only known to the team administering heartbeat. 
 Another scenario might be using a different URL when running the tests under Heartbeat and then running them locally using the Synthetics agent.

--- a/docs/en/observability/synthetics-quickstart-fleet.asciidoc
+++ b/docs/en/observability/synthetics-quickstart-fleet.asciidoc
@@ -11,6 +11,12 @@
 Prefer to use our legacy {beats} for your use case? Refer to <<ingest-uptime>>.
 ****
 
+[IMPORTANT]
+====
+Browser checks are beta (and will never be GA) in version `7.x` and it has significantly changed in version `8.x`.
+We do not recommend using Browser monitors anymore in `7.x` but suggest you try it out in newer versions of `8.x` instead.
+====
+
 [discrete]
 [[synthetics-quickstart-fleet-setup]]
 == Set up Fleet Server

--- a/docs/en/observability/synthetics-quickstart-fleet.asciidoc
+++ b/docs/en/observability/synthetics-quickstart-fleet.asciidoc
@@ -11,11 +11,7 @@
 Prefer to use our legacy {beats} for your use case? Refer to <<ingest-uptime>>.
 ****
 
-[IMPORTANT]
-====
-Browser checks are beta (and will never be GA) in version `7.x` and it has significantly changed in version `8.x`.
-We do not recommend using Browser monitors anymore in `7.x` but suggest you try it out in newer versions of `8.x` instead.
-====
+include::shared/synthetics-note.asciidoc[]
 
 [discrete]
 [[synthetics-quickstart-fleet-setup]]

--- a/docs/en/observability/synthetics-quickstart.asciidoc
+++ b/docs/en/observability/synthetics-quickstart.asciidoc
@@ -7,6 +7,12 @@
 <titleabbrev>Monitor using Docker</titleabbrev>
 ++++
 
+[IMPORTANT]
+====
+Browser checks are beta (and will never be GA) in version `7.x` and it has significantly changed in version `8.x`.
+We do not recommend using Browser monitors anymore in `7.x` but suggest you try it out in newer versions of `8.x` instead.
+====
+
 beta[] A customizable Docker project template is provided to get started with Elastic Synthetics quickly.
 This template provides two types of sample tests: a simple, two-step, inline test,
 and a packaged todo application with a custom suite of tests.

--- a/docs/en/observability/synthetics-quickstart.asciidoc
+++ b/docs/en/observability/synthetics-quickstart.asciidoc
@@ -7,11 +7,7 @@
 <titleabbrev>Monitor using Docker</titleabbrev>
 ++++
 
-[IMPORTANT]
-====
-Browser checks are beta (and will never be GA) in version `7.x` and it has significantly changed in version `8.x`.
-We do not recommend using Browser monitors anymore in `7.x` but suggest you try it out in newer versions of `8.x` instead.
-====
+include::shared/synthetics-note.asciidoc[]
 
 beta[] A customizable Docker project template is provided to get started with Elastic Synthetics quickly.
 This template provides two types of sample tests: a simple, two-step, inline test,

--- a/docs/en/observability/synthetics-visualize.asciidoc
+++ b/docs/en/observability/synthetics-visualize.asciidoc
@@ -5,6 +5,12 @@
 <titleabbrev>Visualize</titleabbrev>
 ++++
 
+[IMPORTANT]
+====
+Browser checks are beta (and will never be GA) in version `7.x` and it has significantly changed in version `8.x`.
+We do not recommend using Browser monitors anymore in `7.x` but suggest you try it out in newer versions of `8.x` instead.
+====
+
 beta[] Synthetic monitoring journeys can be visualized in the {uptime-app} side-by-side with
 your other Uptime monitors.
 

--- a/docs/en/observability/synthetics-visualize.asciidoc
+++ b/docs/en/observability/synthetics-visualize.asciidoc
@@ -5,11 +5,7 @@
 <titleabbrev>Visualize</titleabbrev>
 ++++
 
-[IMPORTANT]
-====
-Browser checks are beta (and will never be GA) in version `7.x` and it has significantly changed in version `8.x`.
-We do not recommend using Browser monitors anymore in `7.x` but suggest you try it out in newer versions of `8.x` instead.
-====
+include::shared/synthetics-note.asciidoc[]
 
 beta[] Synthetic monitoring journeys can be visualized in the {uptime-app} side-by-side with
 your other Uptime monitors.


### PR DESCRIPTION
Synthetics has changed significantly in 8x and is not a good experience in 7x (and is, and always will be beta in 7x).  This PR makes the suggestion not to use browser type monitors in 7x.

It's the same copy on various pages.