### PR TITLE
Update links for APM agents logs

### DIFF
--- a/docs/en/observability/application-logs.asciidoc
+++ b/docs/en/observability/application-logs.asciidoc
@@ -60,9 +60,10 @@ Elastic APM agents can automatically reformat application logs to Elastic Common
 without needing to add an ECS logger dependency or modify the application.
 
 This feature is supported for the following APM agents:
+
 * Ruby
-* Python
-* {apm-java-ref}/logs.html[Java]
+* {apm-py-ref}/logs.html#log-reformatting[Python]
+* {apm-java-ref}/logs.html#log-reformatting[Java]
 
 [float]
 [[log-correlation]]
@@ -85,11 +86,11 @@ Correlating your application logs with trace events allows you to:
 Learn more about log correlation in the APM Guide: {apm-guide-ref}/log-correlation.html[log correlation],
 or in any of the agent-specific ingestion guides:
 
-* {apm-go-ref}/log-correlation.html[Go]
-* {apm-java-ref}/logs.html[Java]
+* {apm-go-ref}/logs.html#log-correlation-ids[Go]
+* {apm-java-ref}/logs.html#log-correlation-ids[Java]
 * {apm-dotnet-ref}/log-correlation.html[.NET]
 * {apm-node-ref}/log-correlation.html[Node.js]
-* {apm-py-ref}/log-correlation.html[Python]
+* {apm-py-ref}/logs.html#log-correlation-ids[Python]
 * {apm-ruby-ref}/log-correlation.html[Ruby]
 // end::correlate-logs[]
 

--- a/docs/en/observability/application-logs.asciidoc
+++ b/docs/en/observability/application-logs.asciidoc
@@ -86,7 +86,7 @@ Correlating your application logs with trace events allows you to:
 Learn more about log correlation in the APM Guide: {apm-guide-ref}/log-correlation.html[log correlation],
 or in any of the agent-specific ingestion guides:
 
-* {apm-go-ref}/logs.html#log-correlation-ids[Go]
+* {apm-go-ref}/logs.html[Go]
 * {apm-java-ref}/logs.html#log-correlation-ids[Java]
 * {apm-dotnet-ref}/log-correlation.html[.NET]
 * {apm-node-ref}/log-correlation.html[Node.js]


### PR DESCRIPTION
go, dotnet, nodejs and ruby agents links are not covered for now as we are waiting for an agent release to update docs.
closes https://github.com/elastic/apm/issues/800