### PR TITLE
Add Fleet/Agent 8.7.0 release notes

### DIFF
--- a/docs/en/ingest-management/elastic-agent/configuration/autodiscovery/kubernetes-conditions-autodiscover.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/autodiscovery/kubernetes-conditions-autodiscover.asciidoc
@@ -95,10 +95,10 @@ NOTE: Pods' labels and annotations can be used in autodiscover conditions. In th
 they are defined in the pods. For example `condition: ${kubernetes.labels.app.kubernetes.io/name} == 'ingress-nginx'`. This should not be confused with the dedoted (by default) labels and annotations
 stored into Elasticsearch(<<kubernetes-provider>>).
 
-WARNING: Before 8.6 release, labels used in autodiscover conditions were dedoted in case `labels.dedot` parameter was set to `true` in Kubernetes Provider 
-configuration (by default `true`). The same did not apply for annotations. This was fixed in 8.6 release. Refer to <<release-notes-8.6.0>>.
+WARNING: Before the 8.6 release, labels used in autodiscover conditions were dedoted in case the `labels.dedot` parameter was set to `true` in Kubernetes Provider 
+configuration (by default `true`). The same did not apply for annotations. This was fixed in 8.6 release. Refer to the Release Notes section of the version 8.6.0 documentation.
 
-WARNING: In some "As a Service" Kubernetes implementations, like GKE, the control plane nodes or even the Pods running on them won’t be visible. In these cases, it won’t be possible to use scheduler metricsets, necessary for this example. Refer https://www.elastic.co/guide/en/beats/metricbeat/current/metricbeat-module-kubernetes.html#_scheduler_and_controllermanager[scheduler and controller manager] to find more information.
+WARNING: In some "As a Service" Kubernetes implementations, like GKE, the control plane nodes or even the Pods running on them won't be visible. In these cases, it won't be possible to use scheduler metricsets, necessary for this example. Refer https://www.elastic.co/guide/en/beats/metricbeat/current/metricbeat-module-kubernetes.html#_scheduler_and_controllermanager[scheduler and controller manager] to find more information.
 
 Following the Redis example, if you deploy another Redis Pod with a different port, it should be detected. To check this, go, for example, to the field `service.address` under `metrics-redis.info-default`. It should be displaying two different services.
 

--- a/docs/en/ingest-management/index.asciidoc
+++ b/docs/en/ingest-management/index.asciidoc
@@ -175,7 +175,7 @@ include::troubleshooting/troubleshooting.asciidoc[leveloffset=+2]
 
 include::troubleshooting/faq.asciidoc[leveloffset=+2]
 
-include::release-notes/release-notes-8.6.asciidoc[leveloffset=+1]
+include::release-notes/release-notes-8.7.asciidoc[leveloffset=+1]
 
 include::elastic-agent/install-fleet-managed-agent.asciidoc[leveloffset=+2]
 

--- a/docs/en/ingest-management/release-notes/release-notes-8.7.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.7.asciidoc
@@ -61,18 +61,6 @@ Do not use `/api/fleet/setup/preconfiguration`. To manage preconfigured agent po
 ====
 
 [discrete]
-[[deprecations-8.7.0]]
-=== Deprecations
-
-The following functionality is deprecated in 8.7.0, and will be removed in
-8.7.0. Deprecated functionality does not have an immediate impact on your
-application, but we strongly recommend you make the necessary updates after you
-upgrade to 8.7.0.
-
-{agent}::
-* add info
-
-[discrete]
 [[new-features-8.7.0]]
 === New features
 
@@ -89,16 +77,18 @@ The 8.7.0 release adds the following new and notable features.
 * Show dataset combo box for input packages {kibana-pull}147015[#147015]
 * Implement a new UI form to support an {agent} shipper in {fleet}  {kibana-pull}145755[#145755]
 
-
+//  {agent-pull}xxxx[#xxxx] {agent-issue}yyyy[#yyyy]
 {agent}::
-* add info
+* Add the Entity Analytics {filebeat} input to {agent} {agent-pull}2196[#2196]
+* Add the ability for the {agent} to receive a diagnostics action {agent-pull}1703[#1703] {agent-issue}1883[#1883]
 
 [discrete]
 [[enhancements-8.7.0]]
 === Enhancements
 
 {agent}::
-* add info
+* Enhance {agent} monitoring configuration to support {filebeat} `/inputs` endpoint {agent-pull}2171[#2171] {beats-issue}33953[#33953]
+* Render {agent} configuration when running `elastic-agent inspect --variables-wait` {agent-pull}2297[#2297] {agent-issue}2206[#2206]
 
 [discrete]
 [[bug-fixes-8.7.0]]
@@ -108,7 +98,15 @@ The 8.7.0 release adds the following new and notable features.
 * Accept raw errors as a fallback to detailed error type. This fixes a bug that enrollment or other operations would fail when an error was returned by Elastic in a raw string instead of JSON format. {fleet-server-pull}2079[#2079]
 
 {agent}::
-* add info
+* Correctly migrate unencrypted {fleet} configuration when upgrading from versions prior to 8.3 {agent-pull}2256[#2256] {agent-issue}2249[#2249]
+* Restore support for memcached/metrics inputs {agent-pull}2298[#2298] {agent-issue}2293[#2293]
+* Fix the log message emitted by the Upgrade Watcher when it detects a crash {agent-pull}2320[#2320]
+* Fix incorrect, temporary reporting of an agent as unhealthy during installation {agent-pull}2325[#2325] {agent-issue}2272[#2272]
+* Correct the permissions of the `state/data/tmp` and `state/data/logs` folders when {agent} is run as a container {agent-pull}2330[#2330] {agent-issue}2315[#2315]
+* Add a timer to periodically check for scheduled actions {agent-pull}2344[#2344] {agent-issue}2343[#2343]
+* Fix a bug that caused {agent} to not start monitoring new Kubernetes pods until it was restarted {agent-pull}2349[#2349] {agent-issue}2269[#2269]
+* Fix possible causes of deadlocks when {agent} shuts down {agent-pull}2352[#2352] {agent-issue}2310[#2310]
+* Fix permission issue on MacOS Ventura and above when enrolling as part of the installation {agent-pull}2314[#2314] {agent-issue}2103[#2103]
 
 // end 8.7.0 relnotes
 

--- a/docs/en/ingest-management/release-notes/release-notes-8.7.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.7.asciidoc
@@ -79,7 +79,6 @@ upgrade to 8.7.0.
 The 8.7.0 release adds the following new and notable features.
 
 {fleet}::
-* Add ability to show FQDN of agents {kibana-pull}150239[#150239]
 * Add `getStatusSummary` query parameter to `GET /api/fleet/agents` API {kibana-pull}149963[#149963]
 * Enable diagnostics feature flag and change query for files to use upload_id {kibana-pull}149575[#149575]
 * Add experimental toggles for doc-value-only {kibana-pull}149131[#149131]

--- a/docs/en/ingest-management/release-notes/release-notes-8.7.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.7.asciidoc
@@ -55,7 +55,7 @@ When you upgrade to 8.7.0, use the `/action_status` endpoint.
 *Details* +
 The `/api/fleet/setup/preconfiguration` API, which was released as generally available by error, has been removed. For more information, refer to {kibana-pull}147199[#147199].
 *Impact* +
-Do not use `/api/fleet/setup/preconfiguration`. To manage preconfigured agent policies, use kibana.yml. For more information, check link:https://www.elastic.co/guide/en/kibana/current/fleet-settings-kb.html#_preconfiguration_settings_for_advanced_use_cases[Preconfigured settings].
+Do not use `/api/fleet/setup/preconfiguration`. To manage preconfigured agent policies, use `kibana.yml`. For more information, check link:https://www.elastic.co/guide/en/kibana/current/fleet-settings-kb.html#_preconfiguration_settings_for_advanced_use_cases[Preconfigured settings].
 ====
 
 [discrete]
@@ -103,7 +103,7 @@ The 8.7.0 release adds the following new and notable features.
 === Bug fixes
 
 {fleet-server}::
-* Accept raw errors as a fallback to detailed error type. This fixes a bug that enrollment or other operatations would fail when an error was returned by Elastic in a raw string instead of JSON format {fleet-server-pull}2079[#2079]
+* Accept raw errors as a fallback to detailed error type. This fixes a bug that enrollment or other operations would fail when an error was returned by Elastic in a raw string instead of JSON format. {fleet-server-pull}2079[#2079]
 
 {agent}::
 * add info

--- a/docs/en/ingest-management/release-notes/release-notes-8.7.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.7.asciidoc
@@ -86,9 +86,10 @@ The 8.7.0 release adds the following new and notable features.
 * Display agent metrics, CPU and memory in the agent list table and agent details page {kibana-pull}149119[#149119]
 * Implement subcategories in integrations UI {kibana-pull}148894[#148894]
 * Add rollout period to upgrade action {kibana-pull}148240[#148240]
-* Add per-policy inactivity timeout + use runtime fields for agent status {kibana-pull}147552[#147552]
+* Add per-policy inactivity timeout and use runtime fields for agent status {kibana-pull}147552[#147552]
 * Show dataset combo box for input packages {kibana-pull}147015[#147015]
-* Add UI controls to setting/outputs to configure new shipper {kibana-pull}145755[#145755]
+* Implement a new UI form to support an {agent} shipper in {fleet}  {kibana-pull}145755[#145755]
+
 
 {agent}::
 * add info

--- a/docs/en/ingest-management/release-notes/release-notes-8.7.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.7.asciidoc
@@ -1,0 +1,222 @@
+// Use these for links to issue and pulls.
+:kibana-issue: https://github.com/elastic/kibana/issues/
+:kibana-pull: https://github.com/elastic/kibana/pull/
+:beats-issue: https://github.com/elastic/beats/issues/
+:beats-pull: https://github.com/elastic/beats/pull/
+:agent-libs-pull: https://github.com/elastic/elastic-agent-libs/pull/
+:agent-issue: https://github.com/elastic/elastic-agent/issues/
+:agent-pull: https://github.com/elastic/elastic-agent/pull/
+:fleet-server-issue: https://github.com/elastic/fleet-server/issues/
+:fleet-server-pull: https://github.com/elastic/fleet-server/pull/
+
+[[release-notes]]
+= Release notes
+
+This section summarizes the changes in each release.
+
+* <<release-notes-8.7.0>>
+
+Also see:
+
+* {kibana-ref}/release-notes.html[{kib} release notes]
+* {beats-ref}/release-notes.html[{beats} release notes]
+
+// begin 8.7.0 relnotes
+
+[[release-notes-8.7.0]]
+== {fleet} and {agent} 8.7.0
+
+Review important information about the {fleet} and {agent} 8.7.0 release.
+
+[discrete]
+[[breaking-changes-8.7.0]]
+=== Breaking changes
+
+Breaking changes can prevent your application from optimal operation and
+performance. Before you upgrade, review the breaking changes, then mitigate the
+impact to your application.
+
+[discrete]
+[[breaking-147616]]
+.Remove the current_upgrades endpoint
+[%collapsible]
+====
+*Details* +
+The `api/fleet/current_upgrades` endpoint has been removed. For more information, refer to {kibana-pull}147616[#147616].
+*Impact* +
+When you upgrade to 8.7.0, use the `/action_status` endpoint.
+====
+
+[discrete]
+[[breaking-147199]]
+.Remove the preconfiguration API route
+[%collapsible]
+====
+*Details* +
+The `/api/fleet/setup/preconfiguration` API, which was released as generally available by error, has been removed. For more information, refer to {kibana-pull}147199[#147199].
+*Impact* +
+Do not use `/api/fleet/setup/preconfiguration`. To manage preconfigured agent policies, use kibana.yml. For more information, check link:https://www.elastic.co/guide/en/kibana/current/fleet-settings-kb.html#_preconfiguration_settings_for_advanced_use_cases[Preconfigured settings].
+====
+
+[discrete]
+[[deprecations-8.7.0]]
+=== Deprecations
+
+The following functionality is deprecated in 8.7.0, and will be removed in
+8.7.0. Deprecated functionality does not have an immediate impact on your
+application, but we strongly recommend you make the necessary updates after you
+upgrade to 8.7.0.
+
+{agent}::
+* add info
+
+[discrete]
+[[new-features-8.7.0]]
+=== New features
+
+The 8.7.0 release adds the following new and notable features.
+
+{fleet}::
+* Add ability to show FQDN of agents {kibana-pull}150239[#150239]
+* Add `getStatusSummary` query parameter to `GET /api/fleet/agents` API {kibana-pull}149963[#149963]
+* Enable diagnostics feature flag and change query for files to use upload_id {kibana-pull}149575[#149575]
+* Add experimental toggles for doc-value-only {kibana-pull}149131[#149131]
+* Display agent metrics, CPU and memory in the agent list table and agent details page {kibana-pull}149119[#149119]
+* Implement subcategories in integrations UI {kibana-pull}148894[#148894]
+* Add rollout period to upgrade action {kibana-pull}148240[#148240]
+* Add per-policy inactivity timeout + use runtime fields for agent status {kibana-pull}147552[#147552]
+* Show dataset combo box for input packages {kibana-pull}147015[#147015]
+* Add UI controls to setting/outputs to configure new shipper {kibana-pull}145755[#145755]
+
+{agent}::
+* add info
+
+[discrete]
+[[enhancements-8.7.0]]
+=== Enhancements
+
+{agent}::
+* add info
+
+[discrete]
+[[bug-fixes-8.7.0]]
+=== Bug fixes
+
+{fleet-server}::
+* Accept raw errors as a fallback to detailed error type. This fixes a bug that enrollment or other operatations would fail when an error was returned by Elastic in a raw string instead of JSON format {fleet-server-pull}2079[#2079]
+
+{agent}::
+* add info
+
+// end 8.7.0 relnotes
+
+
+
+// ---------------------
+//TEMPLATE
+//Use the following text as a template. Remember to replace the version info.
+
+// begin 8.7.x relnotes
+
+//[[release-notes-8.7.x]]
+//== {fleet} and {agent} 8.7.x
+
+//Review important information about the {fleet} and {agent} 8.7.x release.
+
+//[discrete]
+//[[security-updates-8.7.x]]
+//=== Security updates
+
+//{fleet}::
+//* add info
+
+//{agent}::
+//* add info
+
+//[discrete]
+//[[breaking-changes-8.7.x]]
+//=== Breaking changes
+
+//Breaking changes can prevent your application from optimal operation and
+//performance. Before you upgrade, review the breaking changes, then mitigate the
+//impact to your application.
+
+//[discrete]
+//[[breaking-PR#]]
+//.Short description
+//[%collapsible]
+//====
+//*Details* +
+//<Describe new behavior.> For more information, refer to {kibana-pull}PR[#PR].
+
+//*Impact* +
+//<Describe how users should mitigate the change.> For more information, refer to {fleet-guide}/fleet-server.html[Fleet Server].
+//====
+
+//[discrete]
+//[[known-issues-8.7.x]]
+//=== Known issues
+
+//[[known-issue-issue#]]
+//.Short description
+//[%collapsible]
+//====
+
+//*Details*
+
+//<Describe known issue.>
+
+//*Impact* +
+
+//<Describe impact or workaround.>
+
+//====
+
+//[discrete]
+//[[deprecations-8.7.x]]
+//=== Deprecations
+
+//The following functionality is deprecated in 8.7.x, and will be removed in
+//8.7.x. Deprecated functionality does not have an immediate impact on your
+//application, but we strongly recommend you make the necessary updates after you
+//upgrade to 8.7.x.
+
+//{fleet}::
+//* add info
+
+//{agent}::
+//* add info
+
+//[discrete]
+//[[new-features-8.7.x]]
+//=== New features
+
+//The 8.7.x release adds the following new and notable features.
+
+//{fleet}::
+//* add info
+
+//{agent}::
+//* add info
+
+//[discrete]
+//[[enhancements-8.7.x]]
+//=== Enhancements
+
+//{fleet}::
+//* add info
+
+//{agent}::
+//* add info
+
+//[discrete]
+//[[bug-fixes-8.7.x]]
+//=== Bug fixes
+
+//{fleet}::
+//* add info
+
+//{agent}::
+//* add info
+
+// end 8.7.x relnotes

--- a/docs/en/ingest-management/release-notes/release-notes-8.7.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.7.asciidoc
@@ -55,6 +55,7 @@ When you upgrade to 8.7.0, use the `/action_status` endpoint.
 ====
 *Details* +
 The `/api/fleet/setup/preconfiguration` API, which was released as generally available by error, has been removed. For more information, refer to {kibana-pull}147199[#147199].
+
 *Impact* +
 Do not use `/api/fleet/setup/preconfiguration`. To manage preconfigured agent policies, use `kibana.yml`. For more information, check link:https://www.elastic.co/guide/en/kibana/current/fleet-settings-kb.html#_preconfiguration_settings_for_advanced_use_cases[Preconfigured settings].
 ====

--- a/docs/en/ingest-management/release-notes/release-notes-8.7.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.7.asciidoc
@@ -43,6 +43,7 @@ impact to your application.
 ====
 *Details* +
 The `api/fleet/current_upgrades` endpoint has been removed. For more information, refer to {kibana-pull}147616[#147616].
+
 *Impact* +
 When you upgrade to 8.7.0, use the `/action_status` endpoint.
 ====

--- a/docs/en/ingest-management/release-notes/release-notes-8.7.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.7.asciidoc
@@ -61,6 +61,51 @@ Do not use `/api/fleet/setup/preconfiguration`. To manage preconfigured agent po
 ====
 
 [discrete]
+[[known-issues-8.6.2]]
+=== Known issues
+
+[discrete]
+[[known-issue-issue-2066-8-6-2-2]]
+.Osquery live query results can take up to five minutes to show up in {kib}.
+[%collapsible]
+====
+*Details* +
+A known issue in {agent} may prevent live query results from being available
+in the {kib} UI even though the results have been successfully sent to {es}.
+For more information, refer to {agent-issue}2066[#2066].
+
+*Impact* +
+Be aware that the live query results shown in {kib} may be delayed by up to 5 minutes.
+====
+
+[[known-issue-2170-8-6-2-2]]
+.Adding a {fleet-server} integration to an agent results in panic if the agent was not bootstrapped with a {fleet-server}.
+[%collapsible]
+====
+
+*Details*
+
+A panic occurs because the {agent} does not have a `fleet.server` in the `fleet.enc`
+configuration file. When this happens, the agent fails with a message like:
+
+[source,shell]
+----
+panic: runtime error: invalid memory address or nil pointer dereference
+[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x557b8eeafc1d]
+goroutine 86 [running]:
+github.com/elastic/elastic-agent/internal/pkg/agent/application.FleetServerComponentModifier.func1({0xc000652f00, 0xa, 0x10}, 0x557b8fa8eb92?)
+...
+----
+
+For more information, refer to {agent-issue}2170[#2170].
+
+*Impact* +
+
+To work around this problem, uninstall the {agent} and install it again with
+{fleet-server} enabled during the bootstrap process.
+====
+
+[discrete]
 [[new-features-8.7.0]]
 === New features
 

--- a/docs/en/ingest-management/release-notes/release-notes-8.7.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.7.asciidoc
@@ -77,7 +77,6 @@ The 8.7.0 release adds the following new and notable features.
 * Show dataset combo box for input packages {kibana-pull}147015[#147015]
 * Implement a new UI form to support an {agent} shipper in {fleet}  {kibana-pull}145755[#145755]
 
-//  {agent-pull}xxxx[#xxxx] {agent-issue}yyyy[#yyyy]
 {agent}::
 * Add the Entity Analytics {filebeat} input to {agent} {agent-pull}2196[#2196]
 * Add the ability for the {agent} to receive a diagnostics action {agent-pull}1703[#1703] {agent-issue}1883[#1883]


### PR DESCRIPTION
This adds the 8.7.0 Release Notes. See [Preview page](https://observability-docs_2788.docs-preview.app.elstc.co/guide/en/fleet/master/release-notes-8.7.0.html).   ← This preview site seems not to be updating.  `¯\_(ツ)_/¯`

**Notes**:

 - Elastic Agent notes are ready. ~Elastic Agent notes are still TBD. @cmacknz will ensure that the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool) is run before release day and I'll take it from there.~
 - For Fleet Server, I used this [fragments list](https://github.com/elastic/fleet-server/tree/4854b153a3d77e898993193ad6af1b52176850d5/changelog/fragments) which contained just one fragment. If anything more should be added, please let me know.
 - The `kubernetes-conditions-autodiscover.asciidoc` file is included because it contained a broken link to the 8.6 release notes, which is fixed in this PR.

Closes: https://github.com/elastic/ingest-docs/issues/60