### PR TITLE
Update elastic-agent diagnostic command files list

### DIFF
--- a/docs/en/ingest-management/commands.asciidoc
+++ b/docs/en/ingest-management/commands.asciidoc
@@ -43,7 +43,8 @@ This command produces an archive that contains:
 * pre-config.yaml - pre-configuration before variable substitution
 * variables.yaml - current variable contexts from providers
 * computed-config.yaml - configuration after variable substitution
-* components.yaml - expected computed components model from the computed-config.yaml
+* components-expected.yaml - expected computed components model from the computed-config.yaml
+* components-actual.yaml - actual running components model as reported by the runtime manager
 * state.yaml - current state information of all running components
 * goroutine.txt - goroutine dump
 * heap.txt - memory allocation of live objects


### PR DESCRIPTION
Following the merge of https://github.com/elastic/elastic-agent/pull/2380 the list of files generated by the `elastic-agent diagnostics ` command needs to be updated, This PR provides that update