### PR TITLE
[Docs] Fix Table (was markdown)

### DIFF
--- a/docs/en/integrations/system-testing.asciidoc
+++ b/docs/en/integrations/system-testing.asciidoc
@@ -211,13 +211,31 @@ whose input type matches the `input` value will be tested. By default, the first
 
 The `SERVICE_LOGS_DIR` placeholder is not the only one available for use in a data stream's `test-<test_name>-config.yml` file. The complete list of available placeholders is shown below.
 
-| Placeholder name | Data type | Description |
-| --- | --- | --- |
-| `Hostname`| string | Addressable host name of the integration service. |
-| `Ports` | []int | Array of addressable ports the integration service is listening on. |
-| `Port` | int | Alias for `Ports[0]`. Provided as a convenience. |
-| `Logs.Folder.Agent` | string | Path to integration service's logs folder, as addressable by the Agent. |
-| `SERVICE_LOGS_DIR` | string | Alias for `Logs.Folder.Agent`. Provided as a convenience. |
+[cols="1,1,1"]
+|===
+|Placeholder name |Data type |Description
+
+|`Hostname`
+|string
+|Addressable host name of the integration service.
+
+|`Ports`
+|[]int
+|Array of addressable ports the integration service is listening on.
+
+|`Port`
+|int
+|Alias for `Ports[0]`. Provided as a convenience.
+
+|`Logs.Folder.Agent`
+|string
+|Path to integration service's logs folder, as addressable by the Agent.
+
+|`SERVICE_LOGS_DIR`
+|string
+|Alias for `Logs.Folder.Agent`. Provided as a convenience.
+
+|===
 
 Placeholders used in the `test-<test_name>-config.yml` must be enclosed in `{{` and `}}` delimiters, per Handlebars syntax.
 


### PR DESCRIPTION
It appears the table in this documentation was using markdown, therfore it was not rendering correctly. I updated to use asciidoc format.

Not sure if these docs are generated or not but this PR will fix the table directly. 