### PR TITLE
automation: update reviewers and refactor

### DIFF
--- a/.github/Makefile
+++ b/.github/Makefile
@@ -1,3 +1,5 @@
+.SILENT:
+MAKEFLAGS += --no-print-directory
 .SHELLFLAGS = -euc
 SHELL = /bin/bash
 
@@ -6,19 +8,17 @@ SHELL = /bin/bash
 #############################
 PROJECT_MAJOR_VERSION ?= $(shell echo $(CURRENT_RELEASE) | cut -f1 -d.)
 PROJECT_MINOR_VERSION ?= $(shell echo $(CURRENT_RELEASE) | cut -f2 -d.)
-PROJECT_PATCH_VERSION ?= $(shell echo $(CURRENT_RELEASE) | cut -f3 -d.)
 PROJECT_OWNER ?= elastic
 
 RELEASE_BRANCH ?= $(PROJECT_MAJOR_VERSION).$(PROJECT_MINOR_VERSION)
 NEXT_PROJECT_MINOR_VERSION ?= $(PROJECT_MAJOR_VERSION).$(shell expr $(PROJECT_MINOR_VERSION) + 1).0
-NEXT_RELEASE ?= $(PROJECT_MAJOR_VERSION).$(PROJECT_MINOR_VERSION).$(shell expr $(PROJECT_PATCH_VERSION) + 1)
 
 BACKPORT_BRANCH_NAME = add-backport-next-$(NEXT_PROJECT_MINOR_VERSION)
 
 ##############################
 ## observability-docs specific
 ##############################
-PROJECT_REVIEWERS ?= elastic/observablt-robots
+PROJECT_REVIEWERS ?= elastic/obs-docs
 
 ##############################
 ## public make goals
@@ -30,6 +30,10 @@ create-major-minor-release: prepare-major-minor-release create-branch-major-mino
 ## @help:create-next-release:Prepare the original branch for the next release cycle and the relevant PRs.
 .PHONY: create-next-release
 create-next-release: prepare-next-release create-prs-next-release
+
+##############################
+## internal make goals
+##############################
 
 ## Update the references on the github labels using major.minor format. INTERNAL
 .PHONY: update-labels
@@ -67,20 +71,28 @@ create-branch-major-minor-release:
 prepare-next-release:
 	git checkout -b $(BACKPORT_BRANCH_NAME)
 	$(MAKE) update-labels
+	$(MAKE) git-diff
 	if [ ! -z "$$(git status -s)" ]; then \
-    	git status -s; \
-    	git add --all; \
-    	git commit -a -m "[Release] add-backport-next"; \
+		git status -s; \
+		git add --all; \
+		git commit -a -m "[Release] Add backport-$(PROJECT_MAJOR_VERSION).$(PROJECT_MINOR_VERSION)"; \
 	fi
 
 ## @help:create-prs-next-release:Create the PRs with the next release cycle.
 .PHONY: create-prs-next-release
 create-prs-next-release:
 	git checkout $(BACKPORT_BRANCH_NAME)
-	git push --set-upstream origin add-backport-next-$(NEXT_PROJECT_MINOR_VERSION)
+	git push --set-upstream origin $(BACKPORT_BRANCH_NAME)
 	gh pr create \
-		--title "backport: Add $(PROJECT_MAJOR_VERSION).$(PROJECT_MINOR_VERSION) branch" \
+		--title "backport: Add backport-$(PROJECT_MAJOR_VERSION).$(PROJECT_MINOR_VERSION) label" \
 		--body "Merge as soon as $(PROJECT_MAJOR_VERSION).$(PROJECT_MINOR_VERSION) branch was created." \
-		--assignee "$(GITHUB_USERNAME)" \
 		--reviewer "$(PROJECT_REVIEWERS)" \
+		--base main \
 		--label 'Team:Automation' || echo "There are no changes"
+
+## Diff output
+.PHONY: git-diff
+git-diff:
+	@echo "::group::git-diff"
+	git --no-pager  diff || true
+	@echo "::endgroup::"

--- a/.github/workflows/run-minor-release.yml
+++ b/.github/workflows/run-minor-release.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'The version (semver format: major.minor.patch)'
+        description: 'The version (semver format: major.minor.0)'
         required: true
         type: string
 


### PR DESCRIPTION
### What

- Tweak the scripts a bit so they don't use duplicated hardcoded values.
- Assign the reviewers
- Set the branch to be used when creating a PR
- Remove unused variables.

### Test

Given the hypothetical FF for `8.17.0` and using my forked repository then:

```bash
CURRENT_RELEASE=8.17.0 \
PROJECT_OWNER=v1v \
PROJECT_REVIEWERS=v1v \
make -C .github create-major-minor-release create-next-release
```

Produced https://github.com/v1v/observability-docs/pull/3 and https://github.com/v1v/observability-docs/tree/8.17

