### PR TITLE
[synthetics] Add a note about timeout types and defaults

### DIFF
--- a/docs/en/observability/synthetics-configuration.asciidoc
+++ b/docs/en/observability/synthetics-configuration.asciidoc
@@ -56,6 +56,16 @@ An object that defines any variables your tests require.
 
 For available options, see the https://playwright.dev/docs/test-configuration[Playwright documentation].
 
+[NOTE]
+====
+Playwright has two types of timeouts that are used in Elastic Synthetics:
+https://playwright.dev/docs/test-timeouts#action-and-navigation-timeouts[action and navigation timeouts].
+
+Elastic Synthetics uses a default action and navigation timeout of 50 seconds.
+You can override this default using https://playwright.dev/docs/api/class-testoptions#test-options-action-timeout[`actionTimeout`] and https://playwright.dev/docs/api/class-testoptions#test-options-navigation-timeout[`navigationTimeout`]
+in `playwrightOptions`.
+====
+
 [discrete]
 [[synthetics-config-device-emulation]]
 == Device emulation


### PR DESCRIPTION
Closes #2868 

Adds a note to the [Configure Synthetics projects](https://observability-docs_2952.docs-preview.app.elstc.co/guide/en/observability/master/synthetics-configuration.html) page about timeout types, default values, and how to change the default value in your config file. Looks like this ([preview link](https://observability-docs_2952.docs-preview.app.elstc.co/guide/en/observability/master/synthetics-configuration.html#synthetics-configuration-playwright-options)):

<img width="883" alt="Screenshot 2023-05-18 at 11 38 54 AM" src="https://github.com/elastic/observability-docs/assets/10479155/5edd851e-ecf7-466f-9f50-43e348fab14c">

## For the reviewer

@vigneshshanmugam I'm not sure if this is what you had in mind -- I'm very open to suggestions on both the language used and where this information should go in the existing docs! 