### PR TITLE
Fixing content bug in step 3 notice box

### DIFF
--- a/docs/en/observability/ingest-traces.asciidoc
+++ b/docs/en/observability/ingest-traces.asciidoc
@@ -58,8 +58,10 @@ include::./tab-widgets/add-apm-integration/widget.asciidoc[]
 == Step 3: Install and run an {agent} on your machine
 
 ****
-This step is optional for {ess} users as {ecloud} spins up an {agent} instance automatically.
-Unless you want to run a separate {agent} on an edge machine, {ess} users should skip this step.
+As {ecloud} spins up an {agent} instance automatically and 
+Self-managed users instaleed an {agent} instance manually, 
+this step is optional only for users who need to add a new Elastic Agents.
+If you only need to use APM features, {ess} and self-managed users should skip this step.
 ****
 
 {agent} is a single, unified way to add monitoring for logs, metrics, and other


### PR DESCRIPTION
It seems the author thought this step is adding Elastic Agent for the self-managed user. But we already installed Elastic Agent in Step 1 and this box comment made a huge confusion. Step 3 is for adding an additional Elastic Agent that is not related to APM functionality.