### PR TITLE
[synthetics] Document additional lightweight monitor config options

### DIFF
--- a/docs/en/observability/synthetics-reference/lightweight-config/common.asciidoc
+++ b/docs/en/observability/synthetics-reference/lightweight-config/common.asciidoc
@@ -148,7 +148,7 @@ a| One of two modes in which to run the monitor:
 *Default*: `any`
 
 *Example*:
-You're using a DNS-load balancer and want to ping every IP address for the specified hostname.
+If you're using a DNS-load balancer and want to ping every IP address for the specified hostname, you should use `all`.
 
 ////////////////////////
 ipv4

--- a/docs/en/observability/synthetics-reference/lightweight-config/common.asciidoc
+++ b/docs/en/observability/synthetics-reference/lightweight-config/common.asciidoc
@@ -135,6 +135,53 @@ tags:
 tags: ["tag one", "tag two"]
 ----
 
+////////////////////////
+mode
+////////////////////////
+| [[monitor-mode]] *`mode`*
+(`"any"` \| `"all"`)
+a| One of two modes in which to run the monitor:
+
+* `any`: The monitor pings only one IP address for a hostname.
+* `all`: The monitor pings all resolvable IPs for a hostname.
+
+*Default*: `any`
+
+*Example*:
+You're using a DNS-load balancer and want to ping every IP address for the specified hostname.
+
+////////////////////////
+ipv4
+////////////////////////
+| [[monitor-ipv4]] *`ipv4`*
+(<<synthetics-lightweight-data-bool,boolean>>)
+a|  Whether to ping using the ipv4 protocol if hostnames are configured.
+
+*Default*: `true`
+
+*Example*:
+
+[source,yaml]
+----
+ipv4: false
+----
+
+////////////////////////
+ipv6
+////////////////////////
+| [[monitor-ipv6]] *`ipv6`*
+(<<synthetics-lightweight-data-bool,boolean>>)
+a|  Whether to ping using the ipv6 protocol if hostnames are configured.
+
+*Default*: `true`
+
+*Example*:
+
+[source,yaml]
+----
+ipv6: false
+----
+
 |===
 
 :!hardbreaks-option:

--- a/docs/en/observability/synthetics-reference/lightweight-config/http.asciidoc
+++ b/docs/en/observability/synthetics-reference/lightweight-config/http.asciidoc
@@ -23,6 +23,12 @@ When this option is set to a value greater than `0`, the `monitor.ip` field will
 *Default*: `0`
 
 ////////////////////////
+proxy_headers
+////////////////////////
+| [[monitor-http-proxy_headers]] *`proxy_headers`*
+a| Additional headers to send to proxies during `CONNECT` requests.
+
+////////////////////////
 proxy_url
 ////////////////////////
 | [[monitor-http-proxy_url]] *`proxy_url`*
@@ -95,6 +101,14 @@ Set `response.include_body` to one of the options listed below.
 * `on_error`: Include the body if an error is encountered during the check. This is the default.
 * `never`: Never include the body.
 * `always`: Always include the body with checks.
+
+////////////////////////
+response.include_body_max_bytes
+////////////////////////
+*`response.include_body_max_bytes`* (<<synthetics-lightweight-data-numbers,number>>)::
+Set `response.include_body_max_bytes` to control the maximum size of the stored body contents.
++
+*Default*: `1024`
 
 ////////////////////////
 check
@@ -221,7 +235,32 @@ check.response:
       - bar
       - Bar
 ----
+
+////////////////////////
+// check.response.json
+////////////////////////
+*`json`*::: A list of expressions executed against the body when parsed as JSON.
+Body sizes must be less than or equal to 100 MiB.
+
+*`description`*:::: Description...
+
+*`expression`*:::: The following configuration shows how to check the response using
+https://github.com/PaesslerAG/gval/blob/master/README.md[gval] expressions
+when the body contains JSON:
++
+*Example*:
++
+[source,yaml]
+----
+check.response:
+  status: [200]
+  json:
+    - description: check status
+      expression: 'foo.bar == "myValue"'
+----
+
 --
+
 |===
 
 :!hardbreaks-option:

--- a/docs/en/observability/synthetics-reference/lightweight-config/http.asciidoc
+++ b/docs/en/observability/synthetics-reference/lightweight-config/http.asciidoc
@@ -105,7 +105,7 @@ Set `response.include_body` to one of the options listed below.
 ////////////////////////
 response.include_body_max_bytes
 ////////////////////////
-*`response.include_body_max_bytes`* (<<synthetics-lightweight-data-numbers,number>>)::
+*`include_body_max_bytes`* (<<synthetics-lightweight-data-numbers,number>>)::
 Set `response.include_body_max_bytes` to control the maximum size of the stored body contents.
 +
 *Default*: `1024`
@@ -242,7 +242,7 @@ check.response:
 *`json`*::: A list of expressions executed against the body when parsed as JSON.
 Body sizes must be less than or equal to 100 MiB.
 
-*`description`*:::: Description...
+*`description`*:::: A description of the check.
 
 *`expression`*:::: The following configuration shows how to check the response using
 https://github.com/PaesslerAG/gval/blob/master/README.md[gval] expressions


### PR DESCRIPTION
Closes #2843 

Documents additional lightweight monitor config options. Based on https://github.com/elastic/integrations/pull/5798, it looks like the following options were added:

* Common options:
  * [`mode`](https://observability-docs_2923.docs-preview.app.elstc.co/guide/en/observability/master/synthetics-lightweight.html#monitor-mode)
  * [`ipv4`](https://observability-docs_2923.docs-preview.app.elstc.co/guide/en/observability/master/synthetics-lightweight.html#monitor-ipv4)
  * [`ipv6`](https://observability-docs_2923.docs-preview.app.elstc.co/guide/en/observability/master/synthetics-lightweight.html#monitor-ipv6)
* HTTP-only options:
  * [`proxy_headers`](https://observability-docs_2923.docs-preview.app.elstc.co/guide/en/observability/master/synthetics-lightweight.html#monitor-http-proxy_headers)
  * [`response.include_body_max_bytes`](https://observability-docs_2923.docs-preview.app.elstc.co/guide/en/observability/master/synthetics-lightweight.html#monitor-http-response)
  * [`check.response.json`](https://observability-docs_2923.docs-preview.app.elstc.co/guide/en/observability/master/synthetics-lightweight.html#monitor-http-check) (gotta scroll down a bit)

## To do

- [x] @dominiqueclarke verify that this is a complete list of additional options
- [x] @colleenmcginnis @dominiqueclarke refine text (first draft mostly copied over from Heartbeat)

cc @paulb-elastic @andrewvc 