### PR TITLE
Explain how to upgrade SLOs out of beta

### DIFF
--- a/docs/en/observability/slo-overview.asciidoc
+++ b/docs/en/observability/slo-overview.asciidoc
@@ -65,6 +65,34 @@ image::images/slo-dashboard-panel.png[]
 See {kibana-ref}/dashboard.html[Dashboard and visualizations] to learn how to add panels to a Dashboard.
 
 [discrete]
+[[slo-upgrade-to-ga]]
+== Upgrade from beta to GA
+
+Starting in version 8.12.0, SLOs are generally available (GA).
+If you're upgrading from a beta version of SLOs (available in 8.11.0 and earlier),
+you must migrate your SLO definitions to a new format.
+
+[%collapsible]
+.Migrate your SLO definitions
+====
+To migrate your SLO definitions, open the SLO overview.
+A banner will display the number of outdated SLOs detected.
+For each outdated SLO, click **Reset**. If you no longer need the SLO, select **Delete**.
+
+If you have a large number of SLO definitions, it is possible to automate this process.
+To do this, you'll need to use two Elastic APIs:
+
+* https://github.com/elastic/kibana/blob/9cb830fe9a021cda1d091effbe3e0cd300220969/x-pack/plugins/observability/docs/openapi/slo/bundled.yaml#L453-L514[SLO Definitions Find API] (`/api/observability/slos/_definitions`)
+* https://github.com/elastic/kibana/blob/9cb830fe9a021cda1d091effbe3e0cd300220969/x-pack/plugins/observability/docs/openapi/slo/bundled.yaml#L368-L410[SLO Reset API] (`/api/observability/slos/${id}/_reset`)
+
+Pass in `includeOutdatedOnly=1` as a query parameter to the Definitions Find API.
+This will display your outdated SLO definitions.
+Loop through this list, one by one, calling the Reset API on each outdated SLO definition.
+The Reset API loads the outdated SLO definition and resets it to the new format required for GA.
+Once an SLO is reset, it will start to regenerate SLIs and summary data.
+====
+
+[discrete]
 [[slo-overview-next-steps]]
 == Next steps
 To get started using SLOs to measure your service performance, see the following pages:


### PR DESCRIPTION
### Summary

8.12.0 introduces a breaking change to SLOs. This PR explains how users can upgrade (reset) their SLOs to the new format required in 8.12.0+.

Closes https://github.com/elastic/observability-docs/issues/3511.