### PR TITLE
[synthetics]: remove --no-headless flag from cli flags

### DIFF
--- a/docs/en/observability/synthetics-command-reference.asciidoc
+++ b/docs/en/observability/synthetics-command-reference.asciidoc
@@ -36,9 +36,6 @@ Filters journey with the given tag(s).
 One of `junit`, `default`, or `json`. Use the JUnit reporter to provide easily parsed output to CI
 servers like Jenkins.
 
-*`--no-headless`*::
-Runs with the browser in headful mode.
-
 *`--inline`*::
 Instead of reading from a file, `cat` inline scripted journeys and pipe them through `stdin`.
 For example, `cat path/to/file.js | npx @elastic/synthetics --inline`.


### PR DESCRIPTION
+ We recently removed this flag in the Synthetics agent and no longer supported. 