### PR TITLE
[apm docs consolidation] Copy recent /apm-server docs edits (8.10)

### DIFF
--- a/docs/en/apm-server/getting-started-apm-server.asciidoc
+++ b/docs/en/apm-server/getting-started-apm-server.asciidoc
@@ -284,12 +284,12 @@ If you are running Windows XP, you may need to download and install PowerShell.
 [source,shell]
 ----------------------------------------------------------------------
 PS > cd 'C:\Program Files\APM-Server'
-PS C:\Program Files\APM-Server> .\install-service-apm-server.ps1
+PS C:\Program Files\APM-Server> .\install-service.ps1
 ----------------------------------------------------------------------
 
 NOTE: If script execution is disabled on your system,
 you need to set the execution policy for the current session to allow the script to run.
-For example: `PowerShell.exe -ExecutionPolicy UnRestricted -File .\install-service-apm-server.ps1`.
+For example: `PowerShell.exe -ExecutionPolicy UnRestricted -File .\install-service.ps1`.
 
 endif::[]
 

--- a/docs/en/apm-server/known-issues.asciidoc
+++ b/docs/en/apm-server/known-issues.asciidoc
@@ -35,7 +35,7 @@ Failed installing package [apm] due to error: [ResponseError: mapper_parsing_exc
 ----
 
 // Link to fix?
-A fix for this issue is in progress: https://github.com/elastic/kibana/pull/171712[elastic/kibana#171712].
+A fix was released in 8.11.2: https://github.com/elastic/kibana/pull/171712[elastic/kibana#171712].
 
 
 // TEMPLATE


### PR DESCRIPTION
Related to https://github.com/elastic/observability-docs/pull/3536

Note: Does not include changes from https://github.com/elastic/apm-server/pull/12222 because it was not backported to 8.10.