### PR TITLE
[Profiling] Update name of filter fields

### DIFF
--- a/docs/en/observability/profiling-tag-data-query.asciidoc
+++ b/docs/en/observability/profiling-tag-data-query.asciidoc
@@ -8,7 +8,7 @@ The only config setting you may want to change is `project-id` (default value is
 
 The `-project-id` flag, or the `project-id` key in the host-agent configuration file, splits profiling data into logical groups that you control.
 
-You can assign any non-zero, unsigned integer <= 4095 to a host-agent deployment you control. In Kibana, the KQL field `service.name` is mapped to `project-id` and you can use it to split or filter data.
+You can assign any non-zero, unsigned integer <= 4095 to a host-agent deployment you control. In Kibana, the KQL field `profiling.project.id` is mapped to `project-id` and you can use it to split or filter data.
 
 You may want to set a per-environment project ID (for example, dev=3, staging=2, production=1), a per-datacenter project ID (for example,
 DC1=1, DC2=2), or even a per-k8s-cluster project ID (for example, us-west2-production=100, eu-west1-production=101).

--- a/docs/en/observability/universal-profiling.asciidoc
+++ b/docs/en/observability/universal-profiling.asciidoc
@@ -167,11 +167,11 @@ Language (https://www.elastic.co/guide/en/kibana/current/kuery-query.html[KQL]).
 
 Most notably, you may want to filter on:
 
-* `service.name`: the corresponding value of `project-id` host-agent flag, logical group of deployed host-agents
+* `profiling.project.id`: the corresponding value of `project-id` host-agent flag, logical group of deployed host-agents
 * `process.thread.name`: the process' thread name, e.g. `python`, `java`, or `kauditd`
 * `orchestrator.resource.name`: the name of the group of the containerized deployment as set by the orchestrator
 * `container.name`: the name of the single container instance, as set by the container engine
-* `host.name` or `host.ipstring`: the machine's hostname or IP address (useful for debugging issues on a single Virtual Machine)
+* `host.name` or `host.ip`: the machine's hostname or IP address (useful for debugging issues on a single Virtual Machine)
 
 [discrete]
 [[profiling-differential-views-intro]]


### PR DESCRIPTION
With this commit we update the names of two fields that users can use in Kibana filters:

* `service.name` has changed to `profiling.project.id`
* `host.ipstring` has changed to `host.ip`