### PR TITLE
Update splunk-get-started.asciidoc

### DIFF
--- a/docs/en/observability/splunk-get-started.asciidoc
+++ b/docs/en/observability/splunk-get-started.asciidoc
@@ -4,11 +4,13 @@
 :modulename: system nginx mysql
 
 [[splunk-get-started]]
-= Get started with data from Splunk (Experimental)
+= Get started with data from Splunk
 
 ++++
 <titleabbrev>Data from Splunk</titleabbrev>
 ++++
+
+preview::[]
 
 Apache, AWS CloudTrail, Nginx, and Zeek integrations offer the ability
 to seamlessly ingest data from a Splunk Enterprise instance.  Data


### PR DESCRIPTION
### Summary

Remove `experimental` terminology and replace with `tech preview` callout.