### PR TITLE
[synthetics] Update docs to reflect the changes to `expect` 

### DIFF
--- a/docs/en/observability/synthetics-create-test.asciidoc
+++ b/docs/en/observability/synthetics-create-test.asciidoc
@@ -163,7 +163,7 @@ Use Playwright to simulate and validate user workflows including:
 * Simulating https://playwright.dev/docs/api/class-mouse[mouse],
   https://playwright.dev/docs/api/class-touchscreen[touch], or
   https://playwright.dev/docs/api/class-keyboard[keyboard] events.
-* Making assertions using https://playwright.dev/docs/test-assertions[`@playwright/test`'s `expect` function].
+* Making assertions using https://playwright.dev/docs/test-assertions[`@playwright/test`'s `expect` function]. Read more in <<synthetics-make-assertions>>.
 
 Visit the https://playwright.dev/docs[Playwright documentation] for information.
 
@@ -179,14 +179,18 @@ There is also some Playwright functionality that is not supported out-of-the-box
 in Elastic Synthetics including:
 
 * https://playwright.dev/docs/api/class-video[Videos]
+* The https://playwright.dev/docs/api/class-locatorassertions#locator-assertions-to-have-screenshot-1[`toHaveScreenshot`] and https://playwright.dev/docs/api/class-snapshotassertions[`toMatchSnapshot`] assertions
 
 [discrete]
 [[synthetics-make-assertions]]
 = Make assertions
 
-Check that a value meets a specific condition.
 A more complex `step` might wait for a page element to be selected
 and then make sure that it matches an expected value.
+
+Elastic Synthetics uses `@playwright/test`'s `expect` function to make assertions and
+supports all https://playwright.dev/docs/test-assertions[Playwright assertions] _except_
+`toHaveScreenshot` and `toMatchSnapshot`.
 
 For example, on a page using the following HTML:
 
@@ -215,9 +219,6 @@ step('Assert placeholder text', async () => {
 <1> Find the `input` element with class `new-todo`.
 <2> Use the assertion library provided by the Synthetics agent to check that
 the value of the `placeholder` attribute matches a specific string.
-
-Elastic Synthetics uses https://playwright.dev/docs/test-assertions[`@playwright/test`'s `expect` function].
-For a complete list of available assertions, refer to https://playwright.dev/docs/api/class-genericassertions#methods[the Playwright documentation].
 
 [discrete]
 [[synthetics-request-param]]

--- a/docs/en/observability/synthetics-create-test.asciidoc
+++ b/docs/en/observability/synthetics-create-test.asciidoc
@@ -188,9 +188,10 @@ in Elastic Synthetics including:
 A more complex `step` might wait for a page element to be selected
 and then make sure that it matches an expected value.
 
-Elastic Synthetics uses `@playwright/test`'s `expect` function to make assertions and
-supports all https://playwright.dev/docs/test-assertions[Playwright assertions] _except_
-`toHaveScreenshot` and `toMatchSnapshot`.
+Elastic Synthetics uses `@playwright/test`'s `expect` function to make assertions
+and supports most https://playwright.dev/docs/test-assertions[Playwright assertions].
+Elastic Synthetics does _not_ support https://playwright.dev/docs/api/class-locatorassertions#locator-assertions-to-have-screenshot-1[`toHaveScreenshot`]
+or any https://playwright.dev/docs/api/class-snapshotassertions[Snapshot Assertions].
 
 For example, on a page using the following HTML:
 

--- a/docs/en/observability/synthetics-create-test.asciidoc
+++ b/docs/en/observability/synthetics-create-test.asciidoc
@@ -155,8 +155,7 @@ For more details on getting started with the Synthetics Recorder, refer to <<syn
 == Playwright syntax
 
 Inside the callback for each step, you'll likely use a lot of Playwright syntax.
-Many Playwright classes are supported in the Elastic Synthetics library to simulate
-user workflows including tasks like:
+Use Playwright to simulate and validate user workflows including:
 
 * Interacting with the https://playwright.dev/docs/api/class-browser[browser]
   or the current https://playwright.dev/docs/api/class-page[page] (like in the example above).
@@ -164,17 +163,15 @@ user workflows including tasks like:
 * Simulating https://playwright.dev/docs/api/class-mouse[mouse],
   https://playwright.dev/docs/api/class-touchscreen[touch], or
   https://playwright.dev/docs/api/class-keyboard[keyboard] events.
+* Making assertions using https://playwright.dev/docs/test-assertions[`@playwright/test`'s `expect` function].
 
 Visit the https://playwright.dev/docs[Playwright documentation] for information.
 
 However, not all Playwright functionality should be used with Elastic Synthetics.
-
 In some cases, there are alternatives to Playwright functionality built into the
 Elastic Synthetics library. These alternatives are designed to work better for
 synthetic monitoring. Do _not_ use Playwright syntax to:
 
-* *Make assertions*. Use Elastic Synthetics's `expect` methods instead.
-  Read more in <<synthetics-make-assertions>>.
 * *Make API requests.* Use Elastic Synthetic's `request`
   parameter instead. Read more in <<synthetics-request-param>>.
 
@@ -219,37 +216,8 @@ step('Assert placeholder text', async () => {
 <2> Use the assertion library provided by the Synthetics agent to check that
 the value of the `placeholder` attribute matches a specific string.
 
-[discrete]
-[[synthetics-assertions-methods]]
-== Supported `expect` methods
-
-:jest: https://jestjs.io/docs
-
-* {jest}/expect#not[`not ()`]
-* {jest}/expect#resolves[`resolves ()`]
-* {jest}/expect#rejects[`rejects ()`]
-* {jest}/expect#tobevalue[`toBe (expected)`]
-* {jest}/expect#tobeclosetonumber-numdigits[`toBeCloseTo (expected, numDigits?)`]
-* {jest}/expect#tobedefined[`toBeDefined ()`]
-* {jest}/expect#tobefalsy[`toBeFalsy ()`]
-* {jest}/expect#tobegreaterthannumber\--bigint[`toBeGreaterThan (expected)`]
-* {jest}/expect#tobegreaterthanorequalnumber\--bigint[`toBeGreaterThanOrEqual (expected)`]
-* {jest}/expect#tobeinstanceofclass[`toBeInstanceOf (expected)`]
-* {jest}/expect#tobelessthannumber\--bigint[`toBeLessThan (expected)`]
-* {jest}/expect#tobelessthanorequalnumber\--bigint[`toBeLessThanOrEqual (expected)`]
-* {jest}/expect#tobenull[`toBeNull ()`]
-* {jest}/expect#tobetruthy[`toBeTruthy ()`]
-* {jest}/expect#tobeundefined[`toBeUndefined ()`]
-* {jest}/expect#tobenan[`toBeNaN ()`]
-* {jest}/expect#tocontainitem[`toContain (expected)`]
-* {jest}/expect#tocontainequalitem[`toContainEqual (expected)`]
-* {jest}/expect#toequalvalue[`toEqual (expected)`]
-* {jest}/expect#tohavelengthnumber[`toHaveLength (expected)`]
-* {jest}/expect#tohavepropertykeypath-value[`toHaveProperty (keyPath, value?)`]
-* {jest}/expect#tomatchregexp\--string[`toMatch (expected)`]
-* {jest}/expect#tomatchobjectobject[`toMatchObject (expected)`]
-* {jest}/expect#tostrictequalvalue[`toStrictEqual (expected)`]
-
+Elastic Synthetics uses https://playwright.dev/docs/test-assertions[`@playwright/test`'s `expect` function].
+For a complete list of available assertions, refer to https://playwright.dev/docs/api/class-genericassertions#methods[the Playwright documentation].
 
 [discrete]
 [[synthetics-request-param]]


### PR DESCRIPTION
Closes #3206

Currently the docs list the supported [Jest `expect` methods](https://www.elastic.co/guide/en/observability/current/synthetics-create-test.html#synthetics-assertions-methods). As of [@elastic/synthetics v1.5.0](https://github.com/elastic/synthetics/releases/tag/v1.5.0), we use Playwright Test `expect` assertions. This replaces the list of supported Jest methods with links to the Playwright assertion docs.

👋  @vigneshshanmugam I'm not sure if I've captured everything correctly.

cc @paulb-elastic 