### PR TITLE
[DOCS] Remove content reuse for cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ To build the docs:
 2. Run the `build_docs` script, passing in the path to the `index.asciidoc` and resource paths to other repos that contain source files. For example, to build the Observability Guide and open it in the browser, run:
 
 ```
-../docs/build_docs --doc ./docs/en/observability/index.asciidoc --chunk 1 --resource ../apm-server/docs/guide --resource ../kibana/docs --resource ../ingest-docs/docs --open
+../docs/build_docs --doc ./docs/en/observability/index.asciidoc --chunk 1 --resource ../apm-server/docs/guide --resource ../ingest-docs/docs --open
 ```
 
-The above command assumes that [elastic/docs](https://github.com/elastic/docs), [elastic/beats](https://github.com/elastic/beats), [elastic/kibana](https://github.com/elastic/kibana), and [elastic/apm-server](https://github.com/elastic/apm-server) are checked out into the same parent directory.
+The above command assumes that [elastic/docs](https://github.com/elastic/docs), [elastic/beats](https://github.com/elastic/beats), and [elastic/apm-server](https://github.com/elastic/apm-server) are checked out into the same parent directory.
 
 If you prefer to use aliases, you can load the [elastic/docs/doc_build_aliases.sh file](https://github.com/elastic/docs/blob/master/doc_build_aliases.sh), which has the resources defined for you.

--- a/docs/en/observability/index.asciidoc
+++ b/docs/en/observability/index.asciidoc
@@ -25,7 +25,6 @@ include::{docs-root}/shared/attributes.asciidoc[]
 
 :apm-repo-dir:         {apm-server-root}/docs
 :shared:               {observability-docs-root}/docs/en/shared
-:kibana-repo-dir:      {kibana-root}/docs
 
 :synthetics_version: v1.3.0
 :project-monitors: project monitors

--- a/docs/en/observability/manage-cases.asciidoc
+++ b/docs/en/observability/manage-cases.asciidoc
@@ -65,10 +65,8 @@ For self-managed {kib}:
 . Create a preconfigured email connector.
 +
 --
-NOTE: At this time, email notifications support only preconfigured connectors,
-which are defined in the `kibana.yml` file. For examples, refer to
-{kibana-ref}/email-action-type.html#preconfigured-email-configuration[Preconfigured email connector]
-and {kibana-ref}/email-action-type.html#configuring-email[Configuring email connectors for well-known services].
+NOTE: At this time, email notifications support only {kibana-ref}/pre-configured-connectors.html[preconfigured email connectors],
+which are defined in the `kibana.yml` file.
 --
 . Set the `notifications.connectors.default.email` {kib} setting to the name of
 your email connector.

--- a/docs/en/observability/manage-cases.asciidoc
+++ b/docs/en/observability/manage-cases.asciidoc
@@ -46,7 +46,36 @@ When you export cases as {kibana-ref}/managing-saved-objects.html[saved objects]
 [[add-case-notifications]]
 == Add email notifications
 
-include::{kibana-repo-dir}/management/cases/manage-cases.asciidoc[tag=case-notifications]
+You can configure email notifications that occur when users are assigned to
+cases.
+
+For hosted {kib} on {ess}:
+
+. Add the email addresses to the monitoring email allowlist. Follow the steps in
+{cloud}/ec-watcher.html#ec-watcher-allowlist[Send alerts by email].
++
+--
+You do not need to take any more steps to configure an email connector or update
+{kib} user settings, since the preconfigured Elastic-Cloud-SMTP connector is
+used by default.
+--
+
+For self-managed {kib}:
+
+. Create a preconfigured email connector.
++
+--
+NOTE: At this time, email notifications support only preconfigured connectors,
+which are defined in the `kibana.yml` file. For examples, refer to
+{kibana-ref}/email-action-type.html#preconfigured-email-configuration[Preconfigured email connector]
+and {kibana-ref}/email-action-type.html#configuring-email[Configuring email connectors for well-known services].
+--
+. Set the `notifications.connectors.default.email` {kib} setting to the name of
+your email connector.
+. If you want the email notifications to contain links back to the case, you
+must configure the {kibana-ref}/settings.html#server-publicBaseUrl[server.publicBaseUrl] setting.
+
+When you subsequently add assignees to cases, they receive an email.
 
 [discrete]
 [[manage-case-observability]]


### PR DESCRIPTION
This PR removes a tagged region to err on the side of simplicity as we migrate our content.