### PR TITLE
Additional permission for creating Agent Policy

### DIFF
--- a/docs/en/observability/synthetics-role-write.asciidoc
+++ b/docs/en/observability/synthetics-role-write.asciidoc
@@ -95,6 +95,10 @@ The user who is setting up a new Private Location will need the following privil
 | `Fleet`: `All`
 | Access to Fleet in {kib}.
 
+| {kibana-ref}/kibana-privileges.html[Kibana]
+| `Integrations`: `read`
+| Access to Integrations in {kib}.
+
 |====
 
 [discrete]


### PR DESCRIPTION
As per https://github.com/elastic/observability-docs/pull/3008/files#r1246607585, an additional `read` permission is needed for setting up the Agent Policy for a Private Location