### PR TITLE
[DOCS] List privileges to add alerts to cases

### DIFF
--- a/docs/en/observability/grant-cases-access.asciidoc
+++ b/docs/en/observability/grant-cases-access.asciidoc
@@ -20,7 +20,7 @@ a|
 NOTE: Roles without `All` *{connectors-feature}* feature privileges cannot create, add, delete, or modify case connectors.
 
 | Give assignee access to cases
-a| `All` for the *Cases* feature under *{observability}*.
+a|`All` for the *Cases* feature under *{observability}*.
 
 NOTE: Before a user can be assigned to a case, they must log into {kib} at
 least once, which creates a user profile.
@@ -31,6 +31,11 @@ least once, which creates a user profile.
 a| `Read` for the *Cases* feature under *{observability}* with the deletion sub-feature enabled.
 
 NOTE: These privileges also enable you to delete comments and alerts from a case.
+
+| Give access to add alerts to cases
+a|
+* `All` for the *Cases* feature under *{observability}*.
+* `Read` for an *{observability}* feature that has alerts
 
 | Revoke all access to cases | `None` for the *Cases* feature under *{observability}*.
 

--- a/docs/en/observability/grant-cases-access.asciidoc
+++ b/docs/en/observability/grant-cases-access.asciidoc
@@ -20,7 +20,7 @@ a|
 NOTE: Roles without `All` *{connectors-feature}* feature privileges cannot create, add, delete, or modify case connectors.
 
 | Give assignee access to cases
-a|`All` for the *Cases* feature under *{observability}*.
+a| `All` for the *Cases* feature under *{observability}*.
 
 NOTE: Before a user can be assigned to a case, they must log into {kib} at
 least once, which creates a user profile.

--- a/docs/en/observability/grant-cases-access.asciidoc
+++ b/docs/en/observability/grant-cases-access.asciidoc
@@ -35,7 +35,7 @@ NOTE: These privileges also enable you to delete comments and alerts from a case
 | Give access to add alerts to cases
 a|
 * `All` for the *Cases* feature under *{observability}*.
-* `Read` for an *{observability}* feature that has alerts
+* `Read` for an *{observability}* feature that has alerts.
 
 | Revoke all access to cases | `None` for the *Cases* feature under *{observability}*.
 


### PR DESCRIPTION
Relates to https://github.com/elastic/kibana/issues/146864

This PR updates https://www.elastic.co/guide/en/observability/master/grant-cases-access.html to include the necessary privileges for adding alerts to cases.