### PR TITLE
backport: Add 8.9 branch

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -217,7 +217,7 @@ pull_request_rules:
   - name: backport patches to 8.9 branch
     conditions:
       - merged
-      - label=backport-v8.9.0
+      - label=backport-8.9
     actions:
       backport:
         assignees:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -214,3 +214,16 @@ pull_request_rules:
         labels:
           - "backport"
         title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"
+  - name: backport patches to 8.9 branch
+    conditions:
+      - merged
+      - label=backport-v8.9.0
+    actions:
+      backport:
+        assignees:
+          - "{{ author }}"
+        branches:
+          - "8.9"
+        labels:
+          - "backport"
+        title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"


### PR DESCRIPTION
Merge as soon as 8.9 branch was created. Auto-merge is not yet supported, see https://github.com/Mergifyio/mergify-engine/discussions/2821