### PR TITLE
Add missing log types into firehose documentation

### DIFF
--- a/docs/en/aws-firehose/aws-firehose-setup.asciidoc
+++ b/docs/en/aws-firehose/aws-firehose-setup.asciidoc
@@ -116,6 +116,12 @@ The following is a list of common AWS log types and the *`es_datastream_name`* v
 | https://docs.elastic.co/en/integrations/aws/cloudfront[Cloudfront]
 | `logs-aws.cloudfront_logs-default`
 
+| https://docs.elastic.co/en/integrations/aws/cloudtrail[Cloudtrail]
+| `logs-aws.cloudtrail-default`
+
+| https://docs.elastic.co/en/integrations/aws/cloudwatch[CloudWatch]
+| `logs-aws.cloudwatch_logs-default`
+
 | https://docs.elastic.co/en/integrations/aws/ec2[EC2 (via Cloudwatch)]
 | `logs-aws.ec2_logs-default`
 


### PR DESCRIPTION
This PR is to add missing log types into firehose documentation: Cloudtrail and CloudWatch.