### PR TITLE
Sync Stateful SLO docs with Serverless

### DIFF
--- a/docs/en/observability/slo-overview.asciidoc
+++ b/docs/en/observability/slo-overview.asciidoc
@@ -37,7 +37,12 @@ From the SLO overview, you can see all of your SLOs and a quick summary of what'
 [role="screenshot"]
 image::images/slo-dashboard.png[]
 
-Click an SLO to see a detailed view. This view includes SLI history, error budget burn down charts, and current active alerts if you've set any <<slo-burn-rate-alert,SLO burn rate alert rules>> for the SLO.
+Select an SLO from the overview to see additional details including:
+
+* **Burn rate:** the percentage of bad events over different time periods (1h, 6h, 24h, 72h) and the risk of exhausting your error budget within those time periods.
+* **Historical SLI:** the SLI value and how it's trending over the SLO time window.
+* **Error budget burn down:** the remaining error budget and how it's trending over the SLO time window.
+* **Alerts:** active alerts if you've set any <<slo-burn-rate-alert,SLO burn rate alert rules>> for the SLO.
 
 [role="screenshot"]
 image::images/slo-detailed-view.png[]


### PR DESCRIPTION
### Summary

Brings over https://github.com/elastic/staging-serverless-observability-docs/pull/131.

Related to https://github.com/elastic/observability-docs/pull/3503 and https://github.com/elastic/staging-serverless-observability-docs/pull/210.