### PR TITLE
Set expectations for the Synthetics Recorder

### DIFF
--- a/docs/en/observability/synthetics-recorder.asciidoc
+++ b/docs/en/observability/synthetics-recorder.asciidoc
@@ -3,6 +3,8 @@
 
 beta[]
 
+IMPORTANT: As with any script recording technology, the Elastic Synthetics Recorder should be thought of as a tool to help create the main structure of the script. For simpler sites it may well be enough to have created the final script, but for more complex and dynamic sites, or to limit flakiness, some further scripting may be needed.
+
 You can use the Synthetics Recorder to <<synthetics-create-test, write a synthetic test>> by interacting with a web page and exporting journey code that reflects all the actions you took.
 
 image::images/synthetics-create-test-script-recorder.png[Elastic Synthetics Recorder after recording a journey and clicking Export]

--- a/docs/en/observability/synthetics-recorder.asciidoc
+++ b/docs/en/observability/synthetics-recorder.asciidoc
@@ -3,7 +3,7 @@
 
 beta[]
 
-IMPORTANT: As with any script recording technology, the Elastic Synthetics Recorder should be thought of as a tool to help create the main structure of the script. For simpler sites it may well be enough to have created the final script, but for more complex and dynamic sites, or to limit flakiness, some further scripting may be needed.
+IMPORTANT: As with any script recording technology, the Elastic Synthetics Recorder should be used as a tool to help create the main structure of the script. For simpler sites, you may be able to use the Synthetics Recorder's output directly to create a synthetic monitor, but for more complex and dynamic sites, or to limit flakiness, you'll likely need to edit its output before using it to create a monitor.
 
 You can use the Synthetics Recorder to <<synthetics-create-test, write a synthetic test>> by interacting with a web page and exporting journey code that reflects all the actions you took.
 


### PR DESCRIPTION
Set some expectations for how the Recorder should be considered when using.  Whilst we have https://github.com/elastic/observability-docs/issues/2818 to add a more detailed _best practice_ guide, this is to add some expectations directly in the recorder docs.