### PR TITLE
[main] Fixing content bug in step 3 notice box (#2757)

### DIFF
--- a/docs/en/observability/ingest-traces.asciidoc
+++ b/docs/en/observability/ingest-traces.asciidoc
@@ -58,8 +58,9 @@ include::./tab-widgets/add-apm-integration/widget.asciidoc[]
 == Step 3: Install and run an {agent} on your machine
 
 ****
-This step is optional for {ess} users as {ecloud} spins up an {agent} instance automatically.
-Unless you want to run a separate {agent} on an edge machine, {ess} users should skip this step.
+This step is optional for both {ess} and self-managed users as
+{ecloud} spins up an {agent} instance automatically, and self managed users installed an {agent} instance manually in Step 1.
+Unless you need to add additional {agent}s, skip this step.
 ****
 
 {agent} is a single, unified way to add monitoring for logs, metrics, and other


### PR DESCRIPTION
# Backport

This will backport the following commits from `8.6` to `main`:
 - [Fixing content bug in step 3 notice box (#2757)](https://github.com/elastic/observability-docs/pull/2757)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)