### PR TITLE
Add post-processing step to tidy up API docs section headers

### DIFF
--- a/docs/en/ingest-management/fleet/api-generated/README.md
+++ b/docs/en/ingest-management/fleet/api-generated/README.md
@@ -6,6 +6,8 @@ Open API specifications (OAS) exist in JSON for Fleet, though they are experimen
 
 A preview of the API specifications can be added to the Fleet and Elastic Agent Guide by using the following process:
 
+. Make sure that your system has perl enabled.
+
 . Create a local clone of the [elastic/kibana](https://github.com/elastic/kibana) and [elastic/observability-docs](https://github.com/elastic/observability-docs) repositories in your `$GIT_PATH` directory.
 
 . Install [OpenAPI Generator](https://openapi-generator.tech/docs/installation),
@@ -22,6 +24,11 @@ or a similar tool that can generate HTML output from OAS.
 . Rename the output files. For example:
   ```
   mv $GIT_HOME/observability-docs/docs/en/ingest-management/fleet/api-generated/rules/index.html $GIT_HOME/observability-docs/docs/en/ingest-management/fleet/api-generated/rules/fleet-apis-passthru.asciidoc
+  ```
+
+. Run a perl search-and-replace command to fix the header text for each section of the API page:
+  ```
+  perl -i -pe'while (s/">[A-Z][^ ]*[a-z]\K([A-Z])/ $1/g) {}' $GIT_HOME/observability-docs/docs/en/ingest-management/fleet/api-generated/rules/fleet-apis-passthru.asciidoc
   ```
 
 . If you're creating a new set of API output, you will need to have a page that incorporates the output by using passthrough blocks. For more information, refer to [Asciidoctor docs](https://docs.asciidoctor.org/asciidoc/latest/pass/pass-block/)

--- a/docs/en/ingest-management/fleet/api-generated/rules/fleet-apis-passthru.asciidoc
+++ b/docs/en/ingest-management/fleet/api-generated/rules/fleet-apis-passthru.asciidoc
@@ -20,13 +20,13 @@ Any modifications made to this file will be overwritten.
 
   <h3>Table of Contents </h3>
   <div class="method-summary"></div>
-  <h4><a href="#AgentActions">AgentActions</a></h4>
+  <h4><a href="#AgentActions">Agent Actions</a></h4>
   <ul>
   <li><a href="#agentActionCancel"><code><span class="http-method">post</span> /agents/{agentId}/actions/{actionId}/cancel</code></a></li>
   <li><a href="#agentsActionStatus"><code><span class="http-method">get</span> /agents/action_status</code></a></li>
   <li><a href="#newAgentAction"><code><span class="http-method">post</span> /agents/{agentId}/actions</code></a></li>
   </ul>
-  <h4><a href="#AgentBinaryDownloadSources">AgentBinaryDownloadSources</a></h4>
+  <h4><a href="#AgentBinaryDownloadSources">Agent Binary Download Sources</a></h4>
   <ul>
   <li><a href="#deleteDownloadSource"><code><span class="http-method">delete</span> /agent_download_sources/{sourceId}</code></a></li>
   <li><a href="#getDownloadSources"><code><span class="http-method">get</span> /agent_download_sources</code></a></li>
@@ -34,7 +34,7 @@ Any modifications made to this file will be overwritten.
   <li><a href="#postDownloadSources"><code><span class="http-method">post</span> /agent_download_sources</code></a></li>
   <li><a href="#updateDownloadSource"><code><span class="http-method">put</span> /agent_download_sources/{sourceId}</code></a></li>
   </ul>
-  <h4><a href="#AgentPolicies">AgentPolicies</a></h4>
+  <h4><a href="#AgentPolicies">Agent Policies</a></h4>
   <ul>
   <li><a href="#agentPolicyCopy"><code><span class="http-method">post</span> /agent_policies/{agentPolicyId}/copy</code></a></li>
   <li><a href="#agentPolicyDownload"><code><span class="http-method">get</span> /agent_policies/{agentPolicyId}/download</code></a></li>
@@ -46,7 +46,7 @@ Any modifications made to this file will be overwritten.
   <li><a href="#deleteAgentPolicy"><code><span class="http-method">post</span> /agent_policies/delete</code></a></li>
   <li><a href="#updateAgentPolicy"><code><span class="http-method">put</span> /agent_policies/{agentPolicyId}</code></a></li>
   </ul>
-  <h4><a href="#AgentStatus">AgentStatus</a></h4>
+  <h4><a href="#AgentStatus">Agent Status</a></h4>
   <ul>
   <li><a href="#getAgentData"><code><span class="http-method">get</span> /agent_status/data</code></a></li>
   <li><a href="#getAgentStatus"><code><span class="http-method">get</span> /agent_status</code></a></li>
@@ -74,11 +74,11 @@ Any modifications made to this file will be overwritten.
   <li><a href="#updateAgent"><code><span class="http-method">put</span> /agents/{agentId}</code></a></li>
   <li><a href="#upgradeAgent"><code><span class="http-method">post</span> /agents/{agentId}/upgrade</code></a></li>
   </ul>
-  <h4><a href="#DataStreams">DataStreams</a></h4>
+  <h4><a href="#DataStreams">Data Streams</a></h4>
   <ul>
   <li><a href="#dataStreamsList"><code><span class="http-method">get</span> /data_streams</code></a></li>
   </ul>
-  <h4><a href="#ElasticPackageManagerEPM">ElasticPackageManagerEPM</a></h4>
+  <h4><a href="#ElasticPackageManagerEPM">Elastic Package Manager EPM</a></h4>
   <ul>
   <li><a href="#bulkInstallPackages"><code><span class="http-method">post</span> /epm/packages/_bulk</code></a></li>
   <li><a href="#deletePackage"><code><span class="http-method">delete</span> /epm/packages/{pkgName}/{pkgVersion}</code></a></li>
@@ -96,7 +96,7 @@ Any modifications made to this file will be overwritten.
   <li><a href="#packagesGetVerificationKeyId"><code><span class="http-method">get</span> /epm/verification_key_id</code></a></li>
   <li><a href="#updatePackage"><code><span class="http-method">put</span> /epm/packages/{pkgName}/{pkgVersion}</code></a></li>
   </ul>
-  <h4><a href="#EnrollmentAPIKeys">EnrollmentAPIKeys</a></h4>
+  <h4><a href="#EnrollmentAPIKeys">Enrollment APIKeys</a></h4>
   <ul>
   <li><a href="#createEnrollmentApiKeys"><code><span class="http-method">post</span> /enrollment_api_keys</code></a></li>
   <li><a href="#createEnrollmentApiKeysDeprecated"><code><span class="http-method">post</span> /enrollment-api-keys</code></a></li>
@@ -107,14 +107,14 @@ Any modifications made to this file will be overwritten.
   <li><a href="#getEnrollmentApiKeys"><code><span class="http-method">get</span> /enrollment_api_keys</code></a></li>
   <li><a href="#getEnrollmentApiKeysDeprecated"><code><span class="http-method">get</span> /enrollment-api-keys</code></a></li>
   </ul>
-  <h4><a href="#FleetInternals">FleetInternals</a></h4>
+  <h4><a href="#FleetInternals">Fleet Internals</a></h4>
   <ul>
   <li><a href="#fleetServerHealthCheck"><code><span class="http-method">post</span> /health_check</code></a></li>
   <li><a href="#getSettings"><code><span class="http-method">get</span> /settings</code></a></li>
   <li><a href="#setup"><code><span class="http-method">post</span> /setup</code></a></li>
   <li><a href="#updateSettings"><code><span class="http-method">put</span> /settings</code></a></li>
   </ul>
-  <h4><a href="#FleetServerHosts">FleetServerHosts</a></h4>
+  <h4><a href="#FleetServerHosts">Fleet Server Hosts</a></h4>
   <ul>
   <li><a href="#deleteFleetServerHosts"><code><span class="http-method">delete</span> /fleet_server_hosts/{itemId}</code></a></li>
   <li><a href="#getFleetServerHosts"><code><span class="http-method">get</span> /fleet_server_hosts</code></a></li>
@@ -135,7 +135,7 @@ Any modifications made to this file will be overwritten.
   <li><a href="#postOutputs"><code><span class="http-method">post</span> /outputs</code></a></li>
   <li><a href="#updateOutput"><code><span class="http-method">put</span> /outputs/{outputId}</code></a></li>
   </ul>
-  <h4><a href="#PackagePolicies">PackagePolicies</a></h4>
+  <h4><a href="#PackagePolicies">Package Policies</a></h4>
   <ul>
   <li><a href="#bulkGetPackagePolicies"><code><span class="http-method">post</span> /package_policies/_bulk_get</code></a></li>
   <li><a href="#createPackagePolicy"><code><span class="http-method">post</span> /package_policies</code></a></li>
@@ -155,13 +155,13 @@ Any modifications made to this file will be overwritten.
   <li><a href="#postFleetProxies"><code><span class="http-method">post</span> /proxies</code></a></li>
   <li><a href="#updateFleetProxies"><code><span class="http-method">put</span> /proxies/{itemId}</code></a></li>
   </ul>
-  <h4><a href="#ServiceTokens">ServiceTokens</a></h4>
+  <h4><a href="#ServiceTokens">Service Tokens</a></h4>
   <ul>
   <li><a href="#generateServiceToken"><code><span class="http-method">post</span> /service_tokens</code></a></li>
   <li><a href="#generateServiceTokenDeprecated"><code><span class="http-method">post</span> /service-tokens</code></a></li>
   </ul>
 
-  <h1><a name="AgentActions">AgentActions</a></h1>
+  <h1><a name="AgentActions">Agent Actions</a></h1>
   <div class="method"><a name="agentActionCancel"/>
     <div class="method-path">
     <a class="up" href="#__Methods">Up</a>
@@ -235,7 +235,9 @@ Any modifications made to this file will be overwritten.
 
       <div class="param-desc"><span class="param-type">Query Parameter</span> &mdash; The number of items to return default: 20 </div><div class="param">page (optional)</div>
 
-      <div class="param-desc"><span class="param-type">Query Parameter</span> &mdash;  default: 1 </div>
+      <div class="param-desc"><span class="param-type">Query Parameter</span> &mdash;  default: 1 </div><div class="param">errorSize (optional)</div>
+
+      <div class="param-desc"><span class="param-type">Query Parameter</span> &mdash;  default: 5 </div>
     </div>  <!-- field-items -->
 
 
@@ -254,6 +256,15 @@ Any modifications made to this file will be overwritten.
     "nbAgentsActioned" : 0.8008281904610115,
     "creationTime" : "creationTime",
     "cancellationTime" : "cancellationTime",
+    "latestErrors" : [ {
+      "agentId" : "agentId",
+      "error" : "error",
+      "timestamp" : "timestamp"
+    }, {
+      "agentId" : "agentId",
+      "error" : "error",
+      "timestamp" : "timestamp"
+    } ],
     "type" : "type",
     "newPolicyId" : "newPolicyId",
     "version" : "version",
@@ -269,6 +280,15 @@ Any modifications made to this file will be overwritten.
     "nbAgentsActioned" : 0.8008281904610115,
     "creationTime" : "creationTime",
     "cancellationTime" : "cancellationTime",
+    "latestErrors" : [ {
+      "agentId" : "agentId",
+      "error" : "error",
+      "timestamp" : "timestamp"
+    }, {
+      "agentId" : "agentId",
+      "error" : "error",
+      "timestamp" : "timestamp"
+    } ],
     "type" : "type",
     "newPolicyId" : "newPolicyId",
     "version" : "version",
@@ -369,7 +389,7 @@ Any modifications made to this file will be overwritten.
         <a href="#fleet_server_health_check_400_response">fleet_server_health_check_400_response</a>
   </div> <!-- method -->
   <hr/>
-  <h1><a name="AgentBinaryDownloadSources">AgentBinaryDownloadSources</a></h1>
+  <h1><a name="AgentBinaryDownloadSources">Agent Binary Download Sources</a></h1>
   <div class="method"><a name="deleteDownloadSource"/>
     <div class="method-path">
     <a class="up" href="#__Methods">Up</a>
@@ -669,7 +689,7 @@ Any modifications made to this file will be overwritten.
         <a href="#fleet_server_health_check_400_response">fleet_server_health_check_400_response</a>
   </div> <!-- method -->
   <hr/>
-  <h1><a name="AgentPolicies">AgentPolicies</a></h1>
+  <h1><a name="AgentPolicies">Agent Policies</a></h1>
   <div class="method"><a name="agentPolicyCopy"/>
     <div class="method-path">
     <a class="up" href="#__Methods">Up</a>
@@ -1403,7 +1423,7 @@ Any modifications made to this file will be overwritten.
         <a href="#fleet_server_health_check_400_response">fleet_server_health_check_400_response</a>
   </div> <!-- method -->
   <hr/>
-  <h1><a name="AgentStatus">AgentStatus</a></h1>
+  <h1><a name="AgentStatus">Agent Status</a></h1>
   <div class="method"><a name="getAgentData"/>
     <div class="method-path">
     <a class="up" href="#__Methods">Up</a>
@@ -3018,7 +3038,7 @@ Any modifications made to this file will be overwritten.
         <a href="#fleet_server_health_check_400_response">fleet_server_health_check_400_response</a>
   </div> <!-- method -->
   <hr/>
-  <h1><a name="DataStreams">DataStreams</a></h1>
+  <h1><a name="DataStreams">Data Streams</a></h1>
   <div class="method"><a name="dataStreamsList"/>
     <div class="method-path">
     <a class="up" href="#__Methods">Up</a>
@@ -3096,7 +3116,7 @@ Any modifications made to this file will be overwritten.
         <a href="#fleet_server_health_check_400_response">fleet_server_health_check_400_response</a>
   </div> <!-- method -->
   <hr/>
-  <h1><a name="ElasticPackageManagerEPM">ElasticPackageManagerEPM</a></h1>
+  <h1><a name="ElasticPackageManagerEPM">Elastic Package Manager EPM</a></h1>
   <div class="method"><a name="bulkInstallPackages"/>
     <div class="method-path">
     <a class="up" href="#__Methods">Up</a>
@@ -4111,7 +4131,7 @@ Any modifications made to this file will be overwritten.
         <a href="#fleet_server_health_check_400_response">fleet_server_health_check_400_response</a>
   </div> <!-- method -->
   <hr/>
-  <h1><a name="EnrollmentAPIKeys">EnrollmentAPIKeys</a></h1>
+  <h1><a name="EnrollmentAPIKeys">Enrollment APIKeys</a></h1>
   <div class="method"><a name="createEnrollmentApiKeys"/>
     <div class="method-path">
     <a class="up" href="#__Methods">Up</a>
@@ -4614,7 +4634,7 @@ Any modifications made to this file will be overwritten.
         <a href="#fleet_server_health_check_400_response">fleet_server_health_check_400_response</a>
   </div> <!-- method -->
   <hr/>
-  <h1><a name="FleetInternals">FleetInternals</a></h1>
+  <h1><a name="FleetInternals">Fleet Internals</a></h1>
   <div class="method"><a name="fleetServerHealthCheck"/>
     <div class="method-path">
     <a class="up" href="#__Methods">Up</a>
@@ -4847,7 +4867,7 @@ Any modifications made to this file will be overwritten.
         <a href="#fleet_server_health_check_400_response">fleet_server_health_check_400_response</a>
   </div> <!-- method -->
   <hr/>
-  <h1><a name="FleetServerHosts">FleetServerHosts</a></h1>
+  <h1><a name="FleetServerHosts">Fleet Server Hosts</a></h1>
   <div class="method"><a name="deleteFleetServerHosts"/>
     <div class="method-path">
     <a class="up" href="#__Methods">Up</a>
@@ -5661,7 +5681,7 @@ Any modifications made to this file will be overwritten.
         <a href="#fleet_server_health_check_400_response">fleet_server_health_check_400_response</a>
   </div> <!-- method -->
   <hr/>
-  <h1><a name="PackagePolicies">PackagePolicies</a></h1>
+  <h1><a name="PackagePolicies">Package Policies</a></h1>
   <div class="method"><a name="bulkGetPackagePolicies"/>
     <div class="method-path">
     <a class="up" href="#__Methods">Up</a>
@@ -6498,7 +6518,7 @@ Any modifications made to this file will be overwritten.
         <a href="#fleet_server_health_check_400_response">fleet_server_health_check_400_response</a>
   </div> <!-- method -->
   <hr/>
-  <h1><a name="ServiceTokens">ServiceTokens</a></h1>
+  <h1><a name="ServiceTokens">Service Tokens</a></h1>
   <div class="method"><a name="generateServiceToken"/>
     <div class="method-path">
     <a class="up" href="#__Methods">Up</a>
@@ -6639,6 +6659,7 @@ Any modifications made to this file will be overwritten.
     <li><a href="#agent_type"><code>agent_type</code> - Agent type</a></li>
     <li><a href="#agents_action_status_200_response"><code>agents_action_status_200_response</code> - </a></li>
     <li><a href="#agents_action_status_200_response_items_inner"><code>agents_action_status_200_response_items_inner</code> - </a></li>
+    <li><a href="#agents_action_status_200_response_items_inner_latestErrors_inner"><code>agents_action_status_200_response_items_inner_latestErrors_inner</code> - </a></li>
     <li><a href="#bulk_get_agent_policies_200_response"><code>bulk_get_agent_policies_200_response</code> - </a></li>
     <li><a href="#bulk_get_agent_policies_request"><code>bulk_get_agent_policies_request</code> - </a></li>
     <li><a href="#bulk_get_package_policies_200_response"><code>bulk_get_package_policies_200_response</code> - </a></li>
@@ -6838,7 +6859,7 @@ Any modifications made to this file will be overwritten.
 <div class="param">access_api_key_id (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
 <div class="param">default_api_key_id (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
 <div class="param">policy_id (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
-<div class="param">policy_revision (optional)</div><div class="param-desc"><span class="param-type"><a href="#number">BigDecimal</a></span>  </div>
+<div class="param">policy_revision (optional)</div><div class="param-desc"><span class="param-type"><a href="#number">Big Decimal</a></span>  </div>
 <div class="param">last_checkin (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
 <div class="param">user_provided_metadata (optional)</div><div class="param-desc"><span class="param-type"><a href="#">Object</a></span>  </div>
 <div class="param">local_metadata (optional)</div><div class="param-desc"><span class="param-type"><a href="#">Object</a></span>  </div>
@@ -6946,8 +6967,8 @@ Any modifications made to this file will be overwritten.
     <h3><a name="agent_metrics"><code>agent_metrics</code> - </a> <a class="up" href="#__Models">Up</a></h3>
     <div class='model-description'></div>
     <div class="field-items">
-      <div class="param">cpu_avg (optional)</div><div class="param-desc"><span class="param-type"><a href="#number">BigDecimal</a></span> Average agent CPU usage during the last 5 minutes, number between 0-1 </div>
-<div class="param">memory_size_byte_avg (optional)</div><div class="param-desc"><span class="param-type"><a href="#number">BigDecimal</a></span> Average agent memory consumption during the last 5 minutes </div>
+      <div class="param">cpu_avg (optional)</div><div class="param-desc"><span class="param-type"><a href="#number">Big Decimal</a></span> Average agent CPU usage during the last 5 minutes, number between 0-1 </div>
+<div class="param">memory_size_byte_avg (optional)</div><div class="param-desc"><span class="param-type"><a href="#number">Big Decimal</a></span> Average agent memory consumption during the last 5 minutes </div>
     </div>  <!-- field-items -->
   </div>
   <div class="model">
@@ -6965,13 +6986,13 @@ Any modifications made to this file will be overwritten.
 <div class="param">monitoring_output_id (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
 <div class="param">fleet_server_host_id (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
 <div class="param">download_source_id (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
-<div class="param">unenroll_timeout (optional)</div><div class="param-desc"><span class="param-type"><a href="#number">BigDecimal</a></span>  </div>
-<div class="param">inactivity_timeout (optional)</div><div class="param-desc"><span class="param-type"><a href="#number">BigDecimal</a></span>  </div>
+<div class="param">unenroll_timeout (optional)</div><div class="param-desc"><span class="param-type"><a href="#number">Big Decimal</a></span>  </div>
+<div class="param">inactivity_timeout (optional)</div><div class="param-desc"><span class="param-type"><a href="#number">Big Decimal</a></span>  </div>
 <div class="param">package_policies (optional)</div><div class="param-desc"><span class="param-type"><a href="#package_policy">array[package_policy]</a></span> This field is present only when retrieving a single agent policy, or when retrieving a list of agent policy with the ?full=true parameter </div>
 <div class="param">updated_on (optional)</div><div class="param-desc"><span class="param-type"><a href="#DateTime">Date</a></span>  format: date-time</div>
 <div class="param">updated_by (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
-<div class="param">revision (optional)</div><div class="param-desc"><span class="param-type"><a href="#number">BigDecimal</a></span>  </div>
-<div class="param">agents (optional)</div><div class="param-desc"><span class="param-type"><a href="#number">BigDecimal</a></span>  </div>
+<div class="param">revision (optional)</div><div class="param-desc"><span class="param-type"><a href="#number">Big Decimal</a></span>  </div>
+<div class="param">agents (optional)</div><div class="param-desc"><span class="param-type"><a href="#number">Big Decimal</a></span>  </div>
 <div class="param">agent_features (optional)</div><div class="param-desc"><span class="param-type"><a href="#agent_policy_agent_features_inner">array[agent_policy_agent_features_inner]</a></span>  </div>
     </div>  <!-- field-items -->
   </div>
@@ -7006,8 +7027,8 @@ Any modifications made to this file will be overwritten.
 <div class="param">monitoring_output_id (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
 <div class="param">fleet_server_host_id (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
 <div class="param">download_source_id (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
-<div class="param">unenroll_timeout (optional)</div><div class="param-desc"><span class="param-type"><a href="#number">BigDecimal</a></span>  </div>
-<div class="param">inactivity_timeout (optional)</div><div class="param-desc"><span class="param-type"><a href="#number">BigDecimal</a></span>  </div>
+<div class="param">unenroll_timeout (optional)</div><div class="param-desc"><span class="param-type"><a href="#number">Big Decimal</a></span>  </div>
+<div class="param">inactivity_timeout (optional)</div><div class="param-desc"><span class="param-type"><a href="#number">Big Decimal</a></span>  </div>
 <div class="param">agent_features (optional)</div><div class="param-desc"><span class="param-type"><a href="#agent_policy_agent_features_inner">array[agent_policy_agent_features_inner]</a></span>  </div>
     </div>  <!-- field-items -->
   </div>
@@ -7065,9 +7086,9 @@ Any modifications made to this file will be overwritten.
     <div class='model-description'></div>
     <div class="field-items">
       <div class="param">items </div><div class="param-desc"><span class="param-type"><a href="#agent_policy">array[agent_policy]</a></span>  </div>
-<div class="param">total </div><div class="param-desc"><span class="param-type"><a href="#number">BigDecimal</a></span>  </div>
-<div class="param">page </div><div class="param-desc"><span class="param-type"><a href="#number">BigDecimal</a></span>  </div>
-<div class="param">perPage </div><div class="param-desc"><span class="param-type"><a href="#number">BigDecimal</a></span>  </div>
+<div class="param">total </div><div class="param-desc"><span class="param-type"><a href="#number">Big Decimal</a></span>  </div>
+<div class="param">page </div><div class="param-desc"><span class="param-type"><a href="#number">Big Decimal</a></span>  </div>
+<div class="param">perPage </div><div class="param-desc"><span class="param-type"><a href="#number">Big Decimal</a></span>  </div>
     </div>  <!-- field-items -->
   </div>
   <div class="model">
@@ -7084,8 +7105,8 @@ Any modifications made to this file will be overwritten.
 <div class="param">monitoring_output_id (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
 <div class="param">fleet_server_host_id (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
 <div class="param">download_source_id (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
-<div class="param">unenroll_timeout (optional)</div><div class="param-desc"><span class="param-type"><a href="#number">BigDecimal</a></span>  </div>
-<div class="param">inactivity_timeout (optional)</div><div class="param-desc"><span class="param-type"><a href="#number">BigDecimal</a></span>  </div>
+<div class="param">unenroll_timeout (optional)</div><div class="param-desc"><span class="param-type"><a href="#number">Big Decimal</a></span>  </div>
+<div class="param">inactivity_timeout (optional)</div><div class="param-desc"><span class="param-type"><a href="#number">Big Decimal</a></span>  </div>
 <div class="param">agent_features (optional)</div><div class="param-desc"><span class="param-type"><a href="#agent_policy_agent_features_inner">array[agent_policy_agent_features_inner]</a></span>  </div>
     </div>  <!-- field-items -->
   </div>
@@ -7115,11 +7136,11 @@ Any modifications made to this file will be overwritten.
       <div class="param">actionId </div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
 <div class="param">status </div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
         <div class="param-enum-header">Enum:</div>
-        <div class="param-enum">COMPLETE</div><div class="param-enum">EXPIRED</div><div class="param-enum">CANCELLED</div><div class="param-enum">FAILED</div><div class="param-enum">IN_PROGRESS</div>
-<div class="param">nbAgentsActioned </div><div class="param-desc"><span class="param-type"><a href="#number">BigDecimal</a></span>  </div>
-<div class="param">nbAgentsActionCreated </div><div class="param-desc"><span class="param-type"><a href="#number">BigDecimal</a></span>  </div>
-<div class="param">nbAgentsAck </div><div class="param-desc"><span class="param-type"><a href="#number">BigDecimal</a></span>  </div>
-<div class="param">nbAgentsFailed </div><div class="param-desc"><span class="param-type"><a href="#number">BigDecimal</a></span>  </div>
+        <div class="param-enum">COMPLETE</div><div class="param-enum">EXPIRED</div><div class="param-enum">CANCELLED</div><div class="param-enum">FAILED</div><div class="param-enum">IN_PROGRESS</div><div class="param-enum">ROLLOUT_PASSED</div>
+<div class="param">nbAgentsActioned </div><div class="param-desc"><span class="param-type"><a href="#number">Big Decimal</a></span>  </div>
+<div class="param">nbAgentsActionCreated </div><div class="param-desc"><span class="param-type"><a href="#number">Big Decimal</a></span>  </div>
+<div class="param">nbAgentsAck </div><div class="param-desc"><span class="param-type"><a href="#number">Big Decimal</a></span>  </div>
+<div class="param">nbAgentsFailed </div><div class="param-desc"><span class="param-type"><a href="#number">Big Decimal</a></span>  </div>
 <div class="param">version (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
 <div class="param">startTime (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
 <div class="param">type (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
@@ -7128,6 +7149,16 @@ Any modifications made to this file will be overwritten.
 <div class="param">cancellationTime (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
 <div class="param">newPolicyId (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
 <div class="param">creationTime </div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
+<div class="param">latestErrors (optional)</div><div class="param-desc"><span class="param-type"><a href="#agents_action_status_200_response_items_inner_latestErrors_inner">array[agents_action_status_200_response_items_inner_latestErrors_inner]</a></span> latest errors that happened when the agents executed the action </div>
+    </div>  <!-- field-items -->
+  </div>
+  <div class="model">
+    <h3><a name="agents_action_status_200_response_items_inner_latestErrors_inner"><code>agents_action_status_200_response_items_inner_latestErrors_inner</code> - </a> <a class="up" href="#__Models">Up</a></h3>
+    <div class='model-description'></div>
+    <div class="field-items">
+      <div class="param">agentId (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
+<div class="param">error (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
+<div class="param">timestamp (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
     </div>  <!-- field-items -->
   </div>
   <div class="model">
@@ -7203,7 +7234,7 @@ Any modifications made to this file will be overwritten.
     <h3><a name="bulk_request_diagnostics_request"><code>bulk_request_diagnostics_request</code> - </a> <a class="up" href="#__Models">Up</a></h3>
     <div class='model-description'></div>
     <div class="field-items">
-      <div class="param">batchSize (optional)</div><div class="param-desc"><span class="param-type"><a href="#number">BigDecimal</a></span>  </div>
+      <div class="param">batchSize (optional)</div><div class="param-desc"><span class="param-type"><a href="#number">Big Decimal</a></span>  </div>
 <div class="param">agents </div><div class="param-desc"><span class="param-type"><a href="#bulk_reassign_agents_request_agents">bulk_reassign_agents_request_agents</a></span>  </div>
     </div>  <!-- field-items -->
   </div>
@@ -7223,7 +7254,7 @@ Any modifications made to this file will be overwritten.
       <div class="param">agents </div><div class="param-desc"><span class="param-type"><a href="#bulk_reassign_agents_request_agents">bulk_reassign_agents_request_agents</a></span>  </div>
 <div class="param">tagsToAdd (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">array[String]</a></span>  </div>
 <div class="param">tagsToRemove (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">array[String]</a></span>  </div>
-<div class="param">batchSize (optional)</div><div class="param-desc"><span class="param-type"><a href="#number">BigDecimal</a></span>  </div>
+<div class="param">batchSize (optional)</div><div class="param-desc"><span class="param-type"><a href="#number">Big Decimal</a></span>  </div>
     </div>  <!-- field-items -->
   </div>
   <div class="model">
@@ -7232,7 +7263,7 @@ Any modifications made to this file will be overwritten.
     <div class="field-items">
       <div class="param">version </div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> version to upgrade to </div>
 <div class="param">source_uri (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> alternative upgrade binary download url </div>
-<div class="param">rollout_duration_seconds (optional)</div><div class="param-desc"><span class="param-type"><a href="#number">BigDecimal</a></span> rolling upgrade window duration in seconds </div>
+<div class="param">rollout_duration_seconds (optional)</div><div class="param-desc"><span class="param-type"><a href="#number">Big Decimal</a></span> rolling upgrade window duration in seconds </div>
 <div class="param">start_time (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> start time of upgrade in ISO 8601 format </div>
 <div class="param">agents </div><div class="param-desc"><span class="param-type"><a href="#bulk_reassign_agents_request_agents">bulk_reassign_agents_request_agents</a></span>  </div>
 <div class="param">force (optional)</div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span> Force upgrade, skipping validation (should be used with caution) </div>
@@ -7279,8 +7310,8 @@ Any modifications made to this file will be overwritten.
 <div class="param">type (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
 <div class="param">package (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
 <div class="param">package_version (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
-<div class="param">last_activity_ms (optional)</div><div class="param-desc"><span class="param-type"><a href="#number">BigDecimal</a></span>  </div>
-<div class="param">size_in_bytes (optional)</div><div class="param-desc"><span class="param-type"><a href="#number">BigDecimal</a></span>  </div>
+<div class="param">last_activity_ms (optional)</div><div class="param-desc"><span class="param-type"><a href="#number">Big Decimal</a></span>  </div>
+<div class="param">size_in_bytes (optional)</div><div class="param-desc"><span class="param-type"><a href="#number">Big Decimal</a></span>  </div>
 <div class="param">size_in_bytes_formatted (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
 <div class="param">dashboard (optional)</div><div class="param-desc"><span class="param-type"><a href="#data_stream_dashboard_inner">array[data_stream_dashboard_inner]</a></span>  </div>
     </div>  <!-- field-items -->
@@ -7373,7 +7404,7 @@ Any modifications made to this file will be overwritten.
     <h3><a name="fleet_server_health_check_400_response"><code>fleet_server_health_check_400_response</code> - </a> <a class="up" href="#__Models">Up</a></h3>
     <div class='model-description'></div>
     <div class="field-items">
-      <div class="param">statusCode (optional)</div><div class="param-desc"><span class="param-type"><a href="#number">BigDecimal</a></span>  </div>
+      <div class="param">statusCode (optional)</div><div class="param-desc"><span class="param-type"><a href="#number">Big Decimal</a></span>  </div>
 <div class="param">error (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
 <div class="param">message (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
     </div>  <!-- field-items -->
@@ -7442,7 +7473,7 @@ Any modifications made to this file will be overwritten.
 <div class="param">output_permissions (optional)</div><div class="param-desc"><span class="param-type"><a href="#full_agent_policy_output_permissions_1_value">map[String, full_agent_policy_output_permissions_1_value]</a></span>  </div>
 <div class="param">fleet (optional)</div><div class="param-desc"><span class="param-type"><a href="#full_agent_policy_fleet">full_agent_policy_fleet</a></span>  </div>
 <div class="param">inputs </div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
-<div class="param">revision (optional)</div><div class="param-desc"><span class="param-type"><a href="#number">BigDecimal</a></span>  </div>
+<div class="param">revision (optional)</div><div class="param-desc"><span class="param-type"><a href="#number">Big Decimal</a></span>  </div>
 <div class="param">agent (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
 <div class="param">download_source_id (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
     </div>  <!-- field-items -->
@@ -7501,7 +7532,7 @@ Any modifications made to this file will be overwritten.
     <div class="field-items">
       <div class="param">id </div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
 <div class="param">name </div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
-<div class="param">revision </div><div class="param-desc"><span class="param-type"><a href="#number">BigDecimal</a></span>  </div>
+<div class="param">revision </div><div class="param-desc"><span class="param-type"><a href="#number">Big Decimal</a></span>  </div>
 <div class="param">type </div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
 <div class="param">data_stream </div><div class="param-desc"><span class="param-type"><a href="#full_agent_policy_input_allOf_data_stream">full_agent_policy_input_allOf_data_stream</a></span>  </div>
 <div class="param">use_output </div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
@@ -7515,7 +7546,7 @@ Any modifications made to this file will be overwritten.
     <div class="field-items">
       <div class="param">id </div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
 <div class="param">name </div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
-<div class="param">revision </div><div class="param-desc"><span class="param-type"><a href="#number">BigDecimal</a></span>  </div>
+<div class="param">revision </div><div class="param-desc"><span class="param-type"><a href="#number">Big Decimal</a></span>  </div>
 <div class="param">type </div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
 <div class="param">data_stream </div><div class="param-desc"><span class="param-type"><a href="#full_agent_policy_input_allOf_data_stream">full_agent_policy_input_allOf_data_stream</a></span>  </div>
 <div class="param">use_output </div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
@@ -7683,9 +7714,9 @@ Any modifications made to this file will be overwritten.
     <div class="field-items">
       <div class="param">list (optional)</div><div class="param-desc"><span class="param-type"><a href="#agent">array[agent]</a></span>  </div>
 <div class="param">items </div><div class="param-desc"><span class="param-type"><a href="#agent">array[agent]</a></span>  </div>
-<div class="param">total </div><div class="param-desc"><span class="param-type"><a href="#number">BigDecimal</a></span>  </div>
-<div class="param">page </div><div class="param-desc"><span class="param-type"><a href="#number">BigDecimal</a></span>  </div>
-<div class="param">perPage </div><div class="param-desc"><span class="param-type"><a href="#number">BigDecimal</a></span>  </div>
+<div class="param">total </div><div class="param-desc"><span class="param-type"><a href="#number">Big Decimal</a></span>  </div>
+<div class="param">page </div><div class="param-desc"><span class="param-type"><a href="#number">Big Decimal</a></span>  </div>
+<div class="param">perPage </div><div class="param-desc"><span class="param-type"><a href="#number">Big Decimal</a></span>  </div>
 <div class="param">statusSummary (optional)</div><div class="param-desc"><span class="param-type"><a href="#get_agents_response_statusSummary">get_agents_response_statusSummary</a></span>  </div>
     </div>  <!-- field-items -->
   </div>
@@ -7693,15 +7724,15 @@ Any modifications made to this file will be overwritten.
     <h3><a name="get_agents_response_statusSummary"><code>get_agents_response_statusSummary</code> - </a> <a class="up" href="#__Models">Up</a></h3>
     <div class='model-description'></div>
     <div class="field-items">
-      <div class="param">offline (optional)</div><div class="param-desc"><span class="param-type"><a href="#number">BigDecimal</a></span>  </div>
-<div class="param">error (optional)</div><div class="param-desc"><span class="param-type"><a href="#number">BigDecimal</a></span>  </div>
-<div class="param">online (optional)</div><div class="param-desc"><span class="param-type"><a href="#number">BigDecimal</a></span>  </div>
-<div class="param">inactive (optional)</div><div class="param-desc"><span class="param-type"><a href="#number">BigDecimal</a></span>  </div>
-<div class="param">enrolling (optional)</div><div class="param-desc"><span class="param-type"><a href="#number">BigDecimal</a></span>  </div>
-<div class="param">unenrolling (optional)</div><div class="param-desc"><span class="param-type"><a href="#number">BigDecimal</a></span>  </div>
-<div class="param">unenrolled (optional)</div><div class="param-desc"><span class="param-type"><a href="#number">BigDecimal</a></span>  </div>
-<div class="param">updating (optional)</div><div class="param-desc"><span class="param-type"><a href="#number">BigDecimal</a></span>  </div>
-<div class="param">degradedQuote (optional)</div><div class="param-desc"><span class="param-type"><a href="#number">BigDecimal</a></span>  </div>
+      <div class="param">offline (optional)</div><div class="param-desc"><span class="param-type"><a href="#number">Big Decimal</a></span>  </div>
+<div class="param">error (optional)</div><div class="param-desc"><span class="param-type"><a href="#number">Big Decimal</a></span>  </div>
+<div class="param">online (optional)</div><div class="param-desc"><span class="param-type"><a href="#number">Big Decimal</a></span>  </div>
+<div class="param">inactive (optional)</div><div class="param-desc"><span class="param-type"><a href="#number">Big Decimal</a></span>  </div>
+<div class="param">enrolling (optional)</div><div class="param-desc"><span class="param-type"><a href="#number">Big Decimal</a></span>  </div>
+<div class="param">unenrolling (optional)</div><div class="param-desc"><span class="param-type"><a href="#number">Big Decimal</a></span>  </div>
+<div class="param">unenrolled (optional)</div><div class="param-desc"><span class="param-type"><a href="#number">Big Decimal</a></span>  </div>
+<div class="param">updating (optional)</div><div class="param-desc"><span class="param-type"><a href="#number">Big Decimal</a></span>  </div>
+<div class="param">degradedQuote (optional)</div><div class="param-desc"><span class="param-type"><a href="#number">Big Decimal</a></span>  </div>
     </div>  <!-- field-items -->
   </div>
   <div class="model">
@@ -7718,7 +7749,7 @@ Any modifications made to this file will be overwritten.
     <div class="field-items">
       <div class="param">id </div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
 <div class="param">title </div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
-<div class="param">count </div><div class="param-desc"><span class="param-type"><a href="#number">BigDecimal</a></span>  </div>
+<div class="param">count </div><div class="param-desc"><span class="param-type"><a href="#number">Big Decimal</a></span>  </div>
     </div>  <!-- field-items -->
   </div>
   <div class="model">
@@ -7727,7 +7758,7 @@ Any modifications made to this file will be overwritten.
     <div class="field-items">
       <div class="param">id </div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
 <div class="param">title </div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
-<div class="param">count </div><div class="param-desc"><span class="param-type"><a href="#number">BigDecimal</a></span>  </div>
+<div class="param">count </div><div class="param-desc"><span class="param-type"><a href="#number">Big Decimal</a></span>  </div>
     </div>  <!-- field-items -->
   </div>
   <div class="model">
@@ -7753,9 +7784,9 @@ Any modifications made to this file will be overwritten.
     <div class="field-items">
       <div class="param">list (optional)</div><div class="param-desc"><span class="param-type"><a href="#enrollment_api_key">array[enrollment_api_key]</a></span>  </div>
 <div class="param">items </div><div class="param-desc"><span class="param-type"><a href="#enrollment_api_key">array[enrollment_api_key]</a></span>  </div>
-<div class="param">page </div><div class="param-desc"><span class="param-type"><a href="#number">BigDecimal</a></span>  </div>
-<div class="param">perPage </div><div class="param-desc"><span class="param-type"><a href="#number">BigDecimal</a></span>  </div>
-<div class="param">total </div><div class="param-desc"><span class="param-type"><a href="#number">BigDecimal</a></span>  </div>
+<div class="param">page </div><div class="param-desc"><span class="param-type"><a href="#number">Big Decimal</a></span>  </div>
+<div class="param">perPage </div><div class="param-desc"><span class="param-type"><a href="#number">Big Decimal</a></span>  </div>
+<div class="param">total </div><div class="param-desc"><span class="param-type"><a href="#number">Big Decimal</a></span>  </div>
     </div>  <!-- field-items -->
   </div>
   <div class="model">
@@ -7885,9 +7916,9 @@ Any modifications made to this file will be overwritten.
     <div class='model-description'></div>
     <div class="field-items">
       <div class="param">items </div><div class="param-desc"><span class="param-type"><a href="#package_policy">array[package_policy]</a></span>  </div>
-<div class="param">total (optional)</div><div class="param-desc"><span class="param-type"><a href="#number">BigDecimal</a></span>  </div>
-<div class="param">page (optional)</div><div class="param-desc"><span class="param-type"><a href="#number">BigDecimal</a></span>  </div>
-<div class="param">perPage (optional)</div><div class="param-desc"><span class="param-type"><a href="#number">BigDecimal</a></span>  </div>
+<div class="param">total (optional)</div><div class="param-desc"><span class="param-type"><a href="#number">Big Decimal</a></span>  </div>
+<div class="param">page (optional)</div><div class="param-desc"><span class="param-type"><a href="#number">Big Decimal</a></span>  </div>
+<div class="param">perPage (optional)</div><div class="param-desc"><span class="param-type"><a href="#number">Big Decimal</a></span>  </div>
     </div>  <!-- field-items -->
   </div>
   <div class="model">
@@ -8007,7 +8038,7 @@ Any modifications made to this file will be overwritten.
     <div class='model-description'></div>
     <div class="field-items">
       <div class="param">body (optional)</div><div class="param-desc"><span class="param-type"><a href="#number">array[BigDecimal]</a></span>  </div>
-<div class="param">statusCode (optional)</div><div class="param-desc"><span class="param-type"><a href="#number">BigDecimal</a></span>  </div>
+<div class="param">statusCode (optional)</div><div class="param-desc"><span class="param-type"><a href="#number">Big Decimal</a></span>  </div>
 <div class="param">headers (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
     </div>  <!-- field-items -->
   </div>
@@ -8080,10 +8111,10 @@ Any modifications made to this file will be overwritten.
     <div class="field-items">
       <div class="param">disk_queue_enabled (optional)</div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span>  </div>
 <div class="param">disk_queue_path (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
-<div class="param">disk_queue_max_size (optional)</div><div class="param-desc"><span class="param-type"><a href="#number">BigDecimal</a></span>  </div>
+<div class="param">disk_queue_max_size (optional)</div><div class="param-desc"><span class="param-type"><a href="#number">Big Decimal</a></span>  </div>
 <div class="param">disk_queue_encryption_enabled (optional)</div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span>  </div>
 <div class="param">disk_queue_compression_enabled (optional)</div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span>  </div>
-<div class="param">compression_level (optional)</div><div class="param-desc"><span class="param-type"><a href="#number">BigDecimal</a></span>  </div>
+<div class="param">compression_level (optional)</div><div class="param-desc"><span class="param-type"><a href="#number">Big Decimal</a></span>  </div>
 <div class="param">loadbalance (optional)</div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span>  </div>
     </div>  <!-- field-items -->
   </div>
@@ -8207,7 +8238,7 @@ Any modifications made to this file will be overwritten.
     <div class='model-description'></div>
     <div class="field-items">
       <div class="param">id </div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
-<div class="param">revision </div><div class="param-desc"><span class="param-type"><a href="#number">BigDecimal</a></span>  </div>
+<div class="param">revision </div><div class="param-desc"><span class="param-type"><a href="#number">Big Decimal</a></span>  </div>
 <div class="param">inputs </div><div class="param-desc"><span class="param-type"><a href="#new_package_policy_inputs_inner">array[new_package_policy_inputs_inner]</a></span>  </div>
 <div class="param">enabled (optional)</div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span>  </div>
 <div class="param">package (optional)</div><div class="param-desc"><span class="param-type"><a href="#new_package_policy_package">new_package_policy_package</a></span>  </div>
@@ -8223,7 +8254,7 @@ Any modifications made to this file will be overwritten.
     <div class='model-description'></div>
     <div class="field-items">
       <div class="param">id </div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
-<div class="param">revision </div><div class="param-desc"><span class="param-type"><a href="#number">BigDecimal</a></span>  </div>
+<div class="param">revision </div><div class="param-desc"><span class="param-type"><a href="#number">Big Decimal</a></span>  </div>
 <div class="param">inputs (optional)</div><div class="param-desc"><span class="param-type"><a href="#AnyType">array[oas_any_type_not_mapped]</a></span>  </div>
     </div>  <!-- field-items -->
   </div>
@@ -8279,7 +8310,7 @@ Any modifications made to this file will be overwritten.
     <div class='model-description'></div>
     <div class="field-items">
       <div class="param">body (optional)</div><div class="param-desc"><span class="param-type"><a href="#">Object</a></span>  </div>
-<div class="param">statusCode (optional)</div><div class="param-desc"><span class="param-type"><a href="#number">BigDecimal</a></span>  </div>
+<div class="param">statusCode (optional)</div><div class="param-desc"><span class="param-type"><a href="#number">Big Decimal</a></span>  </div>
 <div class="param">headers (optional)</div><div class="param-desc"><span class="param-type"><a href="#">Object</a></span>  </div>
     </div>  <!-- field-items -->
   </div>
@@ -8288,7 +8319,7 @@ Any modifications made to this file will be overwritten.
     <div class='model-description'></div>
     <div class="field-items">
       <div class="param">body (optional)</div><div class="param-desc"><span class="param-type"><a href="#packages_get_verification_key_id_200_response_body">packages_get_verification_key_id_200_response_body</a></span>  </div>
-<div class="param">statusCode (optional)</div><div class="param-desc"><span class="param-type"><a href="#number">BigDecimal</a></span>  </div>
+<div class="param">statusCode (optional)</div><div class="param-desc"><span class="param-type"><a href="#number">Big Decimal</a></span>  </div>
 <div class="param">headers (optional)</div><div class="param-desc"><span class="param-type"><a href="#">Object</a></span>  </div>
     </div>  <!-- field-items -->
   </div>
@@ -8460,7 +8491,7 @@ Any modifications made to this file will be overwritten.
     <div class="field-items">
       <div class="param">error (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
 <div class="param">message (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
-<div class="param">statusCode (optional)</div><div class="param-desc"><span class="param-type"><a href="#number">BigDecimal</a></span>  </div>
+<div class="param">statusCode (optional)</div><div class="param-desc"><span class="param-type"><a href="#number">Big Decimal</a></span>  </div>
         <div class="param-enum-header">Enum:</div>
         <div class="param-enum">400</div>
     </div>  <!-- field-items -->
@@ -8572,7 +8603,7 @@ Any modifications made to this file will be overwritten.
     <div class='model-description'></div>
     <div class="field-items">
       <div class="param">id </div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
-<div class="param">revision </div><div class="param-desc"><span class="param-type"><a href="#number">BigDecimal</a></span>  </div>
+<div class="param">revision </div><div class="param-desc"><span class="param-type"><a href="#number">Big Decimal</a></span>  </div>
 <div class="param">inputs </div><div class="param-desc"><span class="param-type"><a href="#new_package_policy_inputs_inner">array[new_package_policy_inputs_inner]</a></span>  </div>
 <div class="param">enabled (optional)</div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span>  </div>
 <div class="param">package (optional)</div><div class="param-desc"><span class="param-type"><a href="#new_package_policy_package">new_package_policy_package</a></span>  </div>


### PR DESCRIPTION
This adds a _perl_ step into the API generation README instructions and also updates the API docs output, so that the section headers have spaces between words. It's not perfect: We still have one header reading as `Enrollment APIKeys` rather than `Enrollment API Keys`, but it's better than before. The original `ElasticPackageManagerAPM` now renders as `Elastic Package Manager EPM`.

Ideally we don't want to introduce somewhat arcane code into our docs processes, but this is just a one line command, and these generated docs are essentially a stop-gap fix while we wait for a better implementation.

Note: I used perl so that the command is the same across operating systems.

**Original:**
![Screenshot 2023-03-09 at 11 06 12 AM](https://user-images.githubusercontent.com/41695641/224083487-26fb7cee-9c3c-4bd1-be74-636f9e0b22a5.png)

**Fixed up:**
![Screenshot 2023-03-09 at 11 07 16 AM](https://user-images.githubusercontent.com/41695641/224083518-09834582-61b0-46a3-bde1-34d2173c2047.png)

