### PR TITLE
Change hosts to single string non-array

### DIFF
--- a/docs/en/observability/synthetics-lightweight.asciidoc
+++ b/docs/en/observability/synthetics-lightweight.asciidoc
@@ -51,12 +51,12 @@ heartbeat.monitors:
 - type: icmp
   id: ping-myhost
   name: My Host Ping
-  hosts: ["myhost"]
+  hosts: "myhost"
   schedule: '@every 5m'
 - type: tcp
   id: myhost-tcp-echo
   name: My Host TCP Echo
-  hosts: ["myhost:777"]  # default TCP Echo Protocol
+  hosts: "myhost:777"  # default TCP Echo Protocol
   check.send: "Check"
   check.receive: "Check"
   schedule: '@every 60s'


### PR DESCRIPTION
Lightweight Synthetics checks don't support multiple hosts as an array, as per https://github.com/elastic/synthetics/issues/627, but the docs suggest it can be, so updating to clarify it's a single string value.