### PR TITLE
Add inactivity timeout documentation

### DIFF
--- a/docs/en/ingest-management/fleet/fleet-manage-agents.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-manage-agents.asciidoc
@@ -18,8 +18,8 @@ To manage your {agent}s, go to *Management > {fleet} > Agents* in {kib}. On the
 |<<unenroll-elastic-agent>>
 |Unenroll {agent}s from {fleet}.
 
-|<<set-enrollment-timeout>>
-|Set enrollment timeout to force unenroll inactive {agent}s.
+|<<set-inactivity-timeout>>
+|Set inactivity timeout to move {agent}s to inactive status after being offline for the set amount of time.
 
 |<<upgrade-elastic-agent>>
 |Upgrade {agent}s to the latest version.

--- a/docs/en/ingest-management/fleet/monitor-elastic-agent.asciidoc
+++ b/docs/en/ingest-management/fleet/monitor-elastic-agent.asciidoc
@@ -39,7 +39,7 @@ binary, or enrolling or unenrolling from {fleet}.
 
 | **Offline** | The {agent} has not checked in during the expected time period.
 
-| **Inactive** | The {agent} is no longer enrolled in {fleet}. The agent must reenroll to connect to {fleet} again.
+| **Inactive** | The {agent} is valid, but has been removed from the main {fleet} UI according to your <<set-inactivity-timeout,inactivity timeout>>.
 
 |===
 

--- a/docs/en/ingest-management/fleet/set-inactivity-timeout.asciidoc
+++ b/docs/en/ingest-management/fleet/set-inactivity-timeout.asciidoc
@@ -1,9 +1,5 @@
 [[set-inactivity-timeout]]
-= Set inactivity timeout for ephemeral hosts
-
-++++
-<titleabbrev>Set inactivity timeout</titleabbrev>
-++++
+= Set inactivity timeout
 
 [[why-set-inactivity-timeout]]
 == Why set an inactivity timeout?
@@ -14,10 +10,10 @@ declutter the {fleet} UI.
 
 Once {fleet-server} receives a check-in from an inactive {agent}, it returns to healthy status. 
 
-For example, if an employee is on holiday with their laptop off while they're away, 
+For example, if an employee is on holiday with their laptop off, 
 the {agent} will transition to offline then inactive once the inactivity timeout limit is reached. 
 This prevents the inactive {agent} from cluttering the {fleet} UI, and,
-onnce the employee returns, the {agent} checks in and returns to healthy status with valid API keys to use. 
+once the employee returns, the {agent} checks in and returns to healthy status with valid API keys. 
 
 If an {agent} is no longer valid, you can manually <<unenroll-elastic-agent,unenroll>> inactive {agent}s to revoke the API keys. 
 Unenrolled agents need to be re-enrolled to be operational again.

--- a/docs/en/ingest-management/fleet/set-inactivity-timeout.asciidoc
+++ b/docs/en/ingest-management/fleet/set-inactivity-timeout.asciidoc
@@ -1,0 +1,41 @@
+[[set-inactivity-timeout]]
+= Set inactivity timeout for ephemeral hosts
+
+++++
+<titleabbrev>Set inactivity timeout</titleabbrev>
+++++
+
+[[why-set-inactivity-timeout]]
+== Why set an inactivity timeout?
+
+The inactivity timeout moves {agent}s to *inactive* status after being offline for a set amount of time. 
+Inactive {agent}s are still valid {agent}s, but are removed from the main {fleet} UI allowing you to better manage {agent}s and 
+declutter the {fleet} UI.
+
+Once {fleet-server} receives a check-in from an inactive {agent}, it returns to healthy status. 
+
+For example, if an employee is on holiday with their laptop off while they're away, 
+the {agent} will transition to offline then inactive once the inactivity timeout limit is reached. 
+This prevents the inactive {agent} from cluttering the {fleet} UI, and,
+onnce the employee returns, the {agent} checks in and returns to healthy status with valid API keys to use. 
+
+If an {agent} is no longer valid, you can manually <<unenroll-elastic-agent,unenroll>> inactive {agent}s to revoke the API keys. 
+Unenrolled agents need to be re-enrolled to be operational again.
+
+For more on {agent} statuses, see <<view-agent-status, view agent status>>.
+
+
+[[setting-inactivity-timeout]]
+== Set the inactivity timeout
+
+Set the inactivity timeout in the {agent} policy to the amount of time after which an offline {agent} becomes inactive.
+
+To set the inactivity timeout:
+
+. In *{fleet}*, select *Agent policies*.
+
+. Click the policy name, then click *Settings*.
+
+. In the *Inactivity timeout* field, enter a value in seconds.
+
+The default value is 1209600 seconds or two weeks.

--- a/docs/en/ingest-management/fleet/set-inactivity-timeout.asciidoc
+++ b/docs/en/ingest-management/fleet/set-inactivity-timeout.asciidoc
@@ -4,7 +4,7 @@
 [[why-set-inactivity-timeout]]
 == Why set an inactivity timeout?
 
-The inactivity timeout moves {agent}s to *inactive* status after being offline for a set amount of time. 
+The inactivity timeout moves {agent}s to inactive status after being offline for a set amount of time. 
 Inactive {agent}s are still valid {agent}s, but are removed from the main {fleet} UI allowing you to better manage {agent}s and 
 declutter the {fleet} UI.
 
@@ -12,8 +12,8 @@ Once {fleet-server} receives a check-in from an inactive {agent}, it returns to 
 
 For example, if an employee is on holiday with their laptop off, 
 the {agent} will transition to offline then inactive once the inactivity timeout limit is reached. 
-This prevents the inactive {agent} from cluttering the {fleet} UI, and,
-once the employee returns, the {agent} checks in and returns to healthy status with valid API keys. 
+This prevents the inactive {agent} from cluttering the {fleet} UI.
+Once the employee returns, the {agent} checks in and returns to healthy status with valid API keys. 
 
 If an {agent} is no longer valid, you can manually <<unenroll-elastic-agent,unenroll>> inactive {agent}s to revoke the API keys. 
 Unenrolled agents need to be re-enrolled to be operational again.
@@ -24,7 +24,7 @@ For more on {agent} statuses, see <<view-agent-status, view agent status>>.
 [[setting-inactivity-timeout]]
 == Set the inactivity timeout
 
-Set the inactivity timeout in the {agent} policy to the amount of time after which an offline {agent} becomes inactive.
+Set the inactivity timeout in the {agent} policy to the amount of time after which you want an offline {agent} become inactive.
 
 To set the inactivity timeout:
 

--- a/docs/en/ingest-management/fleet/set-inactivity-timeout.asciidoc
+++ b/docs/en/ingest-management/fleet/set-inactivity-timeout.asciidoc
@@ -32,6 +32,4 @@ To set the inactivity timeout:
 
 . Click the policy name, then click *Settings*.
 
-. In the *Inactivity timeout* field, enter a value in seconds.
-
-The default value is 1209600 seconds or two weeks.
+. In the *Inactivity timeout* field, enter a value in seconds. The default value is 1209600 seconds or two weeks.

--- a/docs/en/ingest-management/fleet/set-inactivity-timeout.asciidoc
+++ b/docs/en/ingest-management/fleet/set-inactivity-timeout.asciidoc
@@ -1,19 +1,16 @@
 [[set-inactivity-timeout]]
 = Set inactivity timeout
 
-[[why-set-inactivity-timeout]]
-== Why set an inactivity timeout?
-
 The inactivity timeout moves {agent}s to inactive status after being offline for a set amount of time. 
 Inactive {agent}s are still valid {agent}s, but are removed from the main {fleet} UI allowing you to better manage {agent}s and 
 declutter the {fleet} UI.
 
-Once {fleet-server} receives a check-in from an inactive {agent}, it returns to healthy status. 
+When {fleet-server} receives a check-in from an inactive {agent}, it returns to healthy status. 
 
 For example, if an employee is on holiday with their laptop off, 
 the {agent} will transition to offline then inactive once the inactivity timeout limit is reached. 
 This prevents the inactive {agent} from cluttering the {fleet} UI.
-Once the employee returns, the {agent} checks in and returns to healthy status with valid API keys. 
+When the employee returns, the {agent} checks in and returns to healthy status with valid API keys. 
 
 If an {agent} is no longer valid, you can manually <<unenroll-elastic-agent,unenroll>> inactive {agent}s to revoke the API keys. 
 Unenrolled agents need to be re-enrolled to be operational again.
@@ -24,7 +21,7 @@ For more on {agent} statuses, see <<view-agent-status, view agent status>>.
 [[setting-inactivity-timeout]]
 == Set the inactivity timeout
 
-Set the inactivity timeout in the {agent} policy to the amount of time after which you want an offline {agent} become inactive.
+Set the inactivity timeout in the {agent} policy to the amount of time after which you want an offline {agent} to become inactive.
 
 To set the inactivity timeout:
 

--- a/docs/en/ingest-management/index.asciidoc
+++ b/docs/en/ingest-management/index.asciidoc
@@ -101,7 +101,7 @@ include::fleet/fleet-manage-agents.asciidoc[leveloffset=+2]
 
 include::fleet/unenroll-elastic-agent.asciidoc[leveloffset=+3]
 
-include::fleet/set-elastic-agent-enrollment-timeout.asciidoc[leveloffset=+3]
+include::fleet/set-inactivity-timeout.asciidoc[leveloffset=+3]
 
 include::fleet/upgrade-elastic-agent.asciidoc[leveloffset=+3]
 


### PR DESCRIPTION
Closes issues [2352](https://github.com/elastic/observability-docs/issues/2352) and [2543](https://github.com/elastic/observability-docs/issues/2543).

### Summary

I've added the **Set inactivity timeout** section and updated information on statuses and links regarding setting the unenrollment timeout. 

@nimarezainia In the [suggested documentation](https://docs.google.com/document/d/1sWXzljzvuIccpreHou-xD7STo6nSpy6vWhDVzdVI6jw/edit), there was some additional information on agent statuses and lifecycle. Some of that information is [here](https://www.elastic.co/guide/en/fleet/8.6/monitor-elastic-agent.html#view-agent-status), which I have linked to from the **Set inactivity timeout** doc. Maybe we can update the information there to explain that better. Let me know if this is ok.

I am also wondering if we still want to document the unenrollment timeout as deprecated since it's still in the UI. Not with a full page on setting it, but a brief mention somewhere.