### PR TITLE
Universal Profiling: add integration installation

### DIFF
--- a/docs/en/observability/profiling-get-started.asciidoc
+++ b/docs/en/observability/profiling-get-started.asciidoc
@@ -12,6 +12,7 @@ On this page, you'll learn how to configure and use Universal Profiling. This pa
 * Prerequisites to setting up Universal Profiling
 * Setting up Universal Profiling in your {ecloud} deployment
 * Installing the host-agent
+* Installing the Universal Profiling Agent integration
 
 We would appreciate feedback on your experience with this product and any other profiling pain points you may have.
 See the <<profiling-send-feedback, send feedback>> section of the troubleshooting documentation for more information.

--- a/docs/en/observability/profiling-get-started.asciidoc
+++ b/docs/en/observability/profiling-get-started.asciidoc
@@ -131,7 +131,7 @@ overwritten with the `version` parameter in the Helm values file.
 [[profiling-install-integration]]
 == Install the Universal Profiling Agent integration
 
-If you do not wish to install the host agent in standalone mode as shown in <<profiling-install-host-agent>>, you can allow the Elastic Agent to orchestrate the installation instead. You will need to install the Universal Profiling Agent integration to accomplish this.
+If you do not wish to install the host agent in standalone mode as shown in <<profiling-install-host-agent>>, you can allow the Elastic Agent to orchestrate the installation instead by using the Universal Profiling Agent integration.
 
 To install the Universal Profiling Agent integration, you need to:
 
@@ -165,7 +165,7 @@ Continue to the next section to use the information you've collected to add the 
 
 . Turn on **Display beta integrations** in the left sidebar.
 
-. In the **Search for integrations** text field, enter `Universal`.
+. In the **Search for integrations** text field, enter `Universal Profiling Agent`.
 
 . Select the **Universal Profiling Agent** card.
 

--- a/docs/en/observability/profiling-get-started.asciidoc
+++ b/docs/en/observability/profiling-get-started.asciidoc
@@ -133,34 +133,37 @@ overwritten with the `version` parameter in the Helm values file.
 
 [discrete]
 [[find-apm-configuration]]
-=== Find APM configuration
+=== Collect APM configuration information
 
-{ecloud} runs a hosted version of {integrations-server} that includes the APM integration.
+{ecloud} runs a hosted version of the {integrations-server} that includes the APM integration.
+To find your APM integration and collect the information needed to install the Universal Profiling Agent integration, follow these steps:
 
-. In {kib}, navigate to **Fleet** > **Agent policies** and select the **Elastic Cloud agent policy**.
+. Under **Management** in the {kib} left navigation, go to **Fleet → Agent policies** and select **Elastic Cloud agent policy**.
 
-. Click **Elastic APM** in the **Names** column.
+. Select **Elastic APM** from the **Name** column.
 
-. Inside the **General** > **Server configuration** section, write down the value in the **URL** field.
+. Under the *General*  heading, find the *Server configuration* section and write down the value in the *URL* field.
 
-. Inside the **Agent authorization** > **Maximum number of API keys of Agent authentication** section, write down the value in the **Secret token** field.
+. Scroll down to **Agent authorization**. Under **Maximum number of API keys of Agent authentication**, write down the value in the **Secret token** field.
+
+Continue to the next section to use the information you've collected to add the Universal Profiling Agent integration.
 
 [discrete]
 [[add-integration]]
 === Add integration
 
-. Navigate to **Management** > **Integrations**.
+. Under **Management** in the left navigation, select **Integrations**.
 
-. Toggle **Display beta integrations** to the on position in the left sidebar.
+. Turn on **Display beta integrations** in the left sidebar.
 
 . In the **Search for integrations** text field, enter `Universal`.
 
-. Click on the **Universal Profiling Agent** card.
+. Select the **Universal Profiling Agent** card.
 
 . Click **Add Universal Profiling Agent**.
 
-. Inside the **Universal Profiling Agent** > **Settings** section, add the URL from <<find-apm-configuration>> above to the **Universal Profiling collector endpoint** field.
-
-. Inside the **Universal Profiling Agent** > **Settings** section, add the secret token from <<find-apm-configuration>> above to the **Authorization** field.
+. In **Universal Profiling Agent → Settings**, add the information you collected from the  <<find-apm-configuration>> section: 
+.. Add the URL from <<find-apm-configuration>> to the **Universal Profiling collector endpoint** field.
+.. Add the secret token from <<find-apm-configuration>> to the **Authorization** field.
 
 . Click **Save and continue**.

--- a/docs/en/observability/profiling-get-started.asciidoc
+++ b/docs/en/observability/profiling-get-started.asciidoc
@@ -34,14 +34,14 @@ Before setting up Universal Profiling, make sure you meet the following requirem
 
 Universal Profiling is a system-wide profiling solution with additional support for PHP, Python, Java (or any JVM language), Go, Rust, C/C++, Node.js/V8, Ruby, and Perl.
 
-The minimum supported versions of each interpreter are: 
+The minimum supported versions of each interpreter are:
 
 * JVM/JDK: 7
-* Python: 3.6 
+* Python: 3.6
 * V8: 8.1.0
-* Perl: 5.28 
-* PHP: 7.3 
-* Ruby: 2.5 
+* Perl: 5.28
+* PHP: 7.3
+* Ruby: 2.5
 
 [discrete]
 [[profiling-prereqs-config-example]]
@@ -65,7 +65,7 @@ Even if you're profiling a smaller fleet, we recommend configuring at least two 
 
 To set up Universal Profiling on your {ecloud} deployment, you need to:
 
-- Enable the Universal Profiling app in Kibana 
+- Enable the Universal Profiling app in Kibana
 - Configure data ingestion
 
 [discrete]
@@ -85,13 +85,13 @@ After enabling Universal Profiling on your deployment for the first time, select
 [role="screenshot"]
 image::images/profiling-setup-popup.png[]
 
-Click *Set up Universal Profiling* to configure data ingestion. 
+Click *Set up Universal Profiling* to configure data ingestion.
 
 NOTE: To configure data ingestion, you need elevated privileges, typically the `elastic` user.
 
 If you're upgrading from a previous version with Universal Profiling enabled, see the <<profiling-upgrade,upgrade guide>>.
 
-IMPORTANT: When upgrading, you must remove all existing profiling data. 
+IMPORTANT: When upgrading, you must remove all existing profiling data.
 We still recommend upgrading as the latest version contains several improvements and new features.
 
 [discrete]
@@ -99,7 +99,7 @@ We still recommend upgrading as the latest version contains several improvements
 == Install the host-agent
 
 The host-agent profiles your fleet. You need to install and configure it on every machine that you want to profile.
-The host-agent needs  `root` / `CAP_SYS_ADMIN` privileges to run. 
+The host-agent needs  `root` / `CAP_SYS_ADMIN` privileges to run.
 
 After clicking *Set up Universal Profiling* in the previous step, you'll see the instructions for installing the host-agent.
 You can also find these instructions by clicking the *Add data* button in the top-right corner of the page.
@@ -126,3 +126,41 @@ https://container-library.elastic.co/r/observability/profiling-agent[Elastic con
 
 * For {k8s} deployments, the Helm chart version is already used to configure the same container image, unless
 overwritten with the `version` parameter in the Helm values file.
+
+[discrete]
+[[profiling-install-integration]]
+== Install the Universal Profiling Agent integration
+
+[discrete]
+[[find-apm-configuration]]
+=== Find APM configuration
+
+{ecloud} runs a hosted version of {integrations-server} that includes the APM integration.
+
+. In {kib}, navigate to **Fleet** > **Agent policies** and select the **Elastic Cloud agent policy**.
+
+. Click **Elastic APM** in the **Names** column.
+
+. Inside the **General** > **Server configuration** section, write down the value in the **URL** field.
+
+. Inside the **Agent authorization** > **Maximum number of API keys of Agent authentication** section, write down the value in the **Secret token** field.
+
+[discrete]
+[[add-integration]]
+=== Add integration
+
+. Navigate to **Management** > **Integrations**.
+
+. Toggle **Display beta integrations** to the on position in the left sidebar.
+
+. In the **Search for integrations** text field, enter `Universal`.
+
+. Click on the **Universal Profiling Agent** card.
+
+. Click **Add Universal Profiling Agent**.
+
+. Inside the **Universal Profiling Agent** > **Settings** section, add the URL from <<find-apm-configuration>> above to the **Universal Profiling collector endpoint** field.
+
+. Inside the **Universal Profiling Agent** > **Settings** section, add the secret token from <<find-apm-configuration>> above to the **Authorization** field.
+
+. Click **Save and continue**.

--- a/docs/en/observability/profiling-get-started.asciidoc
+++ b/docs/en/observability/profiling-get-started.asciidoc
@@ -131,6 +131,15 @@ overwritten with the `version` parameter in the Helm values file.
 [[profiling-install-integration]]
 == Install the Universal Profiling Agent integration
 
+If you do not wish to install the host agent in standalone mode as shown in <<profiling-install-host-agent>>, you can allow the Elastic Agent to orchestrate the installation instead. You will need to install the Universal Profiling Agent integration to accomplish this.
+
+To install the Universal Profiling Agent integration, you need to:
+
+. Collect relevant information from the APM configuration.
+. Use that information to add the Universal Profiling Agent integration.
+
+See the steps in the following sections for more information.
+
 [discrete]
 [[find-apm-configuration]]
 === Collect APM configuration information
@@ -162,7 +171,7 @@ Continue to the next section to use the information you've collected to add the 
 
 . Click **Add Universal Profiling Agent**.
 
-. In **Universal Profiling Agent → Settings**, add the information you collected from the  <<find-apm-configuration>> section:
+. In **Universal Profiling Agent → Settings**, add the information you collected from the <<find-apm-configuration>> section:
 .. Add the URL from <<find-apm-configuration>> to the **Universal Profiling collector endpoint** field.
 .. Add the secret token from <<find-apm-configuration>> to the **Authorization** field.
 

--- a/docs/en/observability/profiling-get-started.asciidoc
+++ b/docs/en/observability/profiling-get-started.asciidoc
@@ -162,7 +162,7 @@ Continue to the next section to use the information you've collected to add the 
 
 . Click **Add Universal Profiling Agent**.
 
-. In **Universal Profiling Agent → Settings**, add the information you collected from the  <<find-apm-configuration>> section: 
+. In **Universal Profiling Agent → Settings**, add the information you collected from the  <<find-apm-configuration>> section:
 .. Add the URL from <<find-apm-configuration>> to the **Universal Profiling collector endpoint** field.
 .. Add the secret token from <<find-apm-configuration>> to the **Authorization** field.
 


### PR DESCRIPTION
This PR adds the end user facing documentation for installing the Universal Profiling Agent integration.

Fixes elastic/prodfiler#3176