### PR TITLE
[apm docs consolidation] Copy recent /apm-server docs edits

### DIFF
--- a/docs/en/observability/apm/apm-k8s-attacher.asciidoc
+++ b/docs/en/observability/apm/apm-k8s-attacher.asciidoc
@@ -1,5 +1,5 @@
-[[apm-mutating-admission-webhook]]
-= APM Attacher
+[[apm-k8s-attacher]]
+= APM K8S Attacher
 
 preview::[]
 

--- a/docs/en/observability/apm/features.asciidoc
+++ b/docs/en/observability/apm/features.asciidoc
@@ -13,7 +13,7 @@
 * <<cross-cluster-search>>
 * <<span-compression>>
 * <<monitoring-aws-lambda>>
-* <<apm-mutating-admission-webhook>>
+* <<apm-k8s-attacher>>
 
 include::./apm-data-security.asciidoc[]
 
@@ -31,4 +31,4 @@ include::./span-compression.asciidoc[]
 
 include::./aws-lambda-extension.asciidoc[leveloffset=+2]
 
-include::./apm-mutating-webhook.asciidoc[leveloffset=+2]
+include::./apm-k8s-attacher.asciidoc[leveloffset=+2]

--- a/docs/en/observability/apm/getting-started-apm-server.asciidoc
+++ b/docs/en/observability/apm/getting-started-apm-server.asciidoc
@@ -285,12 +285,12 @@ If you are running Windows XP, you may need to download and install PowerShell.
 [source,shell]
 ----------------------------------------------------------------------
 PS > cd 'C:\Program Files\APM-Server'
-PS C:\Program Files\APM-Server> .\install-service-apm-server.ps1
+PS C:\Program Files\APM-Server> .\install-service.ps1
 ----------------------------------------------------------------------
 
 NOTE: If script execution is disabled on your system,
 you need to set the execution policy for the current session to allow the script to run.
-For example: `PowerShell.exe -ExecutionPolicy UnRestricted -File .\install-service-apm-server.ps1`.
+For example: `PowerShell.exe -ExecutionPolicy UnRestricted -File .\install-service.ps1`.
 
 endif::[]
 

--- a/docs/en/observability/apm/known-issues.asciidoc
+++ b/docs/en/observability/apm/known-issues.asciidoc
@@ -35,8 +35,7 @@ Failed installing package [apm] due to error: [ResponseError: mapper_parsing_exc
 ----
 
 // Link to fix?
-A fix for this issue is in progress: https://github.com/elastic/kibana/pull/171712[elastic/kibana#171712].
-
+A fix was released in 8.11.2: https://github.com/elastic/kibana/pull/171712[elastic/kibana#171712].
 
 // TEMPLATE
 

--- a/docs/en/observability/redirects.asciidoc
+++ b/docs/en/observability/redirects.asciidoc
@@ -155,3 +155,9 @@ Refer to <<custom-threshold-alert>>.
 === Logs Overview
 
 For an overview of ingesting and viewing logs in {observability}, refer to <<logs-checklist>>.
+
+[role="exclude",id="apm-mutating-admission-webhook"]
+==== APM Attacher
+
+This page has moved.
+Please see <<apm-k8s-attacher>>.


### PR DESCRIPTION
Related to https://github.com/elastic/obs-docs-projects/issues/216

A [few edits to the /apm-server repo's /docs directory](https://github.com/elastic/apm-server/commits/main/docs) snuck in between https://github.com/elastic/docs/pull/2873 and https://github.com/elastic/apm-server/pull/12341. This PR copies those changes to the equivalent pages in the Observability guide:

- [x] https://github.com/elastic/apm-server/pull/12222
- [x] https://github.com/elastic/apm-server/pull/12196
- [x] https://github.com/elastic/apm-server/pull/12343

Note: Next I'll open PRs to backport to the APM guide.

cc @carsonip 