### PR TITLE
Update `/welcome-to-elastic` link in AWS firehose docs

### DIFF
--- a/docs/en/aws-firehose/aws-firehose-troubleshooting.asciidoc
+++ b/docs/en/aws-firehose/aws-firehose-troubleshooting.asciidoc
@@ -13,7 +13,7 @@ You can use the monitoring tab in the Firehose console to ensure there are incom
 [role="screenshot"]
 image::images/firehose-monitoring.png[Firehose monitoring page showing some charts of delivery success percentage and throughput]
 
-By default Firehose also logs to a Cloudwatch log group with the name `/aws/kinesisfirehose/<delivery stream name>`, which is automatically created when the delivery stream is created. 
+By default Firehose also logs to a Cloudwatch log group with the name `/aws/kinesisfirehose/<delivery stream name>`, which is automatically created when the delivery stream is created.
 Two log streams, `DestinationDelivery` and `BackupDelivery`, are created in this log group.
 
 The backup settings in the delivery stream specify how failed delivery requests are handled.
@@ -23,7 +23,7 @@ See <<aws-firehose-config-backup-settings>> for details on configuring backups t
 [[aws-firehose-scaling]]
 == Scaling
 Firehose can https://docs.aws.amazon.com/firehose/latest/dev/limits.html[automatically scale] to handle very high throughput.
-If your Elastic deployment is not properly configured for the data volume coming from Firehose, it could cause a bottleneck, which may lead to increased ingest times or indexing failures. 
+If your Elastic deployment is not properly configured for the data volume coming from Firehose, it could cause a bottleneck, which may lead to increased ingest times or indexing failures.
 
 There are several facets to optimizing the underlying Elasticsearch performance, but Elastic Cloud provides several ready-to-use hardware profiles which can provide a good starting point.
 Other factors which can impact performance are https://www.elastic.co/guide/en/elasticsearch/reference/current/size-your-shards.html[shard sizing], https://www.elastic.co/guide/en/elasticsearch/reference/current/tune-for-indexing-speed.html[indexing configuration], and https://www.elastic.co/guide/en/elasticsearch/reference/current/index-lifecycle-management.html[index lifecycle management (ILM)].
@@ -32,5 +32,5 @@ Other factors which can impact performance are https://www.elastic.co/guide/en/e
 [[aws-firehose-support]]
 == Support
 
-If you encounter further problems, please contact Elastic support by following the instructions https://www.elastic.co/guide/en/welcome-to-elastic/current/get-support-help.html[here]. 
+If you encounter further problems, please contact Elastic support by following the instructions {estc-welcome-current}/get-support-help.html[here].
 


### PR DESCRIPTION
**Problem:** In https://github.com/elastic/docs/pull/2752, we updated the URL prefix (`welcome-to-elastic`) and name for the "Welcome to Elastic Docs" docs. However, we still have some stray links that use the old `/welcome-to-elastic` URL prefix

**Solution:** Replace an outdated link with one that uses an attribute.