### PR TITLE
Point to `shared` files instead of Beats book

### DIFF
--- a/docs/en/observability/logs-ecs-application.asciidoc
+++ b/docs/en/observability/logs-ecs-application.asciidoc
@@ -143,7 +143,7 @@ include::tab-widgets/logs/filebeat-setup-widget.asciidoc[]
 
 From the {filebeat} installation directory, start filebeat by running the command that aligns with your system:
 
-include::{beats-root}/libbeat/docs/tab-widgets/start-widget-filebeat.asciidoc[]
+include::{observability-docs-root}/docs/en/shared/copied-from-beats/start-filebeat/start-widget-filebeat.asciidoc[]
 
 [discrete]
 [[ingest-ecs-logs-with-agent]]

--- a/docs/en/observability/logs-plaintext.asciidoc
+++ b/docs/en/observability/logs-plaintext.asciidoc
@@ -107,7 +107,7 @@ include::tab-widgets/logs/filebeat-setup-widget.asciidoc[]
 
 From the {filebeat} installation directory, start filebeat by running the command that aligns with your system:
 
-include::{beats-root}/libbeat/docs/tab-widgets/start-widget-filebeat.asciidoc[]
+include::{observability-docs-root}/docs/en/shared/copied-from-beats/start-filebeat/start-widget-filebeat.asciidoc[]
 
 [discrete]
 [[step-5-plaintext-parse-logs-with-an-ingest-pipeline]]


### PR DESCRIPTION
In https://github.com/elastic/observability-docs/commit/a9ffa532d1f451ab839bfd6270105b97f807fe4e we re-added the Beats book as a dependency (which we removed in https://github.com/elastic/observability-docs/pull/2992). I _think_ we should be able to point to the copied files in the `shared` directory instead of relying on the Beats book. 