### PR TITLE
[DOCS] Rename Generative AI connector to OpenAI

### DIFF
--- a/docs/en/observability/observability-ai-assistant.asciidoc
+++ b/docs/en/observability/observability-ai-assistant.asciidoc
@@ -3,7 +3,7 @@
 
 preview::[]
 
-The AI Assistant uses generative AI, powered by a {kibana-ref}/gen-ai-action-type.html[connector] for OpenAI or Azure OpenAI Service, to provide:
+The AI Assistant uses generative AI, powered by a {kibana-ref}/openai-action-type.html[connector] for OpenAI or Azure OpenAI Service, to provide:
 
 * *Contextual insights* — open prompts throughout {observability} that explain errors and messages and suggest remediation. 
 * *Chat* —  have conversations with the AI Assistant. Chat uses function calling to request, analyze, and visualize your data.
@@ -35,7 +35,7 @@ The AI assistant requires the following:
 [[data-information]]
 == Your data and the AI Assistant
 
-Elastic does not store or examine prompts or results used by the AI Assistant, or use this data for model training. This includes anything you send the model, such as alert or event data, detection rule configurations, queries, and prompts. However, any data you provide to the AI Assistant will be processed by the third-party provider you chose when setting up the Generative AI connector as part of the assistant setup.
+Elastic does not store or examine prompts or results used by the AI Assistant, or use this data for model training. This includes anything you send the model, such as alert or event data, detection rule configurations, queries, and prompts. However, any data you provide to the AI Assistant will be processed by the third-party provider you chose when setting up the OpenAI connector as part of the assistant setup.
 
 Elastic does not control third-party tools, and assumes no responsibility or liability for their content, operation, or use, nor for any loss or damage that may arise from your using such tools. Please exercise caution when using AI tools with personal, sensitive, or confidential information. Any data you submit may be used by the provider for AI training or other purposes. There is no guarantee that the provider will keep any information you provide secure or confidential. You should familiarize yourself with the privacy practices and terms of use of any generative AI tools prior to use.
 
@@ -50,7 +50,7 @@ To set up the AI Assistant:
 * https://platform.openai.com/docs/api-reference[OpenAI]
 * https://learn.microsoft.com/en-us/azure/cognitive-services/openai/reference[Azure OpenAI Service]
 
-. From *{stack-manage-app}* -> *{connectors-ui}* in {kib}, create a {kibana-ref}/gen-ai-action-type.html[Generative AI connector]. 
+. From *{stack-manage-app}* -> *{connectors-ui}* in {kib}, create a {kibana-ref}/openai-action-type.html[OpenAI connector]. 
 . Authenticate communication between {observability} and the AI provider by providing the following information:
 .. Enter the AI provider's API endpoint URL in the *URL* field.
 .. Enter the API key you created in the previous step in the *API Key* field. 


### PR DESCRIPTION
Relates to https://github.com/elastic/kibana/issues/166960

This PR must be merged after https://github.com/elastic/kibana/pull/167519, which renames the "Generative AI connector" and its documentation to "OpenAI connector".