### PR TITLE
docs: remove old videos

### DIFF
--- a/docs/en/observability/apm.asciidoc
+++ b/docs/en/observability/apm.asciidoc
@@ -6,27 +6,7 @@ It allows you to monitor software services and applications in real time, by
 collecting detailed performance information on response time for incoming requests,
 database queries, calls to caches, external HTTP requests, and more.
 
-// Conditionally display a screenshot or video depending on what the
-// current documentation version is.
-
-ifeval::["{is-current-version}"=="true"]
-++++
-<script type="text/javascript" async src="https://play.vidyard.com/embed/v4.js"></script>
-<img
-  style="width: 100%; margin: auto; display: block;"
-  class="vidyard-player-embed"
-  src="https://play.vidyard.com/wRx7KPY4ajh4ktyLhLJLox.jpg"
-  data-uuid="wRx7KPY4ajh4ktyLhLJLox"
-  data-v="4"
-  data-type="inline"
-/>
-</br>
-++++
-endif::[]
-
-ifeval::["{is-current-version}"=="false"]
 [role="screenshot"]
 image::images/apm-app-landing.png[{apm-app} in {kib}]
-endif::[]
 
 To learn more, see {apm-guide-ref}/index.html[APM Overview].

--- a/docs/en/observability/monitor-infra/analyze-metrics.asciidoc
+++ b/docs/en/observability/monitor-infra/analyze-metrics.asciidoc
@@ -10,24 +10,6 @@ Using {agent} integrations, you can ingest and analyze metrics from servers,
 Docker containers, Kubernetes orchestrations, explore and analyze application
 telemetry, and more.
 
-// Conditionally display a screenshot or video depending on what the
-// current documentation version is.
-
-ifeval::["{is-current-version}"=="true"]
-++++
-<script type="text/javascript" async src="https://play.vidyard.com/embed/v4.js"></script>
-<img
-  style="width: 100%; margin: auto; display: block;"
-  class="vidyard-player-embed"
-  src="https://play.vidyard.com/XEFrGuQrWqYjgB9XqfgzSH.jpg"
-  data-uuid="XEFrGuQrWqYjgB9XqfgzSH"
-  data-v="4"
-  data-type="inline"
-/>
-</br>
-++++
-endif::[]
-
 To access the {infrastructure-app} from the main {kib} menu, go to
 **Observability -> Infrastructure**. The {infrastructure-app} provides a few
 different views of your data.
@@ -35,7 +17,7 @@ different views of your data.
 [cols="1,1"]
 |===
 | **Inventory**
-|Provides a metrics-driven view of your entire infrastructure grouped by the resources that you are monitoring. 
+|Provides a metrics-driven view of your entire infrastructure grouped by the resources that you are monitoring.
 
 <<view-infrastructure-metrics,Learn more about the Inventory page > >>
 

--- a/docs/en/observability/monitor-logs.asciidoc
+++ b/docs/en/observability/monitor-logs.asciidoc
@@ -14,27 +14,7 @@ for quick navigation. You can also use {ml} to detect specific log
 anomalies automatically and categorize log messages to quickly identify patterns in your
 log events.
 
-// Conditionally display a screenshot or video depending on what the
-// current documentation version is.
-
-ifeval::["{is-current-version}"=="true"]
-++++
-<script type="text/javascript" async src="https://play.vidyard.com/embed/v4.js"></script>
-<img
-  style="width: 100%; margin: auto; display: block;"
-  class="vidyard-player-embed"
-  src="https://play.vidyard.com/ZWSdKk4waG1bKf7oRa6Dvq.jpg"
-  data-uuid="ZWSdKk4waG1bKf7oRa6Dvq"
-  data-v="4"
-  data-type="inline"
-/>
-</br>
-++++
-endif::[]
-
-ifeval::["{is-current-version}"=="false"]
 [role="screenshot"]
 image::images/logs-app.png[{logs-app} in {kib}]
-endif::[]
 
 To view the {logs-app}, go to *{observability} > Logs*.

--- a/docs/en/observability/tail-logs.asciidoc
+++ b/docs/en/observability/tail-logs.asciidoc
@@ -8,24 +8,6 @@ along with the power of search.
 Click *Stream Live* to view a continuous flow of log messages in real time, or
 click *Stop streaming* to view historical logs from a specified time range.
 
-// Conditionally display a video depending on what the
-// current documentation version is.
-
-ifeval::["{is-current-version}"=="true"]
-++++
-<script type="text/javascript" async src="https://play.vidyard.com/embed/v4.js"></script>
-<img
-  style="width: 100%; margin: auto; display: block;"
-  class="vidyard-player-embed"
-  src="https://play.vidyard.com/TSusZfvvRvg78qRaeYTfey.jpg"
-  data-uuid="TSusZfvvRvg78qRaeYTfey"
-  data-v="4"
-  data-type="inline"
-/>
-</br>
-++++
-endif::[]
-
 [discrete]
 [[filter-logs]]
 == Filter logs

--- a/docs/en/observability/user-experience.asciidoc
+++ b/docs/en/observability/user-experience.asciidoc
@@ -14,28 +14,8 @@ all of which can impact how your application performs on end-user machines.
 
 Powered by the APM Real user monitoring (RUM) agent, all it takes is a few lines of code to begin surfacing key user experience metrics.
 
-// Conditionally display a screenshot or video depending on what the
-// current documentation version is.
-
-ifeval::["{is-current-version}"=="true"]
-++++
-<script type="text/javascript" async src="https://play.vidyard.com/embed/v4.js"></script>
-<img
-  style="width: 100%; margin: auto; display: block;"
-  class="vidyard-player-embed"
-  src="https://play.vidyard.com/eVQoHfHNgGxBeuAZ5rCtXq.jpg"
-  data-uuid="eVQoHfHNgGxBeuAZ5rCtXq"
-  data-v="4"
-  data-type="inline"
-/>
-</br>
-++++
-endif::[]
-
-ifeval::["{is-current-version}"=="false"]
 [role="screenshot"]
 image::images/user-experience-tab.png[{user-experience} tab]
-endif::[]
 
 [discrete]
 [[why-user-experience]]


### PR DESCRIPTION
### Summary

Removes the old, outdated videos from our documentation.

Closes https://github.com/elastic/docs-projects/issues/69.