### PR TITLE
[apm docs consolidation] Clean up 

### DIFF
--- a/docs/en/apm-server/release-notes.asciidoc
+++ b/docs/en/apm-server/release-notes.asciidoc
@@ -9,19 +9,7 @@ This section summarizes the changes in each release.
 
 **APM integration and APM Server**
 
-* <<release-notes-8.12>>
-* <<release-notes-8.11>>
-* <<release-notes-8.10>>
-* <<release-notes-8.9>>
-* <<release-notes-8.8>>
-* <<release-notes-8.7>>
-* <<release-notes-8.6>>
-* <<release-notes-8.5>>
-* <<release-notes-8.4>>
-* <<release-notes-8.3>>
-* <<release-notes-8.2>>
-* <<release-notes-8.1>>
-* <<release-notes-8.0>>
+include::{apm-server-root}/CHANGELOG.asciidoc[tag=list]
 
 Looking for a previous version? See the {apm-guide-7x}/release-notes.html[7.x release notes].
 
@@ -45,4 +33,4 @@ See the {kibana-ref}/release-notes.html[Kibana release notes].
 
 * https://github.com/elastic/apm-aws-lambda/blob/main/CHANGELOG.asciidoc[Elastic APM AWS Lambda extension]
 
-include::{apm-server-root}/CHANGELOG.asciidoc[]
+include::{apm-server-root}/CHANGELOG.asciidoc[tag=includes]


### PR DESCRIPTION
Dependent on /apm-server PR (coming soon)

There's some content we want to leave behind in /apm-server and `include` in this repo:

* [x] **Release notes/breaking changes**: Manage release notes 100% in the /apm-server repo (https://github.com/elastic/observability-docs/commit/9f043cd8a01b5e2392edbabe5dae0d53daf86719)
* [ ] **Sample data**: Keep sample data in /apm server including `docs/spec` (and `docs/data`?) directory