### PR TITLE
docs(apm-server): update golang version in version.asciidoc

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,3 +3,5 @@
 # For more info, see https://help.github.com/articles/about-codeowners/
 
 * @elastic/obs-docs
+
+/docs/en/observability/apm/version.asciidoc   @elastic/apm-server

--- a/.github/updatecli.d/bump-golang.yml
+++ b/.github/updatecli.d/bump-golang.yml
@@ -1,0 +1,42 @@
+---
+name: Bump golang version to latest version in the APM Server docs.
+pipelineid: 'updatecli-bump-golang'
+
+actions:
+  default:
+    title: '[updatecli] Bump Golang version to {{ source "latestGoVersion" }}'
+    kind: github/pullrequest
+    scmid: default
+    spec:
+      description: |-
+        ### What
+        Bump go release version with the latest available version in https://github.com/elastic/apm-server
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: '{{ requiredEnv "GIT_USER" }}'
+      email: '{{ requiredEnv "GIT_EMAIL" }}'
+      owner: elastic
+      repository: observability-docs
+      token: '{{ requiredEnv "GITHUB_TOKEN" }}'
+      username: '{{ requiredEnv "GIT_USER" }}'
+      branch: main
+
+sources:
+  latestGoVersion:
+    kind: file
+    spec:
+      file: https://raw.githubusercontent.com/elastic/apm-server/main/.go-version
+
+targets:
+  update-version-asciidoc:
+    name: 'Update version.asciidoc with Golang version {{ source "latestGoVersion" }}'
+    sourceid: latestGoVersion
+    scmid: default
+    kind: file
+    spec:
+      file: docs/en/observability/apm/version.asciidoc
+      matchpattern: '(:go-version:) \d+.\d+.\d+'
+      replacepattern: '$1 {{ source "latestGoVersion" }}'

--- a/.github/workflows/bump-golang.yml
+++ b/.github/workflows/bump-golang.yml
@@ -4,7 +4,7 @@ name: bump-golang
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 20 * * 6'
+    - cron: '0 3 * * 1-6'
 
 permissions:
     contents: read

--- a/.github/workflows/bump-golang.yml
+++ b/.github/workflows/bump-golang.yml
@@ -1,0 +1,22 @@
+---
+name: bump-golang
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 20 * * 6'
+
+permissions:
+    contents: read
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: elastic/apm-pipeline-library/.github/actions/updatecli@current
+        with:
+          vaultUrl: ${{ secrets.VAULT_ADDR }}
+          vaultRoleId: ${{ secrets.VAULT_ROLE_ID }}
+          vaultSecretId: ${{ secrets.VAULT_SECRET_ID }}
+          pipeline: ./.github/updatecli.d/bump-golang.yml


### PR DESCRIPTION
### What

Update the Golang version when the version has been updated in https://github.com/elastic/apm-server/blob/main/.go-version.

Notify the APM-server team when changes need to be reviewed... However, we could automate the merge since those changes already exist in the main branch.

### Why

https://github.com/elastic/apm-server/pull/12412 caused it since https://github.com/elastic/apm-server/pull/12341 moved the version.asciidoc in this repository.


### Question

This is only supported for the `main` branch, so we might need to support the same for the existing active release branches. I'd like to discuss this in a follow-up. 
