### PR TITLE
Add footnote for log file beats shipper install layout

### DIFF
--- a/docs/en/ingest-management/tab-widgets/install-layout.asciidoc
+++ b/docs/en/ingest-management/tab-widgets/install-layout.asciidoc
@@ -10,7 +10,7 @@ Main {agent} {fleet} encrypted configuration
 `/Library/Elastic/Agent/data/elastic-agent-*/logs/elastic-agent-json.log`::
 Log files for {agent}footnote:lognumbering[Logs file names end with a date and optional number: log-date.ndjson, log-date-1.ndjson, and so on as new files are created during rotation.]
 `/Library/Elastic/Agent/data/elastic-agent-*/logs/default/*-json.log`::
-Log files for {beats} shippers
+Log files for {beats} shippers footnote:lognumbering[]
 `/usr/bin/elastic-agent`::
 Shell wrapper installed into PATH
 

--- a/docs/en/ingest-management/tab-widgets/install-layout.asciidoc
+++ b/docs/en/ingest-management/tab-widgets/install-layout.asciidoc
@@ -10,7 +10,7 @@ Main {agent} {fleet} encrypted configuration
 `/Library/Elastic/Agent/data/elastic-agent-*/logs/elastic-agent-json.log`::
 Log files for {agent}footnote:lognumbering[Logs file names end with a date and optional number: log-date.ndjson, log-date-1.ndjson, and so on as new files are created during rotation.]
 `/Library/Elastic/Agent/data/elastic-agent-*/logs/default/*-json.log`::
-Log files for {beats} shippers footnote:lognumbering[]
+Log files for {beats} shippersfootnote:lognumbering[]
 `/usr/bin/elastic-agent`::
 Shell wrapper installed into PATH
 


### PR DESCRIPTION
This adds a footnote to the Beats shippers section of the [Installation layout](https://www.elastic.co/guide/en/fleet/8.1/installation-layout.html#installation-layout) page, since those log file names now support date/timestamps.

Closes: [#30792](https://github.com/elastic/beats/issues/30792)