### PR TITLE
[Synthetics] Document the support matrix for the various Synthetics components

### DIFF
--- a/docs/en/observability/index.asciidoc
+++ b/docs/en/observability/index.asciidoc
@@ -142,6 +142,8 @@ include::synthetics-traffic-filters.asciidoc[leveloffset=+2]
 
 include::synthetics-migrate-integration.asciidoc[leveloffset=+2]
 
+include::synthetics-support-matrix.asciidoc[leveloffset=+2]
+
 // User experience
 include::user-experience.asciidoc[leveloffset=+1]
 

--- a/docs/en/observability/synthetics-support-matrix.asciidoc
+++ b/docs/en/observability/synthetics-support-matrix.asciidoc
@@ -3,36 +3,45 @@
 
 There are various components that make up the Synthetics solution, which are supported in the following configurations:
 
-* {synthetics-app}
-** GA from 8.8.0
-** For managing lightweight and browser monitors configured through the <<synthetics-get-started-ui,{synthetics-app}>>
-** Reporting for lightweight and browser monitors configured through the <<synthetics-get-started-ui,{synthetics-app}>> and/or <<synthetics-get-started-project,{project-monitors-cap}>>
-* {project-monitors-cap}
-** GA from 8.8.0
-** For managing lightweight and browser monitors configured as <<synthetics-get-started-project,{project-monitors-cap}>>
-* Elastic’s global managed testing infrastructure
-** GA from 8.8.0
-** Elastic’s infrastructure for running lightweight and browser monitors configured through the <<synthetics-get-started-ui,{synthetics-app}>> and/or <<synthetics-get-started-project,{project-monitors-cap}>>
-* {private-location}s
-** GA from 8.8.0
-** For running lightweight and browser monitors from your self-managed infrastructure
-** Relies on the Synthetics integration 1.0.0 or above
-*** Any _inline_ or _Zip URL_ monitors configured with the beta Synthetics integration prior to 1.0.0, are not supported and will stop running in the future
-** Shipped as the `elastic-agent-complete` Docker image
-* Heartbeat with Uptime
-** GA as defined in the standard https://www.elastic.co/support/matrix[Support matrix]
-** For running lightweight monitors via YML configuration running on self-managed infrastructure
-*** Browser based monitors are not supported in this configuration
-* Standalone {agent}
-** GA as defined in the standard https://www.elastic.co/support/matrix[Support matrix]
-** For running lightweight monitors via YML configuration running on self-managed infrastructure with standalone {agent}
-*** Browser based monitors are not supported in this configuration
-** Results for monitors configured in this way are be available in Uptime (not the {synthetics-app})
-* Synthetics Recorder
-** macOS - High Sierra and newer
-** Windows - Windows 10 and newer
-** Linux:
-*** Ubuntu - 14.04 and newer
-*** Fedora - 24 and newer
-*** Debian - 8 and newer
+|===
+| Component | Support
 
+| {synthetics-app}
+a| * GA from 8.8.0
+* For managing lightweight and browser monitors configured through the <<synthetics-get-started-ui,{synthetics-app}>>
+* Reporting for lightweight and browser monitors configured through the <<synthetics-get-started-ui,{synthetics-app}>> and/or <<synthetics-get-started-project,{project-monitors-cap}>>
+
+| {project-monitors-cap}
+a| * GA from 8.8.0
+* For managing lightweight and browser monitors configured as <<synthetics-get-started-project,{project-monitors-cap}>>
+
+| Elastic’s global managed testing infrastructure
+a| * GA from 8.8.0
+* Elastic’s infrastructure for running lightweight and browser monitors configured through the <<synthetics-get-started-ui,{synthetics-app}>> and/or <<synthetics-get-started-project,{project-monitors-cap}>>
+
+| * {private-location}s
+a| * GA from 8.8.0
+* For running lightweight and browser monitors from your self-managed infrastructure
+* Relies on the Synthetics integration 1.0.0 or above
+** Any _inline_ or _Zip URL_ monitors configured with the beta Synthetics integration prior to 1.0.0, are not supported and will stop running in the future
+* Shipped as the `elastic-agent-complete` Docker image
+
+| Heartbeat with Uptime
+a| * GA as defined in the standard https://www.elastic.co/support/matrix[Support matrix]
+* For running lightweight monitors via YML configuration running on self-managed infrastructure
+** Browser based monitors are not supported in this configuration
+
+| Standalone {agent}
+a| * GA as defined in the standard https://www.elastic.co/support/matrix[Support matrix]
+* For running lightweight monitors via YML configuration running on self-managed infrastructure with standalone {agent}
+** Browser based monitors are not supported in this configuration
+* Results for monitors configured in this way are be available in Uptime (not the {synthetics-app})
+
+| Synthetics Recorder
+a| * macOS - High Sierra and newer
+* Windows - Windows 10 and newer
+* Linux:
+** Ubuntu - 14.04 and newer
+** Fedora - 24 and newer
+** Debian - 8 and newer
+|===

--- a/docs/en/observability/synthetics-support-matrix.asciidoc
+++ b/docs/en/observability/synthetics-support-matrix.asciidoc
@@ -20,14 +20,14 @@ There are various components that make up the Synthetics solution, which are sup
 *** Any _inline_ or _Zip URL_ monitors configured with the beta Synthetics integration prior to 1.0.0, are not supported and will stop running in the future
 ** Shipped as the `elastic-agent-complete` Docker image
 * Heartbeat with Uptime
-** GA as defined in the standard {https://www.elastic.co/support/matrix}[Support matrix]
+** GA as defined in the standard https://www.elastic.co/support/matrix[Support matrix]
 ** For running lightweight monitors via YML configuration running on self-managed infrastructure
 *** Browser based monitors are not supported in this configuration
 * Standalone {agent}
-** GA as defined in the standard {https://www.elastic.co/support/matrix}[Support matrix]
+** GA as defined in the standard https://www.elastic.co/support/matrix[Support matrix]
 ** For running lightweight monitors via YML configuration running on self-managed infrastructure with standalone {agent}
 *** Browser based monitors are not supported in this configuration
-** Results for monitors configured in this way are be available in Uptime (not {synthetics-app})
+** Results for monitors configured in this way are be available in Uptime (not the {synthetics-app})
 * Synthetics Recorder
 ** TBC
 

--- a/docs/en/observability/synthetics-support-matrix.asciidoc
+++ b/docs/en/observability/synthetics-support-matrix.asciidoc
@@ -3,31 +3,31 @@
 
 There are various components that make up the Synthetics solution, which are supported in the following configurations:
 
-* Synthetics app (Kibana) 
+* {synthetics-app}
 ** GA from 8.8.0
-** For managing lightweight and browser monitors configured through the [Synthetics app](synthetics-get-started-ui.html)
-** Reporting for lightweight and browser monitors configured through the [Synthetics app](synthetics-get-started-ui.html) and/or [project monitors](synthetics-get-started-project.html)
-* Project Monitors
+** For managing lightweight and browser monitors configured through the <<synthetics-get-started-ui,{synthetics-app}>>
+** Reporting for lightweight and browser monitors configured through the <<synthetics-get-started-ui,{synthetics-app}>> and/or <<synthetics-get-started-project,{project-monitors-cap}>>
+* {project-monitors-cap}
 ** GA from 8.8.0
-** For managing lightweight and browser monitors configured as [project monitors](synthetics-get-started-project.html)
+** For managing lightweight and browser monitors configured as <<synthetics-get-started-project,{project-monitors-cap}>>
 * Elastic’s global managed testing infrastructure
 ** GA from 8.8.0
-** Elastic’s infrastructure for running lightweight and browser monitors configured through the [Synthetics app](synthetics-get-started-ui.html) and/or [project monitors](synthetics-get-started-project.html)
-* Private locations
+** Elastic’s infrastructure for running lightweight and browser monitors configured through the <<synthetics-get-started-ui,{synthetics-app}>> and/or <<synthetics-get-started-project,{project-monitors-cap}>>
+* {private-location}s
 ** GA from 8.8.0
 ** For running lightweight and browser monitors from your self-managed infrastructure
 ** Relies on the Synthetics integration 1.0.0 or above
 *** Any _inline_ or _Zip URL_ monitors configured with the beta Synthetics integration prior to 1.0.0, are not supported and will stop running in the future
-** Shipped as a Docker image using the [elastic-agent-complete](synthetics-private-location.html#synthetics-private-location-connect) version of the image
+** Shipped as the `elastic-agent-complete` Docker image
 * Heartbeat with Uptime
-** GA as defined in the standard [Support matrix](https://www.elastic.co/support/matrix)
+** GA as defined in the standard {https://www.elastic.co/support/matrix}[Support matrix]
 ** For running lightweight monitors via YML configuration running on self-managed infrastructure
 *** Browser based monitors are not supported in this configuration
-* Standalone Elastic Agent
-** GA as defined in the standard [Support matrix](https://www.elastic.co/support/matrix)
-** For running lightweight monitors via YML configuration running on self-managed infrastructure with standalone Elastic Agent
+* Standalone {agent}
+** GA as defined in the standard {https://www.elastic.co/support/matrix}[Support matrix]
+** For running lightweight monitors via YML configuration running on self-managed infrastructure with standalone {agent}
 *** Browser based monitors are not supported in this configuration
-** Results for monitors configured in this way are be available in Uptime (not the Synthetics app)
+** Results for monitors configured in this way are be available in Uptime (not {synthetics-app})
 * Synthetics Recorder
 ** TBC
 

--- a/docs/en/observability/synthetics-support-matrix.asciidoc
+++ b/docs/en/observability/synthetics-support-matrix.asciidoc
@@ -1,4 +1,33 @@
 [[synthetics-support-matrix]]
 = Synthetics support matrix
 
+There are various components that make up the Synthetics solution, which are supported in the following configurations:
+
+* Synthetics app (Kibana) 
+  * GA from 8.8.0
+  * For managing lightweight and browser monitors configured through the [Synthetics app](synthetics-get-started-ui.html)
+  * Reporting for lightweight and browser monitors configured through the [Synthetics app](synthetics-get-started-ui.html) and/or [project monitors](synthetics-get-started-project.html)
+* Project Monitors
+  * GA from 8.8.0
+  * For managing lightweight and browser monitors configured as [project monitors](synthetics-get-started-project.html)
+* Elastic’s global managed testing infrastructure
+  * GA from 8.8.0
+  * Elastic’s infrastructure for running lightweight and browser monitors configured through the [Synthetics app](synthetics-get-started-ui.html) and/or [project monitors](synthetics-get-started-project.html)
+* Private locations
+  * GA from 8.8.0
+  * For running lightweight and browser monitors from your self-managed infrastructure
+  * Relies on the Synthetics integration 1.0.0 or above
+    * Any _inline_ or _Zip URL_ monitors configured with the beta Synthetics integration prior to 1.0.0, are not supported and will stop running in the future
+  * Shipped as a Docker image using the [elastic-agent-complete](synthetics-private-location.html#synthetics-private-location-connect) version of the image
+* Heartbeat with Uptime
+  * GA as defined in the standard [Support matrix](https://www.elastic.co/support/matrix)
+  * For running lightweight monitors via YML configuration running on self-managed infrastructure
+    * Browser based monitors are not supported in this configuration
+* Standalone Elastic Agent
+  * GA as defined in the standard [Support matrix](https://www.elastic.co/support/matrix)
+  * For running lightweight monitors via YML configuration running on self-managed infrastructure with standalone Elastic Agent
+    * Browser based monitors are not supported in this configuration
+  * Results for monitors configured in this way are be available in Uptime (not the Synthetics app)
+* Synthetics Recorder
+  * TBC
 

--- a/docs/en/observability/synthetics-support-matrix.asciidoc
+++ b/docs/en/observability/synthetics-support-matrix.asciidoc
@@ -1,0 +1,4 @@
+[[synthetics-support-matrix]]
+= Synthetics support matrix
+
+

--- a/docs/en/observability/synthetics-support-matrix.asciidoc
+++ b/docs/en/observability/synthetics-support-matrix.asciidoc
@@ -4,30 +4,30 @@
 There are various components that make up the Synthetics solution, which are supported in the following configurations:
 
 * Synthetics app (Kibana) 
-  * GA from 8.8.0
-  * For managing lightweight and browser monitors configured through the [Synthetics app](synthetics-get-started-ui.html)
-  * Reporting for lightweight and browser monitors configured through the [Synthetics app](synthetics-get-started-ui.html) and/or [project monitors](synthetics-get-started-project.html)
+** GA from 8.8.0
+** For managing lightweight and browser monitors configured through the [Synthetics app](synthetics-get-started-ui.html)
+** Reporting for lightweight and browser monitors configured through the [Synthetics app](synthetics-get-started-ui.html) and/or [project monitors](synthetics-get-started-project.html)
 * Project Monitors
-  * GA from 8.8.0
-  * For managing lightweight and browser monitors configured as [project monitors](synthetics-get-started-project.html)
+** GA from 8.8.0
+** For managing lightweight and browser monitors configured as [project monitors](synthetics-get-started-project.html)
 * Elastic’s global managed testing infrastructure
-  * GA from 8.8.0
-  * Elastic’s infrastructure for running lightweight and browser monitors configured through the [Synthetics app](synthetics-get-started-ui.html) and/or [project monitors](synthetics-get-started-project.html)
+** GA from 8.8.0
+** Elastic’s infrastructure for running lightweight and browser monitors configured through the [Synthetics app](synthetics-get-started-ui.html) and/or [project monitors](synthetics-get-started-project.html)
 * Private locations
-  * GA from 8.8.0
-  * For running lightweight and browser monitors from your self-managed infrastructure
-  * Relies on the Synthetics integration 1.0.0 or above
-    * Any _inline_ or _Zip URL_ monitors configured with the beta Synthetics integration prior to 1.0.0, are not supported and will stop running in the future
-  * Shipped as a Docker image using the [elastic-agent-complete](synthetics-private-location.html#synthetics-private-location-connect) version of the image
+** GA from 8.8.0
+** For running lightweight and browser monitors from your self-managed infrastructure
+** Relies on the Synthetics integration 1.0.0 or above
+*** Any _inline_ or _Zip URL_ monitors configured with the beta Synthetics integration prior to 1.0.0, are not supported and will stop running in the future
+** Shipped as a Docker image using the [elastic-agent-complete](synthetics-private-location.html#synthetics-private-location-connect) version of the image
 * Heartbeat with Uptime
-  * GA as defined in the standard [Support matrix](https://www.elastic.co/support/matrix)
-  * For running lightweight monitors via YML configuration running on self-managed infrastructure
-    * Browser based monitors are not supported in this configuration
+** GA as defined in the standard [Support matrix](https://www.elastic.co/support/matrix)
+** For running lightweight monitors via YML configuration running on self-managed infrastructure
+*** Browser based monitors are not supported in this configuration
 * Standalone Elastic Agent
-  * GA as defined in the standard [Support matrix](https://www.elastic.co/support/matrix)
-  * For running lightweight monitors via YML configuration running on self-managed infrastructure with standalone Elastic Agent
-    * Browser based monitors are not supported in this configuration
-  * Results for monitors configured in this way are be available in Uptime (not the Synthetics app)
+** GA as defined in the standard [Support matrix](https://www.elastic.co/support/matrix)
+** For running lightweight monitors via YML configuration running on self-managed infrastructure with standalone Elastic Agent
+*** Browser based monitors are not supported in this configuration
+** Results for monitors configured in this way are be available in Uptime (not the Synthetics app)
 * Synthetics Recorder
-  * TBC
+** TBC
 

--- a/docs/en/observability/synthetics-support-matrix.asciidoc
+++ b/docs/en/observability/synthetics-support-matrix.asciidoc
@@ -4,44 +4,48 @@
 There are various components that make up the Synthetics solution, which are supported in the following configurations:
 
 |===
-| Component | Support
+| Product area | GA support | Details
 
-| {synthetics-app}
-a| * GA from 8.8.0
-* For managing lightweight and browser monitors configured through the <<synthetics-get-started-ui,{synthetics-app}>>
-* Reporting for lightweight and browser monitors configured through the <<synthetics-get-started-ui,{synthetics-app}>> and/or <<synthetics-get-started-project,{project-monitors-cap}>>
+| *{synthetics-app}*
+| 8.8.0 and higher
+a| * For creating and managing lightweight and browser monitors configured through the <<synthetics-get-started-ui,{synthetics-app}>>
+* For reporting for lightweight and browser monitors configured through the <<synthetics-get-started-ui,{synthetics-app}>> and/or <<synthetics-get-started-project,{project-monitors-cap}>>
 
-| {project-monitors-cap}
-a| * GA from 8.8.0
-* For managing lightweight and browser monitors configured as <<synthetics-get-started-project,{project-monitors-cap}>>
+| *{project-monitors-cap}*
+| 8.8.0 and higher
+a| For creating and managing lightweight and browser monitors configured as <<synthetics-get-started-project,{project-monitors-cap}>>
 
-| Elastic’s global managed testing infrastructure
-a| * GA from 8.8.0
-* Elastic’s infrastructure for running lightweight and browser monitors configured through the <<synthetics-get-started-ui,{synthetics-app}>> and/or <<synthetics-get-started-project,{project-monitors-cap}>>
+| *Elastic’s global managed testing infrastructure*
+| 8.8.0 and higher
+a| Elastic’s infrastructure for running lightweight and browser monitors configured through the <<synthetics-get-started-ui,{synthetics-app}>> and/or <<synthetics-get-started-project,{project-monitors-cap}>>
 
-| * {private-location}s
-a| * GA from 8.8.0
-* For running lightweight and browser monitors from your self-managed infrastructure
+| *{private-location}s*
+| 8.8.0 and higher
+a| * For running lightweight and browser monitors from your self-managed infrastructure
 * Relies on the Synthetics integration 1.0.0 or above
 ** Any _inline_ or _Zip URL_ monitors configured with the beta Synthetics integration prior to 1.0.0, are not supported and will stop running in the future
 * Shipped as the `elastic-agent-complete` Docker image
 
-| Heartbeat with Uptime
-a| * GA as defined in the standard https://www.elastic.co/support/matrix[Support matrix]
-* For running lightweight monitors via YML configuration running on self-managed infrastructure
-** Browser based monitors are not supported in this configuration
+| *Heartbeat with Uptime*
+| As defined in the standard https://www.elastic.co/support/matrix[Support matrix]
+a| * For running lightweight monitors via YML configuration running on self-managed infrastructure
+* Browser-based monitors are not supported in this configuration
 
-| Standalone {agent}
-a| * GA as defined in the standard https://www.elastic.co/support/matrix[Support matrix]
-* For running lightweight monitors via YML configuration running on self-managed infrastructure with standalone {agent}
-** Browser based monitors are not supported in this configuration
-* Results for monitors configured in this way are be available in Uptime (not the {synthetics-app})
+| *Standalone {agent}*
+| As defined in the standard https://www.elastic.co/support/matrix[Support matrix]
+a| * For running lightweight monitors via YML configuration running on self-managed infrastructure with standalone {agent}
+* Browser-based monitors are not supported in this configuration
+* Results for monitors configured using the standalone {agent} are available in the {uptime-app} (_not_ the {synthetics-app})
 
-| Synthetics Recorder
-a| * macOS - High Sierra and newer
+| *Synthetics Recorder*
+| 
+a| System requirements: 
+
+* macOS - High Sierra and newer
 * Windows - Windows 10 and newer
 * Linux:
 ** Ubuntu - 14.04 and newer
 ** Fedora - 24 and newer
 ** Debian - 8 and newer
+
 |===

--- a/docs/en/observability/synthetics-support-matrix.asciidoc
+++ b/docs/en/observability/synthetics-support-matrix.asciidoc
@@ -29,5 +29,10 @@ There are various components that make up the Synthetics solution, which are sup
 *** Browser based monitors are not supported in this configuration
 ** Results for monitors configured in this way are be available in Uptime (not the {synthetics-app})
 * Synthetics Recorder
-** TBC
+** macOS - High Sierra and newer
+** Windows - Windows 10 and newer
+** Linux:
+*** Ubuntu - 14.04 and newer
+*** Fedora - 24 and newer
+*** Debian - 8 and newer
 


### PR DESCRIPTION
Synthetics is made up of a number of product components and is run differently to some of the other Elastic solutions, and so does not really fit in with the main [Support matrix](https://www.elastic.co/support/matrix).

This PR is intended to create a support matrix page specifically for Synthetics (similar to something similar that [APM Agent](https://www.elastic.co/guide/en/apm/guide/current/agent-server-compatibility.html) has).