### PR TITLE
Delete templates/ILM on profiling upgrade

### DIFF
--- a/docs/en/observability/profiling-upgrade.asciidoc
+++ b/docs/en/observability/profiling-upgrade.asciidoc
@@ -78,7 +78,8 @@ PUT /_cluster/settings
 . Select all resulting index templates, and click the *Delete templates* button.
 . Switch to the *Component Templates* tab, and  search for `profiling-` in the search bar.
 . Select all resulting component templates, and click the *Delete component templates* button.
-. From the navigation menu, go to *Index Lifecycle Policies*, search for `profiling` in the search bar and click on the trash icon in the *Actions* column.
+. From the navigation menu, go to *Index Lifecycle Policies*, search for `profiling` in the search bar, and click the trash icon in the *Actions* column.
+
 
 Verify that no ingestion is happening by reloading the *Data Streams* and *Indices* pages and ensuring that there are no data streams or indices with the `profiling-` prefix.
 

--- a/docs/en/observability/profiling-upgrade.asciidoc
+++ b/docs/en/observability/profiling-upgrade.asciidoc
@@ -74,6 +74,11 @@ PUT /_cluster/settings
 . Select all resulting data streams, and click the *Delete data streams* button.
 . Switch to the *Indices* tab, enable *Include hidden indices*, and  search for `profiling-` in the search bar.
 . Select all resulting indices, click the *Manage indices* button, and select *Delete indices* from the drop-down menu.
+. Switch to the *Index Templates* tab, and  search for `profiling-` in the search bar.
+. Select all resulting index templates, and click the *Delete templates* button.
+. Switch to the *Component Templates* tab, and  search for `profiling-` in the search bar.
+. Select all resulting component templates, and click the *Delete component templates* button.
+. From the navigation menu, go to *Index Lifecycle Policies*, search for `profiling` in the search bar and click on the trash icon in the *Actions* column.
 
 Verify that no ingestion is happening by reloading the *Data Streams* and *Indices* pages and ensuring that there are no data streams or indices with the `profiling-` prefix.
 


### PR DESCRIPTION
With this commit we amend the instructions to delete data on profiling upgrade (only required for pre-GA versions) to also include deletion of index templates, component templates and the ILM policy. This ensures a smooth upgrade without any leftovers.