### PR TITLE
Adds APM rule to list of rules in O11y alerting

### DIFF
--- a/docs/en/observability/create-alerts.asciidoc
+++ b/docs/en/observability/create-alerts.asciidoc
@@ -49,7 +49,7 @@ preview:[] To temporarily suppress notifications for _all_ rules, create a {kiba
 
 
 Extend your rules by connecting them to actions that use built-in *connectors* for email,
-{ibm-r}, Index, JIRA, Microsoft Teams, PagerDuty, Server log, {sn} ITSM, and Slack.
+{ibm-r}, Index, JIRA, Microsoft Teams, PagerDuty, Server log, {sn} ITSM, Opsgenie and Slack.
 Also supported is a powerful webhook output letting you tie into other third-party systems.
 Connectors allow actions to talk to these services and integrations.
 
@@ -61,6 +61,7 @@ Learn how to create specific types of rules:
 * <<monitor-status-alert,Monitor status rule>>
 * <<tls-certificate-alert,TLS certificate rule>>
 * <<duration-anomaly-alert,Uptime duration anomaly rule>>
+* <<apm-alerts,APM rules>>
 
 [discrete]
 [[create-alerts-rules-details]]
@@ -168,3 +169,5 @@ include::uptime-duration-anomaly-alert.asciidoc[leveloffset=+1]
 include::slo-burn-rate-alert.asciidoc[leveloffset=+1]
 
 include::view-observability-alerts.asciidoc[leveloffset=+1]
+
+include::apm-alerts.asciidoc[leveloffset=+1]

--- a/docs/en/observability/create-alerts.asciidoc
+++ b/docs/en/observability/create-alerts.asciidoc
@@ -61,7 +61,8 @@ Learn how to create specific types of rules:
 * <<monitor-status-alert,Monitor status rule>>
 * <<tls-certificate-alert,TLS certificate rule>>
 * <<duration-anomaly-alert,Uptime duration anomaly rule>>
-* <<apm-alerts,APM rules>>
+* {kibana-ref}/apm-alerts.html[APM rules]
+* <<slo-burn-rate-alert,SLO burn rate rule>>
 
 [discrete]
 [[create-alerts-rules-details]]
@@ -170,4 +171,4 @@ include::slo-burn-rate-alert.asciidoc[leveloffset=+1]
 
 include::view-observability-alerts.asciidoc[leveloffset=+1]
 
-include::apm-alerts.asciidoc[leveloffset=+1]
+include::slo-burn-rate-alert.asciidoc[leveloffset=+1]


### PR DESCRIPTION
Adds APM rule and link to the corresponding docs https://www.elastic.co/guide/en/kibana/current/apm-alerts.html to the list of Observability rules.