### PR TITLE
[DOCS] Update queue statement in Elastic Agent

### DIFF
--- a/docs/en/ingest-management/beats-agent-comparison.asciidoc
+++ b/docs/en/ingest-management/beats-agent-comparison.asciidoc
@@ -164,9 +164,8 @@ configuration experience.
 |Autodiscover is facilitated through <<dynamic-input-configuration,dynamic inputs>>. {agent} does not support hints-based autodiscovery.
 
 |{filebeat-ref}/configuring-internal-queue.html[Internal queues]
-|{agent} does not expose the internal memory queues to the end user. You can
-configure output queue parameters to tune your environment, and the Agent takes
-care of configuring the internal queues to accomplish your tuning intent.
+|{fleet}-managed {agent} does not allow to configure the internal memory queues to the end user. You can configure 
+the queue settings on the Standalone {agent}.
 
 |{filebeat-ref}/load-balancing.html[Load balance output hosts]
 |Within the {fleet} UI, you can add YAML settings to configure multiple hosts

--- a/docs/en/ingest-management/beats-agent-comparison.asciidoc
+++ b/docs/en/ingest-management/beats-agent-comparison.asciidoc
@@ -164,8 +164,9 @@ configuration experience.
 |Autodiscover is facilitated through <<dynamic-input-configuration,dynamic inputs>>. {agent} does not support hints-based autodiscovery.
 
 |{filebeat-ref}/configuring-internal-queue.html[Internal queues]
-|{fleet}-managed {agent} does not allow to configure the internal memory queues to the end user. You can configure 
-the queue settings on the Standalone {agent}.
+|{fleet}-managed {agent} does not support configuration of the internal memory
+queues by an end user. You can configure the output queue settings in standalone
+{agents}.
 
 |{filebeat-ref}/load-balancing.html[Load balance output hosts]
 |Within the {fleet} UI, you can add YAML settings to configure multiple hosts


### PR DESCRIPTION
Elastic Agent managed by fleet doesn't allow tweaking queue settings.
This should be backported to any version in the past.

Feel free to reword/edit.