### PR TITLE
Add cases to troubleshooting and support matrix pages

### DIFF
--- a/docs/en/observability/synthetics-support-matrix.asciidoc
+++ b/docs/en/observability/synthetics-support-matrix.asciidoc
@@ -52,8 +52,8 @@ a| System requirements:
 
 | *Output to Elasticsearch*
 | 
-a| Synthetics must have a direct connection to {es}, whether running monitors from Elastic's global managed testing infrastructure, or from {private-location}s.
+a| Synthetics must have a direct connection to {es}, whether running monitors from Elastic's global managed testing infrastructure or from {private-location}s.
 
-Do not configure any ingest pipelines, or output via Logstash as this will prevent Synthetics from working properly and is not supported.
+Do not configure any ingest pipelines or output via Logstash as this will prevent Synthetics from working properly and is not supported.
 
 |===

--- a/docs/en/observability/synthetics-support-matrix.asciidoc
+++ b/docs/en/observability/synthetics-support-matrix.asciidoc
@@ -50,4 +50,10 @@ a| System requirements:
 ** Fedora - 24 and newer
 ** Debian - 8 and newer
 
+| *Output to Elasticsearch*
+| 
+a| Synthetics must have a direct connection to {es}, whether running monitors from Elastic's global managed testing infrastructure, or from {private-location}s.
+
+Do not configure any ingest pipelines, or output via Logstash as this will prevent Synthetics from working properly and is not supported.
+
 |===

--- a/docs/en/observability/synthetics-troubleshooting.asciidoc
+++ b/docs/en/observability/synthetics-troubleshooting.asciidoc
@@ -74,6 +74,18 @@ If you have configured a monitor but don't see any results for that monitor in t
 Do not configure any ingest pipelines, or output via Logstash as this will prevent Synthetics from working properly and is not <<synthetics-support-matrix,supported>>.
 
 [discrete]
+[[synthetics-troubleshooting-no-agent-running]]
+== Browser monitor configured to run on a {private-location} not running to schedule
+
+If you have browser monitors configured to run on a {private-location} but notice one or more of them are not running to their schedule, there may be too many monitors trying to run concurrently, causing some of them to skip their scheduled run.
+
+Due to the aditional hardware overhead of running browser monitors, we limit each {private-location} to only run two browser monitors at the same time. Depending on how many browser monitors you have configured to run on the {private-location} and their schedule, the {private-location} may not be able to run them all because that would need more than two simultaneous browser tests to be running.
+
+When this happens, you will see a message in the logs such as `2 tasks have missed their schedule deadlines by more than 1 second in the last 15s` (these will be visible from inside the Agent diagnostic .zip file, and the numbers/periods may be different in your logs).
+
+If this is happening, you can either increase the number of concurrent browser monitors allowed (as described in <<synthetics-private-location-scaling>>, paying attention to the scaling and hardware requirements documented), or create multiple {private-location}s and spread your browser monitors across them more evenly (effectively horizontally scaling your {private-location}s).
+
+[discrete]
 [[synthetics-troubleshooting-get-help]]
 = Get help
 

--- a/docs/en/observability/synthetics-troubleshooting.asciidoc
+++ b/docs/en/observability/synthetics-troubleshooting.asciidoc
@@ -69,28 +69,39 @@ To fix this, make sure there is an agent configured to run against the agent pol
 [[synthetics-troubleshooting-no-direct-es-connection]]
 == No results from a monitor
 
-If you have configured a monitor but don't see any results for that monitor in the {synthetics-app}, whether running them from Elastic's global managed testing infrastructure, or from {private-location}s, ensure Synthetics has a direct connection to {es}.
+If you have configured a monitor but don't see any results for that monitor in the {synthetics-app}, whether running them from Elastic's global managed testing infrastructure or from {private-location}s, ensure Synthetics has a direct connection to {es}.
 
-Do not configure any ingest pipelines, or output via Logstash as this will prevent Synthetics from working properly and is not <<synthetics-support-matrix,supported>>.
+Do not configure any ingest pipelines or output via Logstash as this will prevent Synthetics from working properly and is not <<synthetics-support-matrix,supported>>.
 
 [discrete]
 [[synthetics-troubleshooting-missing-browser-schedules]]
 == Browser monitor configured to run on a {private-location} not running to schedule
 
-If you have browser monitors configured to run on a {private-location} but notice one or more of them are not running to their schedule, this could be because:
+If you have browser monitors configured to run on a {private-location} but notice one or more of them are not running as scheduled, this could be because:
 
-* Your monitor runs for longer than the frequency you have set
+* The time it takes for your monitor to run is longer than the frequency you have set
 * There may be too many monitors trying to run concurrently, causing some of them to skip their scheduled run
 
-You may also see a message in the logs such as `2 tasks have missed their schedule deadlines by more than 1 second in the last 15s` (these will be visible from inside the Agent diagnostic .zip file, and the numbers/periods may be different in your logs).
+You may also see a message in the logs such as `2 tasks have missed their schedule deadlines by more than 1 second in the last 15s`. These will be visible from inside the Agent diagnostic ZIP file, and the numbers and time periods may be different in your logs.
 
-It's worth checking the first condition initially. Check the total duration of your monitor and ensure it's less than your scheduled frequency. For example, if you have a monitor that takes 90 seconds to run in total, setting a schedule of 1 minute will cause this problem. After 1 minute, the test is still running and so another one will not be started. In effect, this monitor will end up running every 2 minutes even though you have configured it to run every 1 minute.
+Start by identifying the cause of the issue. First, check if the time it takes the monitor to run is less than the scheduled frequency:
 
-If this is not the case for you, then there may be too many browser monitors attempting to run on the {private-location}.
+1. Go to the Synthetics app.
+2. Click the monitor, then click **Go to monitor**.
+3. Go to the [Overview tab](https://www.elastic.co/guide/en/observability/current/synthetics-analyze.html#synthetics-analyze-individual-monitors-overview) to see the _Avg. duration_. You can also view the duration for individual runs in the [History tab](https://www.elastic.co/guide/en/observability/current/synthetics-analyze.html#synthetics-analyze-individual-monitors-history).
+4. Compare the duration to the scheduled frequency. If the duration is _greater than_ the scheduled frequency, for example if the monitor that takes 90 seconds to run and its scheduled frequency is 1 minute, the next scheduled run will not occur because the current one is still running so you may see results for every other scheduled run.
 
-Due to the additional hardware overhead of running browser monitors, we limit each {private-location} to only run two browser monitors at the same time. Depending on how many browser monitors you have configured to run on the {private-location} and their schedule, the {private-location} may not be able to run them all because that would need more than two simultaneous browser tests to be running.
+To fix this, you can either:
 
-If this is happening, you can either increase the number of concurrent browser monitors allowed (as described in <<synthetics-private-location-scaling>>, paying attention to the scaling and hardware requirements documented), or create multiple {private-location}s and spread your browser monitors across them more evenly (effectively horizontally scaling your {private-location}s).
+* Change the frequency so the monitor runs less often.
+* Refactor the monitor so it can run in a shorter amount of time.
+
+If the duration is _less than_ the scheduled frequency or the suggestion above do not fix the issue, then there may be too many browser monitors attempting to run on the Private Location. Due to the additional hardware overhead of running browser monitors, we limit each Private Location to only run two browser monitors at the same time. Depending on how many browser monitors you have configured to run on the Private Location and their schedule, the Private Location may not be able to run them all because that would need more than two simultaneous browser tests to be running.
+
+To fix this issue, you can either:
+
+* Increase the number of concurrent browser monitors allowed (as described in [Scaling Private Locations](https://observability-docs_3105.docs-preview.app.elstc.co/guide/en/observability/master/synthetics-private-location.html#synthetics-private-location-scaling), paying attention to the scaling and hardware requirements documented).
+* Create multiple Private Locations and spread your browser monitors across them more evenly (effectively horizontally scaling your Private Locations).
 
 [discrete]
 [[synthetics-troubleshooting-get-help]]

--- a/docs/en/observability/synthetics-troubleshooting.asciidoc
+++ b/docs/en/observability/synthetics-troubleshooting.asciidoc
@@ -74,7 +74,7 @@ If you have configured a monitor but don't see any results for that monitor in t
 Do not configure any ingest pipelines, or output via Logstash as this will prevent Synthetics from working properly and is not <<synthetics-support-matrix,supported>>.
 
 [discrete]
-[[synthetics-troubleshooting-no-agent-running]]
+[[synthetics-troubleshooting-missing-browser-schedules]]
 == Browser monitor configured to run on a {private-location} not running to schedule
 
 If you have browser monitors configured to run on a {private-location} but notice one or more of them are not running to their schedule, this could be because:

--- a/docs/en/observability/synthetics-troubleshooting.asciidoc
+++ b/docs/en/observability/synthetics-troubleshooting.asciidoc
@@ -77,11 +77,18 @@ Do not configure any ingest pipelines, or output via Logstash as this will preve
 [[synthetics-troubleshooting-no-agent-running]]
 == Browser monitor configured to run on a {private-location} not running to schedule
 
-If you have browser monitors configured to run on a {private-location} but notice one or more of them are not running to their schedule, there may be too many monitors trying to run concurrently, causing some of them to skip their scheduled run.
+If you have browser monitors configured to run on a {private-location} but notice one or more of them are not running to their schedule, this could be because:
 
-Due to the aditional hardware overhead of running browser monitors, we limit each {private-location} to only run two browser monitors at the same time. Depending on how many browser monitors you have configured to run on the {private-location} and their schedule, the {private-location} may not be able to run them all because that would need more than two simultaneous browser tests to be running.
+* Your monitor runs for longer than the frequency you have set
+* There may be too many monitors trying to run concurrently, causing some of them to skip their scheduled run
 
-When this happens, you will see a message in the logs such as `2 tasks have missed their schedule deadlines by more than 1 second in the last 15s` (these will be visible from inside the Agent diagnostic .zip file, and the numbers/periods may be different in your logs).
+You may also see a message in the logs such as `2 tasks have missed their schedule deadlines by more than 1 second in the last 15s` (these will be visible from inside the Agent diagnostic .zip file, and the numbers/periods may be different in your logs).
+
+It's worth checking the first condition initially. Check the total duration of your monitor and ensure it's less than your scheduled frequency. For example, if you have a monitor that takes 90 seconds to run in total, setting a schedule of 1 minute will cause this problem. After 1 minute, the test is still running and so another one will not be started. In effect, this monitor will end up running every 2 minutes even though you have configured it to run every 1 minute.
+
+If this is not the case for you, then there may be too many browser monitors attempting to run on the {private-location}.
+
+Due to the additional hardware overhead of running browser monitors, we limit each {private-location} to only run two browser monitors at the same time. Depending on how many browser monitors you have configured to run on the {private-location} and their schedule, the {private-location} may not be able to run them all because that would need more than two simultaneous browser tests to be running.
 
 If this is happening, you can either increase the number of concurrent browser monitors allowed (as described in <<synthetics-private-location-scaling>>, paying attention to the scaling and hardware requirements documented), or create multiple {private-location}s and spread your browser monitors across them more evenly (effectively horizontally scaling your {private-location}s).
 

--- a/docs/en/observability/synthetics-troubleshooting.asciidoc
+++ b/docs/en/observability/synthetics-troubleshooting.asciidoc
@@ -66,6 +66,14 @@ in the {synthetics-app}.
 To fix this, make sure there is an agent configured to run against the agent policy.
 
 [discrete]
+[[synthetics-troubleshooting-no-direct-es-connection]]
+== No results from a monitor
+
+If you have configured a monitor but don't see any results for that monitor in the {synthetics-app}, whether running them from Elastic's global managed testing infrastructure, or from {private-location}s, ensure Synthetics has a direct connection to {es}.
+
+Do not configure any ingest pipelines, or output via Logstash as this will prevent Synthetics from working properly and is not <<synthetics-support-matrix,supported>>.
+
+[discrete]
 [[synthetics-troubleshooting-get-help]]
 = Get help
 

--- a/docs/en/observability/synthetics-troubleshooting.asciidoc
+++ b/docs/en/observability/synthetics-troubleshooting.asciidoc
@@ -88,7 +88,7 @@ Start by identifying the cause of the issue. First, check if the time it takes t
 
 1. Go to the Synthetics app.
 2. Click the monitor, then click **Go to monitor**.
-3. Go to the [Overview tab](https://www.elastic.co/guide/en/observability/current/synthetics-analyze.html#synthetics-analyze-individual-monitors-overview) to see the _Avg. duration_. You can also view the duration for individual runs in the [History tab](https://www.elastic.co/guide/en/observability/current/synthetics-analyze.html#synthetics-analyze-individual-monitors-history).
+3. Go to the https://www.elastic.co/guide/en/observability/current/synthetics-analyze.html#synthetics-analyze-individual-monitors-overview[Overview tab] to see the _Avg. duration_. You can also view the duration for individual runs in the https://www.elastic.co/guide/en/observability/current/synthetics-analyze.html#synthetics-analyze-individual-monitors-history[History tab].
 4. Compare the duration to the scheduled frequency. If the duration is _greater than_ the scheduled frequency, for example if the monitor that takes 90 seconds to run and its scheduled frequency is 1 minute, the next scheduled run will not occur because the current one is still running so you may see results for every other scheduled run.
 
 To fix this, you can either:
@@ -100,7 +100,7 @@ If the duration is _less than_ the scheduled frequency or the suggestion above d
 
 To fix this issue, you can either:
 
-* Increase the number of concurrent browser monitors allowed (as described in [Scaling Private Locations](https://observability-docs_3105.docs-preview.app.elstc.co/guide/en/observability/master/synthetics-private-location.html#synthetics-private-location-scaling), paying attention to the scaling and hardware requirements documented).
+* Increase the number of concurrent browser monitors allowed (as described in https://observability-docs_3105.docs-preview.app.elstc.co/guide/en/observability/master/synthetics-private-location.html#synthetics-private-location-scaling[Scaling Private Locations]), paying attention to the scaling and hardware requirements documented).
 * Create multiple Private Locations and spread your browser monitors across them more evenly (effectively horizontally scaling your Private Locations).
 
 [discrete]

--- a/docs/en/observability/synthetics-troubleshooting.asciidoc
+++ b/docs/en/observability/synthetics-troubleshooting.asciidoc
@@ -86,22 +86,22 @@ You may also see a message in the logs such as `2 tasks have missed their schedu
 
 Start by identifying the cause of the issue. First, check if the time it takes the monitor to run is less than the scheduled frequency:
 
-1. Go to the Synthetics app.
+1. Go to the {synthetics-app}.
 2. Click the monitor, then click **Go to monitor**.
-3. Go to the https://www.elastic.co/guide/en/observability/current/synthetics-analyze.html#synthetics-analyze-individual-monitors-overview[Overview tab] to see the _Avg. duration_. You can also view the duration for individual runs in the https://www.elastic.co/guide/en/observability/current/synthetics-analyze.html#synthetics-analyze-individual-monitors-history[History tab].
+3. Go to the <<synthetics-analyze-individual-monitors-overview,Overview tab>> to see the _Avg. duration_. You can also view the duration for individual runs in the <<synthetics-analyze-individual-monitors-history,History tab>>.
 4. Compare the duration to the scheduled frequency. If the duration is _greater than_ the scheduled frequency, for example if the monitor that takes 90 seconds to run and its scheduled frequency is 1 minute, the next scheduled run will not occur because the current one is still running so you may see results for every other scheduled run.
-
++
 To fix this, you can either:
-
++
 * Change the frequency so the monitor runs less often.
 * Refactor the monitor so it can run in a shorter amount of time.
 
-If the duration is _less than_ the scheduled frequency or the suggestion above do not fix the issue, then there may be too many browser monitors attempting to run on the Private Location. Due to the additional hardware overhead of running browser monitors, we limit each Private Location to only run two browser monitors at the same time. Depending on how many browser monitors you have configured to run on the Private Location and their schedule, the Private Location may not be able to run them all because that would need more than two simultaneous browser tests to be running.
+If the duration is _less than_ the scheduled frequency or the suggestion above does not fix the issue, then there may be too many browser monitors attempting to run on the {private-location}. Due to the additional hardware overhead of running browser monitors, we limit each {private-location} to only run two browser monitors at the same time. Depending on how many browser monitors you have configured to run on the {private-location} and their schedule, the {private-location} may not be able to run them all because it would require more than two browser tests to be running simultaneously.
 
 To fix this issue, you can either:
 
-* Increase the number of concurrent browser monitors allowed (as described in https://observability-docs_3105.docs-preview.app.elstc.co/guide/en/observability/master/synthetics-private-location.html#synthetics-private-location-scaling[Scaling Private Locations]), paying attention to the scaling and hardware requirements documented).
-* Create multiple Private Locations and spread your browser monitors across them more evenly (effectively horizontally scaling your Private Locations).
+* Increase the number of concurrent browser monitors allowed (as described in <<synthetics-private-location-scaling,Scaling Private Locations>>), paying attention to the scaling and hardware requirements documented).
+* Create multiple {private-location}s and spread your browser monitors across them more evenly (effectively horizontally scaling your {private-location}s).
 
 [discrete]
 [[synthetics-troubleshooting-get-help]]


### PR DESCRIPTION
Added about a direct ES connection being needed on the Support Matrix and troubleshooting pages as it has come up with users of the Service, not just with Private Locations, so need to make this message clearer.

Also added a note about scaling as mentioned in https://github.com/elastic/observability-docs/pull/3081#issuecomment-1644436758