### PR TITLE
Small fix for new templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/community-request.yaml
+++ b/.github/ISSUE_TEMPLATE/community-request.yaml
@@ -1,7 +1,7 @@
 name: "Community documentation request"
 description: Request a documentation change or enhancement.
 title: "[REQUEST]: "
-labels: ["request", "Team:Docs", "💝 community"]
+labels: ["Request", "💝 community"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/community-request.yaml
+++ b/.github/ISSUE_TEMPLATE/community-request.yaml
@@ -1,6 +1,6 @@
 name: "Community documentation request"
 description: Request a documentation change or enhancement.
-title: "[REQUEST]: "
+title: "[Request]: "
 labels: ["Request", "💝 community"]
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/elastic-request.yaml
+++ b/.github/ISSUE_TEMPLATE/elastic-request.yaml
@@ -1,7 +1,6 @@
 name: "Internal documentation request (Elastic employees)"
 description: Request a documentation change or enhancement.
-title: "[REQUEST]: "
-labels: ["Team:Docs"]
+title: "[Request]: "
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
Removes `Team:Docs` label as it just adds noise.