### PR TITLE
Profiling: replace ela.st with artifacts.elastic.co

### DIFF
--- a/docs/en/observability/profiling-add-symbols.asciidoc
+++ b/docs/en/observability/profiling-add-symbols.asciidoc
@@ -13,8 +13,8 @@ compile to native code (C, C++, Rust, Go, etc.), you need to push symbols to the
 
 Click the appropriate link for your system to download the `symbtool` binary:
 
- * https://ela.st/symbtool-linux-amd64[x86_64] 
- * https://ela.st/symbtool-linux-arm64[ARM64]
+ * https://artifacts.elastic.co/downloads/prodfiler/symbtool-{version}-linux-x86_64.tar.gz[x86_64] 
+ * https://artifacts.elastic.co/downloads/prodfiler/symbtool-{version}-linux-arm64.tar.gz[ARM64]
 
 
 NOTE: The `symbtool` binary currently requires a Linux machine.


### PR DESCRIPTION
Take advantage of the DRA process and replace the custom ela.st links with artifacts.elastic.co.