### PR TITLE
Update troubleshooting with file sharing tip for macOS

### DIFF
--- a/docs/en/ingest-management/troubleshooting/troubleshooting.asciidoc
+++ b/docs/en/ingest-management/troubleshooting/troubleshooting.asciidoc
@@ -601,6 +601,20 @@ to `false`, and then save the integration.
 To scale the {fleet-server} deployment, {ecloud} starts new containers or shuts down old ones when hosted {agent}s are required or no longer needed. The old {agent}s will show in the Agents list for 24 hours then automatically disappear.
 
 [discrete]
+[[mac-file-sharing]]
+== {agent} fails to enroll with {fleet-server} running on localhost.
+
+If you're testing {fleet-server} locally on a macOS system using localhost (`https://127.0.0.1:8220`) as the Host URL, you may encounter this error:
+
+[source,sh]
+----
+Error: fail to enroll: fail to execute request to fleet-server: 
+lookup My-MacBook-Pro.local: no such host
+----
+
+This can occur on newer macOS software. To resolve the problem, link:https://support.apple.com/en-ca/guide/mac-help/mh17131/mac[ensure that file sharing is enabled] on your local system.
+
+[discrete]
 [[hosted-agent-8-x-upgrade-fail]]
 == APM & {fleet} fails to upgrade to 8.x on {ecloud}
 
@@ -620,3 +634,4 @@ curl -u elastic:<password> --request POST \
   --header 'Content-Type: application/json' \
   --header 'kbn-xsrf: xyz' \
 ----
+


### PR DESCRIPTION
Updates the Fleet [troubleshooting page](https://www.elastic.co/guide/en/fleet/current/fleet-troubleshooting.html) wrt the macOS file sharing issue.

**Preview:**
![Screenshot 2023-03-27 at 2 01 45 PM](https://user-images.githubusercontent.com/41695641/228027399-67045698-ca80-4aa4-bdb8-64507578d64f.png)
