### PR TITLE
[synthetics] Typo fix: `module` -> `monitor`

### DIFF
--- a/docs/en/observability/synthetics-reference/lightweight-config/common.asciidoc
+++ b/docs/en/observability/synthetics-reference/lightweight-config/common.asciidoc
@@ -70,7 +70,7 @@ enabled
 ////////////////////////
 | [[monitor-enabled]] *`enabled`*
 (<<synthetics-lightweight-data-bool,boolean>>)
-a| Whether the module is enabled.
+a| Whether the monitor is enabled.
 
 *Default*: `true`
 


### PR DESCRIPTION
I missed [this comment](https://github.com/elastic/observability-docs/pull/2729#pullrequestreview-1371903211) earlier. 🙈  Thanks @vigneshshanmugam! 