### PR TITLE
Added the --no-headless option back in

### DIFF
--- a/docs/en/observability/synthetics-command-reference.asciidoc
+++ b/docs/en/observability/synthetics-command-reference.asciidoc
@@ -72,6 +72,11 @@ Runs with the browser in headful mode.
 +
 This is the same as running `--playwright-options '{"headless": false}'`.
 
+[NOTE]
+=====
+Headful mode is only to be used locally when testing, to help see the browser being shown and to interact with DOM elements. Do not attempt to run in headful mode when running through Elastic's global managed testing infrastructure, or {private-location}s.
+=====
+
 `-h, --help`::
 Shows help for the `npx @elastic/synthetics` command.
 

--- a/docs/en/observability/synthetics-command-reference.asciidoc
+++ b/docs/en/observability/synthetics-command-reference.asciidoc
@@ -67,6 +67,11 @@ Throttling can also be disabled in the configuration file using
 <<synthetics-configuration-monitor,`monitor.throttling`>>.
 The value defined via the CLI will take precedence.
 
+`--no-headless`::
+Runs with the browser in headful mode.
++
+This is the same as running `--playwright-options '{"headless": false}'`.
+
 `-h, --help`::
 Shows help for the `npx @elastic/synthetics` command.
 

--- a/docs/en/observability/synthetics-command-reference.asciidoc
+++ b/docs/en/observability/synthetics-command-reference.asciidoc
@@ -70,11 +70,11 @@ The value defined via the CLI will take precedence.
 `--no-headless`::
 Runs with the browser in headful mode.
 +
-This is the same as running `--playwright-options '{"headless": false}'`.
+This is the same as setting https://playwright.dev/docs/api/class-testoptions#test-options-headless[Playwright's `headless` option] to `false` by running `--playwright-options '{"headless": false}'`.
 
 [NOTE]
 =====
-Headful mode is only to be used locally when testing, to help see the browser being shown and to interact with DOM elements. Do not attempt to run in headful mode when running through Elastic's global managed testing infrastructure, or {private-location}s.
+Headful mode should only be used locally to see the browser and interact with DOM elements directly for testing purposes. Do not attempt to run in headful mode when running through Elastic's global managed testing infrastructure or {private-location}s as this is not supported.
 =====
 
 `-h, --help`::


### PR DESCRIPTION
This capability has been added back in via https://github.com/elastic/synthetics/pull/813 so adding back to the docs