### PR TITLE
Remove connector info for ingesting external data

### DIFF
--- a/docs/en/observability/observability-ai-assistant.asciidoc
+++ b/docs/en/observability/observability-ai-assistant.asciidoc
@@ -5,7 +5,7 @@ preview::[]
 
 The AI Assistant uses generative AI, powered by a {kibana-ref}/openai-action-type.html[connector] for OpenAI or Azure OpenAI Service, to provide:
 
-* *Contextual insights* — open prompts throughout {observability} that explain errors and messages and suggest remediation. 
+* *Contextual insights* — open prompts throughout {observability} that explain errors and messages and suggest remediation.
 * *Chat* —  have conversations with the AI Assistant. Chat uses function calling to request, analyze, and visualize your data.
 
 [role="screenshot"]
@@ -28,7 +28,7 @@ The AI assistant requires the following:
 * An https://www.elastic.co/pricing[Enterprise subscription].
 * An account with a third-party generative AI provider that supports function calling. The Observability AI Assistant supports the following providers:
 ** OpenAI `gpt-4`+.
-** Azure OpenAI Service `gpt-4`(0613) or `gpt-4-32k`(0613) with API version `2023-07-01-preview` or more recent. 
+** Azure OpenAI Service `gpt-4`(0613) or `gpt-4-32k`(0613) with API version `2023-07-01-preview` or more recent.
 * The knowledge base requires a 4 GB {ml} node.
 
 [discrete]
@@ -50,26 +50,24 @@ To set up the AI Assistant:
 * https://platform.openai.com/docs/api-reference[OpenAI]
 * https://learn.microsoft.com/en-us/azure/cognitive-services/openai/reference[Azure OpenAI Service]
 
-. From *{stack-manage-app}* -> *{connectors-ui}* in {kib}, create a {kibana-ref}/openai-action-type.html[OpenAI connector]. 
+. From *{stack-manage-app}* -> *{connectors-ui}* in {kib}, create a {kibana-ref}/openai-action-type.html[OpenAI connector].
 . Authenticate communication between {observability} and the AI provider by providing the following information:
 .. Enter the AI provider's API endpoint URL in the *URL* field.
-.. Enter the API key you created in the previous step in the *API Key* field. 
+.. Enter the API key you created in the previous step in the *API Key* field.
 
 [discrete]
 [[obs-ai-add-data]]
 == Add data to the AI Assistant knowledge base
 
-The AI Assistant uses {ml-docs}/ml-nlp-elser.html[ELSER], Elastic's semantic search engine, to recall data from its internal knowledge base index to create retrieval augmented generation (RAG) responses. Adding data such as Runbooks, GitHub issues, internal documentation, and Slack messages to the knowledge base gives the AI Assistant context to provide more specific assistance. 
+The AI Assistant uses {ml-docs}/ml-nlp-elser.html[ELSER], Elastic's semantic search engine, to recall data from its internal knowledge base index to create retrieval augmented generation (RAG) responses. Adding data such as Runbooks, GitHub issues, internal documentation, and Slack messages to the knowledge base gives the AI Assistant context to provide more specific assistance.
 
 NOTE: Your AI provider may collect telemetry when using the AI Assistant. Contact your AI provider for information on how data is collected.
 
-You can add information to the knowledge base by asking the AI Assistant to remember something while chatting (for example, "remember this for next time"). The assistant will create a summary of the information and add it to the knowledge base. 
+You can add information to the knowledge base by asking the AI Assistant to remember something while chatting (for example, "remember this for next time"). The assistant will create a summary of the information and add it to the knowledge base.
 
 You can also add external data to the knowledge base by completing the following steps:
 
-. Ingest external data (GitHub issues, Markdown files, Jira tickets, text files, etc.) into {es} in one of the following ways:
-** {enterprise-search-ref}/connectors.html[Elastic connectors]. For example, the {enterprise-search-ref}/connectors-github.html[GitHub connector] can automatically capture, sync, and index issues, markdown files, pull requests, and repositories to Elasticsearch.
-** {es} {ref}/docs-index_.html[Index API].
+. Ingest external data (GitHub issues, Markdown files, Jira tickets, text files, etc.) into {es} using the {es} {ref}/docs-index_.html[Index API].
 . Reindex your data into the AI Assistant's knowledge base index by completing the following query in *Management* -> *Dev Tools* in {kib}. Update the following fields before reindexing:
 ** `InternalDocsIndex` — name of the index where your internal documents are stored.
 ** `text_field` — name of the field containing your internal documents' text.
@@ -124,7 +122,7 @@ This opens the AI Assistant flyout, where you can ask the assistant questions ab
 [role="screenshot"]
 image::images/obs-ai-chat.png[Observability AI assistant chat, 60%]
 
-The AI Assistant uses functions to include relevant context in the chat conversation through text, data, and visual components. Both you and the AI Assistant can suggest functions. You can also edit the AI Assistant's function suggestions and inspect function responses. 
+The AI Assistant uses functions to include relevant context in the chat conversation through text, data, and visual components. Both you and the AI Assistant can suggest functions. You can also edit the AI Assistant's function suggestions and inspect function responses.
 
 The following table lists available functions:
 
@@ -154,7 +152,7 @@ AI Assistant contextual prompts throughout {observability} provide the following
 - *Logs* — explains log messages and generates search patterns to find similar issues.
 - *Alerting* — provides possible causes and remediation suggestions for log rate changes.
 
-For example, in the log details, you'll see prompts for *What's this message?* and *How do I find similar log messages?*: 
+For example, in the log details, you'll see prompts for *What's this message?* and *How do I find similar log messages?*:
 
 [role="screenshot"]
 image::images/obs-ai-logs-prompts.png[]


### PR DESCRIPTION
Connectors aren't currently available for ingesting external data into the AI Assistant knowledge base.

Actual non-whitespace deletion changes located [here](https://github.com/elastic/observability-docs/pull/3378/files#diff-2c019fd3961068e3a5b86f2abe9a7128e4b6bc0b492ddca3fe09bd34084022b8L70-R70).