### PR TITLE
[synthetics] Add note about `--tags` and `--match` flags

### DIFF
--- a/docs/en/observability/synthetics-command-reference.asciidoc
+++ b/docs/en/observability/synthetics-command-reference.asciidoc
@@ -52,6 +52,13 @@ Does not apply throttling.
 *`-h, --help`*::
 Shows help for the `npx @elastic/synthetics` command.
 
+[NOTE]
+=====
+The `--tags` and `--match` flags for filtering are only supported when you grep or
+run synthetic tests locally. Filtering is _not_ supported in any other subcommands
+like `init`, `push`, and `location`.
+=====
+
 [discrete]
 [[elastic-synthetics-init-command]]
 = `@elastic/synthetics init`

--- a/docs/en/observability/synthetics-command-reference.asciidoc
+++ b/docs/en/observability/synthetics-command-reference.asciidoc
@@ -56,7 +56,7 @@ Shows help for the `npx @elastic/synthetics` command.
 =====
 The `--tags` and `--match` flags for filtering are only supported when you grep or
 run synthetic tests locally. Filtering is _not_ supported in any other subcommands
-like `init`, `push`, and `location`.
+like `init`, `push`, and `locations`.
 =====
 
 [discrete]


### PR DESCRIPTION
Fixes https://github.com/elastic/observability-docs/issues/3041

Adds a note about the Elastic Synthetics CLI's `--tags` and `--match` flags.