### PR TITLE
Add definitions for matches and matches phrase

### DIFF
--- a/docs/en/observability/logs-threshold-alert.asciidoc
+++ b/docs/en/observability/logs-threshold-alert.asciidoc
@@ -13,9 +13,11 @@ image::images/log-threshold-alert.png[Log threshold alert configuration]
 
 The comparators available for conditions depend on the chosen field. The combinations available are:
 
-- Numeric fields: *more than*, *more than or equals*, *less than*, or *less than or equals*.
-- Aggregatable fields: *is* and *is not*.
-- Non-aggregatable fields: *matches*, *does not match*, *matches phrase*, *does not match phrase*.
+* Numeric fields: *more than*, *more than or equals*, *less than*, or *less than or equals*.
+* Aggregatable fields: *is* and *is not*.
+* Non-aggregatable fields: *matches*, *does not match*, *matches phrase* (), *does not match phrase*.
+** *Matches* queries for some or all of the contents of the following field regardless of order. 
+** *Matches phrase* queries for the exact contents of the following field in the same order.
 
 There are several key supported use cases. You can create rules based on fields containing or matching a text pattern,
 rules based on a numeric field and arithmetic operator, or a single rule with multiple conditions.


### PR DESCRIPTION
This PR closes [Issue 2667](https://github.com/elastic/observability-docs/issues/2667) and adds definitions for the matches and matches phrase comparators when creating a logs threshold rule.