### PR TITLE
Remove unnecessary links

### DIFF
--- a/docs/en/observability/logs-stream.asciidoc
+++ b/docs/en/observability/logs-stream.asciidoc
@@ -204,11 +204,6 @@ Notice the text in your message isn't parsed, so you can't filter by any individ
 
 NOTE: These fields are part of the {ecs-ref}/ecs-reference.html[Elastic Common Schema (ECS)]. The ECS defines a common set of fields that you can use across Elasticsearch when storing data, including log and metric data.
 
-See the following sections for information on extracting specific fields:
-
-- <<logs-stream-extract-timestamp>>
-- <<logs-stream-extract-log-level>>
-
 [discrete]
 [[logs-stream-extract-timestamp]]
 == Extract the `@timestamp` field
@@ -253,7 +248,7 @@ PUT _ingest/pipeline/logs-example-default
 }
 ----
 
-. Set these values for your pipeline:
+Set these values for your pipeline:
 - `_ingest/pipeline/logs-example-default` – The name of the pipeline,`logs-example-default`, needs to match the name of your data stream. You'll set up your data stream in the next section. See the {fleet-guide}/data-streams.html#data-streams-naming-scheme[data stream naming scheme] for more information.
 - `field` – The field you're extracting data from, `message` in this case.
 - `pattern`– The pattern of the elements in your log data. The following pattern extracts the timestamp, `2023-08-08T13:45:12.123Z`, to the `@timestamp` field, while the rest of the message, `WARN 192.168.1.101 Disk usage exceeds 90%.`, stays in the `message` field.


### PR DESCRIPTION
Removed links to sections for extracting specific fields. The OTP navigation takes care of this and the sections are somewhat dependent on the previous sections, so it's probably best to remove them.