### PR TITLE
Remove book-scoped attributes

### DIFF
--- a/docs/en/observability/exploratory-data-visualizations.asciidoc
+++ b/docs/en/observability/exploratory-data-visualizations.asciidoc
@@ -155,25 +155,25 @@ The following table shows which data types are available for each report type:
 |===
 |Data type | Synthetics monitoring | User experience (RUM) | Mobile experience
 
-| Monitor duration |{y} | |
-| Up Pings |{y} | |
-| Down Pings | {y} | |
-| Step duration | {y} | |
-| DOM content loaded | {y} | |
-| Document complete (onLoad) | {y} | |
-| Largest contentful paint | {y} | {y} |
-| First contentful paint | {y} | {y} |
-| Page load time | {y} | {y} |
-| Cumulative layout shift | {y} | {y} |
-| Page views | | {y} |
-| Backend time | | {y} |
-| Total blocking time | | {y} |
-| First input delay | | {y} |
-| Latency | | | {y}
-| Throughput | | | {y}
-| System memory usage | | | {y}
-| CPU usage | | | {y}
-| Number of devices | | | {y}
+| Monitor duration |{yes-icon} | |
+| Up Pings |{yes-icon} | |
+| Down Pings | {yes-icon} | |
+| Step duration | {yes-icon} | |
+| DOM content loaded | {yes-icon} | |
+| Document complete (onLoad) | {yes-icon} | |
+| Largest contentful paint | {yes-icon} | {yes-icon} |
+| First contentful paint | {yes-icon} | {yes-icon} |
+| Page load time | {yes-icon} | {yes-icon} |
+| Cumulative layout shift | {yes-icon} | {yes-icon} |
+| Page views | | {yes-icon} |
+| Backend time | | {yes-icon} |
+| Total blocking time | | {yes-icon} |
+| First input delay | | {yes-icon} |
+| Latency | | | {yes-icon}
+| Throughput | | | {yes-icon}
+| System memory usage | | | {yes-icon}
+| CPU usage | | | {yes-icon}
+| Number of devices | | | {yes-icon}
 | System CPU usage | | |
 | Docker CPU usage | | |
 // lint ignore k8s

--- a/docs/en/observability/index.asciidoc
+++ b/docs/en/observability/index.asciidoc
@@ -5,8 +5,6 @@
 include::{docs-root}/shared/versions/stack/{source_branch}.asciidoc[]
 include::{docs-root}/shared/attributes.asciidoc[]
 
-:synthetics_version: v1.3.0
-
 include::landing-page/page.asciidoc[]
 
 // What is Observability?

--- a/docs/en/observability/index.asciidoc
+++ b/docs/en/observability/index.asciidoc
@@ -8,15 +8,6 @@ include::{docs-root}/shared/attributes.asciidoc[]
 :y: image:images/green-check.svg[yes]
 :n: image:images/red-x.svg[no]
 
-:apm-py-ref-v:         https://www.elastic.co/guide/en/apm/agent/python/{apm-py-branch}
-:apm-node-ref-v:       https://www.elastic.co/guide/en/apm/agent/nodejs/{apm-node-branch}
-:apm-rum-ref-v:        https://www.elastic.co/guide/en/apm/agent/rum-js/{apm-rum-branch}
-:apm-ruby-ref-v:       https://www.elastic.co/guide/en/apm/agent/ruby/{apm-ruby-branch}
-:apm-java-ref-v:       https://www.elastic.co/guide/en/apm/agent/java/{apm-java-branch}
-:apm-go-ref-v:         https://www.elastic.co/guide/en/apm/agent/go/{apm-go-branch}
-:apm-ios-ref-v:        https://www.elastic.co/guide/en/apm/agent/swift/{apm-ios-branch}
-:apm-dotnet-ref-v:     https://www.elastic.co/guide/en/apm/agent/dotnet/{apm-dotnet-branch}
-
 :synthetics_version: v1.3.0
 :project-monitors: project monitors
 :project-monitors-cap: Project monitors

--- a/docs/en/observability/index.asciidoc
+++ b/docs/en/observability/index.asciidoc
@@ -17,15 +17,6 @@ include::{docs-root}/shared/attributes.asciidoc[]
 :apm-ios-ref-v:        https://www.elastic.co/guide/en/apm/agent/swift/{apm-ios-branch}
 :apm-dotnet-ref-v:     https://www.elastic.co/guide/en/apm/agent/dotnet/{apm-dotnet-branch}
 
-:apm-server-root:      {docdir}/../../../../apm-server
-:beats-root:           {docdir}/../../../../beats
-
-:fleet-repo-dir: {observability-docs-root}/docs/en/ingest-management
-:tab-widgets: {fleet-repo-dir}/tab-widgets
-
-:apm-repo-dir:         {apm-server-root}/docs
-:shared:               {observability-docs-root}/docs/en/shared
-
 :synthetics_version: v1.3.0
 :project-monitors: project monitors
 :project-monitors-cap: Project monitors

--- a/docs/en/observability/index.asciidoc
+++ b/docs/en/observability/index.asciidoc
@@ -6,10 +6,6 @@ include::{docs-root}/shared/versions/stack/{source_branch}.asciidoc[]
 include::{docs-root}/shared/attributes.asciidoc[]
 
 :synthetics_version: v1.3.0
-:project-monitors: project monitors
-:project-monitors-cap: Project monitors
-:synthetics-app: Synthetics app
-:private-location: Private Location
 
 include::landing-page/page.asciidoc[]
 

--- a/docs/en/observability/index.asciidoc
+++ b/docs/en/observability/index.asciidoc
@@ -5,9 +5,6 @@
 include::{docs-root}/shared/versions/stack/{source_branch}.asciidoc[]
 include::{docs-root}/shared/attributes.asciidoc[]
 
-:y: image:images/green-check.svg[yes]
-:n: image:images/red-x.svg[no]
-
 :synthetics_version: v1.3.0
 :project-monitors: project monitors
 :project-monitors-cap: Project monitors

--- a/docs/en/observability/ingest-traces.asciidoc
+++ b/docs/en/observability/ingest-traces.asciidoc
@@ -56,7 +56,7 @@ or secret token to match your APM agents.
 --
 // this if directive includes the same file, but changes the file path based on where this guide is built
 ifndef::apm-integration-docs[]
-include::{apm-repo-dir}/tab-widgets/install-agents-widget.asciidoc[]
+include::{apm-server-root}/docs/tab-widgets/install-agents-widget.asciidoc[]
 endif::[]
 
 ifdef::apm-integration-docs[]

--- a/docs/en/observability/monitor-aws-beats.asciidoc
+++ b/docs/en/observability/monitor-aws-beats.asciidoc
@@ -135,7 +135,7 @@ an Elastic deployment to store and analyze the data and an agent to collect and
 ship the data.
 
 :leveloffset: +3
-include::{shared}/install-configure-filebeat.asciidoc[]
+include::{observability-docs-root}/docs/en/shared/install-configure-filebeat.asciidoc[]
 :leveloffset: -3
 
 [discrete]
@@ -325,7 +325,7 @@ Please see {metricbeat-ref}/metricbeat-module-aws.html#aws-api-requests[AWS API 
 In a new terminal window, run the following commands.
 
 :leveloffset: +3
-include::{shared}/install-configure-metricbeat.asciidoc[]
+include::{observability-docs-root}/docs/en/shared/install-configure-metricbeat.asciidoc[]
 :leveloffset: -3
 
 Now that the output is working, you are going to set up the {aws} module.

--- a/docs/en/observability/monitor-azure-beats.asciidoc
+++ b/docs/en/observability/monitor-azure-beats.asciidoc
@@ -272,7 +272,7 @@ You can run {metricbeat} on any machine. This {tutorial} uses a small
 Azure VM, *B2s* (2 vCPUs, 4 GB memory), with an Ubuntu distribution.
 
 :leveloffset: +3
-include::{shared}/install-configure-metricbeat.asciidoc[]
+include::{observability-docs-root}/docs/en/shared/install-configure-metricbeat.asciidoc[]
 :leveloffset: -3
 
 Now that the output is working, you are going to set up the input (Azure).

--- a/docs/en/observability/monitor-gcp.asciidoc
+++ b/docs/en/observability/monitor-gcp.asciidoc
@@ -111,7 +111,7 @@ machine. This {tutorial} uses a small {gcp} instance, e2-small (2 vCPUs,
 2 GB memory), with an Ubuntu distribution.
 
 :leveloffset: +3
-include::{shared}/install-configure-metricbeat.asciidoc[]
+include::{observability-docs-root}/docs/en/shared/install-configure-metricbeat.asciidoc[]
 :leveloffset: -3
 
 Now that the output is working, you are going to set up the input (GCP).
@@ -192,7 +192,7 @@ Now that {metricbeat} is up and running, configure {filebeat} to
 collect Google Cloud logs.
 
 :leveloffset: +3
-include::{shared}/install-configure-filebeat.asciidoc[]
+include::{observability-docs-root}/docs/en/shared/install-configure-filebeat.asciidoc[]
 :leveloffset: -3
 
 Now that the output is working, you are going to set up the input ({gcp}).

--- a/docs/en/observability/monitor-java-app.asciidoc
+++ b/docs/en/observability/monitor-java-app.asciidoc
@@ -419,7 +419,7 @@ The log entries are ingested containing timestamps like the following.
 To read the log file and send it to {es}, {filebeat} is required. To download and install {filebeat},
 use the commands that work with your system:
 
-include::{shared}/copied-from-beats/install-filebeat/install-widget-filebeat.asciidoc[]
+include::{observability-docs-root}/docs/en/shared/copied-from-beats/install-filebeat/install-widget-filebeat.asciidoc[]
 
 . Use the {filebeat} keystore to store {filebeat-ref}/keystore.html[secure
 settings]. Let’s store the Cloud ID in the keystore.
@@ -515,7 +515,7 @@ output.elasticsearch:
 
 To send data to {es}, start {filebeat}.
 
-include::{shared}/copied-from-beats/start-filebeat/start-widget-filebeat.asciidoc[]
+include::{observability-docs-root}/docs/en/shared/copied-from-beats/start-filebeat/start-widget-filebeat.asciidoc[]
 
 In the log output, you should see the following line.
 
@@ -1231,7 +1231,7 @@ standard Prometheus format.
 To send metrics to {es}, {metricbeat} is required. To download and install {metricbeat},
 use the commands that work with your system:
 
-include::{shared}/copied-from-beats/install-metricbeat/install-widget-metricbeat.asciidoc[]
+include::{observability-docs-root}/docs/en/shared/copied-from-beats/install-metricbeat/install-widget-metricbeat.asciidoc[]
 
 . Similar to the {filebeat} setup, run the initial set up of all the dashboards
 using the admin user, and then use an API key.
@@ -1321,7 +1321,7 @@ password to the keystore and refer to both in the configuration.
 
 . Start {metricbeat}.
 
-include::{shared}/copied-from-beats/start-metricbeat/start-widget-metricbeat.asciidoc[]
+include::{observability-docs-root}/docs/en/shared/copied-from-beats/start-metricbeat/start-widget-metricbeat.asciidoc[]
 
 Verify that the Prometheus events are flowing into
 {es}.
@@ -1986,7 +1986,7 @@ of a service, but also graph latencies over time, and get notified about expirin
 To send uptime data to {es}, {heartbeat} (the polling component) is required. To download
 and install {heartbeat}, use the commands that work with your system:
 
-include::{shared}/copied-from-beats/install-heartbeat/install-widget-heartbeat.asciidoc[]
+include::{observability-docs-root}/docs/en/shared/copied-from-beats/install-heartbeat/install-widget-heartbeat.asciidoc[]
 
 After downloading and unpacking, we have to set up the cloud id and the
 password one more time.
@@ -2063,7 +2063,7 @@ processors:
 +
 . Now start {heartbeat} and wait a couple of minutes to get some data.
 
-include::{shared}/copied-from-beats/start-heartbeat/start-widget-heartbeat.asciidoc[]
+include::{observability-docs-root}/docs/en/shared/copied-from-beats/start-heartbeat/start-widget-heartbeat.asciidoc[]
 
 To view the {uptime-app},
 select *{observability}* -> *Uptime*. The overview looks

--- a/docs/en/observability/monitor-k8s/monitor-k8s-application-performance.asciidoc
+++ b/docs/en/observability/monitor-k8s/monitor-k8s-application-performance.asciidoc
@@ -63,7 +63,7 @@ is as easy as installing a library and adding a few lines of code.
 
 Select your application's language for details:
 
-include::{shared}/install-apm-agents-kube/widget.asciidoc[]
+include::{observability-docs-root}/docs/en/shared/install-apm-agents-kube/widget.asciidoc[]
 
 [discrete]
 === Step 4: Configure Kubernetes data

--- a/docs/en/shared/install-configure-filebeat.asciidoc
+++ b/docs/en/shared/install-configure-filebeat.asciidoc
@@ -3,7 +3,7 @@
 
 Download and install {filebeat}.
 
-include::{shared}/copied-from-beats/install-filebeat/install-widget-filebeat.asciidoc[]
+include::{observability-docs-root}/docs/en/shared/copied-from-beats/install-filebeat/install-widget-filebeat.asciidoc[]
 
 [discrete]
 = Set up assets

--- a/docs/en/shared/install-configure-metricbeat.asciidoc
+++ b/docs/en/shared/install-configure-metricbeat.asciidoc
@@ -3,7 +3,7 @@
 
 Download and install {metricbeat}.
 
-include::{shared}/copied-from-beats/install-metricbeat/install-widget-metricbeat.asciidoc[]
+include::{observability-docs-root}/docs/en/shared/copied-from-beats/install-metricbeat/install-widget-metricbeat.asciidoc[]
 
 [discrete]
 = Set up assets


### PR DESCRIPTION
🍷  Pairs with https://github.com/elastic/docs/pull/2735

Removes book-scoped attributes from /observability-docs using several approaches:

* Replacing file path attributes with hard-coded values.
* Moving paths to other web pages to `shared/attributes.asciidoc` in the /docs repo.
* Replacing book-scoped icon attributes with the cross-site attributes.
* Moving common term attributes to shared/attributes.asciidoc in the /docs repo.
* Moving non-Stack version attributes to shared/versions/ in the /docs repo.

Note: I expect the build to fail until https://github.com/elastic/docs/pull/2735 is merged.