### PR TITLE
Add the logs resource guide

### DIFF
--- a/docs/en/observability/index.asciidoc
+++ b/docs/en/observability/index.asciidoc
@@ -58,15 +58,19 @@ include::apm.asciidoc[leveloffset=+1]
 include::application-logs.asciidoc[leveloffset=+2]
 
 // Logs
-include::monitor-logs.asciidoc[leveloffset=+1]
+include::logs-overview.asciidoc[leveloffset=+1]
 
-include::tail-logs.asciidoc[leveloffset=+2]
+include::logs-checklist.asciidoc[leveloffset=+2]
 
-include::categorize-logs.asciidoc[leveloffset=+2]
+include::monitor-logs.asciidoc[leveloffset=+2]
 
-include::inspect-log-anomalies.asciidoc[leveloffset=+2]
+include::tail-logs.asciidoc[leveloffset=+3]
 
-include::configure-logs-sources.asciidoc[leveloffset=+2]
+include::categorize-logs.asciidoc[leveloffset=+3]
+
+include::inspect-log-anomalies.asciidoc[leveloffset=+3]
+
+include::configure-logs-sources.asciidoc[leveloffset=+3]
 
 // Infrastructure
 include::monitor-infra/analyze-metrics.asciidoc[leveloffset=+1]

--- a/docs/en/observability/logs-checklist.asciidoc
+++ b/docs/en/observability/logs-checklist.asciidoc
@@ -1,6 +1,10 @@
 [[logs-checklist]]
 = Logs resource guide
 
+++++
+<titleabbrev>Resource guide</titleabbrev>
+++++
+
 In this guide, you'll find resources on sending log data to {es}, configuring your logs, and analyzing your logs. 
 
 [discrete]
@@ -11,9 +15,9 @@ If you're new to ingesting, viewing, and analyzing logs with Elastic, see <<logs
 
 [discrete]
 [[logs-send-data-checklist]]
-== Send data to {es}
+== Send logs data to {es}
 
-You can send data to {es} in different ways depending on your needs: 
+You can send logs data to {es} in different ways depending on your needs: 
 
 - {agent}
 - {filebeat} 

--- a/docs/en/observability/logs-checklist.asciidoc
+++ b/docs/en/observability/logs-checklist.asciidoc
@@ -23,7 +23,7 @@ You can send logs data to {es} in different ways depending on your needs:
 - {filebeat} 
 
 When choosing between {agent} and {beats}, consider the different features and functionalities between the two options. 
-See {fleet-guide}/beats-agent-comparison.html[{agent} and {beats} capabilities] for more information which option best fits your situation.
+See {fleet-guide}/beats-agent-comparison.html[{agent} and {beats} capabilities] for more information on which option best fits your situation.
 
 [discrete]
 [[agent-ref-guide]]
@@ -33,7 +33,7 @@ You have the following options when installing and managing an {agent}:
 
 * *{fleet}-managed {agent}*
 +
-Install an {agent} and use {fleet} in {kib} to define,configure, and manage your agents in a central location.
+Install an {agent} and use {fleet} in {kib} to define, configure, and manage your agents in a central location.
 +
 See {fleet-guide}/install-fleet-managed-elastic-agent.html[install {fleet}-managed {agent}].
 
@@ -97,7 +97,7 @@ See <<application-logs>>.
 
 [discrete]
 [[logs-alerts-checklist]]
-== Create a logs threshold alerts
+== Create a logs threshold alert
 
 You can create a rule to send an alert when the log aggregation exceeds a threshold.
 See <<logs-threshold-alert>>.

--- a/docs/en/observability/logs-checklist.asciidoc
+++ b/docs/en/observability/logs-checklist.asciidoc
@@ -1,0 +1,99 @@
+[[logs-checklist]]
+= Logs resource guide
+
+In this guide, you'll find resources on sending log data to {es}, configuring your logs, and analyzing your logs. 
+
+[discrete]
+[[logs-getting-started-checklist]]
+== Get started with logs
+
+If you're new to ingesting, viewing, and analyzing logs with Elastic, see <<logs-metrics-get-started, Get started with logs and metrics>> for an overview of adding integrations, installing and running an {agent}, and monitoring logs.
+
+[discrete]
+[[logs-send-data-checklist]]
+== Send data to {es}
+
+You can send data to {es} in different ways depending on your needs: 
+
+- {agent}
+- {filebeat} 
+
+When choosing between {agent} and {beats}, consider the different features and functionalities between the two options. 
+See {fleet-guide}/beats-agent-comparison.html[{agent} and {beats} capabilities] for more information which option best fits your situation.
+
+[discrete]
+[[agent-ref-guide]]
+=== {agent}
+{agent} uses https://www.elastic.co/integrations/data-integrations[integrations] to ingest logs from Kubernetes, MySQL, and many more data sources.
+You have the following options when installing and managing an {agent}:
+
+* *{fleet}-managed {agent}*
++
+Install an {agent} and use {fleet} in {kib} to define,configure, and manage your agents in a central location.
++
+See {fleet-guide}/install-fleet-managed-elastic-agent.html[install {fleet}-managed {agent}].
+
+* *Standalone {agent}*
++
+Install an {agent} and manually configure it locally on the system where it’s installed. 
+You are responsible for managing and upgrading the agents. 
+This approach is reserved for advanced users only.
++
+See {fleet-guide}/install-standalone-elastic-agent.html[install standalone {agent}].
+
+* *{agent} in a containerized environment*
++
+Run an {agent} inside of a container -- either with {fleet-server} or standalone.
++
+See {fleet-guide}/install-elastic-agents-in-containers.html[install {agent} in containers].
+
+[discrete]
+[[beats-ref-guide]]
+=== {filebeat}
+{filebeat} is a lightweight shipper for forwarding and centralizing log data.
+Installed as an agent on your servers, {filebeat} monitors the log files or locations that you specify, collects log events, and forwards them 
+either to https://www.elastic.co/products/elasticsearch[Elasticsearch] or
+https://www.elastic.co/products/logstash[Logstash] for indexing.
+
+- {filebeat-ref}/filebeat-overview.html[{filebeat} overview] – general information on {filebeat} and how it works.
+- {filebeat-ref}/filebeat-installation-configuration.html[{filebeat} quick start] – basic installation instructions to get you started.
+- {filebeat-ref}/setting-up-and-running.html[Set up and run {filebeat}] – information on how to install, set up, and run {filebeat}.
+
+[discrete]
+[[logs-configure-data-checklist]]
+== Configure logs
+
+The following resources provide information on configuring your logs:
+
+- {ref}/data-streams.html[Data streams] – store append-only time series data across multiple indices while giving you a single named resource for requests.
+- {kibana-ref}/data-views.html[Data views] – to point to your log data from a specific time or to all indices that contain your log data.  
+- {ref}/example-using-index-lifecycle-policy.html[Index lifecycle management] – configure the built-in logs policy based on your application's performance, resilience, and retention requirements.
+- {ref}/common-log-format-example.html[Ingest pipeline] – to parse server logs in the Common Log Format before indexing.
+- {ref}/mapping.html[Mapping] – define how data is stored and indexed.
+
+[discrete]
+[[logs-monitor-checklist]]
+== View and monitor logs
+
+With the {logs-app} in {kib} you can search, filter, and tail all your logs ingested into {es} in one place.
+
+The following resources provide information on viewing and monitoring your logs:
+
+- <<tail-logs>> – monitor all of the log events flowing in from your servers, virtual machines, and containers in a centralized view.
+- <<inspect-log-anomalies>> use {ml} to detect log anomalies automatically.
+- <<categorize-logs>> – use {ml} to categorize log messages to quickly identify patterns in your log events.
+- <<configure-data-sources>> – Specify the source configuration for logs in the Logs app settings in the Kibana configuration file.
+
+[discrete]
+[[logs-app-checklist]]
+== Application logs
+
+Application logs provide valuable insight into events that have occurred within your services and applications.
+See <<application-logs>>. 
+
+[discrete]
+[[logs-alerts-checklist]]
+== Create a logs threshold alerts
+
+You can create a rule to send an alert when the log aggregation exceeds a threshold.
+See <<logs-threshold-alert>>.

--- a/docs/en/observability/logs-overview.asciidoc
+++ b/docs/en/observability/logs-overview.asciidoc
@@ -1,0 +1,11 @@
+[[logs-observability-overview]]
+= Logs overview
+
+++++
+<titleabbrev>Logs</titleabbrev>
+++++
+
+Elastic Observability allows you to deploy and manage logs at aa petabyte scale, giving you insights into your logs in minutes. You can also search across your logs in one place, troubleshoot in real-time, and detect patterns and outliers with categorization and anomaly detection. For more information, see the following links:
+
+- The <<logs-checklist>> consolidates links to documentation on sending log data, configuring logs, and analyzing logs.
+- <<monitor-logs>> has information on visualizing and analyzing logs.

--- a/docs/en/observability/logs-overview.asciidoc
+++ b/docs/en/observability/logs-overview.asciidoc
@@ -5,7 +5,7 @@
 <titleabbrev>Logs</titleabbrev>
 ++++
 
-Elastic Observability allows you to deploy and manage logs at aa petabyte scale, giving you insights into your logs in minutes. You can also search across your logs in one place, troubleshoot in real-time, and detect patterns and outliers with categorization and anomaly detection. For more information, see the following links:
+Elastic Observability allows you to deploy and manage logs at a petabyte scale, giving you insights into your logs in minutes. You can also search across your logs in one place, troubleshoot in real-time, and detect patterns and outliers with categorization and anomaly detection. For more information, see the following links:
 
 - The <<logs-checklist>> consolidates links to documentation on sending log data, configuring logs, and analyzing logs.
 - <<monitor-logs>> has information on visualizing and analyzing logs.


### PR DESCRIPTION
### Summary
This PR closes [issue 90](https://github.com/elastic/obs-docs-projects/issues/90). 

This PR aims to create a one-page cheat sheet that includes the logging user flow, a brief outline of how the pieces work together, and links to existing documentation.