### PR TITLE
Update ESF publishing script version

### DIFF
--- a/docs/en/observability/aws-deploy-elastic-serverless-forwarder.asciidoc
+++ b/docs/en/observability/aws-deploy-elastic-serverless-forwarder.asciidoc
@@ -535,7 +535,7 @@ continuing-queue:
 
 A bash script for publishing the Elastic Serverless Forwarder directly to your {aws} account is available from the https://github.com/elastic/elastic-serverless-forwarder[Elastic Serverless Forwarder repository].
 
-Download the https://raw.githubusercontent.com/elastic/elastic-serverless-forwarder/lambda-v1.6.0/publish_lambda.sh[`publish_lambda.sh` script] and follow the instructions below.
+Download the https://raw.githubusercontent.com/elastic/elastic-serverless-forwarder/lambda-v1.8.0/publish_lambda.sh[`publish_lambda.sh` script] and follow the instructions below.
 
 ==== Script arguments
 [source, bash]


### PR DESCRIPTION
The current docs contain a link to an outdated version of the publishing script for ESF. In particular, the linked version does not include this commit

https://github.com/elastic/elastic-serverless-forwarder/commit/d055adc136ffba45ef847db0f3ee873c48072b55

This PR updates the link to v1.8.0 (the latest)