### PR TITLE
[synthetics] Add `lightweight` to list of directories created on `init`

### DIFF
--- a/docs/en/observability/synthetics-get-started-project.asciidoc
+++ b/docs/en/observability/synthetics-get-started-project.asciidoc
@@ -95,7 +95,8 @@ NOTE: If you are pushing to a <<synthetics-private-location,private location>>, 
 
 Then, take a look at key files and directories inside your project:
 
-* `journeys` is where you'll add `.yaml`, `.ts`, and `.js` files defining your monitors. When you create a new project, this directory will contain files defining sample monitors.
+* `journeys` is where you'll add `.ts` and `.js` files defining your browser monitors. When you create a new project, this directory will contain files defining sample monitors.
+* `lightweight` is where you'll add `.yaml` files defining your lightweight monitors.  When you create a new project, this directory will contain a file defining sample monitors.
 * `synthetics.config.ts` contains settings for your project. When you create a new project, it will contain some basic configuration options that you can customize later.
 * `package.json` contains NPM settings for your project. Learn more in the https://docs.npmjs.com/about-packages-and-modules[NPM documentation].
 * `.github` contains sample workflow files to use with GitHub Actions.


### PR DESCRIPTION
Addresses https://github.com/elastic/observability-docs/pull/2593#pullrequestreview-1335229705: 

>When a new folder has been `init` we separate out the browser and lightweight examples
>* The `journeys` folder just contains the browser examples
>* The `lightweight` folder contains an example `heartbeat.yml`
>
>So the info is mostly correct, just needs rearranging on the page a bit.

Making this change separately from #2593 so it can be backported to 8.6.