### PR TITLE
Clarify a direct connection to ES is required

### DIFF
--- a/docs/en/observability/synthetics-private-location.asciidoc
+++ b/docs/en/observability/synthetics-private-location.asciidoc
@@ -32,6 +32,12 @@ Before running a monitor on a {private-location}, you'll need to:
 * <<synthetics-private-location-connect,Connect {fleet} to the {stack}>> and enroll an {agent} in {fleet}.
 * <<synthetics-private-location-add>> in the {synthetics-app}.
 
+[IMPORTANT]
+====
+{private-location}s running through {agent} must have a direct connection to {es}.
+Do not configure any ingest pipelines, or output via Logstash as this will prevent Synthetics from working properly and is not synthetics-support-matrix.html[supported].
+====
+
 [discrete]
 [[synthetics-private-location-fleet-agent]]
 = Set up {fleet-server} and {agent}

--- a/docs/en/observability/synthetics-private-location.asciidoc
+++ b/docs/en/observability/synthetics-private-location.asciidoc
@@ -35,7 +35,7 @@ Before running a monitor on a {private-location}, you'll need to:
 [IMPORTANT]
 ====
 {private-location}s running through {agent} must have a direct connection to {es}.
-Do not configure any ingest pipelines, or output via Logstash as this will prevent Synthetics from working properly and is not <<synthetics-get-started-project,supported>>.
+Do not configure any ingest pipelines, or output via Logstash as this will prevent Synthetics from working properly and is not <<synthetics-support-matrix,supported>>.
 ====
 
 [discrete]

--- a/docs/en/observability/synthetics-private-location.asciidoc
+++ b/docs/en/observability/synthetics-private-location.asciidoc
@@ -35,7 +35,7 @@ Before running a monitor on a {private-location}, you'll need to:
 [IMPORTANT]
 ====
 {private-location}s running through {agent} must have a direct connection to {es}.
-Do not configure any ingest pipelines, or output via Logstash as this will prevent Synthetics from working properly and is not synthetics-support-matrix.html[supported].
+Do not configure any ingest pipelines, or output via Logstash as this will prevent Synthetics from working properly and is not <<synthetics-get-started-project,supported>>.
 ====
 
 [discrete]

--- a/docs/en/observability/synthetics-support-matrix.asciidoc
+++ b/docs/en/observability/synthetics-support-matrix.asciidoc
@@ -25,6 +25,8 @@ a| * For running lightweight and browser monitors from your self-managed infrast
 * Relies on the Synthetics integration 1.0.0 or above
 ** Any _inline_ or _Zip URL_ monitors configured with the beta Synthetics integration prior to 1.0.0, are not supported and will stop running in the future
 * Shipped as the `elastic-agent-complete` Docker image
+* Must have a direct connection to {es}
+** Do not configure any ingest pipelines or Logstash output
 
 | *Heartbeat with Uptime*
 | As defined in the standard https://www.elastic.co/support/matrix[Support matrix]


### PR DESCRIPTION
Fixes https://github.com/elastic/beats/issues/34725

Confirms that a direct connection to Elasticsearch is needed for Synthetics