### PR TITLE
Remove Beats dependency

### DIFF
--- a/docs/en/observability/index.asciidoc
+++ b/docs/en/observability/index.asciidoc
@@ -24,7 +24,6 @@ include::{docs-root}/shared/attributes.asciidoc[]
 :tab-widgets: {fleet-repo-dir}/tab-widgets
 
 :apm-repo-dir:         {apm-server-root}/docs
-:beats-repo-dir:       {beats-root}/libbeat/docs
 :shared:               {observability-docs-root}/docs/en/shared
 :kibana-repo-dir:      {kibana-root}/docs
 

--- a/docs/en/observability/monitor-java-app.asciidoc
+++ b/docs/en/observability/monitor-java-app.asciidoc
@@ -419,7 +419,7 @@ The log entries are ingested containing timestamps like the following.
 To read the log file and send it to {es}, {filebeat} is required. To download and install {filebeat},
 use the commands that work with your system:
 
-include::{beats-repo-dir}/tab-widgets/install-widget-filebeat.asciidoc[]
+include::{shared}/copied-from-beats/install-filebeat/install-widget-filebeat.asciidoc[]
 
 . Use the {filebeat} keystore to store {filebeat-ref}/keystore.html[secure
 settings]. Let’s store the Cloud ID in the keystore.
@@ -515,7 +515,7 @@ output.elasticsearch:
 
 To send data to {es}, start {filebeat}.
 
-include::{beats-repo-dir}/tab-widgets/start-widget-filebeat.asciidoc[]
+include::{shared}/copied-from-beats/start-filebeat/start-widget-filebeat.asciidoc[]
 
 In the log output, you should see the following line.
 
@@ -1231,7 +1231,7 @@ standard Prometheus format.
 To send metrics to {es}, {metricbeat} is required. To download and install {metricbeat},
 use the commands that work with your system:
 
-include::{beats-repo-dir}/tab-widgets/install-widget-metricbeat.asciidoc[]
+include::{shared}/copied-from-beats/install-metricbeat/install-widget-metricbeat.asciidoc[]
 
 . Similar to the {filebeat} setup, run the initial set up of all the dashboards
 using the admin user, and then use an API key.
@@ -1321,7 +1321,7 @@ password to the keystore and refer to both in the configuration.
 
 . Start {metricbeat}.
 
-include::{beats-repo-dir}/tab-widgets/start-widget-metricbeat.asciidoc[]
+include::{shared}/copied-from-beats/start-metricbeat/start-widget-metricbeat.asciidoc[]
 
 Verify that the Prometheus events are flowing into
 {es}.
@@ -1986,7 +1986,7 @@ of a service, but also graph latencies over time, and get notified about expirin
 To send uptime data to {es}, {heartbeat} (the polling component) is required. To download
 and install {heartbeat}, use the commands that work with your system:
 
-include::{beats-repo-dir}/tab-widgets/install-widget-heartbeat.asciidoc[]
+include::{shared}/copied-from-beats/install-heartbeat/install-widget-heartbeat.asciidoc[]
 
 After downloading and unpacking, we have to set up the cloud id and the
 password one more time.
@@ -2063,7 +2063,7 @@ processors:
 +
 . Now start {heartbeat} and wait a couple of minutes to get some data.
 
-include::{beats-repo-dir}/tab-widgets/start-widget-heartbeat.asciidoc[]
+include::{shared}/copied-from-beats/start-heartbeat/start-widget-heartbeat.asciidoc[]
 
 To view the {uptime-app},
 select *{observability}* -> *Uptime*. The overview looks

--- a/docs/en/observability/troubleshoot-uptime-mapping-issues.asciidoc
+++ b/docs/en/observability/troubleshoot-uptime-mapping-issues.asciidoc
@@ -10,10 +10,10 @@
 There are situations in which {heartbeat} data can be indexed without the correct mappings applied.
 These situations cannot occur with the {elastic-agent} configured via {fleet}, only with standalone {heartbeat} or {elastic-agent} running in standalone mode.
 This can occur when the underlying `heartbeat-VERSION` {ilm-init} alias is deleted manually or when {heartbeat} writes data
-through an intermediary such as {ls} without the `setup` command being run. 
+through an intermediary such as {ls} without the `setup` command being run.
 When running {elastic-agent} in standalone mode this can happen if manually setup data streams have incorrect mappings.
 
-To fix this problem, you typically need to remove your {heartbeat} indices and data streams. 
+To fix this problem, you typically need to remove your {heartbeat} indices and data streams.
 Then you must create new ones with the appropriate mappings installed. To achieve this, follow the steps below.
 
 [discrete]
@@ -37,12 +37,12 @@ If using {elastic-agent} you will want to fix any issues with custom data stream
 
 The below command will cause {heartbeat} to perform its setup processes and recreate the index template properly.
 
-NOTE: For more information on how to use this command, you can reference the
-{heartbeat-ref}/heartbeat-installation-configuration.html[{heartbeat} quickstart guide].
+[source,bash]
+----
+./heartbeat setup -e
+----
 
---
-include::{beats-repo-dir}/tab-widgets/setup-widget.asciidoc[]
---
+For more information on how to use this command, or if you're using DEB, RPM, or Windows, see the {heartbeat-ref}/heartbeat-installation-configuration.html[{heartbeat} quickstart guide].
 
 This command performs the necessary startup tasks and ensures that your indices have the appropriate mapping going forward.
 

--- a/docs/en/shared/copied-from-beats/install-filebeat/install-widget-filebeat.asciidoc
+++ b/docs/en/shared/copied-from-beats/install-filebeat/install-widget-filebeat.asciidoc
@@ -1,0 +1,96 @@
+:beatname_uc: Filebeat
+:beatname_lc: filebeat
+++++
+<div class="tabs" data-tab-group="os">
+  <div role="tablist" aria-label="Install-f">
+    <button role="tab"
+            aria-selected="true"
+            aria-controls="deb-tab-install-filebeat"
+            id="deb-install-filebeat">
+      DEB
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="rpm-tab-install-filebeat"
+            id="rpm-install-filebeat"
+            tabindex="-1">
+      RPM
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="mac-tab-install-filebeat"
+            id="mac-install-filebeat"
+            tabindex="-1">
+      MacOS
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="linux-tab-install-filebeat"
+            id="linux-install-filebeat"
+            tabindex="-1">
+      Linux
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="win-tab-install-filebeat"
+            id="win-install-filebeat"
+            tabindex="-1">
+      Windows
+    </button>
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="deb-tab-install-filebeat"
+       aria-labelledby="deb-install-filebeat">
+++++
+
+include::../shared/install.asciidoc[tag=deb]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="rpm-tab-install-filebeat"
+       aria-labelledby="rpm-install-filebeat"
+       hidden="">
+++++
+
+include::../shared/install.asciidoc[tag=rpm]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="mac-tab-install-filebeat"
+       aria-labelledby="mac-install-filebeat"
+       hidden="">
+++++
+
+include::../shared/install.asciidoc[tag=mac]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="linux-tab-install-filebeat"
+       aria-labelledby="linux-install-filebeat"
+       hidden="">
+++++
+
+include::../shared/install.asciidoc[tag=linux]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="win-tab-install-filebeat"
+       aria-labelledby="win-install-filebeat"
+       hidden="">
+++++
+
+include::../shared/install.asciidoc[tag=win]
+
+++++
+  </div>
+</div>
+++++

--- a/docs/en/shared/copied-from-beats/install-heartbeat/install-widget-heartbeat.asciidoc
+++ b/docs/en/shared/copied-from-beats/install-heartbeat/install-widget-heartbeat.asciidoc
@@ -1,0 +1,96 @@
+:beatname_uc: Heartbeat
+:beatname_lc: heartbeat
+++++
+<div class="tabs" data-tab-group="os">
+  <div role="tablist" aria-label="Install-h">
+    <button role="tab"
+            aria-selected="true"
+            aria-controls="deb-tab-install-heartbeat"
+            id="deb-install-heartbeat">
+      DEB
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="rpm-tab-install-heartbeat"
+            id="rpm-install-heartbeat"
+            tabindex="-1">
+      RPM
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="mac-tab-install-heartbeat"
+            id="mac-install-heartbeat"
+            tabindex="-1">
+      MacOS
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="linux-tab-install-heartbeat"
+            id="linux-install-heartbeat"
+            tabindex="-1">
+      Linux
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="win-tab-install-heartbeat"
+            id="win-install-heartbeat"
+            tabindex="-1">
+      Windows
+    </button>
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="deb-tab-install-heartbeat"
+       aria-labelledby="deb-install-heartbeat">
+++++
+
+include::../shared/install.asciidoc[tag=deb]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="rpm-tab-install-heartbeat"
+       aria-labelledby="rpm-install-heartbeat"
+       hidden="">
+++++
+
+include::../shared/install.asciidoc[tag=rpm]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="mac-tab-install-heartbeat"
+       aria-labelledby="mac-install-heartbeat"
+       hidden="">
+++++
+
+include::../shared/install.asciidoc[tag=mac]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="linux-tab-install-heartbeat"
+       aria-labelledby="linux-install-heartbeat"
+       hidden="">
+++++
+
+include::../shared/install.asciidoc[tag=linux]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="win-tab-install-heartbeat"
+       aria-labelledby="win-install-heartbeat"
+       hidden="">
+++++
+
+include::../shared/install.asciidoc[tag=win]
+
+++++
+  </div>
+</div>
+++++

--- a/docs/en/shared/copied-from-beats/install-metricbeat/install-widget-metricbeat.asciidoc
+++ b/docs/en/shared/copied-from-beats/install-metricbeat/install-widget-metricbeat.asciidoc
@@ -1,0 +1,96 @@
+:beatname_uc: Metricbeat
+:beatname_lc: metricbeat
+++++
+<div class="tabs" data-tab-group="os">
+  <div role="tablist" aria-label="Install-m">
+    <button role="tab"
+            aria-selected="true"
+            aria-controls="deb-tab-install-metricbeat"
+            id="deb-install-metricbeat">
+      DEB
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="rpm-tab-install-metricbeat"
+            id="rpm-install-metricbeat"
+            tabindex="-1">
+      RPM
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="mac-tab-install-metricbeat"
+            id="mac-install-metricbeat"
+            tabindex="-1">
+      MacOS
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="linux-tab-install-metricbeat"
+            id="linux-install-metricbeat"
+            tabindex="-1">
+      Linux
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="win-tab-install-metricbeat"
+            id="win-install-metricbeat"
+            tabindex="-1">
+      Windows
+    </button>
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="deb-tab-install-metricbeat"
+       aria-labelledby="deb-install-metricbeat">
+++++
+
+include::../shared/install.asciidoc[tag=deb]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="rpm-tab-install-metricbeat"
+       aria-labelledby="rpm-install-metricbeat"
+       hidden="">
+++++
+
+include::../shared/install.asciidoc[tag=rpm]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="mac-tab-install-metricbeat"
+       aria-labelledby="mac-install-metricbeat"
+       hidden="">
+++++
+
+include::../shared/install.asciidoc[tag=mac]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="linux-tab-install-metricbeat"
+       aria-labelledby="linux-install-metricbeat"
+       hidden="">
+++++
+
+include::../shared/install.asciidoc[tag=linux]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="win-tab-install-metricbeat"
+       aria-labelledby="win-install-metricbeat"
+       hidden="">
+++++
+
+include::../shared/install.asciidoc[tag=win]
+
+++++
+  </div>
+</div>
+++++

--- a/docs/en/shared/copied-from-beats/shared/install.asciidoc
+++ b/docs/en/shared/copied-from-beats/shared/install.asciidoc
@@ -1,0 +1,124 @@
+// tag::deb[]
+ifeval::["{release-state}"=="unreleased"]
+
+Version {version} of {beatname_uc} has not yet been released.
+
+endif::[]
+
+ifeval::["{release-state}"!="unreleased"]
+
+["source","sh",subs="attributes"]
+------------------------------------------------
+curl -L -O https://artifacts.elastic.co/downloads/beats/{beatname_lc}/{beatname_lc}-{version}-amd64.deb
+sudo dpkg -i {beatname_lc}-{version}-amd64.deb
+------------------------------------------------
+
+endif::[]
+// end::deb[]
+
+// tag::rpm[]
+ifeval::["{release-state}"=="unreleased"]
+
+Version {version} of {beatname_uc} has not yet been released.
+
+endif::[]
+
+ifeval::["{release-state}"!="unreleased"]
+
+["source","sh",subs="attributes"]
+------------------------------------------------
+curl -L -O https://artifacts.elastic.co/downloads/beats/{beatname_lc}/{beatname_lc}-{version}-x86_64.rpm
+sudo rpm -vi {beatname_lc}-{version}-x86_64.rpm
+------------------------------------------------
+
+endif::[]
+// end::rpm[]
+
+// tag::mac[]
+ifeval::["{release-state}"=="unreleased"]
+
+Version {version} of {beatname_uc} has not yet been released.
+
+endif::[]
+
+ifeval::["{release-state}"!="unreleased"]
+
+["source","sh",subs="attributes"]
+------------------------------------------------
+curl -L -O https://artifacts.elastic.co/downloads/beats/{beatname_lc}/{beatname_lc}-{version}-darwin-x86_64.tar.gz
+tar xzvf {beatname_lc}-{version}-darwin-x86_64.tar.gz
+------------------------------------------------
+
+endif::[]
+// end::mac[]
+
+// tag::linux[]
+ifeval::["{release-state}"=="unreleased"]
+
+Version {version} of {beatname_uc} has not yet been released.
+
+endif::[]
+
+ifeval::["{release-state}"!="unreleased"]
+
+["source","sh",subs="attributes"]
+------------------------------------------------
+curl -L -O https://artifacts.elastic.co/downloads/beats/{beatname_lc}/{beatname_lc}-{version}-linux-x86_64.tar.gz
+tar xzvf {beatname_lc}-{version}-linux-x86_64.tar.gz
+------------------------------------------------
+
+endif::[]
+// end::linux[]
+
+// tag::win[]
+ifeval::["{release-state}"=="unreleased"]
+
+Version {version} of {beatname_uc} has not yet been released.
+
+endif::[]
+
+ifeval::["{release-state}"!="unreleased"]
+
+. Download the {beatname_uc} Windows zip file from the
+https://www.elastic.co/downloads/beats/{beatname_lc}[downloads page].
+
+. Extract the contents of the zip file into `C:\Program Files`.
+
+. Rename the +{beatname_lc}-<version>-windows+ directory to +{beatname_uc}+.
+
+. Open a PowerShell prompt as an Administrator (right-click the PowerShell icon
+and select *Run As Administrator*).
+
+. From the PowerShell prompt, run the following commands to install
+{beatname_uc} as a Windows service:
++
+["source","sh",subs="attributes"]
+----------------------------------------------------------------------
+PS > cd 'C:{backslash}Program Files{backslash}{beatname_uc}'
+PS C:{backslash}Program Files{backslash}{beatname_uc}> .{backslash}install-service-{beatname_lc}.ps1
+----------------------------------------------------------------------
+
+NOTE: If script execution is disabled on your system, you need to set the
+execution policy for the current session to allow the script to run. For
+example:
++PowerShell.exe -ExecutionPolicy UnRestricted -File .\install-service-{beatname_lc}.ps1+.
+
+endif::[]
+// end::win[]
+
+// tag::win-short[]
+ifeval::["{release-state}"=="unreleased"]
+
+Version {version} of {beatname_uc} has not yet been released.
+
+endif::[]
+
+ifeval::["{release-state}"!="unreleased"]
+
+. Download the {beatname_uc} Windows zip file from the
+https://www.elastic.co/downloads/beats/{beatname_lc}[downloads page].
+
+. Extract the contents of the zip file into `C:\Program Files`.
+
+endif::[]
+// end::win-short[]

--- a/docs/en/shared/copied-from-beats/shared/start.asciidoc
+++ b/docs/en/shared/copied-from-beats/shared/start.asciidoc
@@ -1,0 +1,99 @@
+// tag::deb[]
+
+:beatname_url: {beats-ref-root}/{beatname_lc}/{branch}
+
+["source","sh",subs="attributes"]
+----------------------------------------------------------------------
+sudo service {beatname_pkg} start
+----------------------------------------------------------------------
+
+// tag::initd-note[]
+NOTE: If you use an `init.d` script to start {beatname_uc}, you can't specify command
+line flags (see {beatname_url}/command-line-options.html[Command reference]). To specify flags, start {beatname_uc} in
+the foreground.
+
+// end::initd-note[]
+
+Also see {beatname_url}/running-with-systemd.html[{beatname_uc} and systemd].
+// end::deb[]
+
+// tag::rpm[]
+["source","sh",subs="attributes"]
+----------------------------------------------------------------------
+sudo service {beatname_pkg} start
+----------------------------------------------------------------------
+
+include::start.asciidoc[tag=initd-note]
+
+Also see {beatname_url}/running-with-systemd.html[{beatname_uc} and systemd].
+
+// end::rpm[]
+
+// tag::mac[]
+ifndef::has_modules_command[]
+["source","sh",subs="attributes,callouts"]
+----------------------------------------------------------------------
+sudo chown root {beatname_lc}.yml <1>
+sudo ./{beatname_lc} -e
+----------------------------------------------------------------------
+<1> You'll be running {beatname_uc} as root, so you need to change ownership
+of the configuration file, or run {beatname_uc} with `--strict.perms=false`
+specified. See
+{beats-ref}/config-file-permissions.html[Config File Ownership and Permissions].
+endif::has_modules_command[]
+ifdef::has_modules_command[]
+["source","sh",subs="attributes,callouts"]
+----------------------------------------------------------------------
+sudo chown root {beatname_lc}.yml <1>
+sudo chown root modules.d/{modulename}.yml <1>
+sudo ./{beatname_lc} -e
+----------------------------------------------------------------------
+<1> You'll be running {beatname_uc} as root, so you need to change ownership of the
+configuration file and any configurations enabled in the `modules.d` directory,
+or run {beatname_uc} with `--strict.perms=false` specified. See
+{beats-ref}/config-file-permissions.html[Config File Ownership and Permissions].
+endif::has_modules_command[]
+// end::mac[]
+
+// tag::linux[]
+
+ifndef::has_modules_command[]
+["source","sh",subs="attributes,callouts"]
+----------------------------------------------------------------------
+sudo chown root {beatname_lc}.yml <1>
+sudo ./{beatname_lc} -e
+----------------------------------------------------------------------
+<1> You'll be running {beatname_uc} as root, so you need to change ownership
+of the configuration file, or run {beatname_uc} with `--strict.perms=false`
+specified. See
+{beats-ref}/config-file-permissions.html[Config File Ownership and Permissions].
+endif::has_modules_command[]
+ifdef::has_modules_command[]
+["source","sh",subs="attributes,callouts"]
+----------------------------------------------------------------------
+sudo chown root {beatname_lc}.yml <1>
+sudo chown root modules.d/{modulename}.yml <1>
+sudo ./{beatname_lc} -e
+----------------------------------------------------------------------
+<1> You'll be running {beatname_uc} as root, so you need to change ownership of the
+configuration file and any configurations enabled in the `modules.d` directory,
+or run {beatname_uc} with `--strict.perms=false` specified. See
+{beats-ref}/config-file-permissions.html[Config File Ownership and Permissions].
+endif::has_modules_command[]
+
+// end::linux[]
+
+// tag::win[]
+["source","sh",subs="attributes"]
+----------------------------------------------------------------------
+PS C:{backslash}Program Files{backslash}{beatname_lc}> Start-Service {beatname_lc}
+----------------------------------------------------------------------
+
+By default, Windows log files are stored in +C:{backslash}ProgramData{backslash}{beatname_lc}\Logs+.
+
+ifeval::["{beatname_lc}"=="metricbeat"]
+NOTE: On Windows, statistics about system load and swap usage are currently
+not captured
+endif::[]
+
+// end::win[]

--- a/docs/en/shared/copied-from-beats/start-filebeat/start-filebeat.asciidoc
+++ b/docs/en/shared/copied-from-beats/start-filebeat/start-filebeat.asciidoc
@@ -1,0 +1,56 @@
+// tag::deb[]
+
+:beatname_url: {beats-ref-root}/{beatname_lc}/{branch}
+
+["source","sh",subs="attributes"]
+----
+sudo service {beatname_pkg} start
+----
+
+// tag::initd-note[]
+NOTE: If you use an `init.d` script to start {beatname_uc}, you can't specify command
+line flags (see {beatname_url}/command-line-options.html[Command reference]). To specify flags, start {beatname_uc} in
+the foreground.
+
+// end::initd-note[]
+
+Also see {beatname_url}/running-with-systemd.html[{beatname_uc} and systemd].
+// end::deb[]
+
+// tag::rpm[]
+["source","sh",subs="attributes"]
+----
+sudo service {beatname_pkg} start
+----
+
+include::../shared/start.asciidoc[tag=initd-note]
+
+Also see {beatname_url}/running-with-systemd.html[{beatname_uc} and systemd].
+
+// end::rpm[]
+
+// tag::mac[]
+["source","sh",subs="attributes,callouts"]
+----
+./{beatname_lc} -e
+----
+// end::mac[]
+
+// tag::linux[]
+
+["source","sh",subs="attributes,callouts"]
+----
+./{beatname_lc} -e
+----
+
+// end::linux[]
+
+// tag::win[]
+["source","sh",subs="attributes"]
+----
+PS C:{backslash}Program Files{backslash}{beatname_lc}> Start-Service {beatname_lc}
+----
+
+By default, Windows log files are stored in +C:{backslash}ProgramData{backslash}{beatname_lc}\Logs+.
+
+// end::win[]

--- a/docs/en/shared/copied-from-beats/start-filebeat/start-widget-filebeat.asciidoc
+++ b/docs/en/shared/copied-from-beats/start-filebeat/start-widget-filebeat.asciidoc
@@ -1,0 +1,97 @@
+:beatname_uc: Filebeat
+:beatname_lc: filebeat
+:beatname_pkg: filebeat
+++++
+<div class="tabs" data-tab-group="os">
+  <div role="tablist" aria-label="Start-f">
+    <button role="tab"
+            aria-selected="true"
+            aria-controls="deb-tab-start-filebeat"
+            id="deb-start-filebeat">
+      DEB
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="rpm-tab-start-filebeat"
+            id="rpm-start-filebeat"
+            tabindex="-1">
+      RPM
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="mac-tab-start-filebeat"
+            id="mac-start-filebeat"
+            tabindex="-1">
+      MacOS
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="linux-tab-start-filebeat"
+            id="linux-start-filebeat"
+            tabindex="-1">
+      Linux
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="win-tab-start-filebeat"
+            id="win-start-filebeat"
+            tabindex="-1">
+      Windows
+    </button>
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="deb-tab-start-filebeat"
+       aria-labelledby="deb-start-filebeat">
+++++
+
+include::start-filebeat.asciidoc[tag=deb]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="rpm-tab-start-filebeat"
+       aria-labelledby="rpm-start-filebeat"
+       hidden="">
+++++
+
+include::start-filebeat.asciidoc[tag=rpm]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="mac-tab-start-filebeat"
+       aria-labelledby="mac-start-filebeat"
+       hidden="">
+++++
+
+include::start-filebeat.asciidoc[tag=mac]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="linux-tab-start-filebeat"
+       aria-labelledby="linux-start-filebeat"
+       hidden="">
+++++
+
+include::start-filebeat.asciidoc[tag=linux]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="win-tab-start-filebeat"
+       aria-labelledby="win-start-filebeat"
+       hidden="">
+++++
+
+include::start-filebeat.asciidoc[tag=win]
+
+++++
+  </div>
+</div>
+++++

--- a/docs/en/shared/copied-from-beats/start-heartbeat/start-widget-heartbeat.asciidoc
+++ b/docs/en/shared/copied-from-beats/start-heartbeat/start-widget-heartbeat.asciidoc
@@ -1,0 +1,97 @@
+:beatname_uc: Heartbeat
+:beatname_lc: heartbeat
+:beatname_pkg: heartbeat
+++++
+<div class="tabs" data-tab-group="os">
+  <div role="tablist" aria-label="Start-h">
+    <button role="tab"
+            aria-selected="true"
+            aria-controls="deb-tab-start-heartbeat"
+            id="deb-start-heartbeat">
+      DEB
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="rpm-tab-start-heartbeat"
+            id="rpm-start-heartbeat"
+            tabindex="-1">
+      RPM
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="mac-tab-start-heartbeat"
+            id="mac-start-heartbeat"
+            tabindex="-1">
+      MacOS
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="linux-tab-start-heartbeat"
+            id="linux-start-heartbeat"
+            tabindex="-1">
+      Linux
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="win-tab-start-heartbeat"
+            id="win-start-heartbeat"
+            tabindex="-1">
+      Windows
+    </button>
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="deb-tab-start-heartbeat"
+       aria-labelledby="deb-start-heartbeat">
+++++
+
+include::../shared/start.asciidoc[tag=deb]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="rpm-tab-start-heartbeat"
+       aria-labelledby="rpm-start-heartbeat"
+       hidden="">
+++++
+
+include::../shared/start.asciidoc[tag=rpm]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="mac-tab-start-heartbeat"
+       aria-labelledby="mac-start-heartbeat"
+       hidden="">
+++++
+
+include::../shared/start.asciidoc[tag=mac]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="linux-tab-start-heartbeat"
+       aria-labelledby="linux-start-heartbeat"
+       hidden="">
+++++
+
+include::../shared/start.asciidoc[tag=linux]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="win-tab-start-heartbeat"
+       aria-labelledby="win-start-heartbeat"
+       hidden="">
+++++
+
+include::../shared/start.asciidoc[tag=win]
+
+++++
+  </div>
+</div>
+++++

--- a/docs/en/shared/copied-from-beats/start-metricbeat/start-widget-metricbeat.asciidoc
+++ b/docs/en/shared/copied-from-beats/start-metricbeat/start-widget-metricbeat.asciidoc
@@ -1,0 +1,97 @@
+:beatname_uc: Metricbeat
+:beatname_lc: metricbeat
+:beatname_pkg: metricbeat
+++++
+<div class="tabs" data-tab-group="os">
+  <div role="tablist" aria-label="Start-m">
+    <button role="tab"
+            aria-selected="true"
+            aria-controls="deb-tab-start-metricbeat"
+            id="deb-start-metricbeat">
+      DEB
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="rpm-tab-start-metricbeat"
+            id="rpm-start-metricbeat"
+            tabindex="-1">
+      RPM
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="mac-tab-start-metricbeat"
+            id="mac-start-metricbeat"
+            tabindex="-1">
+      MacOS
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="linux-tab-start-metricbeat"
+            id="linux-start-metricbeat"
+            tabindex="-1">
+      Linux
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="win-tab-start-metricbeat"
+            id="win-start-metricbeat"
+            tabindex="-1">
+      Windows
+    </button>
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="deb-tab-start-metricbeat"
+       aria-labelledby="deb-start-metricbeat">
+++++
+
+include::../shared/start.asciidoc[tag=deb]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="rpm-tab-start-metricbeat"
+       aria-labelledby="rpm-start-metricbeat"
+       hidden="">
+++++
+
+include::../shared/start.asciidoc[tag=rpm]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="mac-tab-start-metricbeat"
+       aria-labelledby="mac-start-metricbeat"
+       hidden="">
+++++
+
+include::../shared/start.asciidoc[tag=mac]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="linux-tab-start-metricbeat"
+       aria-labelledby="linux-start-metricbeat"
+       hidden="">
+++++
+
+include::../shared/start.asciidoc[tag=linux]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="win-tab-start-metricbeat"
+       aria-labelledby="win-start-metricbeat"
+       hidden="">
+++++
+
+include::../shared/start.asciidoc[tag=win]
+
+++++
+  </div>
+</div>
+++++

--- a/docs/en/shared/install-configure-filebeat.asciidoc
+++ b/docs/en/shared/install-configure-filebeat.asciidoc
@@ -3,7 +3,7 @@
 
 Download and install {filebeat}.
 
-include::{beats-repo-dir}/tab-widgets/install-widget-filebeat.asciidoc[]
+include::{shared}/copied-from-beats/install-filebeat/install-widget-filebeat.asciidoc[]
 
 [discrete]
 = Set up assets

--- a/docs/en/shared/install-configure-metricbeat.asciidoc
+++ b/docs/en/shared/install-configure-metricbeat.asciidoc
@@ -3,7 +3,7 @@
 
 Download and install {metricbeat}.
 
-include::{beats-repo-dir}/tab-widgets/install-widget-metricbeat.asciidoc[]
+include::{shared}/copied-from-beats/install-metricbeat/install-widget-metricbeat.asciidoc[]
 
 [discrete]
 = Set up assets


### PR DESCRIPTION
### Summary

This PR copies over Beats `install` and `start` widgets so we can remove the Observability Guide dependency on the `elastic/beats` repository.

* Closes https://github.com/elastic/observability-docs/issues/2969.