### PR TITLE
[Profiling] correctly document minimum kernel for ARM64

### DIFF
--- a/docs/en/observability/profiling-get-started.asciidoc
+++ b/docs/en/observability/profiling-get-started.asciidoc
@@ -23,7 +23,8 @@ See the <<profiling-send-feedback, send feedback>> section of the troubleshootin
 Before setting up Universal Profiling, make sure you meet the following requirements:
 
 * An {stack} deployment on http://cloud.elastic.co[{ecloud}] at version 8.7.0 or higher. Universal Profiling is currently only available on Elastic Cloud.
-* The workloads you're profiling must be running on Linux machines with x86_64 CPUs and kernel version >= 4.15.
+* The workloads you're profiling must be running on Linux machines with x86_64 or ARM64 CPUs.
+* The minimum supported kernel version is either 4.15 for x86_64 or 5.5 for ARM64 machines.
 * The Integrations Server must be enabled on your {ecloud} deployment.
 * Credentials (username and password) for the `superuser` Elasticsearch role (typically, the `elastic` user).
 


### PR DESCRIPTION
This corrects the documentation for the minimum supported kernel version for profiling. The text further used to incorrectly state that a x86_64 machine is required, but we've also been supporting ARM64 since at least 8.9 (hence the backport). 

Corresponding universal profiling issue: https://github.com/elastic/prodfiler/issues/3833