### PR TITLE
[Logs] Update data stream for streaming logs

### DIFF
--- a/docs/en/observability/logs-stream.asciidoc
+++ b/docs/en/observability/logs-stream.asciidoc
@@ -41,14 +41,14 @@ include::{ingest-docs-root}/docs/en/ingest-management/tab-widgets/run-standalone
 
 During installation, you're prompted with some questions:
 
-. When asked if you want to install the agent as a service, enter `Y`. 
+. When asked if you want to install the agent as a service, enter `Y`.
 . When asked if you want to enroll the agent in Fleet, enter `n`.
 
 [discrete]
 [[logs-stream-agent-config]]
 == Step 3: Configure the {agent}
 
-With your agent installed, configure it by updating the `elastic-agent.yml` file. 
+With your agent installed, configure it by updating the `elastic-agent.yml` file.
 
 [discrete]
 [[logs-stream-yml-location]]
@@ -76,7 +76,8 @@ inputs:
     type: filestream
     streams:
       - id: your-log-stream-id
-        data_stream.dataset: generic
+        data_stream:
+          dataset: example
         paths:
           - /var/log/your-logs.log
 ----
@@ -94,8 +95,8 @@ image::images/es-endpoint-cluster-id.png[{es} endpoint and cluster id location, 
 NOTE: The API key format should be `<id>:<key>`. Make sure you selected *Beats* when you created your API key. Base64 encoded API keys are not currently supported in this configuration.
 - `inputs.id` – A unique identifier for your input.
 - `type` – The type of input. For collecting logs, set this to `filestream`.
-- `streams.id` – A unique identifier for your stream of log data. 
-- `data_stream.dataset` – The name for your dataset data stream. Name this data stream anything that signifies the source of the data. The default value is `generic`.
+- `streams.id` – A unique identifier for your stream of log data.
+- `data_stream.dataset` – The name for your dataset data stream. Name this data stream anything that signifies the source of the data. In this example, we've set the dataset to `example`. The default value is `generic`.
 - `paths` – The path to your log files. You can also use a pattern like `/var/log/your-logs.log*`.
 
 [discrete]
@@ -119,7 +120,7 @@ include::{ingest-docs-root}/docs/en/ingest-management/tab-widgets/start-widget.a
 If you're not seeing your log files in {kib}, verify the following in the `elastic-agent.yml` file:
 
 - The path to your logs file under `paths` is correct.
-- Your API key is in `<id>:<key>` format. If not, your API key may be in an unsupported format, and you'll need to create an API key in *Beats* format. 
+- Your API key is in `<id>:<key>` format. If not, your API key may be in an unsupported format, and you'll need to create an API key in *Beats* format.
 
 If you're still running into issues, see {fleet-guide}/fleet-troubleshooting.html[{agent} troubleshooting] and {fleet-guide}/elastic-agent-configuration.html[Configure standalone Elastic Agents].
 

--- a/docs/en/observability/logs-stream.asciidoc
+++ b/docs/en/observability/logs-stream.asciidoc
@@ -96,7 +96,7 @@ NOTE: The API key format should be `<id>:<key>`. Make sure you selected *Beats* 
 - `inputs.id` – A unique identifier for your input.
 - `type` – The type of input. For collecting logs, set this to `filestream`.
 - `streams.id` – A unique identifier for your stream of log data.
-- `data_stream.dataset` – The name for your dataset data stream. Name this data stream anything that signifies the source of the data. In this example, we've set the dataset to `example`. The default value is `generic`.
+- `data_stream.dataset` – The name for your dataset data stream. Name this data stream anything that signifies the source of the data. In this configuration, the dataset is set to `example`. The default value is `generic`.
 - `paths` – The path to your log files. You can also use a pattern like `/var/log/your-logs.log*`.
 
 [discrete]


### PR DESCRIPTION
This PR closes Issue [3398](https://github.com/elastic/observability-docs/issues/3398).

The data stream differed between the stream a log and parse logs documentation causes some frustration for users moving through them.  