### PR TITLE
Universal Profiling: add probabilistic profiling

### DIFF
--- a/docs/en/observability/index.asciidoc
+++ b/docs/en/observability/index.asciidoc
@@ -173,6 +173,7 @@ include::profiling-advanced-configuration.asciidoc[leveloffset=+2]
 include::profiling-tag-data-query.asciidoc[leveloffset=+3]
 include::profiling-add-symbols.asciidoc[leveloffset=+3]
 include::profiling-use-a-proxy.asciidoc[leveloffset=+3]
+include::profiling-probabilistic-profiling.asciidoc[leveloffset=+3]
 
 include::profiling-upgrade.asciidoc[leveloffset=+2]
 

--- a/docs/en/observability/profiling-advanced-configuration.asciidoc
+++ b/docs/en/observability/profiling-advanced-configuration.asciidoc
@@ -9,3 +9,4 @@ See the following sections for more information:
 * <<profiling-tag-data-query, Tag data for querying>>: Tag data collected by the host-agent into multiple logical groups so they can be queried in Kibana.
 * <<profiling-add-symbols, Add symbols for native frames>>: Push symbols to your cluster so you can see function names and line numbers in traces of applications written in programming languages that compile to native code (C, C++, Rust, Go, etc.).
 * <<profiling-use-a-proxy,Use a proxy>>:  Set up an HTTP proxy if your infrastructure host-agent installation needs one to reach {ecloud}.
+* <<profiling-probabilistic-profiling, Configure probabilistic profiling>>: Configure Universal Profiling Agent to run in probabilistic profiling mode.

--- a/docs/en/observability/profiling-probabilistic-profiling.asciidoc
+++ b/docs/en/observability/profiling-probabilistic-profiling.asciidoc
@@ -3,25 +3,28 @@
 
 beta::[]
 
-Configuring probabilistic profiling is a viable option to reduce storage costs.
+Probabilistic profiling allows you to reduce storage costs by collecting a representative sample of profiling data. 
+Over time and across the Universal Profiling agent fleet, this configuration results in approximately 50% of deployed agents collecting profiles at any given time. 
+This reduces storage costs with the trade-off that profile collection is not enabled at all times on all Universal Profiling agents.
 
-The option `-probabilistic-threshold` expects an unsigned integer as argument. If set to a value
-between 1 and 99 will enable probabilistic profiling. Every probabilistic interval a random number
-between 0 and 99 is chosen. If the given probabilistic threshold is greater than this random
-number, the agent will collect profiles from this system for the duration of the interval.
+[[discrete]]
+== Configure probabilistic profiling
 
-The option `-probabilistic-interval` expects a time duration and defines the time interval for
-which probabilistic profiling will be enabled or disabled. Its default value is 1 minute.
+To configure probabilistic profiling,  set the `-probabilistic-threshold` and `probabilistic-interval` options.
 
-The following example shows how to configure the Universal Profiling Agent with a threshold of 50
-and an interval of 2 minutes and 30 seconds:
+Set the `-probabilistic-threshold` option to a unsigned integer between 1 and 99 to enable probabilistic profiling. At every probabilistic interval, a random number
+between 0 and 99 is chosen. If the probabilistic threshold that you've set is greater than this random
+number, the agent collects profiles from this system for the duration of the interval.
+
+Set the `-probabilistic-interval` option to a time duration to define the time interval for
+which probabilistic profiling is either enabled or disabled. The default value is 1 minute.
+
+[[discrete]]
+== Example
+
+The following example shows how to configure the Universal Profiling agent with a threshold of 50 and an interval of 2 minutes and 30 seconds:
 
 [source,bash]
 ----
 sudo pf-host-agent/pf-host-agent -probabilistic-threshold=50 -probabilistic-interval=2m30s ...'
 ----
-
-Over time and across the Universal Profiling Agent fleet, this configuration is expected to result
-in ~50% of deployed agents collecting profiles at any given time. This reduces storage costs by
-accepting the trade-off of not having profile collection enabled all the time on all Universal
-Profiling Agents.

--- a/docs/en/observability/profiling-probabilistic-profiling.asciidoc
+++ b/docs/en/observability/profiling-probabilistic-profiling.asciidoc
@@ -4,8 +4,8 @@
 beta::[]
 
 Probabilistic profiling allows you to reduce storage costs by collecting a representative sample of profiling data. 
-Over time and across the Universal Profiling agent fleet, this configuration results in approximately 50% of deployed agents collecting profiles at any given time. 
-This reduces storage costs with the trade-off that profile collection is not enabled at all times on all Universal Profiling agents.
+Over time and across the Profiling Host Agent fleet, this configuration results in approximately 50% of deployed agents collecting profiles at any given time.
+This reduces storage costs with the trade-off that profile collection is not enabled at all times on all Profiling Host Agent.
 
 [discrete]
 == Configure probabilistic profiling

--- a/docs/en/observability/profiling-probabilistic-profiling.asciidoc
+++ b/docs/en/observability/profiling-probabilistic-profiling.asciidoc
@@ -1,0 +1,27 @@
+[[profiling-probabilistic-profiling]]
+= Configure probabilistic profiling
+
+beta::[]
+
+Configuring probabilistic profiling is a viable option to reduce storage costs.
+
+The option `-probabilistic-threshold` expects an unsigned integer as argument. If set to a value
+between 1 and 99 will enable probabilistic profiling. Every probabilistic interval a random number
+between 0 and 99 is chosen. If the given probabilistic threshold is greater than this random
+number, the agent will collect profiles from this system for the duration of the interval.
+
+The option `-probabilistic-interval` expects a time duration and defines the time interval for
+which probabilistic profiling will be enabled or disabled. Its default value is 1 minute.
+
+The following example shows how to configure the Universal Profiling Agent with a threshold of 50
+and an interval of 2 minutes and 30 seconds:
+
+[source,bash]
+----
+sudo pf-host-agent/pf-host-agent -probabilistic-threshold=50 -probabilistic-interval=2m30s ...'
+----
+
+Over time and across the Universal Profiling Agent fleet, this configuration is expected to result
+in ~50% of deployed agents collecting profiles at any given time. This reduces storage costs by
+accepting the trade-off of not having profile collection enabled all the time on all Universal
+Profiling Agents.

--- a/docs/en/observability/profiling-probabilistic-profiling.asciidoc
+++ b/docs/en/observability/profiling-probabilistic-profiling.asciidoc
@@ -7,7 +7,7 @@ Probabilistic profiling allows you to reduce storage costs by collecting a repre
 Over time and across the Universal Profiling agent fleet, this configuration results in approximately 50% of deployed agents collecting profiles at any given time. 
 This reduces storage costs with the trade-off that profile collection is not enabled at all times on all Universal Profiling agents.
 
-[[discrete]]
+[discrete]
 == Configure probabilistic profiling
 
 To configure probabilistic profiling,  set the `-probabilistic-threshold` and `probabilistic-interval` options.
@@ -19,7 +19,7 @@ number, the agent collects profiles from this system for the duration of the int
 Set the `-probabilistic-interval` option to a time duration to define the time interval for
 which probabilistic profiling is either enabled or disabled. The default value is 1 minute.
 
-[[discrete]]
+[discrete]
 == Example
 
 The following example shows how to configure the Universal Profiling agent with a threshold of 50 and an interval of 2 minutes and 30 seconds:


### PR DESCRIPTION
We have implemented probabilistic profiling in https://github.com/elastic/prodfiler/issues/3162. This PR adds the end user facing documentation so it can be configured if required.
 
Fixes https://github.com/elastic/prodfiler/issues/3163