### PR TITLE
Update upgrade-elastic-agent.asciidoc

### DIFF
--- a/docs/en/ingest-management/fleet/upgrade-elastic-agent.asciidoc
+++ b/docs/en/ingest-management/fleet/upgrade-elastic-agent.asciidoc
@@ -69,7 +69,7 @@ that you can upgrade.
 image::images/upgrade-single-agent.png[Menu for upgrading a single {agent}]
 +
 The **Upgrade agent** option is grayed out if an upgrade is unavailable or
-the {kib} version is lower than the agent version.
+the {kib} version is not higher or equal than the agent version.
 
 . In the Upgrade agent window, select an upgrade version and click
 **Upgrade agent**.

--- a/docs/en/ingest-management/fleet/upgrade-elastic-agent.asciidoc
+++ b/docs/en/ingest-management/fleet/upgrade-elastic-agent.asciidoc
@@ -69,7 +69,7 @@ that you can upgrade.
 image::images/upgrade-single-agent.png[Menu for upgrading a single {agent}]
 +
 The **Upgrade agent** option is grayed out if an upgrade is unavailable or
-the {kib} version is not higher or equal than the agent version.
+the {kib} version is below or equal to the agent version.
 
 . In the Upgrade agent window, select an upgrade version and click
 **Upgrade agent**.


### PR DESCRIPTION
In the document there is written that the "Upgrade Agent" function in Fleet is grayed out if the kibana server version is lower than the Agent version. The kibana version must be higher than the agent version.

Kibana version must be higher so that option is shown. The original description is not really clear and confusing. IMHO