### PR TITLE
Clarify path to anomaly detection page

### DIFF
--- a/docs/en/observability/monitor-infra/inspect-metric-anomalies.asciidoc
+++ b/docs/en/observability/monitor-infra/inspect-metric-anomalies.asciidoc
@@ -20,7 +20,7 @@ Once you create {ml} jobs, you can not change the settings. You can
 recreate these jobs later. However, you will remove any previously detected anomalies.
 
 // lint ignore anomaly-detection observability
-1. In the side navigation, click *Observability -> Infrastructure -> Anomaly detection*.
+1. Go to *Observability -> Infrastructure -> Inventory* and click the *Anomaly detection* link at the top of the page.
 2. You’ll be prompted to create a {ml} job for *Hosts* or 
 *Kubernetes Pods*. Click *Enable*.
 3. Choose a start date for the {ml} analysis.


### PR DESCRIPTION
The existing docs are confusing because they lead users to believe there should be an Anomaly detection nav item.