### PR TITLE
[synthetics] Add synthetics troubleshooting page

### DIFF
--- a/docs/en/observability/index.asciidoc
+++ b/docs/en/observability/index.asciidoc
@@ -142,6 +142,8 @@ include::synthetics-support-matrix.asciidoc[leveloffset=+2]
 
 include::synthetics-security-encryption.asciidoc[leveloffset=+2]
 
+include::synthetics-troubleshooting.asciidoc[leveloffset=+2]
+
 // Uptime
 include::uptime-intro.asciidoc[leveloffset=+1]
 

--- a/docs/en/observability/synthetics-troubleshooting.asciidoc
+++ b/docs/en/observability/synthetics-troubleshooting.asciidoc
@@ -34,7 +34,7 @@ To fix this, a user with <<synthetics-role-setup,admin permissions>> needs to vi
 in {kib}. In 8.8.0 and above, the equivalent of "enabling monitor management" happens automatically in the
 background when a user with <<synthetics-role-setup,admin permissions>> visits the {synthetics-app}.
 
-If a user without <<synthetics-role-setup,admin permissions>> visits the {synthetics-app} before an admin
+If a user _without_ <<synthetics-role-setup,admin permissions>> visits the {synthetics-app} before an admin
 has visited it, the user will see a note that says "Only administrators can enable this feature". That
 note will persist until an admin user visits the {synthetics-app}.
 
@@ -59,8 +59,9 @@ When creating a {private-location}, you have to:
 . <<synthetics-private-location-connect,Connect {fleet} to the {stack}>> and enroll an {agent} in {fleet}.
 . <<synthetics-private-location-add>> in the {synthetics-app}.
 
-If you do not complete the second item, no agents will be configured to run against the agent policy and
-the monitors configured to run on that {private-location} will not be running and you will get no results.
+If you do not complete the second item, no agents will be configured to run against the agent policy, and
+any monitors configured to run on that {private-location} won't be able to run so there will be no results
+in the {synthetics-app}.
 
 To fix this, make sure there is an agent configured to run against the agent policy.
 
@@ -78,5 +79,5 @@ include::troubleshooting.asciidoc[tag=support]
 [[synthetics-troubleshooting-discussion]]
 == Discussion forum
 
-For other questions and feature requests,
-visit our {forum}/c/observability/synthetics/75[discussion forum].
+For other questions and feature requests, visit our
+{forum}/c/observability/synthetics/75[discussion forum].

--- a/docs/en/observability/synthetics-troubleshooting.asciidoc
+++ b/docs/en/observability/synthetics-troubleshooting.asciidoc
@@ -9,8 +9,9 @@
 [[synthetics-troubleshooting-local-debugging]]
 = Local debugging
 
-Use the `DEBUG=synthetics` environment variable to capture Synthetics agent logs when
-running Synthetic tests locally with the <<synthetics-command-reference,Synthetics CLI>>.
+For debugging synthetic tests locally, you can set an environment variable,
+`DEBUG=synthetics`, to capture Synthetics agent logs when running tests locally
+with the <<synthetics-command-reference,Synthetics CLI>>.
 
 [discrete]
 [[synthetics-troubleshooting-common-issues]]
@@ -26,18 +27,16 @@ Synthetic monitors will stop running if you have gone through this workflow:
 . Created a synthetic monitor that is configured to run on Elastic's global managed infrastructure.
 . Upgraded to 8.8.0 or above.
 
-This happens because the permissions you gave the {uptime-app} by clicking *Enable Monitor Management*
-in versions prior to 8.6.0 are not sufficient for using the {synthetics-app} in versions 8.8.0 and above.
+This happens because the permissions granted by clicking *Enable Monitor Management* in versions prior to
+8.6.0 are not sufficient in versions 8.8.0 and above.
 
 To fix this, a user with <<synthetics-role-setup,admin permissions>> needs to visit the {synthetics-app}
 in {kib}. In 8.8.0 and above, the equivalent of "enabling monitor management" happens automatically in the
 background when a user with <<synthetics-role-setup,admin permissions>> visits the {synthetics-app}.
 
 If a user without <<synthetics-role-setup,admin permissions>> visits the {synthetics-app} before an admin
-has visited it, the user will get a message that Synthetics cannot running until an admin user visits the
-{synthetics-app}.
-
-// Should I add more details from the knowledge base link in a note or collapsible block?
+has visited it, the user will see a note that says "Only administrators can enable this feature". That
+note will persist until an admin user visits the {synthetics-app}.
 
 [discrete]
 [[synthetics-troubleshooting-no-agent-running]]

--- a/docs/en/observability/synthetics-troubleshooting.asciidoc
+++ b/docs/en/observability/synthetics-troubleshooting.asciidoc
@@ -10,8 +10,8 @@
 = Local debugging
 
 For debugging synthetic tests locally, you can set an environment variable,
-`DEBUG=synthetics`, to capture Synthetics agent logs when running tests locally
-with the <<synthetics-command-reference,Synthetics CLI>>.
+`DEBUG=synthetics`, to capture Synthetics agent logs when using the
+<<synthetics-command-reference,Synthetics CLI>>.
 
 [discrete]
 [[synthetics-troubleshooting-common-issues]]
@@ -78,4 +78,5 @@ include::troubleshooting.asciidoc[tag=support]
 [[synthetics-troubleshooting-discussion]]
 == Discussion forum
 
-include::troubleshooting.asciidoc[tag=discussion]
+For other questions and feature requests,
+visit our {forum}/c/observability/synthetics/75[discussion forum].

--- a/docs/en/observability/synthetics-troubleshooting.asciidoc
+++ b/docs/en/observability/synthetics-troubleshooting.asciidoc
@@ -18,9 +18,26 @@ running Synthetic tests locally with the <<synthetics-command-reference,Syntheti
 
 [discrete]
 [[synthetics-troubleshooting-missing-api-key]]
-== Missing API key
+== Monitors stopped running after upgrading to 8.8.0 or above
 
-Missing / incorrect API key (should get notification, but how to regenerate if not getting results)
+Synthetic monitors will stop running if you:
+
+* Enabled Monitor Management (in the {uptime-app}) prior to 8.6.0.
+* Created a synthetic monitor that is configured to run on Elastic's global managed infrastructure.
+* Upgraded to 8.8.0 or above.
+
+This happens because the permissions you gave the {uptime-app} by clicking *Enable Monitor Management*
+in versions prior to 8.6.0 are not sufficient for using the {synthetics-app} in versions 8.8.0 and above.
+
+To fix this, a user with <<synthetics-role-setup,admin permissions>> needs to visit the {synthetics-app}
+in {kib}. In 8.8.0 and above, the equivalent of "enabling monitor management" happens automatically in the
+background when a user with <<synthetics-role-setup,admin permissions>> visits the {synthetics-app}.
+
+If a user without <<synthetics-role-setup,admin permissions>> visits the {synthetics-app} before an admin
+has visited it, the user will get a message that Synthetics cannot running until an admin user visits the
+{synthetics-app}.
+
+// Should I add more details from the knowledge base link in a note or collapsible block?
 
 [discrete]
 [[synthetics-troubleshooting-no-agent-running]]

--- a/docs/en/observability/synthetics-troubleshooting.asciidoc
+++ b/docs/en/observability/synthetics-troubleshooting.asciidoc
@@ -20,11 +20,11 @@ running Synthetic tests locally with the <<synthetics-command-reference,Syntheti
 [[synthetics-troubleshooting-missing-api-key]]
 == Monitors stopped running after upgrading to 8.8.0 or above
 
-Synthetic monitors will stop running if you:
+Synthetic monitors will stop running if you have gone through this workflow:
 
-* Enabled Monitor Management (in the {uptime-app}) prior to 8.6.0.
-* Created a synthetic monitor that is configured to run on Elastic's global managed infrastructure.
-* Upgraded to 8.8.0 or above.
+. Enabled Monitor Management (in the {uptime-app}) prior to 8.6.0.
+. Created a synthetic monitor that is configured to run on Elastic's global managed infrastructure.
+. Upgraded to 8.8.0 or above.
 
 This happens because the permissions you gave the {uptime-app} by clicking *Enable Monitor Management*
 in versions prior to 8.6.0 are not sufficient for using the {synthetics-app} in versions 8.8.0 and above.
@@ -41,9 +41,29 @@ has visited it, the user will get a message that Synthetics cannot running until
 
 [discrete]
 [[synthetics-troubleshooting-no-agent-running]]
-== No Agent running
+== No results from a monitor configured to run on a {private-location}
 
-No Agent running with the Private Location Agent Policy (so no results)
+If you have created a {private-location} and configured a monitor to run on that {private-location},
+but don't see any results for that monitor in the {synthetics-app}, make sure there is an agent
+configured to run against the agent policy.
+
+[NOTE]
+=====
+If you attempt to assign an agent policy to a {private-location} _before_ configuring an agent to run
+against the agent policy, you will see a note in the {synthetics-app} UI that the selected agent policy
+has no agents.
+=====
+
+When creating a {private-location}, you have to:
+
+. <<synthetics-private-location-fleet-agent>>.
+. <<synthetics-private-location-connect,Connect {fleet} to the {stack}>> and enroll an {agent} in {fleet}.
+. <<synthetics-private-location-add>> in the {synthetics-app}.
+
+If you do not complete the second item, no agents will be configured to run against the agent policy and
+the monitors configured to run on that {private-location} will not be running and you will get no results.
+
+To fix this, make sure there is an agent configured to run against the agent policy.
 
 [discrete]
 [[synthetics-troubleshooting-get-help]]

--- a/docs/en/observability/synthetics-troubleshooting.asciidoc
+++ b/docs/en/observability/synthetics-troubleshooting.asciidoc
@@ -1,0 +1,45 @@
+[[synthetics-troubleshooting]]
+= Troubleshooting Synthetics
+
+++++
+<titleabbrev>Troubleshooting</titleabbrev>
+++++
+
+[discrete]
+[[synthetics-troubleshooting-local-debugging]]
+= Local debugging
+
+Use the `DEBUG=synthetics` environment variable to capture Synthetics agent logs when
+running Synthetic tests locally with the <<synthetics-command-reference,Synthetics CLI>>.
+
+[discrete]
+[[synthetics-troubleshooting-common-issues]]
+= Common issues
+
+[discrete]
+[[synthetics-troubleshooting-missing-api-key]]
+== Missing API key
+
+Missing / incorrect API key (should get notification, but how to regenerate if not getting results)
+
+[discrete]
+[[synthetics-troubleshooting-no-agent-running]]
+== No Agent running
+
+No Agent running with the Private Location Agent Policy (so no results)
+
+[discrete]
+[[synthetics-troubleshooting-get-help]]
+= Get help
+
+[discrete]
+[[synthetics-troubleshooting-support]]
+== Elastic Support
+
+include::troubleshooting.asciidoc[tag=support]
+
+[discrete]
+[[synthetics-troubleshooting-discussion]]
+== Discussion forum
+
+include::troubleshooting.asciidoc[tag=discussion]

--- a/docs/en/observability/troubleshooting.asciidoc
+++ b/docs/en/observability/troubleshooting.asciidoc
@@ -27,7 +27,5 @@ https://www.elastic.co/subscriptions[Learn more about subscriptions].
 [[troubleshooting-forum]]
 === Discussion forum
 
-// tag::discussion[]
 For other questions and feature requests,
 visit our https://discuss.elastic.co/c/observability[discussion forum].
-// end::discussion[]

--- a/docs/en/observability/troubleshooting.asciidoc
+++ b/docs/en/observability/troubleshooting.asciidoc
@@ -17,13 +17,17 @@ Use the following tools in {kib} to troubleshoot issues across {observability} a
 [[troubleshooting-support]]
 === Elastic Support
 
+// tag::support[]
 We offer a support experience unlike any other.
 Our team of professionals 'speak human and code' and love making your day.
 https://www.elastic.co/subscriptions[Learn more about subscriptions].
+// end::support[]
 
 [float]
 [[troubleshooting-forum]]
 === Discussion forum
 
+// tag::discussion[]
 For other questions and feature requests,
 visit our https://discuss.elastic.co/c/observability[discussion forum].
+// end::discussion[]


### PR DESCRIPTION
Closes #2695 

I added a new troubleshooting page nested under Synthetics and added an outline with the content from #2695  and https://github.com/elastic/observability-docs/pull/3073#discussion_r1263882384. 

@paulb-elastic can you identify the best people to help with the content for "Missing / incorrect API key" and "No Agent running with the Private Location Agent Policy"? @vigneshshanmugam can you help me articulate how "Local debugging" works (I'm not sure if that's the right heading for that section)? 

cc @drewpost 