### PR TITLE
update custom threshold redirect

### DIFF
--- a/docs/en/observability/redirects.asciidoc
+++ b/docs/en/observability/redirects.asciidoc
@@ -52,25 +52,25 @@ instrument applications with APM, refer to
 [role="exclude",id="aws-elastic-serverless-forwarder"]
 === Elastic Serverless Forwarder for AWS
 
-This page no longer exists in the Observability Guide. 
+This page no longer exists in the Observability Guide.
 Refer to {esf-ref}/aws-elastic-serverless-forwarder.html[Elastic Serverless Forwarder for AWS].
 
 [role="exclude",id="aws-deploy-elastic-serverless-forwarder"]
 === Deploy Elastic Serverless Forwarder
 
-This page no longer exists in the Observability Guide. 
+This page no longer exists in the Observability Guide.
 Refer to {esf-ref}/aws-deploy-elastic-serverless-forwarder.html[Deploy Elastic Serverless Forwarder].
 
 [role="exclude",id="aws-elastic-serverless-forwarder-configuration"]
 === Configuration options for Elastic Serverless Forwarder
 
-This page no longer exists in the Observability Guide. 
+This page no longer exists in the Observability Guide.
 Refer to {esf-ref}/aws-elastic-serverless-forwarder-configuration.html[Configuration options for Elastic Serverless Forwarder].
 
 [role="exclude",id="aws-serverless-troubleshooting"]
 === Troubleshooting and error handling
 
-This page no longer exists in the Observability Guide. 
+This page no longer exists in the Observability Guide.
 Refer to {esf-ref}/aws-serverless-troubleshooting.html[Troubleshooting and error handling].
 
 [role="exclude",id="synthetic-monitoring-visualizations"]
@@ -149,4 +149,4 @@ Refer to <<traces-get-started>>.
 [role="exclude" id="threshold-alert"]
 === Create a threshold rule
 
-coming::[8.9.0]
+Refer to <<custom-threshold-alert>>.


### PR DESCRIPTION
Update the custom threshold redirect to send people to the new docs. I believe all references to threshold-alert have been updated, but in case there were any bookmarks, I think this should be updated instead of removed completely.