### PR TITLE
Add documentation clarification

### DIFF
--- a/docs/en/observability/synthetics-configuration.asciidoc
+++ b/docs/en/observability/synthetics-configuration.asciidoc
@@ -79,7 +79,7 @@ For all available options, refer to the https://playwright.dev/docs/test-configu
 
 [NOTE]
 ====
-Synthetics will always run browser monitors in headless mode (it is not possible to configure them to run in headful mode, even if setting Playwright options).
+Do not attempt to run in headful mode (using `headless:false`) when running through Elastic's global managed testing infrastructure or Private Locations as this is not supported.
 ====
 
 Below are details on a few Playwright options that are particularly relevant to Elastic Synthetics including timeouts, timezones, and device emulation.

--- a/docs/en/observability/synthetics-configuration.asciidoc
+++ b/docs/en/observability/synthetics-configuration.asciidoc
@@ -77,6 +77,11 @@ Read more in <<synthetics-params-secrets>>.
 
 For all available options, refer to the https://playwright.dev/docs/test-configuration[Playwright documentation].
 
+[NOTE]
+====
+Synthetics will always run browser monitors in headless mode (it is not possible to configure them to run in headful mode, even if setting Playwright options).
+====
+
 Below are details on a few Playwright options that are particularly relevant to Elastic Synthetics including timeouts, timezones, and device emulation.
 
 [discrete]

--- a/docs/en/observability/synthetics-create-test.asciidoc
+++ b/docs/en/observability/synthetics-create-test.asciidoc
@@ -167,6 +167,11 @@ Use Playwright to simulate and validate user workflows including:
 
 Visit the https://playwright.dev/docs[Playwright documentation] for information.
 
+[NOTE]
+====
+Synthetics will always run browser monitors in headless mode (it is not possible to configure them to run in headful mode, even if setting Playwright options).
+====
+
 However, not all Playwright functionality should be used with Elastic Synthetics.
 In some cases, there are alternatives to Playwright functionality built into the
 Elastic Synthetics library. These alternatives are designed to work better for

--- a/docs/en/observability/synthetics-create-test.asciidoc
+++ b/docs/en/observability/synthetics-create-test.asciidoc
@@ -169,7 +169,7 @@ Visit the https://playwright.dev/docs[Playwright documentation] for information.
 
 [NOTE]
 ====
-Synthetics will always run browser monitors in headless mode (it is not possible to configure them to run in headful mode, even if setting Playwright options).
+Do not attempt to run in headful mode (using `headless:false`) when running through Elastic's global managed testing infrastructure or Private Locations as this is not supported.
 ====
 
 However, not all Playwright functionality should be used with Elastic Synthetics.

--- a/docs/en/observability/synthetics-reference/lightweight-config/http.asciidoc
+++ b/docs/en/observability/synthetics-reference/lightweight-config/http.asciidoc
@@ -6,8 +6,8 @@
 
 // hosts
 | [[monitor-http-hosts]] *`hosts`*
-(list of <<synthetics-lightweight-data-string,string>>s)
-a| *Required*. A list of URLs to ping.
+(<<synthetics-lightweight-data-string,string>>)
+a| *Required*. The URL to ping.
 
 ////////////////////////
 max_redirects
@@ -70,7 +70,7 @@ a| The TLS/SSL connection settings for use with the HTTPS endpoint. If you don't
 - type: http
   id: my-http-service
   name: My HTTP Service
-  hosts: ["https://myhost:443"]
+  hosts: "https://myhost:443"
   schedule: '@every 5s'
   ssl:
     certificate_authorities: ['/etc/ca.crt']

--- a/docs/en/observability/synthetics-reference/lightweight-config/icmp.asciidoc
+++ b/docs/en/observability/synthetics-reference/lightweight-config/icmp.asciidoc
@@ -6,14 +6,14 @@
 
 // hosts
 | [[monitor-icmp-hosts]] *`hosts`*
-(list of <<synthetics-lightweight-data-string,string>>s)
-a| *Required*. A list of hosts to ping.
+(<<synthetics-lightweight-data-string,string>>)
+a| *Required*. The host to ping.
 
 *Example*:
 
 [source,yaml]
 ----
-hosts: ["myhost"]
+hosts: "myhost"
 ----
 
 ////////////////////////

--- a/docs/en/observability/synthetics-reference/lightweight-config/tcp.asciidoc
+++ b/docs/en/observability/synthetics-reference/lightweight-config/tcp.asciidoc
@@ -6,11 +6,8 @@
 
 // hosts
 | [[monitor-tcp-hosts]] *`hosts`*
-(list of <<synthetics-lightweight-data-string,string>>s)
-a| *Required*. A list of hosts to ping. The entries in the list can be:
-
-* *A plain host name, such as `localhost`, or an IP address.*
-  If you specify this option, you must also specify a value for <<monitor-tcp-ports,`ports`>>.  If the monitor is {heartbeat-ref}/configuration-ssl.html[configured to use SSL], Synthetics establishes an SSL/TLS-based connection. Otherwise, it establishes a plain TCP connection.
+(<<synthetics-lightweight-data-string,string>>)
+a| *Required*. The host to ping. The entries in the list can be:
 
 * *A hostname and port, such as `localhost:12345`.*
   Synthetics connects to the port on the specified host. If the monitor is {heartbeat-ref}/configuration-ssl.html[configured to use SSL], Synthetics establishes an SSL/TLS-based connection. Otherwise, it establishes a TCP connection.
@@ -24,32 +21,17 @@ a| *Required*. A list of hosts to ping. The entries in the list can be:
 
 [source,yaml]
 ----
-hosts: ["localhost"]
+hosts: "localhost"
 ----
 
 [source,yaml]
 ----
-hosts: ["localhost:8000"]
+hosts: "localhost:8000"
 ----
 
 [source,yaml]
 ----
-hosts: ["tcp://localhost:8000"]
-----
-
-////////////////
-ports
-////////////////
-| [[monitor-tcp-ports]] *`ports`*
-(list of <<synthetics-lightweight-data-string,string>>s)
-a| A list of ports to ping if the host specified in <<monitor-tcp-hosts,`hosts`>> does not contain a port number. It is generally preferable to use a single value here, since each port will be monitored using a separate `id`, with the given `id` value, used as a prefix in the Synthetics data, and the configured `name` shared across events sent via this check.
-
-*Example*:
-
-[source,yaml]
-----
-hosts: ["localhost"]
-ports: [80, 9200, 5044]
+hosts: "tcp://localhost:8000"
 ----
 
 ////////////////

--- a/docs/en/observability/synthetics-reference/lightweight-config/tcp.asciidoc
+++ b/docs/en/observability/synthetics-reference/lightweight-config/tcp.asciidoc
@@ -15,7 +15,7 @@ a| *Required*. The host to ping. The entries in the list can be:
 * *A full URL using the syntax `scheme://<host>:[port]`*, where:
 ** `scheme` is one of `tcp`, `plain`, `ssl` or `tls`. If `tcp` or `plain` is specified, Synthetics establishes a TCP connection even if the monitor is configured to use SSL. If `tls` or `ssl` is specified, Synthetics establishes an SSL connection. However, if the monitor is not configured to use SSL, the system defaults are used (currently not supported on Windows).
 ** `host` is the hostname.
-** `port` is the port number. If `port` is missing in the URL, the <<monitor-tcp-ports,`ports`>> setting is required.
+** `port` is the port number.
 
 *Examples*:
 

--- a/docs/en/observability/synthetics-reference/lightweight-config/tcp.asciidoc
+++ b/docs/en/observability/synthetics-reference/lightweight-config/tcp.asciidoc
@@ -7,7 +7,7 @@
 // hosts
 | [[monitor-tcp-hosts]] *`hosts`*
 (<<synthetics-lightweight-data-string,string>>)
-a| *Required*. The host to ping. The entries in the list can be:
+a| *Required*. The host to ping. The value can be:
 
 * *A hostname and port, such as `localhost:12345`.*
   Synthetics connects to the port on the specified host. If the monitor is {heartbeat-ref}/configuration-ssl.html[configured to use SSL], Synthetics establishes an SSL/TLS-based connection. Otherwise, it establishes a TCP connection.
@@ -18,11 +18,6 @@ a| *Required*. The host to ping. The entries in the list can be:
 ** `port` is the port number.
 
 *Examples*:
-
-[source,yaml]
-----
-hosts: "localhost"
-----
 
 [source,yaml]
 ----


### PR DESCRIPTION
Following on from https://github.com/elastic/observability-docs/pull/3263, there are more places where this limitation was not reflected in the documentation.  This is also true for not supporting `ports` in Project Monitors.

The docs have also been updated to clarify that monitors cannot run in headful mode, but always headless, and cannot be overridden with Playwright Options.