### PR TITLE
Rearrange the profiler docs for UP agent

### DIFF
--- a/docs/en/observability/profiling-get-started.asciidoc
+++ b/docs/en/observability/profiling-get-started.asciidoc
@@ -91,23 +91,8 @@ We still recommend upgrading as the latest version contains several improvements
 == Install the host-agent 
 You have the following options when installing the host-agent:
 
-. <<profiling-install-host-agent-standalone, Install the host-agent in standalone mode>>
 . <<profiling-install-host-agent-elastic-agent, Install the host-agent using the {agent}>>
-
-[discrete]
-[[profiling-install-host-agent-standalone]]
-== Install the host-agent in standalone mode
-
-The host-agent profiles your fleet. You need to install and configure it on every machine that you want to profile.
-The host-agent needs  `root` / `CAP_SYS_ADMIN` privileges to run.
-
-After clicking *Set up Universal Profiling* in the previous step, you'll see the instructions for installing the host-agent.
-You can also find these instructions by clicking the *Add data* button in the top-right corner of the page.
-
-The following is an example of the provided instructions for {k8s}:
-
-[role="screenshot"]
-image::images/profiling-k8s-hostagent.png[]
+. <<profiling-install-host-agent-standalone, Install the host-agent in standalone mode>>
 
 [discrete]
 [[profiling-install-host-agent-elastic-agent]]
@@ -130,6 +115,21 @@ image::images/profiling-elastic-agent.png[]
 image::images/profililing-elastic-agent-creds.png[]
 +
 . Click **Save and continue**.
+
+[discrete]
+[[profiling-install-host-agent-standalone]]
+== Install the host-agent in standalone mode
+
+The host-agent profiles your fleet. You need to install and configure it on every machine that you want to profile.
+The host-agent needs  `root` / `CAP_SYS_ADMIN` privileges to run.
+
+After clicking *Set up Universal Profiling* in the previous step, you'll see the instructions for installing the host-agent.
+You can also find these instructions by clicking the *Add data* button in the top-right corner of the page.
+
+The following is an example of the provided instructions for {k8s}:
+
+[role="screenshot"]
+image::images/profiling-k8s-hostagent.png[]
 
 [discrete]
 [[profiling-agent-config-notes]]


### PR DESCRIPTION
I think that we should mention Elastic Agent at the top instead fo standalone, to show that Elastic Agent is the preferred way of running it.