### PR TITLE
backport: Add 8.11 branch

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -240,3 +240,16 @@ pull_request_rules:
         labels:
           - "backport"
         title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"
+  - name: backport patches to 8.11 branch
+    conditions:
+      - merged
+      - label=backport-v8.11.0
+    actions:
+      backport:
+        assignees:
+          - "{{ author }}"
+        branches:
+          - "8.11"
+        labels:
+          - "backport"
+        title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -243,7 +243,7 @@ pull_request_rules:
   - name: backport patches to 8.11 branch
     conditions:
       - merged
-      - label=backport-8.10
+      - label=backport-8.11
     actions:
       backport:
         assignees:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -243,7 +243,7 @@ pull_request_rules:
   - name: backport patches to 8.11 branch
     conditions:
       - merged
-      - label=backport-v8.11.0
+      - label=backport-8.10
     actions:
       backport:
         assignees:


### PR DESCRIPTION
Merge as soon as 8.11 branch was created. Auto-merge is not yet supported, see https://github.com/Mergifyio/mergify-engine/discussions/2821