### PR TITLE
Clarify limitations around using field names in agent processor configs

### DIFF
--- a/docs/en/ingest-management/processors/processor-add_cloud_metadata.asciidoc
+++ b/docs/en/ingest-management/processors/processor-add_cloud_metadata.asciidoc
@@ -44,6 +44,8 @@ refer to <<provider-specific-examples>>.
 [discrete]
 == Configuration settings
 
+include::processors.asciidoc[tag=processor-limitations]
+
 [options="header"]
 |===
 | Name | Required | Default | Description

--- a/docs/en/ingest-management/processors/processor-add_cloudfoundry_metadata.asciidoc
+++ b/docs/en/ingest-management/processors/processor-add_cloudfoundry_metadata.asciidoc
@@ -53,6 +53,8 @@ settings.
 [discrete]
 == Configuration settings
 
+include::processors.asciidoc[tag=processor-limitations]
+
 [options="header"]
 |===
 | Name | Required | Default | Description

--- a/docs/en/ingest-management/processors/processor-add_docker_metadata.asciidoc
+++ b/docs/en/ingest-management/processors/processor-add_docker_metadata.asciidoc
@@ -66,6 +66,8 @@ will stop working. When this happens, you can do one of the following:
 [discrete]
 == Configuration settings
 
+include::processors.asciidoc[tag=processor-limitations]
+
 [options="header"]
 |===
 | Name | Required | Default | Description

--- a/docs/en/ingest-management/processors/processor-add_fields.asciidoc
+++ b/docs/en/ingest-management/processors/processor-add_fields.asciidoc
@@ -55,6 +55,8 @@ set as a metadata field.
 [discrete]
 == Configuration settings
 
+include::processors.asciidoc[tag=processor-limitations]
+
 [options="header"]
 |===
 | Name | Required | Default | Description

--- a/docs/en/ingest-management/processors/processor-add_host_metadata.asciidoc
+++ b/docs/en/ingest-management/processors/processor-add_host_metadata.asciidoc
@@ -68,6 +68,8 @@ The fields added to the event look like this:
 [discrete]
 == Configuration settings
 
+include::processors.asciidoc[tag=processor-limitations]
+
 IMPORTANT: If `host.*` fields already exist in the event, they are overwritten by
 default unless you set `replace_fields` to `true` in the processor
 configuration.

--- a/docs/en/ingest-management/processors/processor-add_id.asciidoc
+++ b/docs/en/ingest-management/processors/processor-add_id.asciidoc
@@ -18,6 +18,8 @@ The `add_id` processor generates a unique ID for an event.
 [discrete]
 == Configuration settings
 
+include::processors.asciidoc[tag=processor-limitations]
+
 [options="header"]
 |===
 | Name | Required | Default | Description

--- a/docs/en/ingest-management/processors/processor-add_kubernetes_metadata.asciidoc
+++ b/docs/en/ingest-management/processors/processor-add_kubernetes_metadata.asciidoc
@@ -107,6 +107,8 @@ then enables different indexers and matchers:
 [discrete]
 == Configuration settings
 
+include::processors.asciidoc[tag=processor-limitations]
+
 [options="header"]
 |===
 | Name | Required | Default | Description

--- a/docs/en/ingest-management/processors/processor-add_labels.asciidoc
+++ b/docs/en/ingest-management/processors/processor-add_labels.asciidoc
@@ -49,6 +49,8 @@ Adds these fields to every event:
 [discrete]
 == Configuration settings
 
+include::processors.asciidoc[tag=processor-limitations]
+
 [options="header"]
 |===
 | Name | Required | Default | Description

--- a/docs/en/ingest-management/processors/processor-add_locale.asciidoc
+++ b/docs/en/ingest-management/processors/processor-add_locale.asciidoc
@@ -35,6 +35,8 @@ regular time.
 [discrete]
 == Configuration settings
 
+include::processors.asciidoc[tag=processor-limitations]
+
 [options="header"]
 |===
 | Name | Required | Default | Description

--- a/docs/en/ingest-management/processors/processor-add_network_direction.asciidoc
+++ b/docs/en/ingest-management/processors/processor-add_network_direction.asciidoc
@@ -24,6 +24,8 @@ internal networks.
 [discrete]
 == Configuration settings
 
+include::processors.asciidoc[tag=processor-limitations]
+
 [options="header"]
 |===
 | Name | Required | Default | Description

--- a/docs/en/ingest-management/processors/processor-add_nomad_metadata.asciidoc
+++ b/docs/en/ingest-management/processors/processor-add_nomad_metadata.asciidoc
@@ -28,6 +28,8 @@ Each event is annotated with the following information:
 [discrete]
 == Configuration settings
 
+include::processors.asciidoc[tag=processor-limitations]
+
 [options="header"]
 |===
 | Name | Required | Default | Description

--- a/docs/en/ingest-management/processors/processor-add_observer_metadata.asciidoc
+++ b/docs/en/ingest-management/processors/processor-add_observer_metadata.asciidoc
@@ -60,6 +60,8 @@ The fields added to the event look like this:
 [discrete]
 == Configuration settings
 
+include::processors.asciidoc[tag=processor-limitations]
+
 [options="header"]
 |===
 | Name | Required | Default | Description

--- a/docs/en/ingest-management/processors/processor-add_process_metadata.asciidoc
+++ b/docs/en/ingest-management/processors/processor-add_process_metadata.asciidoc
@@ -58,6 +58,8 @@ Optionally, the process environment can be included, too:
 [discrete]
 == Configuration settings
 
+include::processors.asciidoc[tag=processor-limitations]
+
 [options="header"]
 |===
 | Name | Required | Default | Description

--- a/docs/en/ingest-management/processors/processor-add_tags.asciidoc
+++ b/docs/en/ingest-management/processors/processor-add_tags.asciidoc
@@ -32,6 +32,8 @@ Adds the `environment` field to every event:
 [discrete]
 == Configuration settings
 
+include::processors.asciidoc[tag=processor-limitations]
+
 [options="header"]
 |===
 | Name | Required | Default | Description

--- a/docs/en/ingest-management/processors/processor-communityid.asciidoc
+++ b/docs/en/ingest-management/processors/processor-communityid.asciidoc
@@ -51,6 +51,8 @@ continues without adding the target field.
 [discrete]
 == Configuration settings
 
+include::processors.asciidoc[tag=processor-limitations]
+
 [options="header"]
 |===
 | Name | Required | Default | Description

--- a/docs/en/ingest-management/processors/processor-convert.asciidoc
+++ b/docs/en/ingest-management/processors/processor-convert.asciidoc
@@ -30,6 +30,8 @@ that the value is an IPv4 or IPv6 address.
 [discrete]
 == Configuration settings
 
+include::processors.asciidoc[tag=processor-limitations]
+
 [options="header"]
 |===
 | Name | Required | Default | Description

--- a/docs/en/ingest-management/processors/processor-convert.asciidoc
+++ b/docs/en/ingest-management/processors/processor-convert.asciidoc
@@ -30,7 +30,11 @@ that the value is an IPv4 or IPv6 address.
 [discrete]
 == Configuration settings
 
+// set this attribute for processors that reference event fields
+:works-with-fields:
 include::processors.asciidoc[tag=processor-limitations]
+// reset the attribute to null
+:works-with-fields!:
 
 [options="header"]
 |===

--- a/docs/en/ingest-management/processors/processor-copy_fields.asciidoc
+++ b/docs/en/ingest-management/processors/processor-copy_fields.asciidoc
@@ -37,7 +37,11 @@ Copies the original `message` field to `event.original`:
 [discrete]
 == Configuration settings
 
+// set this attribute for processors that reference event fields
+:works-with-fields:
 include::processors.asciidoc[tag=processor-limitations]
+// reset the attribute to null
+:works-with-fields!:
 
 [options="header"]
 |===

--- a/docs/en/ingest-management/processors/processor-copy_fields.asciidoc
+++ b/docs/en/ingest-management/processors/processor-copy_fields.asciidoc
@@ -37,6 +37,8 @@ Copies the original `message` field to `event.original`:
 [discrete]
 == Configuration settings
 
+include::processors.asciidoc[tag=processor-limitations]
+
 [options="header"]
 |===
 | Name | Required | Default | Description

--- a/docs/en/ingest-management/processors/processor-decode_base64_field.asciidoc
+++ b/docs/en/ingest-management/processors/processor-decode_base64_field.asciidoc
@@ -28,7 +28,11 @@ In this example, `field1` is decoded in `field2`.
 [discrete]
 == Configuration settings
 
+// set this attribute for processors that reference event fields
+:works-with-fields:
 include::processors.asciidoc[tag=processor-limitations]
+// reset the attribute to null
+:works-with-fields!:
 
 [options="header"]
 |===

--- a/docs/en/ingest-management/processors/processor-decode_base64_field.asciidoc
+++ b/docs/en/ingest-management/processors/processor-decode_base64_field.asciidoc
@@ -28,6 +28,8 @@ In this example, `field1` is decoded in `field2`.
 [discrete]
 == Configuration settings
 
+include::processors.asciidoc[tag=processor-limitations]
+
 [options="header"]
 |===
 | Name | Required | Default | Description

--- a/docs/en/ingest-management/processors/processor-decode_cef.asciidoc
+++ b/docs/en/ingest-management/processors/processor-decode_cef.asciidoc
@@ -28,7 +28,11 @@ decoded CEF data contains its own `message` field.
 [discrete]
 == Configuration settings
 
+// set this attribute for processors that reference event fields
+:works-with-fields:
 include::processors.asciidoc[tag=processor-limitations]
+// reset the attribute to null
+:works-with-fields!:
 
 [options="header"]
 |===

--- a/docs/en/ingest-management/processors/processor-decode_cef.asciidoc
+++ b/docs/en/ingest-management/processors/processor-decode_cef.asciidoc
@@ -28,6 +28,8 @@ decoded CEF data contains its own `message` field.
 [discrete]
 == Configuration settings
 
+include::processors.asciidoc[tag=processor-limitations]
+
 [options="header"]
 |===
 | Name | Required | Default | Description

--- a/docs/en/ingest-management/processors/processor-decode_csv_fields.asciidoc
+++ b/docs/en/ingest-management/processors/processor-decode_csv_fields.asciidoc
@@ -30,7 +30,11 @@ NOTE: This processor only works with log inputs.
 [discrete]
 == Configuration settings
 
+// set this attribute for processors that reference event fields
+:works-with-fields:
 include::processors.asciidoc[tag=processor-limitations]
+// reset the attribute to null
+:works-with-fields!:
 
 [options="header"]
 |===

--- a/docs/en/ingest-management/processors/processor-decode_csv_fields.asciidoc
+++ b/docs/en/ingest-management/processors/processor-decode_csv_fields.asciidoc
@@ -30,6 +30,8 @@ NOTE: This processor only works with log inputs.
 [discrete]
 == Configuration settings
 
+include::processors.asciidoc[tag=processor-limitations]
+
 [options="header"]
 |===
 | Name | Required | Default | Description

--- a/docs/en/ingest-management/processors/processor-decode_json_fields.asciidoc
+++ b/docs/en/ingest-management/processors/processor-decode_json_fields.asciidoc
@@ -25,7 +25,11 @@ replaces the strings with valid JSON objects.
 [discrete]
 == Configuration settings
 
+// set this attribute for processors that reference event fields
+:works-with-fields:
 include::processors.asciidoc[tag=processor-limitations]
+// reset the attribute to null
+:works-with-fields!:
 
 [options="header"]
 |===

--- a/docs/en/ingest-management/processors/processor-decode_json_fields.asciidoc
+++ b/docs/en/ingest-management/processors/processor-decode_json_fields.asciidoc
@@ -25,6 +25,8 @@ replaces the strings with valid JSON objects.
 [discrete]
 == Configuration settings
 
+include::processors.asciidoc[tag=processor-limitations]
+
 [options="header"]
 |===
 | Name | Required | Default | Description

--- a/docs/en/ingest-management/processors/processor-decode_xml.asciidoc
+++ b/docs/en/ingest-management/processors/processor-decode_xml.asciidoc
@@ -83,7 +83,11 @@ Will produce the following output:
 [discrete]
 == Configuration settings
 
+// set this attribute for processors that reference event fields
+:works-with-fields:
 include::processors.asciidoc[tag=processor-limitations]
+// reset the attribute to null
+:works-with-fields!:
 
 [options="header"]
 |===

--- a/docs/en/ingest-management/processors/processor-decode_xml.asciidoc
+++ b/docs/en/ingest-management/processors/processor-decode_xml.asciidoc
@@ -83,6 +83,8 @@ Will produce the following output:
 [discrete]
 == Configuration settings
 
+include::processors.asciidoc[tag=processor-limitations]
+
 [options="header"]
 |===
 | Name | Required | Default | Description

--- a/docs/en/ingest-management/processors/processor-decode_xml_wineventlog.asciidoc
+++ b/docs/en/ingest-management/processors/processor-decode_xml_wineventlog.asciidoc
@@ -88,7 +88,11 @@ See <<conditions>> for a list of supported conditions.
 [discrete]
 == Configuration settings
 
+// set this attribute for processors that reference event fields
+:works-with-fields:
 include::processors.asciidoc[tag=processor-limitations]
+// reset the attribute to null
+:works-with-fields!:
 
 [options="header"]
 |===

--- a/docs/en/ingest-management/processors/processor-decode_xml_wineventlog.asciidoc
+++ b/docs/en/ingest-management/processors/processor-decode_xml_wineventlog.asciidoc
@@ -88,6 +88,8 @@ See <<conditions>> for a list of supported conditions.
 [discrete]
 == Configuration settings
 
+include::processors.asciidoc[tag=processor-limitations]
+
 [options="header"]
 |===
 | Name | Required | Default | Description

--- a/docs/en/ingest-management/processors/processor-decompress_gzip_field.asciidoc
+++ b/docs/en/ingest-management/processors/processor-decompress_gzip_field.asciidoc
@@ -28,6 +28,8 @@ In this example, `field1` is decompressed in `field2`.
 [discrete]
 == Configuration settings
 
+include::processors.asciidoc[tag=processor-limitations]
+
 [options="header"]
 |===
 | Name | Required | Default | Description

--- a/docs/en/ingest-management/processors/processor-decompress_gzip_field.asciidoc
+++ b/docs/en/ingest-management/processors/processor-decompress_gzip_field.asciidoc
@@ -28,7 +28,11 @@ In this example, `field1` is decompressed in `field2`.
 [discrete]
 == Configuration settings
 
+// set this attribute for processors that reference event fields
+:works-with-fields:
 include::processors.asciidoc[tag=processor-limitations]
+// reset the attribute to null
+:works-with-fields!:
 
 [options="header"]
 |===

--- a/docs/en/ingest-management/processors/processor-detect_mime_type.asciidoc
+++ b/docs/en/ingest-management/processors/processor-detect_mime_type.asciidoc
@@ -24,6 +24,8 @@ In this example, `http.request.body.content` is used as the source, and
 [discrete]
 == Configuration settings
 
+include::processors.asciidoc[tag=processor-limitations]
+
 [options="header"]
 |===
 | Name | Required | Default | Description

--- a/docs/en/ingest-management/processors/processor-detect_mime_type.asciidoc
+++ b/docs/en/ingest-management/processors/processor-detect_mime_type.asciidoc
@@ -24,7 +24,11 @@ In this example, `http.request.body.content` is used as the source, and
 [discrete]
 == Configuration settings
 
+// set this attribute for processors that reference event fields
+:works-with-fields:
 include::processors.asciidoc[tag=processor-limitations]
+// reset the attribute to null
+:works-with-fields!:
 
 [options="header"]
 |===

--- a/docs/en/ingest-management/processors/processor-dissect.asciidoc
+++ b/docs/en/ingest-management/processors/processor-dissect.asciidoc
@@ -23,7 +23,11 @@ For a full example, see <<dissect-example>>.
 [discrete]
 == Configuration settings
 
+// set this attribute for processors that reference event fields
+:works-with-fields:
 include::processors.asciidoc[tag=processor-limitations]
+// reset the attribute to null
+:works-with-fields!:
 
 [options="header"]
 |===

--- a/docs/en/ingest-management/processors/processor-dissect.asciidoc
+++ b/docs/en/ingest-management/processors/processor-dissect.asciidoc
@@ -23,6 +23,8 @@ For a full example, see <<dissect-example>>.
 [discrete]
 == Configuration settings
 
+include::processors.asciidoc[tag=processor-limitations]
+
 [options="header"]
 |===
 | Name | Required | Default | Description

--- a/docs/en/ingest-management/processors/processor-dns.asciidoc
+++ b/docs/en/ingest-management/processors/processor-dns.asciidoc
@@ -66,6 +66,8 @@ This examples shows all configuration options.
 [discrete]
 == Configuration settings
 
+include::processors.asciidoc[tag=processor-limitations]
+
 [options="header"]
 |===
 | Name | Required | Default | Description

--- a/docs/en/ingest-management/processors/processor-dns.asciidoc
+++ b/docs/en/ingest-management/processors/processor-dns.asciidoc
@@ -66,7 +66,11 @@ This examples shows all configuration options.
 [discrete]
 == Configuration settings
 
+// set this attribute for processors that reference event fields
+:works-with-fields:
 include::processors.asciidoc[tag=processor-limitations]
+// reset the attribute to null
+:works-with-fields!:
 
 [options="header"]
 |===

--- a/docs/en/ingest-management/processors/processor-drop_event.asciidoc
+++ b/docs/en/ingest-management/processors/processor-drop_event.asciidoc
@@ -20,3 +20,5 @@ are dropped.
 ------
 
 See <<conditions>> for a list of supported conditions.
+
+include::processors.asciidoc[tag=processor-limitations]

--- a/docs/en/ingest-management/processors/processor-drop_fields.asciidoc
+++ b/docs/en/ingest-management/processors/processor-drop_fields.asciidoc
@@ -28,6 +28,8 @@ are dropped.
 [discrete]
 == Configuration settings
 
+include::processors.asciidoc[tag=processor-limitations]
+
 [options="header"]
 |===
 | Name | Required | Default | Description

--- a/docs/en/ingest-management/processors/processor-drop_fields.asciidoc
+++ b/docs/en/ingest-management/processors/processor-drop_fields.asciidoc
@@ -28,7 +28,11 @@ are dropped.
 [discrete]
 == Configuration settings
 
+// set this attribute for processors that reference event fields
+:works-with-fields:
 include::processors.asciidoc[tag=processor-limitations]
+// reset the attribute to null
+:works-with-fields!:
 
 [options="header"]
 |===

--- a/docs/en/ingest-management/processors/processor-extract_array.asciidoc
+++ b/docs/en/ingest-management/processors/processor-extract_array.asciidoc
@@ -30,7 +30,11 @@ the `my_array` field, `destination.ip` with the second element, and
 [discrete]
 == Configuration settings
 
+// set this attribute for processors that reference event fields
+:works-with-fields:
 include::processors.asciidoc[tag=processor-limitations]
+// reset the attribute to null
+:works-with-fields!:
 
 [options="header"]
 |===

--- a/docs/en/ingest-management/processors/processor-extract_array.asciidoc
+++ b/docs/en/ingest-management/processors/processor-extract_array.asciidoc
@@ -30,6 +30,8 @@ the `my_array` field, `destination.ip` with the second element, and
 [discrete]
 == Configuration settings
 
+include::processors.asciidoc[tag=processor-limitations]
+
 [options="header"]
 |===
 | Name | Required | Default | Description

--- a/docs/en/ingest-management/processors/processor-fingerprint.asciidoc
+++ b/docs/en/ingest-management/processors/processor-fingerprint.asciidoc
@@ -25,7 +25,11 @@ Nested fields are supported in the following format: `"field1.field2"`, for exam
 [discrete]
 == Configuration settings
 
+// set this attribute for processors that reference event fields
+:works-with-fields:
 include::processors.asciidoc[tag=processor-limitations]
+// reset the attribute to null
+:works-with-fields!:
 
 [options="header"]
 |===

--- a/docs/en/ingest-management/processors/processor-fingerprint.asciidoc
+++ b/docs/en/ingest-management/processors/processor-fingerprint.asciidoc
@@ -25,6 +25,8 @@ Nested fields are supported in the following format: `"field1.field2"`, for exam
 [discrete]
 == Configuration settings
 
+include::processors.asciidoc[tag=processor-limitations]
+
 [options="header"]
 |===
 | Name | Required | Default | Description

--- a/docs/en/ingest-management/processors/processor-include_fields.asciidoc
+++ b/docs/en/ingest-management/processors/processor-include_fields.asciidoc
@@ -24,7 +24,11 @@ list.
 
 See <<conditions>> for a list of supported conditions.
 
+// set this attribute for processors that reference event fields
+:works-with-fields:
 include::processors.asciidoc[tag=processor-limitations]
+// reset the attribute to null
+:works-with-fields!:
 
 You can specify multiple `include_fields` processors under the `processors`
 section.

--- a/docs/en/ingest-management/processors/processor-include_fields.asciidoc
+++ b/docs/en/ingest-management/processors/processor-include_fields.asciidoc
@@ -24,6 +24,8 @@ list.
 
 See <<conditions>> for a list of supported conditions.
 
+include::processors.asciidoc[tag=processor-limitations]
+
 You can specify multiple `include_fields` processors under the `processors`
 section.
 

--- a/docs/en/ingest-management/processors/processor-parse_aws_vpc_flow_log.asciidoc
+++ b/docs/en/ingest-management/processors/processor-parse_aws_vpc_flow_log.asciidoc
@@ -24,7 +24,11 @@ processors:
 [discrete]
 == Configuration settings
 
+// set this attribute for processors that reference event fields
+:works-with-fields:
 include::processors.asciidoc[tag=processor-limitations]
+// reset the attribute to null
+:works-with-fields!:
 
 [options="header"]
 |===

--- a/docs/en/ingest-management/processors/processor-parse_aws_vpc_flow_log.asciidoc
+++ b/docs/en/ingest-management/processors/processor-parse_aws_vpc_flow_log.asciidoc
@@ -24,6 +24,8 @@ processors:
 [discrete]
 == Configuration settings
 
+include::processors.asciidoc[tag=processor-limitations]
+
 [options="header"]
 |===
 | Name  | Required | Default  | Description

--- a/docs/en/ingest-management/processors/processor-rate_limit.asciidoc
+++ b/docs/en/ingest-management/processors/processor-rate_limit.asciidoc
@@ -40,6 +40,8 @@ implementations may allow rate-limited events to be handled differently.
 [discrete]
 == Configuration settings
 
+include::processors.asciidoc[tag=processor-limitations]
+
 [options="header"]
 |===
 | Name | Required | Default | Description

--- a/docs/en/ingest-management/processors/processor-rate_limit.asciidoc
+++ b/docs/en/ingest-management/processors/processor-rate_limit.asciidoc
@@ -40,7 +40,11 @@ implementations may allow rate-limited events to be handled differently.
 [discrete]
 == Configuration settings
 
+// set this attribute for processors that reference event fields
+:works-with-fields:
 include::processors.asciidoc[tag=processor-limitations]
+// reset the attribute to null
+:works-with-fields!:
 
 [options="header"]
 |===

--- a/docs/en/ingest-management/processors/processor-registered_domain.asciidoc
+++ b/docs/en/ingest-management/processors/processor-registered_domain.asciidoc
@@ -31,7 +31,11 @@ This processor uses the Mozilla Public Suffix list to determine the value.
 [discrete]
 == Configuration settings
 
+// set this attribute for processors that reference event fields
+:works-with-fields:
 include::processors.asciidoc[tag=processor-limitations]
+// reset the attribute to null
+:works-with-fields!:
 
 [options="header"]
 |===

--- a/docs/en/ingest-management/processors/processor-registered_domain.asciidoc
+++ b/docs/en/ingest-management/processors/processor-registered_domain.asciidoc
@@ -31,6 +31,8 @@ This processor uses the Mozilla Public Suffix list to determine the value.
 [discrete]
 == Configuration settings
 
+include::processors.asciidoc[tag=processor-limitations]
+
 [options="header"]
 |===
 | Name | Required | Default | Description

--- a/docs/en/ingest-management/processors/processor-rename.asciidoc
+++ b/docs/en/ingest-management/processors/processor-rename.asciidoc
@@ -32,6 +32,8 @@ before assigning values.
 
 [discrete]
 == Configuration settings
+
+include::processors.asciidoc[tag=processor-limitations]
  
 [options="header"]
 |===

--- a/docs/en/ingest-management/processors/processor-rename.asciidoc
+++ b/docs/en/ingest-management/processors/processor-rename.asciidoc
@@ -33,7 +33,11 @@ before assigning values.
 [discrete]
 == Configuration settings
 
+// set this attribute for processors that reference event fields
+:works-with-fields:
 include::processors.asciidoc[tag=processor-limitations]
+// reset the attribute to null
+:works-with-fields!:
  
 [options="header"]
 |===

--- a/docs/en/ingest-management/processors/processor-replace.asciidoc
+++ b/docs/en/ingest-management/processors/processor-replace.asciidoc
@@ -33,7 +33,11 @@ The following example changes the path from `/usr/bin` to `/usr/local/bin`:
 [discrete]
 == Configuration settings
 
+// set this attribute for processors that reference event fields
+:works-with-fields:
 include::processors.asciidoc[tag=processor-limitations]
+// reset the attribute to null
+:works-with-fields!:
 
 [options="header"]
 |===

--- a/docs/en/ingest-management/processors/processor-replace.asciidoc
+++ b/docs/en/ingest-management/processors/processor-replace.asciidoc
@@ -33,6 +33,8 @@ The following example changes the path from `/usr/bin` to `/usr/local/bin`:
 [discrete]
 == Configuration settings
 
+include::processors.asciidoc[tag=processor-limitations]
+
 [options="header"]
 |===
 | Name | Required | Default | Description

--- a/docs/en/ingest-management/processors/processor-script.asciidoc
+++ b/docs/en/ingest-management/processors/processor-script.asciidoc
@@ -82,6 +82,8 @@ function test() {
 [discrete]
 == Configuration settings
 
+include::processors.asciidoc[tag=processor-limitations]
+
 [options="header"]
 |===
 | Name | Required | Default | Description

--- a/docs/en/ingest-management/processors/processor-syslog.asciidoc
+++ b/docs/en/ingest-management/processors/processor-syslog.asciidoc
@@ -66,7 +66,11 @@ Will produce the following output:
 [discrete]
 == Configuration settings
 
+// set this attribute for processors that reference event fields
+:works-with-fields:
 include::processors.asciidoc[tag=processor-limitations]
+// reset the attribute to null
+:works-with-fields!:
 
 [options="header"]
 |===

--- a/docs/en/ingest-management/processors/processor-syslog.asciidoc
+++ b/docs/en/ingest-management/processors/processor-syslog.asciidoc
@@ -66,6 +66,8 @@ Will produce the following output:
 [discrete]
 == Configuration settings
 
+include::processors.asciidoc[tag=processor-limitations]
+
 [options="header"]
 |===
 | Name | Required | Default | Description

--- a/docs/en/ingest-management/processors/processor-timestamp.asciidoc
+++ b/docs/en/ingest-management/processors/processor-timestamp.asciidoc
@@ -61,6 +61,8 @@ parse with this configuration.
 [discrete]
 == Configuration settings
 
+include::processors.asciidoc[tag=processor-limitations]
+
 [options="header"]
 |===
 | Name | Required | Default | Description

--- a/docs/en/ingest-management/processors/processor-timestamp.asciidoc
+++ b/docs/en/ingest-management/processors/processor-timestamp.asciidoc
@@ -61,7 +61,11 @@ parse with this configuration.
 [discrete]
 == Configuration settings
 
+// set this attribute for processors that reference event fields
+:works-with-fields:
 include::processors.asciidoc[tag=processor-limitations]
+// reset the attribute to null
+:works-with-fields!:
 
 [options="header"]
 |===

--- a/docs/en/ingest-management/processors/processor-translate_sid.asciidoc
+++ b/docs/en/ingest-management/processors/processor-translate_sid.asciidoc
@@ -36,6 +36,8 @@ set.
 [discrete]
 == Configuration settings
 
+include::processors.asciidoc[tag=processor-limitations]
+
 [options="header"]
 |===
 | Name | Required | Default | Description

--- a/docs/en/ingest-management/processors/processor-translate_sid.asciidoc
+++ b/docs/en/ingest-management/processors/processor-translate_sid.asciidoc
@@ -36,7 +36,11 @@ set.
 [discrete]
 == Configuration settings
 
+// set this attribute for processors that reference event fields
+:works-with-fields:
 include::processors.asciidoc[tag=processor-limitations]
+// reset the attribute to null
+:works-with-fields!:
 
 [options="header"]
 |===

--- a/docs/en/ingest-management/processors/processor-truncate_fields.asciidoc
+++ b/docs/en/ingest-management/processors/processor-truncate_fields.asciidoc
@@ -27,7 +27,11 @@ This configuration truncates the field named `message` to five characters:
 [discrete]
 == Configuration settings
 
+// set this attribute for processors that reference event fields
+:works-with-fields:
 include::processors.asciidoc[tag=processor-limitations]
+// reset the attribute to null
+:works-with-fields!:
 
 [options="header"]
 |===

--- a/docs/en/ingest-management/processors/processor-truncate_fields.asciidoc
+++ b/docs/en/ingest-management/processors/processor-truncate_fields.asciidoc
@@ -27,6 +27,8 @@ This configuration truncates the field named `message` to five characters:
 [discrete]
 == Configuration settings
 
+include::processors.asciidoc[tag=processor-limitations]
+
 [options="header"]
 |===
 | Name | Required | Default | Description

--- a/docs/en/ingest-management/processors/processor-urldecode.asciidoc
+++ b/docs/en/ingest-management/processors/processor-urldecode.asciidoc
@@ -26,7 +26,11 @@ In this example, `field1` is decoded in `field2`.
 [discrete]
 == Configuration settings
 
+// set this attribute for processors that reference event fields
+:works-with-fields:
 include::processors.asciidoc[tag=processor-limitations]
+// reset the attribute to null
+:works-with-fields!:
 
 [options="header"]
 |===

--- a/docs/en/ingest-management/processors/processor-urldecode.asciidoc
+++ b/docs/en/ingest-management/processors/processor-urldecode.asciidoc
@@ -26,6 +26,8 @@ In this example, `field1` is decoded in `field2`.
 [discrete]
 == Configuration settings
 
+include::processors.asciidoc[tag=processor-limitations]
+
 [options="header"]
 |===
 | Name | Required | Default | Description

--- a/docs/en/ingest-management/processors/processors.asciidoc
+++ b/docs/en/ingest-management/processors/processors.asciidoc
@@ -19,13 +19,27 @@ order they are defined.
 event -> processor 1 -> event1 -> processor 2 -> event2 ...
 ----
 
+// set this attribute to show the full description here
+:works-with-fields:
+
 // tag::processor-limitations[]
 
+ifdef::works-with-fields[]
 NOTE: {agent} processors execute _before_ ingest pipelines, which means that
 your processor configurations cannot refer to fields that are created by ingest
 pipelines or {ls}. For more limitations, refer to <<limitations>>
+endif::[]
+
+ifndef::works-with-fields[]
+NOTE: {agent} processors execute _before_ ingest pipelines, which means that
+they process the raw event data rather than the final event sent to {es}. For
+related limitations, refer to <<limitations>>
+endif::[]
 
 // end::processor-limitations[]
+
+// reset the field to null
+:works-with-fields!:
 
 [discrete]
 [[where-valid]]

--- a/docs/en/ingest-management/processors/processors.asciidoc
+++ b/docs/en/ingest-management/processors/processors.asciidoc
@@ -1,9 +1,9 @@
 [[elastic-agent-processor-configuration]]
 = Define processors
 
-Processors are lightweight processing components that you can use to parse,
-filter, transform, and enrich data at the source. For example, you can use
-processors to:
+{agent} processors are lightweight processing components that you can use to
+parse, filter, transform, and enrich data at the source. For example, you can
+use processors to:
 
 * reduce the number of exported fields
 * enhance events with additional metadata
@@ -18,6 +18,14 @@ order they are defined.
 ----
 event -> processor 1 -> event1 -> processor 2 -> event2 ...
 ----
+
+// tag::processor-limitations[]
+
+NOTE: {agent} processors execute _before_ ingest pipelines, which means that
+your processor configurations cannot refer to fields that are created by ingest
+pipelines or {ls}. For more limitations, refer to <<limitations>>
+
+// end::processor-limitations[]
 
 [discrete]
 [[where-valid]]


### PR DESCRIPTION
We document this limitation in the intro to processors:

"Cannot process data after it’s been converted to the Elastic Common Schema (ECS) because the conversion is performed by Elasticsearch ingest pipelines. This means that your processor configuration cannot refer to fields that are created by ingest pipelines or Logstash because those fields are created after the processor runs, not before."

But in the spirit of "every page is the first page" we should call out this restriction in any processor docs that require users to refer to field names. Let me know if you think I should add this note to _every_ page.

This is related to https://github.com/elastic/integrations/issues/5481, but not a fix.