### PR TITLE
Fix the logs stream index template example

### DIFF
--- a/docs/en/observability/logs-stream.asciidoc
+++ b/docs/en/observability/logs-stream.asciidoc
@@ -343,7 +343,7 @@ PUT _index_template/logs-example-default-template
     "logs@custom",
     "ecs@dynamic_templates"
   ],
-  "ignore_missing_component_templates": ["logs@custom"],
+  "ignore_missing_component_templates": ["logs@custom"]
 }
 ----
 

--- a/docs/en/observability/logs-stream.asciidoc
+++ b/docs/en/observability/logs-stream.asciidoc
@@ -334,7 +334,7 @@ PUT _index_template/logs-example-default-template
   "priority": 500,
   "template": {
     "settings": {
-      "index.default_pipeline":"logs-example"
+      "index.default_pipeline":"logs-example-default"
     }
   },
   "composed_of": [
@@ -371,7 +371,7 @@ The component templates that are set in the previous index template are defined 
 [[logs-stream-create-data-stream]]
 === Create your data stream
 
-Create your data stream using the {fleet-guide}/data-streams.html#data-streams-naming-scheme[data stream naming scheme]. Since The name needs to match the name of your pipeline, name the data stream `logs-example-default`. Post the example log to your data stream with this command:
+Create your data stream using the {fleet-guide}/data-streams.html#data-streams-naming-scheme[data stream naming scheme]. Since the name needs to match the name of your pipeline, name the data stream `logs-example-default`. Post the example log to your data stream with this command:
 
 [source,console]
 ----


### PR DESCRIPTION
Deleted an extra comma from the stream a log index template example.