### PR TITLE
Add Feature Flag page with new FQDN setting

### DIFF
--- a/docs/en/ingest-management/elastic-agent/configuration/elastic-agent-standalone-features.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/elastic-agent-standalone-features.asciidoc
@@ -26,7 +26,7 @@ You can specify the following settings in the Feature Flag section of the
 `elastic-agent.yml` config file.
 
 Fully qualified domain name (FQDN)::
-When enabled, information provided about the current host through <<host-provider,host.name>> key is in FQDN format (`somehost.example.com` rather than `somehost`). This helps you to distinguish between hosts on different domains that have similar names. With `fqdn` enabled, the fully qualified hostname allows each host to be more easily identified when viewed in {kib}.
+When enabled, information provided about the current host through the <<host-provider,host.name>> key ,in events produced by {agent}, is in FQDN format (`somehost.example.com` rather than `somehost`). This helps you to distinguish between hosts on different domains that have similar names. With `fqdn` enabled, the fully qualified hostname allows each host to be more easily identified when viewed in {kib}.
 +
 To enable fully qualified domain names set `enabled: true` for the `fqdn` setting:
 +

--- a/docs/en/ingest-management/elastic-agent/configuration/elastic-agent-standalone-features.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/elastic-agent-standalone-features.asciidoc
@@ -1,0 +1,38 @@
+[[elastic-agent-standalone-feature-flags]]
+= Configure feature flags for standalone {agent}s
+
+++++
+<titleabbrev>Feature flags</titleabbrev>
+++++
+
+include::{fleet-repo-dir}/standalone-note.asciidoc[]
+
+The Feature Flags section of the `elastic-agent.yml` config file contains settings in {agent} that are disabled by default. Having these settings behind a feature flag prevents accidentally exposing any breaking changes that might be inconsistent with the naming formats expected in your configured {agent} output.
+
+To enable any of the settings listed on this page, change the associated `enabled` flag from `false` to `true`.
+
+[source,yaml]
+----
+agent.features:
+  mysetting:
+    enabled: true
+----
+
+[discrete]
+[[elastic-agent-standalone-feature-flag-settings]]
+== Feature flag configuration settings
+
+You can specify the following settings in the Feature Flag section of the
+`elastic-agent.yml` config file.
+
+Fully qualified domain name (FQDN)::
+When enabled, information provided about the current host through <<host-provider,host.name>> key is in FQDN format (`somehost.example.com` rather than `somehost`). This helps you to distinguish between hosts on different domains that have similar names. With `fqdn` enabled, the fully qualified hostname allows each host to be more easily identified when viewed in {kib}.
++
+To enable fully qualified domain names set `enabled: true` for the `fqdn` setting:
++
+["source","yaml",subs="attributes"]
+----
+agent.features:
+  fqdn:
+    enabled: true
+----

--- a/docs/en/ingest-management/elastic-agent/configuration/elastic-agent-standalone-features.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/elastic-agent-standalone-features.asciidoc
@@ -28,6 +28,13 @@ You can specify the following settings in the Feature Flag section of the
 Fully qualified domain name (FQDN)::
 When enabled, information provided about the current host through the <<host-provider,host.name>> key, in events produced by {agent}, is in FQDN format (`somehost.example.com` rather than `somehost`). This helps you to distinguish between hosts on different domains that have similar names. With `fqdn` enabled, the fully qualified hostname allows each host to be more easily identified when viewed in {kib}.
 +
+For FQDN reporting to work as expected, the hostname of the current host must either:
++
+--
+* Have a CNAME entry defined in DNS.
+* Have one of its corresponding IP addresses respond successfully to a reverse DNS lookup.
+--
++
 To enable fully qualified domain names set `enabled: true` for the `fqdn` setting:
 +
 ["source","yaml",subs="attributes"]

--- a/docs/en/ingest-management/elastic-agent/configuration/elastic-agent-standalone-features.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/elastic-agent-standalone-features.asciidoc
@@ -7,7 +7,7 @@
 
 include::{fleet-repo-dir}/standalone-note.asciidoc[]
 
-The Feature Flags section of the elastic-agent.yml config file contains settings in {agent} that are disabled by default. These may include experimental features, changes to behaviors within {agent} or its components, or settings that could cause a breaking change. For example a setting that changes information included in events might be inconsistent with the naming pattern expected in your configured {agent} output.
+The elastic-agent.yml config file contains `Feature Flags` settings that are disabled by default. These may include experimental features, changes to behaviors within {agent} or its components, or settings that could cause a breaking change. For example a setting that changes information included in events might be inconsistent with the naming pattern expected in your configured {agent} output.
 
 To enable any of the settings listed on this page, change the associated `enabled` flag from `false` to `true`.
 

--- a/docs/en/ingest-management/elastic-agent/configuration/elastic-agent-standalone-features.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/elastic-agent-standalone-features.asciidoc
@@ -35,6 +35,8 @@ For FQDN reporting to work as expected, the hostname of the current host must ei
 * Have one of its corresponding IP addresses respond successfully to a reverse DNS lookup.
 --
 +
+If neither pre-requisite is satisfied, `host.name` continues to report the hostname of the current host as if the FQDN feature flag were not enabled.
++
 To enable fully qualified domain names set `enabled: true` for the `fqdn` setting:
 +
 ["source","yaml",subs="attributes"]

--- a/docs/en/ingest-management/elastic-agent/configuration/elastic-agent-standalone-features.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/elastic-agent-standalone-features.asciidoc
@@ -7,7 +7,7 @@
 
 include::{fleet-repo-dir}/standalone-note.asciidoc[]
 
-The Feature Flags section of the `elastic-agent.yml` config file contains settings in {agent} that are disabled by default. Having these settings behind a feature flag prevents accidentally exposing any breaking changes that might be inconsistent with the naming formats expected in your configured {agent} output.
+The Feature Flags section of the elastic-agent.yml config file contains settings in {agent} that are disabled by default. These may include experimental features, changes to behaviors within {agent} or its components, or settings that could cause a breaking change. For example a setting that changes information included in events might be inconsistent with the naming pattern expected in your configured {agent} output.
 
 To enable any of the settings listed on this page, change the associated `enabled` flag from `false` to `true`.
 

--- a/docs/en/ingest-management/elastic-agent/configuration/elastic-agent-standalone-features.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/elastic-agent-standalone-features.asciidoc
@@ -7,7 +7,7 @@
 
 include::{fleet-repo-dir}/standalone-note.asciidoc[]
 
-The elastic-agent.yml config file contains `Feature Flags` settings that are disabled by default. These may include experimental features, changes to behaviors within {agent} or its components, or settings that could cause a breaking change. For example a setting that changes information included in events might be inconsistent with the naming pattern expected in your configured {agent} output.
+The Feature Flags section of the elastic-agent.yml config file contains settings in {agent} that are disabled by default. These may include experimental features, changes to behaviors within {agent} or its components, or settings that could cause a breaking change. For example a setting that changes information included in events might be inconsistent with the naming pattern expected in your configured {agent} output.
 
 To enable any of the settings listed on this page, change the associated `enabled` flag from `false` to `true`.
 

--- a/docs/en/ingest-management/elastic-agent/configuration/elastic-agent-standalone-features.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/elastic-agent-standalone-features.asciidoc
@@ -26,7 +26,7 @@ You can specify the following settings in the Feature Flag section of the
 `elastic-agent.yml` config file.
 
 Fully qualified domain name (FQDN)::
-When enabled, information provided about the current host through the <<host-provider,host.name>> key ,in events produced by {agent}, is in FQDN format (`somehost.example.com` rather than `somehost`). This helps you to distinguish between hosts on different domains that have similar names. With `fqdn` enabled, the fully qualified hostname allows each host to be more easily identified when viewed in {kib}.
+When enabled, information provided about the current host through the <<host-provider,host.name>> key, in events produced by {agent}, is in FQDN format (`somehost.example.com` rather than `somehost`). This helps you to distinguish between hosts on different domains that have similar names. With `fqdn` enabled, the fully qualified hostname allows each host to be more easily identified when viewed in {kib}.
 +
 To enable fully qualified domain names set `enabled: true` for the `fqdn` setting:
 +

--- a/docs/en/ingest-management/index.asciidoc
+++ b/docs/en/ingest-management/index.asciidoc
@@ -155,6 +155,8 @@ include::elastic-agent/configuration/authentication/ssl-settings.asciidoc[levelo
 
 include::elastic-agent/configuration/elastic-agent-standalone-logging.asciidoc[leveloffset=+2]
 
+include::elastic-agent/configuration/elastic-agent-standalone-features.asciidoc[leveloffset=+2]
+
 include::elastic-agent/configuration/autodiscovery/elastic-agent-kubernetes-autodiscovery.asciidoc[leveloffset=+2]
 
 include::elastic-agent/configuration/autodiscovery/kubernetes-conditions-autodiscover.asciidoc[leveloffset=+3]


### PR DESCRIPTION
This updates the Standalone Elastic Agent section with a `Feature flag` page, including the new FQDN setting. 

Note: Hold off on merging until https://github.com/elastic/elastic-agent/pull/2218 is merged.

See: [preview](https://observability-docs_2817.docs-preview.app.elstc.co/guide/en/fleet/master/elastic-agent-standalone-feature-flags.html)

Rel: [#1641](https://github.com/elastic/ingest-dev/issues/1641)

