### PR TITLE
[mergify] Add 8.12 to `.mergify.yml`

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -253,3 +253,16 @@ pull_request_rules:
         labels:
           - "backport"
         title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"
+  - name: backport patches to 8.12 branch
+    conditions:
+      - merged
+      - label=backport-8.12
+    actions:
+      backport:
+        assignees:
+          - "{{ author }}"
+        branches:
+          - "8.12"
+        labels:
+          - "backport"
+        title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"


### PR DESCRIPTION
I thought this was automated, but I didn't see a PR open. I think this should allow us to use `backport-8.12` to backport to the `8.12` branch. @elastic/obs-docs does this look correct? 