### PR TITLE
[DOCS] Create stub page for threshold rule

### DIFF
--- a/docs/en/observability/redirects.asciidoc
+++ b/docs/en/observability/redirects.asciidoc
@@ -140,3 +140,8 @@ Refer to <<synthetics-get-started-project>>.
 === Visualize journeys
 
 Refer to <<synthetics-analyze-journeys>>.
+
+[role="exclude" id="threshold-alert"]
+=== Create a threshold rule
+
+coming::[8.9.0]


### PR DESCRIPTION
Relates to https://github.com/elastic/kibana/issues/160045

This PR creates a hidden page for use in the Kibana doc link service. The URL can subsequently be turned into a full page.