### PR TITLE
[Profiling] Add new field to migration script

### DIFF
--- a/docs/en/observability/profiling-upgrade-migrate.asciidoc
+++ b/docs/en/observability/profiling-upgrade-migrate.asciidoc
@@ -354,6 +354,18 @@ function migrate {
   status_code=$(curl -s -o /dev/null -w "%{http_code}" -I -k -u "$ES_USER":"$ES_PASSWORD" "$ES_HOST/profiling-returnpads-private")
   if [ "$status_code" == "200" ]; then
     rename_regular_index "profiling-returnpads-private"
+    echo "Adding new fields..."
+    curl -s -f -o /dev/null -X PUT -k -u "$ES_USER":"$ES_PASSWORD" "$ES_HOST/profiling-returnpads-private/_mapping" -H 'Content-Type: application/json' -d'
+    {
+      "properties": {
+        "Symbfile.file.id_str": {
+          "type": "keyword",
+          "index": true,
+          "doc_values": false,
+          "store": false
+        }
+      }
+    }'
   fi
 
   echo "Renaming existing fields..."


### PR DESCRIPTION
With this commit we adapt the 8.9 Universal Profiling migration script to add a new field if the respective index exists.

Relates elastic/elasticsearch#97413