### PR TITLE
release: observability-docs automation

### DIFF
--- a/.github/Makefile
+++ b/.github/Makefile
@@ -70,4 +70,4 @@ create-prs-next-release:
 		--body "Merge as soon as $(PROJECT_MAJOR_VERSION).$(PROJECT_MINOR_VERSION) branch was created." \
 		--assignee "$(GITHUB_USERNAME)" \
 		--reviewer "$(PROJECT_REVIEWERS)" \
-		--label 'team:automation' || echo "There are no changes"
+		--label 'Team:Automation' || echo "There are no changes"

--- a/.github/Makefile
+++ b/.github/Makefile
@@ -1,0 +1,73 @@
+.SHELLFLAGS = -euc
+SHELL = /bin/bash
+
+## Project details
+#############################
+PROJECT_MAJOR_VERSION ?= $(shell echo $(CURRENT_RELEASE) | cut -f1 -d.)
+PROJECT_MINOR_VERSION ?= $(shell echo $(CURRENT_RELEASE) | cut -f2 -d.)
+PROJECT_PATCH_VERSION ?= $(shell echo $(CURRENT_RELEASE) | cut -f3 -d.)
+PROJECT_OWNER ?= elastic
+
+RELEASE_BRANCH ?= $(PROJECT_MAJOR_VERSION).$(PROJECT_MINOR_VERSION)
+NEXT_PROJECT_MINOR_VERSION ?= $(PROJECT_MAJOR_VERSION).$(shell expr $(PROJECT_MINOR_VERSION) + 1).0
+NEXT_RELEASE ?= $(PROJECT_MAJOR_VERSION).$(PROJECT_MINOR_VERSION).$(shell expr $(PROJECT_PATCH_VERSION) + 1)
+
+BACKPORT_BRANCH_NAME = add-backport-next-$(NEXT_PROJECT_MINOR_VERSION)
+
+## observability-docs specific
+##############################
+PROJECT_REVIEWERS ?= elastic/observablt-robots
+
+## Update the references on the github labels using major.minor format
+.PHONY: update-labels
+update-labels:
+	echo '  - name: backport patches to $(PROJECT_MAJOR_VERSION).$(PROJECT_MINOR_VERSION) branch' >> .mergify.yml
+	echo '    conditions:'                  >> .mergify.yml
+	echo '      - merged'                   >> .mergify.yml
+	echo '      - base=main'                >> .mergify.yml
+	echo '      - label=backport-$(PROJECT_MAJOR_VERSION).$(PROJECT_MINOR_VERSION)' >> .mergify.yml
+	echo '    actions:'                     >>	.mergify.yml
+	echo '      backport:'                  >>	.mergify.yml
+	echo '        assignees:'               >>	.mergify.yml
+	echo '          - "{{ author }}"'       >>	.mergify.yml
+	echo '        labels:'                  >>	.mergify.yml
+	echo '          - "backport"'           >>	.mergify.yml
+	echo '        branches:'                >>	.mergify.yml
+	echo '          - "$(PROJECT_MAJOR_VERSION).$(PROJECT_MINOR_VERSION)"' >>	.mergify.yml
+	echo '        title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"' >> .mergify.yml
+
+## @help:prepare-major-minor-release:Prepare a major/minor release by creating a new branch reference.
+.PHONY: prepare-major-minor-release
+prepare-major-minor-release:
+	git checkout -b $(RELEASE_BRANCH)
+
+## @help:create-branch-major-minor-release:Pushes the changes on the project folder to the new RELEASE_BRANCH.
+.PHONY: create-branch-major-minor-release
+create-branch-major-minor-release:
+	git push --set-upstream origin $(RELEASE_BRANCH)
+	echo "You have to create a branch rule at https://github.com/$(PROJECT_OWNER)/observability-docs/settings/branch_protection_rules/new"
+	echo "* Require pull request PROJECT_REVIEWERS before merging"
+	echo "* Require status checks to pass before merging - CLA and Lint"
+
+## @help:prepare-next-release:Prepare the original branch for the next release cycle.
+.PHONY: prepare-next-release
+prepare-next-release:
+	git checkout -b $(BACKPORT_BRANCH_NAME)
+	$(MAKE) update-labels
+	if [ ! -z "$$(git status -s)" ]; then \
+    	git status -s; \
+    	git add --all; \
+    	git commit -a -m "[Release] add-backport-next"; \
+	fi
+
+## @help:create-prs-next-release:Create the PRs with the next release cycle.
+.PHONY: create-prs-next-release
+create-prs-next-release:
+	git checkout $(BACKPORT_BRANCH_NAME)
+	git push --set-upstream origin add-backport-next-$(NEXT_PROJECT_MINOR_VERSION)
+	gh pr create \
+		--title "backport: Add $(PROJECT_MAJOR_VERSION).$(PROJECT_MINOR_VERSION) branch" \
+		--body "Merge as soon as $(PROJECT_MAJOR_VERSION).$(PROJECT_MINOR_VERSION) branch was created." \
+		--assignee "$(GITHUB_USERNAME)" \
+		--reviewer "$(PROJECT_REVIEWERS)" \
+		--label 'team:automation' || echo "There are no changes"

--- a/.github/Makefile
+++ b/.github/Makefile
@@ -1,6 +1,7 @@
 .SHELLFLAGS = -euc
 SHELL = /bin/bash
 
+##############################
 ## Project details
 #############################
 PROJECT_MAJOR_VERSION ?= $(shell echo $(CURRENT_RELEASE) | cut -f1 -d.)
@@ -14,11 +15,23 @@ NEXT_RELEASE ?= $(PROJECT_MAJOR_VERSION).$(PROJECT_MINOR_VERSION).$(shell expr $
 
 BACKPORT_BRANCH_NAME = add-backport-next-$(NEXT_PROJECT_MINOR_VERSION)
 
+##############################
 ## observability-docs specific
 ##############################
 PROJECT_REVIEWERS ?= elastic/observablt-robots
 
-## Update the references on the github labels using major.minor format
+##############################
+## public make goals
+##############################
+## @help:create-major-minor-release:Prepare a major/minor release by creating a new branch and pushing to the upstream
+.PHONY: create-major-minor-release
+create-major-minor-release: prepare-major-minor-release create-branch-major-minor-release
+
+## @help:create-next-release:Prepare the original branch for the next release cycle and the relevant PRs.
+.PHONY: create-next-release
+create-next-release: prepare-next-release create-prs-next-release
+
+## Update the references on the github labels using major.minor format. INTERNAL
 .PHONY: update-labels
 update-labels:
 	echo '  - name: backport patches to $(PROJECT_MAJOR_VERSION).$(PROJECT_MINOR_VERSION) branch' >> .mergify.yml

--- a/.github/workflows/run-minor-release.yml
+++ b/.github/workflows/run-minor-release.yml
@@ -1,0 +1,43 @@
+---
+name: run-minor-release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'The version (semver format: major.minor.patch)'
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  
+jobs:
+  run-minor:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set github config
+        run: |
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
+
+      - name: create branch release
+        run: |-
+          echo "### minor - ${CURRENT_RELEASE}" >> $GITHUB_STEP_SUMMARY
+          make -C .github prepare-major-minor-release create-branch-major-minor-release
+
+      - name: prepare next release
+        run: make -C .github prepare-next-release create-prs-next-release
+        env:
+          CURRENT_RELEASE: ${{ inputs.version }}
+
+      - if: ${{ failure() }}
+        uses: elastic/apm-pipeline-library/.github/actions/slack-message@current
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          channel: '#observablt-bots'
+          message: ":traffic_cone: release automation failed for `${{ github.repository }}@${{ inputs.version }}`, @robots-ci please look what's going on <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|here>"

--- a/.github/workflows/run-minor-release.yml
+++ b/.github/workflows/run-minor-release.yml
@@ -24,12 +24,12 @@ jobs:
           git config --global user.name "github-actions[bot]"
 
       - name: create branch release
-        run: |-
-          echo "### minor - ${CURRENT_RELEASE}" >> $GITHUB_STEP_SUMMARY
-          make -C .github prepare-major-minor-release create-branch-major-minor-release
+        run: make -C .github create-major-minor-release
+        env:
+          CURRENT_RELEASE: ${{ inputs.version }}
 
       - name: prepare next release
-        run: make -C .github prepare-next-release create-prs-next-release
+        run: make -C .github create-next-release
         env:
           CURRENT_RELEASE: ${{ inputs.version }}
 


### PR DESCRIPTION
Replaces https://github.com/elastic/ingest-dev/pull/2792 <-- accessible only by Elastic employees


### Test


```bash
$ CURRENT_RELEASE=8.14.0 PROJECT_OWNER=v1v \
make -C .github prepare-major-minor-release create-branch-major-minor-release create-prs-next-release prepare-next-release

```


produced https://github.com/elastic/observability-docs/pull/3429 and https://github.com/v1v/observability-docs/tree/8.14