### PR TITLE
fix: update synthetics agent project id CLI option

### DIFF
--- a/docs/en/observability/synthetics-command-reference.asciidoc
+++ b/docs/en/observability/synthetics-command-reference.asciidoc
@@ -118,7 +118,7 @@ Create monitors in {kib} by using your local journeys.
 
 [source,sh]
 ----
-npx @elastic/synthetics push --auth <api-key> --url <kibana-url> --project <id|name>
+npx @elastic/synthetics push --auth <api-key> --url <kibana-url> --id <id|name>
 ----
 
 [NOTE]
@@ -150,7 +150,7 @@ If you are pushing to a <<private-locations,{private-location}>>, you must use a
 To create an API key, you must be logged into {kib} as a user with the privileges described in
 <<synthetics-role-write>>.
 
-`--project <string>`::
+`--id <string>`::
 A unique id associated with your project.
 It will be used for logically grouping monitors.
 +


### PR DESCRIPTION
+ fix https://github.com/elastic/synthetics/issues/866
+ The project ID option is used as `--id` in the synthetics agent CLI option when pushing the project based monitors. 