### PR TITLE
Universal Profiling: Add host-agent versioning information

### DIFF
--- a/docs/en/observability/profiling-get-started.asciidoc
+++ b/docs/en/observability/profiling-get-started.asciidoc
@@ -128,6 +128,9 @@ https://container-library.elastic.co/r/observability/profiling-agent[Elastic con
 * For {k8s} deployments, the Helm chart version is already used to configure the same container image, unless
 overwritten with the `version` parameter in the Helm values file.
 
+* For {stack} releases 8.8 or higher, ensure you are using `v3` host agents. For 8.7, you need to use `v2`. This is
+reflected in the instructions shown in Kibana. `v3` host agents are incompatible with 8.7 {stack} versions.
+
 [discrete]
 [[profiling-install-integration]]
 == Install the Universal Profiling Agent integration

--- a/docs/en/observability/profiling-troubleshooting.asciidoc
+++ b/docs/en/observability/profiling-troubleshooting.asciidoc
@@ -95,6 +95,14 @@ Verify that the APM server is running by navigating to *{ecloud} → Deployments
 you need to restart the APM server by clicking *Force Restart* under *Integrations Server Management*.
 +
 For non-demo workloads, verify that the Integrations Server has at least the recommended 4GB of RAM. You can check this on the Integrations Server page under *Instances*.
+* The host-agent is incompatible with the {stack} version. In this case, the following message is logged:
++
+[source,logs]
+---
+rpc error: code = FailedPrecondition desc= HostAgent version is unsupported, please upgrade to the latest version
+---
++
+Follow the host-agent deployment instructions shown in Kibana which will always be correct for the {stack} version that you are using.
 
 If you're unable to find a solution to the host-agent failure, you can raise a support request indicating `Universal Profiling` and `host-agent` as the source of the problem.
 


### PR DESCRIPTION
### Summary

- Added potential v2/v3 incompatibility in configuration notes
- Added host-agent versioning mismatch example in troubleshooting