### PR TITLE
Fix firehose documentation on es_datastream_name parameter

### DIFF
--- a/docs/en/aws-firehose/aws-firehose-setup.asciidoc
+++ b/docs/en/aws-firehose/aws-firehose-setup.asciidoc
@@ -101,10 +101,10 @@ A duration of 60-300s should be suitable for most use cases.
 
 *Parameters*:
 
-* Elastic recommends adding *`es_datastream_name`* parameter to help routing data to the correct integration data streams.
-If this parameter is NOT specified, data will be sent to the *`logs-generic-default`* data stream by default.
-*`es_datastream_name`* can be used to route documents to any data stream.
-Only when using Elastic integrations, setting the *`es_datastream_name`* parameter is required.
+* Elastic recommends setting the *`es_datastream_name`* parameter to help route data to the correct integration data streams.
+If this parameter is not specified, data is sent to the *`logs-generic-default`* data stream by default.
+* You can use the *`es_datastream_name`* parameter to route documents to any data stream.
+When using Elastic integrations, you must set this parameter.
 +
 Elastic integrations use data streams with specific naming conventions, and Firehose records need to be routed to the relevant data stream to use preconfigured index mappings, ingest pipelines, and dashboards.
 +

--- a/docs/en/aws-firehose/aws-firehose-setup.asciidoc
+++ b/docs/en/aws-firehose/aws-firehose-setup.asciidoc
@@ -101,7 +101,10 @@ A duration of 60-300s should be suitable for most use cases.
 
 *Parameters*:
 
-* When using Elastic integrations, setting the *`es_datastream_name`* parameter is required.
+* Elastic recommends adding *`es_datastream_name`* parameter to help routing data to the correct integration data streams.
+If this parameter is NOT specified, data will be sent to the *`logs-generic-default`* data stream by default.
+*`es_datastream_name`* can be used to route documents to any data stream.
+Only when using Elastic integrations, setting the *`es_datastream_name`* parameter is required.
 +
 Elastic integrations use data streams with specific naming conventions, and Firehose records need to be routed to the relevant data stream to use preconfigured index mappings, ingest pipelines, and dashboards.
 +


### PR DESCRIPTION
This PR is to address confusion around `es_datastream_name` parameter for Firehose.

closes https://github.com/elastic/obs-infraobs-team/issues/1070