### PR TITLE
Fix references to obsolete Elastic Agent commands

### DIFF
--- a/docs/en/ingest-management/commands.asciidoc
+++ b/docs/en/ingest-management/commands.asciidoc
@@ -428,7 +428,7 @@ Show help for the `inspect` command.
 ----
 elastic-agent inspect
 elastic-agent inspect components --show-config
-elastic-agent inspect components filebeat
+elastic-agent inspect components log-default
 ----
 
 ++++

--- a/docs/en/ingest-management/commands.asciidoc
+++ b/docs/en/ingest-management/commands.asciidoc
@@ -62,9 +62,7 @@ This command is intended for debugging purposes only. The output format and stru
 
 [source,shell]
 ----
-elastic-agent diagnostics [--output <string>]
-                          [--file <string>]
-                          [--timeout <string>]
+elastic-agent diagnostics [--file <string>]
                           [--help]
                           [global-flags]
 ----
@@ -72,19 +70,8 @@ elastic-agent diagnostics [--output <string>]
 [discrete]
 === Options
 
-`--output <string>`::
-Output format. If using `collect`, specify `json` or `yaml` (the default).
-Otherwise specify `json`, `yaml`, or `human` (the default).
-
 `--file`::
-When running `collect`, specifies the output archive name. Defaults to `elastic-agent-diagnostics-<timestamp>.zip`, where the timestamp is the current time in UTC.
-+
-When running `pprof`, specifies the output file name. Defaults to `stdout`.
-
-`--timeout <string>`::
-The timeout value for the `diagnostics collect` or `diagnostics pprof` command.
-Should be longer then `pprof-duration` as the command needs to gather and process the data.
-Must be a string that can be parsed as a `time.Duration` value (default: `30s + pprof-duration`).
+Specifies the output archive name. Defaults to `elastic-agent-diagnostics-<timestamp>.zip`, where the timestamp is the current time in UTC.
 
 `--help`::
 Show help for the `diagnostics` command.

--- a/docs/en/ingest-management/elastic-agent/configuration/autodiscovery/kubernetes-conditions-autodiscover.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/autodiscovery/kubernetes-conditions-autodiscover.asciidoc
@@ -115,7 +115,7 @@ Inside the container <<elastic-agent-cmd-options, inspect the output>> of the co
 
 ["source", "sh", subs="attributes"]
 ------------------------------------------------
-elastic-agent inspect output -o default -c /etc/elastic-agent/agent.yml
+elastic-agent inspect --variables --variables-wait 1s -c /etc/elastic-agent/agent.yml
 ------------------------------------------------
 
 [%collapsible]

--- a/docs/en/ingest-management/elastic-agent/configuration/autodiscovery/kubernetes-hints-autodiscover.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/autodiscovery/kubernetes-hints-autodiscover.asciidoc
@@ -174,7 +174,7 @@ When things do not work as expected, you may need to troubleshoot your setup. He
 +
 ["source", "sh", subs="attributes"]
 ------------------------------------------------
-./elastic-agent inspect output -o default -c /etc/elastic-agent/agent.yml
+./elastic-agent inspect --variables --variables-wait 1s -c /etc/elastic-agent/agent.yml
 ------------------------------------------------
 +
 Specifically, examine how the inputs are being populated.

--- a/docs/en/ingest-management/elastic-agent/configuration/inputs/input-configuration.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/inputs/input-configuration.asciidoc
@@ -10,7 +10,7 @@ By default {agent} collects system metrics, such as CPU, memory, network, and fi
 
 ["source","yaml"]
 -----------------------------------------------------------------------
-- name: system-metrics <1>
+- id: unique-system-metrics-id <1>
   type: system/metrics <2>
   use_output: default <3>
   meta:
@@ -31,7 +31,7 @@ By default {agent} collects system metrics, such as CPU, memory, network, and fi
         - normalized_percentages
 -----------------------------------------------------------------------
 
-<1> User-defined name for the input.
+<1> A unique ID for the input.
 <2> A generic type describing the data.
 <3> The name of the `output` to use. If not specified, `default` will be used.
 <4> Package specification.

--- a/docs/en/ingest-management/elastic-agent/debug-standalone-elastic-agent.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/debug-standalone-elastic-agent.asciidoc
@@ -26,13 +26,15 @@ Returns something like:
 
 [source,yaml]
 ----
-Status: HEALTHY
-Message: (no message)
-Applications:
-  * metricbeat  (HEALTHY)
-                Running
-  * filebeat    (STOPPING)
-                (no message)
+State: HEALTHY
+Message: Running
+Fleet State: STOPPED
+Fleet Message: (no message)
+Components:
+  * log           (HEALTHY)
+                  Healthy: communicating with pid '25423'
+  * filestream    (HEALTHY)
+                  Healthy: communicating with pid '25424'
 ----
 
 By default, this command returns the status in human-readable format. Use the
@@ -204,112 +206,15 @@ Returns something like:
 [[inspect-configuration]]
 == Inspect the {agent} configuration
 
-To inspect the {agent} configuration, run the `inspect` command. For example:
+To inspect the running {agent} configuration refer to <<elastic-agent-inspect-command>>.
+
+To analyze the current state of the agent, inspect log files, and see the running configuration
+of {agent} and the sub-processes it starts, run the `diagnostics` command. For example:
 
 [source,shell]
 ----
-elastic-agent inspect
-----
-
-Use the `--output` flag to inspect the configuration passed to other processes,
-such as {filebeat}. For example:
-
-[source,shell]
-----
-elastic-agent inspect output --output default --program filebeat
-----
-
-Returns something like:
-
-["source","yaml",subs="attributes"]
-----
-[default] filebeat:
-filebeat:
-  inputs:
-  - exclude_files:
-    - .gz$
-    id: logfile-system.auth-default-system
-    index: logs-system.auth-default
-    meta:
-      package:
-        name: system
-        version: {version}
-    multiline:
-      match: after
-      pattern: ^\s
-    name: system-1
-    paths:
-    - /var/log/auth.log*
-    - /var/log/secure*
-    processors:
-    - add_locale: null
-    - add_fields:
-        fields:
-          dataset: system.auth
-          namespace: default
-          type: logs
-        target: data_stream
-    - add_fields:
-        fields:
-          dataset: system.auth
-        target: event
-    - add_fields:
-        fields:
-          id: 3c4a8f14-561a-449f-8935-7485cd494bac
-          snapshot: false
-          version: {version}
-        target: elastic_agent
-    - add_fields:
-        fields:
-          id: 3c4a8f14-561a-449f-8935-7485cd494bac
-        target: agent
-    revision: 1
-    type: log
-  - exclude_files:
-    - .gz$
-    id: logfile-system.syslog-default-system
-    index: logs-system.syslog-default
-    meta:
-      package:
-        name: system
-        version: 1.6.4
-    multiline:
-      match: after
-      pattern: ^\s
-    name: system-1
-    paths:
-    - /var/log/messages*
-    - /var/log/syslog*
-    processors:
-    - add_locale: null
-    - add_fields:
-        fields:
-          dataset: system.syslog
-          namespace: default
-          type: logs
-        target: data_stream
-    - add_fields:
-        fields:
-          dataset: system.syslog
-        target: event
-    - add_fields:
-        fields:
-          id: 3c4a8f14-561a-449f-8935-7485cd494bac
-          snapshot: false
-          version: {version}
-        target: elastic_agent
-    - add_fields:
-        fields:
-          id: 3c4a8f14-561a-449f-8935-7485cd494bac
-        target: agent
-    revision: 1
-    type: log
-output:
-  elasticsearch:
-    api_key: your:apikey
-    hosts:
-    - https://5d87573b66ed4d7f6cd1d2d3f1e30bc5.us-central1.gcp.foundit.no:443
+elastic-agent diagnostics
 ----
 
 For more information about this command, refer to
-<<elastic-agent-inspect-command>>.
+<<elastic-agent-diagnostics-command>>.

--- a/docs/en/ingest-management/elastic-agent/elastic-agent-debug-input-configs.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/elastic-agent-debug-input-configs.asciidoc
@@ -52,91 +52,81 @@ inputs:
           - /var/log/${local_dynamic.key}
 ----
 
-Then run `elastic-agent inspect` to see the generated configuration. For
+Then run `elastic-agent inspect --variables` to see the generated configuration. For
 example:
 
 // lint disable elasticsearch changeme
 [source,shell]
 ----
-$ ./elastic-agent inspect output -o default
-[default] filebeat:
-filebeat:
-  inputs:
-  - index: logs-generic-default
-    paths:
+$ ./elastic-agent inspect --variables
+inputs:
+- enabled: true
+  id: unique-logfile-id-local_dynamic-0
+  original_id: unique-logfile-id
+  processors:
+  - add_fields:
+      fields:
+        custom: match1
+      target: dynamic
+  streams:
+  - paths:
     - /var/log/value1
-    processors:
-    - add_fields:
-        fields:
-          custom: match1
-        target: dynamic
-    - add_fields:
-        fields:
-          dataset: generic
-          namespace: default
-          type: logs
-        target: data_stream
-    - add_fields:
-        fields:
-          dataset: generic
-        target: event
-    type: log
-  - index: logs-generic-default
-    paths:
+  type: logfile
+- enabled: true
+  id: unique-logfile-id-local_dynamic-1
+  original_id: unique-logfile-id
+  processors:
+  - add_fields:
+      fields:
+        custom: match2
+      target: dynamic
+  streams:
+  - paths:
     - /var/log/value2
-    processors:
-    - add_fields:
-        fields:
-          custom: match2
-        target: dynamic
-    - add_fields:
-        fields:
-          dataset: generic
-          namespace: default
-          type: logs
-        target: data_stream
-    - add_fields:
-        fields:
-          dataset: generic
-        target: event
-    type: log
-  - index: logs-generic-default
-    paths:
+  type: logfile
+- enabled: true
+  id: unique-logfile-id-local_dynamic-2
+  original_id: unique-logfile-id
+  processors:
+  - add_fields:
+      fields:
+        custom: match3
+      target: dynamic
+  streams:
+  - paths:
     - /var/log/value3
-    processors:
-    - add_fields:
-        fields:
-          custom: match3
-        target: dynamic
-    - add_fields:
-        fields:
-          dataset: generic
-          namespace: default
-          type: logs
-        target: data_stream
-    - add_fields:
-        fields:
-          dataset: generic
-        target: event
-    type: log
-output:
-  elasticsearch:
-    hosts:
-    - 127.0.0.1:9200
-    password: changeme
-    username: elastic
-
----
-[default] FLEET_MONITORING:
-output:
-  elasticsearch:
+  type: logfile
+outputs:
+  default:
     hosts:
     - 127.0.0.1:9200
     password: changeme
     type: elasticsearch
     username: elastic
-programs:
-- filebeat
+providers:
+  local_dynamic:
+    items:
+    - processors:
+      - add_fields:
+          fields:
+            custom: match1
+          target: dynamic
+      vars:
+        key: value1
+    - processors:
+      - add_fields:
+          fields:
+            custom: match2
+          target: dynamic
+      vars:
+        key: value2
+    - processors:
+      - add_fields:
+          fields:
+            custom: match3
+          target: dynamic
+      vars:
+        key: value3
 
 ---
 ----

--- a/docs/en/ingest-management/troubleshooting/troubleshooting.asciidoc
+++ b/docs/en/ingest-management/troubleshooting/troubleshooting.asciidoc
@@ -296,7 +296,7 @@ Run the following command to generate a zip archive containing diagnostics infor
 
 [source,shell]
 ----
-elastic-agent diagnostics collect
+elastic-agent diagnostics
 ----
 
 This archive collects the following information:
@@ -305,31 +305,12 @@ This archive collects the following information:
 . {beats} (and other process) version numbers and process metadata
 . Local configuration, elastic-agent policy, and the configuration that is rendered and passed to {beats} and other processes
 . {agent}'s local log files
+. {agent} and {beats} pprof profiles
 
 Note that the diagnostics bundle is intended for debugging purposes only, its structure may change between releases.
 
 IMPORTANT: The configuration files in the archive may have credentials in *plain text*.
 These will need to be manually redacted before the archive is shared.
-
-The diagnostics command is also able to collect `pprof` data in the archive if the `--pprof` flag is added when collecting the diagnostic.
-
-To collect the `pprof` data:
-
-. Enable/add `agent.monitoring.pprof.enabled: true` to `elastic-agent.yml`
-. Restart the {agent}
-
-If `agent.monitoring.http.buffer.enabled` is set to `true`, the archive will also contain recent metrics from the {agent} and {beats} processes.
-
-[source,shell]
-----
-elastic-agent diagnostics collect --pprof
-----
-
-By default this command takes a little more than 30 seconds to run because it collects 30 seconds trace and profile information from the {agent} and all underlying {beats}.
-To change the duration of the trace and profile data, set the `--pprof-duration` flag.
-
-To set the timeout value for the collection command, use the `--timeout` flag. The timeout defaults to 30 seconds + `pprof-duration`.
-Use this flag to increase the timeout if the diagnostics command times out before creating the archive.
 
 [discrete]
 [[not-installing-no-logs-in-terminal]]


### PR DESCRIPTION
We changes the available commands in 8.6 and missed a few updates in the documentation. Removes references to obsolete commands everywhere I could find them.

- Closes https://github.com/elastic/elastic-agent/issues/2400