### PR TITLE
Update metric fields

### DIFF
--- a/docs/en/observability/monitor-infra/explore-metrics.asciidoc
+++ b/docs/en/observability/monitor-infra/explore-metrics.asciidoc
@@ -45,7 +45,7 @@ in the second row of the Metrics Explorer configuration.
 +
 4. Let's analyze some host-specific metrics. In the *of* field, delete each one of the system load metrics.
 +
-5. To explore the outbound network traffic, enter the `system.network.out.bytes` metric. This is a monotonically increasing
+5. To explore the outbound network traffic, enter the `host.network.egress.bytes` metric. This is a monotonically increasing
 value, so from the aggregation dropdown, select `Rate`.
 +
 6. Hosts have multiple network interfaces, so it is more meaningful to display one graph for each network interface.
@@ -55,7 +55,7 @@ There is now a separate graph for each network interface.
 +
 7. Let's visualize one of the graphs in {kibana-ref}/tsvb.html[TSVB]. Choose a graph, click *Actions*, and then select *Open In Visualize*.
 +
-In this visualization the max of `system.network.out.bytes` is displayed, filtered by `host.name` and `system.network.name`.
+In this visualization the max of `host.network.egress.bytes` is displayed, filtered by `host.name` and `system.network.name`.
 +
 [role="screenshot"]
 image::images/metrics-time-series.png[Time series chart]

--- a/docs/en/observability/monitor-infra/monitor-servers.asciidoc
+++ b/docs/en/observability/monitor-infra/monitor-servers.asciidoc
@@ -12,9 +12,9 @@ predefined metrics or you can add <<custom-metrics,custom metrics>>.
 
 | *Load* | Average of `system.load.5`.
 
-| *Inbound Traffic* | Derivative of the maximum of `system.network.in.bytes` scaled to a 1 second rate.
+| *Inbound Traffic* | Derivative of the maximum of `host.network.ingress.bytes` scaled to a 1 second rate.
 
-| *Outbound Traffic* | Derivative of the maximum of `system.network.out.bytes` scaled to a 1 second rate.
+| *Outbound Traffic* | Derivative of the maximum of `host.network.egress.bytes` scaled to a 1 second rate.
 
 | *Log Rate* | Derivative of the cumulative sum of the document count scaled to a 1 second rate.
 This metric relies on the same indices as the logs.
@@ -59,7 +59,7 @@ of `system.memory.actual.free`.
 For non-Linux systems, memory used is the average of `system.memory.used.bytes` and memory free is the average
 of `system.memory.free`.
 
-| *Network* | Rates of `system.network.in.bytes` and `system.network.out.bytes`.
+| *Network* | Rates of `host.network.ingress.bytes` and `host.network.egress.bytes`.
 
 | *Log Rate* | Derivative of the cumulative sum of the document count scaled to a 1 second rate.
 This metric relies on the same indices as the logs.


### PR DESCRIPTION
This PR closes [Issue 1935](https://github.com/elastic/observability-docs/issues/1935).

This PR updates replaces old metric fields (system.network.in.bytes, system.network.out.bytes) with new one (host.network.ingress.bytes, host.network.egress.bytes) in the docs. 