### PR TITLE
Clarify when monitors run after creation

### DIFF
--- a/docs/en/observability/synthetics-get-started-project.asciidoc
+++ b/docs/en/observability/synthetics-get-started-project.asciidoc
@@ -195,6 +195,12 @@ with the {kib} URL for the deployment from which to fetch available locations.
 [discrete]
 = View in {kib}
 
+
+[NOTE]
+====
+When a monitor has been created (and also when edited), it will not run immediately but at some point after. After the first run occurs, the monitor will then run regularly based on the frequency configured for the monitor (e.g. every 10 minutes). You can run a manual test if you want to see the results more quickly.
+====
+
 Then, go to the {synthetics-app} in {kib}. You should see your newly pushed monitors running.
 You can also go to the *Management* tab to see the monitors' configuration settings.
 

--- a/docs/en/observability/synthetics-get-started-project.asciidoc
+++ b/docs/en/observability/synthetics-get-started-project.asciidoc
@@ -198,7 +198,7 @@ with the {kib} URL for the deployment from which to fetch available locations.
 
 [NOTE]
 ====
-When a monitor is created or updated, it will not run immediately but at some point after. After the first run occurs, the monitor will begin running regularly based on the frequency configured for the monitor (for example, every 10 minutes). You can run a manual test if you want to see the results more quickly.
+When a monitor is created or updated, the first run might not occur immediately, but the time it takes for the first run to occur will be less than the monitor's configured frequency. For example, if you create a monitor and configure it to run every 10 minutes, the first run will occur within 10 minutes of being created. After the first run, the monitor will begin running regularly based on the configured frequency. You can run a manual test if you want to see the results more quickly.
 ====
 
 Then, go to the {synthetics-app} in {kib}. You should see your newly pushed monitors running.

--- a/docs/en/observability/synthetics-get-started-project.asciidoc
+++ b/docs/en/observability/synthetics-get-started-project.asciidoc
@@ -198,7 +198,7 @@ with the {kib} URL for the deployment from which to fetch available locations.
 
 [NOTE]
 ====
-When a monitor has been created (and also when edited), it will not run immediately but at some point after. After the first run occurs, the monitor will then run regularly based on the frequency configured for the monitor (e.g. every 10 minutes). You can run a manual test if you want to see the results more quickly.
+When a monitor is created or updated, it will not run immediately but at some point after. After the first run occurs, the monitor will begin running regularly based on the frequency configured for the monitor (for example, every 10 minutes). You can run a manual test if you want to see the results more quickly.
 ====
 
 Then, go to the {synthetics-app} in {kib}. You should see your newly pushed monitors running.

--- a/docs/en/observability/synthetics-get-started-ui.asciidoc
+++ b/docs/en/observability/synthetics-get-started-ui.asciidoc
@@ -132,6 +132,11 @@ Read more about available options in <<synthetics-command-reference>>.
 [[uptime-app-view-in-kibana]]
 = View in {kib}
 
+[NOTE]
+====
+When a monitor has been created (and also when edited), it will not run immediately but at some point after. After the first run occurs, the monitor will then run regularly based on the frequency configured for the monitor (e.g. every 10 minutes). You can run a manual test if you want to see the results more quickly.
+====
+
 Navigate to the {synthetics-app} in {kib}, where you can see screenshots of each run,
 set up alerts in case of test failures, and more.
 

--- a/docs/en/observability/synthetics-get-started-ui.asciidoc
+++ b/docs/en/observability/synthetics-get-started-ui.asciidoc
@@ -134,7 +134,7 @@ Read more about available options in <<synthetics-command-reference>>.
 
 [NOTE]
 ====
-When a monitor is created or updated, it will not run immediately but at some point after. After the first run occurs, the monitor will begin running regularly based on the frequency configured for the monitor (for example, every 10 minutes). You can run a manual test if you want to see the results more quickly.
+When a monitor is created or updated, the first run might not occur immediately, but the time it takes for the first run to occur will be less than the monitor's configured frequency. For example, if you create a monitor and configure it to run every 10 minutes, the first run will occur within 10 minutes of being created. After the first run, the monitor will begin running regularly based on the configured frequency. You can run a manual test if you want to see the results more quickly.
 ====
 
 Navigate to the {synthetics-app} in {kib}, where you can see screenshots of each run,

--- a/docs/en/observability/synthetics-get-started-ui.asciidoc
+++ b/docs/en/observability/synthetics-get-started-ui.asciidoc
@@ -134,7 +134,7 @@ Read more about available options in <<synthetics-command-reference>>.
 
 [NOTE]
 ====
-When a monitor has been created (and also when edited), it will not run immediately but at some point after. After the first run occurs, the monitor will then run regularly based on the frequency configured for the monitor (e.g. every 10 minutes). You can run a manual test if you want to see the results more quickly.
+When a monitor is created or updated, it will not run immediately but at some point after. After the first run occurs, the monitor will begin running regularly based on the frequency configured for the monitor (for example, every 10 minutes). You can run a manual test if you want to see the results more quickly.
 ====
 
 Navigate to the {synthetics-app} in {kib}, where you can see screenshots of each run,


### PR DESCRIPTION
We’re clarifying expectation in the UI with [kibana#155307](https://github.com/elastic/kibana/issues/155307) but this adds some details to the docs too