### PR TITLE
Profiling: add upgrade notice of known issues for 8.9 versions

### DIFF
--- a/docs/en/observability/profiling-get-started.asciidoc
+++ b/docs/en/observability/profiling-get-started.asciidoc
@@ -85,13 +85,16 @@ We still recommend upgrading as the latest version contains several improvements
 
 [discrete]
 [[profiling-upgrade-known-issues]]
-==== Known issue during the configuration of data ingestion
+==== Known issue when configuring data ingestion
 
-If you created your {ecloud} deployment starting from a 7.x version or earlier, and you are currently running it on 8.9.0, 8.9.1 or 8.9.2, you may encounter a problem while trying to enable Universal Profiling.
 
-Specifically, clicking the 'Set up Universal Profiling' button triggers an error message that reads **Error while setting up Universal Profiling**.
+If your {ecloud} deployment originated from version 7.x or earlier and is currently running on version 8.9.0–8.9.2, you may encounter a problem while trying to enable Universal Profiling.
 
-To rectify this situation, an upgrade to version 8.9.3 or above is needed.
+Specifically, clicking the *Set up Universal Profiling* button triggers an error message that reads `Error while setting up Universal Profiling`.
+
+
+Upgrade to version 8.9.3 or more recent to fix this issue.
+
 
 [discrete]
 [[profiling-install-host-agent]]

--- a/docs/en/observability/profiling-get-started.asciidoc
+++ b/docs/en/observability/profiling-get-started.asciidoc
@@ -87,7 +87,7 @@ We still recommend upgrading as the latest version contains several improvements
 [[profiling-upgrade-known-issues]]
 ==== Known issue during the configuration of data ingestion
 
-If you created your {ecloud} deployment starting from a 7.x version or earlier, and you are currently running it to 8.9.0, 8.9.1 or 8.9.2, you may encounter a problem while trying to enable Universal Profiling.
+If you created your {ecloud} deployment starting from a 7.x version or earlier, and you are currently running it on 8.9.0, 8.9.1 or 8.9.2, you may encounter a problem while trying to enable Universal Profiling.
 
 Specifically, clicking the 'Set up Universal Profiling' button triggers an error message that reads **Error while setting up Universal Profiling**.
 

--- a/docs/en/observability/profiling-get-started.asciidoc
+++ b/docs/en/observability/profiling-get-started.asciidoc
@@ -63,9 +63,7 @@ Even if you're profiling a smaller fleet, we recommend configuring at least two 
 [[profiling-set-up-on-cloud]]
 == Set up Universal Profiling on an {ecloud} deployment
 
-To set up Universal Profiling on your {ecloud} deployment, you need to:
-
-. <<profiling-configure-data-ingestion, Configure data ingestion>>
+To set up Universal Profiling on your {ecloud} deployment, you need to <<profiling-configure-data-ingestion, configure data ingestion>> first.
 
 [discrete]
 [[profiling-configure-data-ingestion]]
@@ -85,9 +83,19 @@ If you're upgrading from a previous version with Universal Profiling enabled, se
 IMPORTANT: When upgrading, you must remove all existing profiling data.
 We still recommend upgrading as the latest version contains several improvements and new features.
 
-[discrete] 
-[[profiling-install-host-agent]] 
-== Install the host-agent 
+[discrete]
+[[profiling-upgrade-known-issues]]
+==== Known issue during the configuration of data ingestion
+
+If you created your {ecloud} deployment starting from a 7.x version or earlier, and you are currently running it to 8.9.0, 8.9.1 or 8.9.2, you may encounter a problem while trying to enable Universal Profiling.
+
+Specifically, clicking the 'Set up Universal Profiling' button triggers an error message that reads **Error while setting up Universal Profiling**.
+
+To rectify this situation, an upgrade to version 8.9.3 or above is needed.
+
+[discrete]
+[[profiling-install-host-agent]]
+== Install the host-agent
 You have the following options when installing the host-agent:
 
 . <<profiling-install-host-agent-elastic-agent, Install the host-agent using the {agent}>>
@@ -99,12 +107,12 @@ You have the following options when installing the host-agent:
 
 To install the host-agent using the {agent} and the Universal Profiling Agent integration, complete the following steps:
 
-. Copy the `secret token` and `Universal Profiling Collector url` from the Elastic Agent Integration 
+. Copy the `secret token` and `Universal Profiling Collector url` from the Elastic Agent Integration
 +
 [role="screenshot"]
 image::images/profiling-elastic-agent.png[]
 +
-. Click `Manage Universal Profiling Agent in Fleet` to complete the integration. 
+. Click `Manage Universal Profiling Agent in Fleet` to complete the integration.
 . On the Integrations page, click **Add Universal Profiling Agent**.
 . In **Universal Profiling Agent → Settings**, add the information you copied from the *Add profiling data* page:
 .. Add the Universal Profiling collector URL to the **Universal Profiling collector endpoint** field.

--- a/docs/en/observability/profiling-upgrade.asciidoc
+++ b/docs/en/observability/profiling-upgrade.asciidoc
@@ -6,16 +6,6 @@
 ++++
 
 [discrete]
-[[profiling-upgrade-known-issues]]
-== Known issues
-
-If you created your {ecloud} deployment starting from a 7.x version or earlier, and you have upgraded it to 8.9.0, 8.9.1 or 8.9.2, you may encounter a problem while trying to enable Universal Profiling.
-
-Specifically, clicking the 'Set up Universal Profiling' button triggers an error message that reads **Error while setting up Universal Profiling**.
-
-To rectify this situation, an upgrade to version 8.9.3 or above is needed.
-
-[discrete]
 [[profiling-upgrade-process]]
 == Upgrade process
 

--- a/docs/en/observability/profiling-upgrade.asciidoc
+++ b/docs/en/observability/profiling-upgrade.asciidoc
@@ -6,6 +6,16 @@
 ++++
 
 [discrete]
+[[profiling-upgrade-known-issues]]
+== Known issues
+
+If you created your {ecloud} deployment starting from a 7.x version or earlier, and you have upgraded it to 8.9.0, 8.9.1 or 8.9.2, you may encounter a problem while trying to enable Universal Profiling.
+
+Specifically, clicking the 'Set up Universal Profiling' button triggers an error message that reads **Error while setting up Universal Profiling**.
+
+To rectify this situation, an upgrade to version 8.9.3 or above is needed.
+
+[discrete]
 [[profiling-upgrade-process]]
 == Upgrade process
 


### PR DESCRIPTION
We recently discovered a problem in the setup of Universal Profiling for all customers upgrading from 7.x or earlier.

If a customer created their deployment before 8.0, so on any 7.x or earlier ESS version, they had APM server installed without a specific Fleet policy.
The Universal Profiling setup code tries to find that policy, and it was failing for these deployments.

We addressed this bug and fixed it for 8.9.3 and 8.10.0 customers.