### PR TITLE
Remove unused APM attributes

### DIFF
--- a/docs/en/observability/apm.asciidoc
+++ b/docs/en/observability/apm.asciidoc
@@ -24,8 +24,8 @@ endif::[]
 :access_role: {beat_default_index_prefix}_user
 :beat_version_key: observer.version
 :dockerimage: docker.elastic.co/apm/{beatname_lc}:{version}
-:dockergithub: https://github.com/elastic/apm-server-docker/tree/{doc-branch}
-:dockerconfig: https://raw.githubusercontent.com/elastic/apm-server/{doc-branch}/apm-server.docker.yml
+:dockergithub: https://github.com/elastic/apm-server-docker/tree/{branch}
+:dockerconfig: https://raw.githubusercontent.com/elastic/apm-server/{branch}/apm-server.docker.yml
 :discuss_forum: apm
 :github_repo_name: apm-server
 :sample_date_0: 2019.10.20

--- a/docs/en/observability/apm/version.asciidoc
+++ b/docs/en/observability/apm/version.asciidoc
@@ -1,10 +1,3 @@
-// doc-branch can be: master, 8.0, 8.1, etc.
-:doc-branch: master
-:go-version: 1.21.5
-:python: 3.7
-:docker: 1.12
-:docker-compose: 1.11
-
 include::{asciidoc-dir}/../../shared/versions/stack/{source_branch}.asciidoc[]
 
 // Agent link attributes


### PR DESCRIPTION
### Summary

These attributes are not used by the APM documentation. Let's clean 'em up.