### PR TITLE
[apm consolidation] Add temporary redirects back to APM guide (8.11)

### DIFF
--- a/docs/en/observability/redirects.asciidoc
+++ b/docs/en/observability/redirects.asciidoc
@@ -1,3 +1,5 @@
+:apm-guide-move-notice: In versions 8.11 and earlier, this documentation was in the {apm-guide-ref}/apm-overview.html[APM guide].
+
 ["appendix",role="exclude",id="redirects"]
 = Deleted pages
 
@@ -150,3 +152,1018 @@ Refer to <<traces-get-started>>.
 === Create a threshold rule
 
 Refer to <<custom-threshold-alert>>.
+
+[role="exclude",id="getting-started-apm-server"]
+=== Self manage APM Server
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/getting-started-apm-server.html[Self manage APM Server].
+
+[role="exclude",id="_apm_server_binary"]
+=== APM Server binary
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/_apm_server_binary.html[APM Server binary].
+
+[role="exclude",id="installing"]
+=== Step 1: Install
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/installing.html[Step 1: Install].
+
+[role="exclude",id="apm-server-configuration"]
+=== Step 2: Set up and configure
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/apm-server-configuration.html[Step 2: Set up and configure].
+
+[role="exclude",id="apm-server-starting"]
+=== Step 3: Start
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/apm-server-starting.html[Step 3: Start].
+
+[role="exclude",id="next-steps"]
+=== Step 4: Next steps
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/next-steps.html[Step 4: Next steps].
+
+[role="exclude",id="setup-repositories"]
+=== Repositories for APT and YUM
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/setup-repositories.html[Repositories for APT and YUM].
+
+[role="exclude",id="running-on-docker"]
+=== Run APM Server on Docker
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/running-on-docker.html[Run APM Server on Docker].
+
+[role="exclude",id="_fleet_managed_apm_server"]
+=== Fleet-managed APM Server
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/_fleet_managed_apm_server.html[Fleet-managed APM Server].
+
+[role="exclude",id="_step_1_set_up_fleet"]
+=== Step 1: Set up Fleet
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/_step_1_set_up_fleet.html[Step 1: Set up Fleet].
+
+[role="exclude",id="_step_2_add_and_configure_the_apm_integration"]
+=== Step 2: Add and configure the APM integration
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/_step_2_add_and_configure_the_apm_integration.html[Step 2: Add and configure the APM integration].
+
+[role="exclude",id="_step_3_install_apm_agents"]
+=== Step 3: Install APM agents
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/_step_3_install_apm_agents.html[Step 3: Install APM agents].
+
+[role="exclude",id="_step_4_view_your_data"]
+=== Step 4: View your data
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/_step_4_view_your_data.html[Step 4: View your data].
+
+[role="exclude",id="data-model"]
+=== Data Model
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/data-model.html[Data Model].
+
+[role="exclude",id="data-model-spans"]
+=== Spans
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/data-model-spans.html[Spans].
+
+[role="exclude",id="data-model-transactions"]
+=== Transactions
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/data-model-transactions.html[Transactions].
+
+[role="exclude",id="data-model-errors"]
+=== Errors
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/data-model-errors.html[Errors].
+
+[role="exclude",id="data-model-metrics"]
+=== Metrics
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/data-model-metrics.html[Metrics].
+
+[role="exclude",id="data-model-metadata"]
+=== Metadata
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/data-model-metadata.html[Metadata].
+
+[role="exclude",id="features"]
+=== Features
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/features.html[Features].
+
+[role="exclude",id="apm-data-security"]
+=== Data security
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/apm-data-security.html[Data security].
+
+[role="exclude",id="filtering"]
+=== Built-in data filters
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/filtering.html[Built-in data filters].
+
+[role="exclude",id="custom-filter"]
+=== Custom filters
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/custom-filter.html[Custom filters].
+
+[role="exclude",id="data-security-delete"]
+=== Delete sensitive data
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/data-security-delete.html[Delete sensitive data].
+
+[role="exclude",id="apm-distributed-tracing"]
+=== Distributed tracing
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/apm-distributed-tracing.html[Distributed tracing].
+
+[role="exclude",id="apm-rum"]
+=== Real User Monitoring (R
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/apm-rumUM).html[Real User Monitoring (R].
+
+[role="exclude",id="sampling"]
+=== Transaction sampling
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/sampling.html[Transaction sampling].
+
+[role="exclude",id="configure-head-based-sampling"]
+=== Configure head-based sampling
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/configure-head-based-sampling.html[Configure head-based sampling].
+
+[role="exclude",id="configure-tail-based-sampling"]
+=== Configure tail-based sampling
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/configure-tail-based-sampling.html[Configure tail-based sampling].
+
+[role="exclude",id="log-correlation"]
+=== Logging integration
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/log-correlation.html[Logging integration].
+
+[role="exclude",id="cross-cluster-search"]
+=== Cross-cluster search
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/cross-cluster-search.html[Cross-cluster search].
+
+[role="exclude",id="span-compression"]
+=== Span compression
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/span-compression.html[Span compression].
+
+[role="exclude",id="monitoring-aws-lambda"]
+=== Monitoring AWS Lambda Functions
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/monitoring-aws-lambda.html[Monitoring AWS Lambda Functions].
+
+[role="exclude",id="apm-k8s-attacher"]
+=== APM K8S Attacher
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/apm-k8s-attacher.html[APM K8S Attacher].
+
+[role="exclude",id="how-to-guides"]
+=== How-to guides
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/how-to-guides.html[How-to guides].
+
+[role="exclude",id="source-map-how-to"]
+=== Create and upload source maps (RU
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/source-map-how-toM).html[Create and upload source maps (RU].
+
+[role="exclude",id="jaeger-integration"]
+=== Integrate with Jaeger
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/jaeger-integration.html[Integrate with Jaeger].
+
+[role="exclude",id="ingest-pipelines"]
+=== Parse data using ingest pipeline
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/ingest-pipeliness.html[Parse data using ingest pipeline].
+
+[role="exclude",id="custom-index-template"]
+=== View the Elasticsearch index template
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/custom-index-template.html[View the Elasticsearch index template].
+
+[role="exclude",id="open-telemetry"]
+=== OpenTelemetry integration
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/open-telemetry.html[OpenTelemetry integration].
+
+[role="exclude",id="open-telemetry-with-elastic"]
+=== OpenTelemetry API/SDK with Elastic APM agen
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/open-telemetry-with-elasticts.html[OpenTelemetry API/SDK with Elastic APM agen].
+
+[role="exclude",id="open-telemetry-direct"]
+=== OpenTelemetry native support
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/open-telemetry-direct.html[OpenTelemetry native support].
+
+[role="exclude",id="open-telemetry-other-env"]
+=== AWS Lambda Support
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/open-telemetry-other-env.html[AWS Lambda Support].
+
+[role="exclude",id="open-telemetry-collect-metrics"]
+=== Collect metrics
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/open-telemetry-collect-metrics.html[Collect metrics].
+
+[role="exclude",id="open-telemetry-known-limitations"]
+=== Limitations
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/open-telemetry-known-limitations.html[Limitations].
+
+[role="exclude",id="open-telemetry-resource-attributes"]
+=== Resource attributes
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/open-telemetry-resource-attributes.html[Resource attributes].
+
+[role="exclude",id="manage-storage"]
+=== Manage storage
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/manage-storage.html[Manage storage].
+
+[role="exclude",id="apm-data-streams"]
+=== Data streams
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/apm-data-streams.html[Data streams].
+
+[role="exclude",id="ilm-how-to"]
+=== Index lifecycle management
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/ilm-how-to.html[Index lifecycle management].
+
+[role="exclude",id="storage-guide"]
+=== Storage and sizing guide
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/storage-guide.html[Storage and sizing guide].
+
+[role="exclude",id="reduce-apm-storage"]
+=== Reduce storage
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/reduce-apm-storage.html[Reduce storage].
+
+[role="exclude",id="exploring-es-data"]
+=== Explore data in Elasticsearch
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/exploring-es-data.html[Explore data in Elasticsearch].
+
+[role="exclude",id="configuring-howto-apm-server"]
+=== Configure
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/configuring-howto-apm-server.html[Configure].
+
+[role="exclude",id="configuration-process"]
+=== General configuration options
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/configuration-process.html[General configuration options].
+
+[role="exclude",id="configuration-anonymous"]
+=== Anonymous authentication
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/configuration-anonymous.html[Anonymous authentication].
+
+[role="exclude",id="apm-agent-auth"]
+=== APM agent authorization
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/apm-agent-auth.html[APM agent authorization].
+
+[role="exclude",id="configure-agent-config"]
+=== APM agent configuration
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/configure-agent-config.html[APM agent configuration].
+
+[role="exclude",id="configuration-instrumentation"]
+=== Instrumentation
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/configuration-instrumentation.html[Instrumentation].
+
+[role="exclude",id="setup-kibana-endpoint"]
+=== Kibana endpoint
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/setup-kibana-endpoint.html[Kibana endpoint].
+
+[role="exclude",id="configuration-logging"]
+=== Logging
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/configuration-logging.html[Logging].
+
+[role="exclude",id="configuring-output"]
+=== Output
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/configuring-output.html[Output].
+
+[role="exclude",id="configure-cloud-id"]
+=== Elasticsearch Service
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/configure-cloud-id.html[Elasticsearch Service].
+
+[role="exclude",id="elasticsearch-output"]
+=== Elasticsearch
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/elasticsearch-output.html[Elasticsearch].
+
+[role="exclude",id="logstash-output"]
+=== Logstash
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/logstash-output.html[Logstash].
+
+[role="exclude",id="kafka-output"]
+=== Kafka
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/kafka-output.html[Kafka].
+
+[role="exclude",id="redis-output"]
+=== Redis
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/redis-output.html[Redis].
+
+[role="exclude",id="console-output"]
+=== Console
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/console-output.html[Console].
+
+[role="exclude",id="configuration-path"]
+=== Project paths
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/configuration-path.html[Project paths].
+
+[role="exclude",id="configuration-rum"]
+=== Real User Monitoring (RUM)
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/configuration-rum.html[Real User Monitoring (RUM)].
+
+[role="exclude",id="configuration-ssl-landing"]
+=== SSL/TLS settings
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/configuration-ssl-landing.html[SSL/TLS settings].
+
+[role="exclude",id="configuration-ssl"]
+=== SSL/TLS output settings
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/configuration-ssl.html[SSL/TLS output settings].
+
+[role="exclude",id="agent-server-ssl"]
+=== SSL/TLS input settings
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/agent-server-ssl.html[SSL/TLS input settings].
+
+[role="exclude",id="tail-based-samling-config"]
+=== Tail-based sampling
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/tail-based-samling-config.html[Tail-based sampling].
+
+[role="exclude",id="config-env"]
+=== Use environment variables
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/config-envin the configuration.html[Use environment variables ].
+
+[role="exclude",id="setting-up-and-running"]
+=== Advanced setup
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/setting-up-and-running.html[Advanced setup].
+
+[role="exclude",id="directory-layout"]
+=== Installation layout
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/directory-layout.html[Installation layout].
+
+[role="exclude",id="keystore"]
+=== Secrets keystore
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/keystore.html[Secrets keystore].
+
+[role="exclude",id="command-line-options"]
+=== Command reference
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/command-line-options.html[Command reference].
+
+[role="exclude",id="tune-data-ingestion"]
+=== Tune data ingestion
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/tune-data-ingestion.html[Tune data ingestion].
+
+[role="exclude",id="high-availability"]
+=== High Availability
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/high-availability.html[High Availability].
+
+[role="exclude",id="running-with-systemd"]
+=== APM Server and systemd
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/running-with-systemd.html[APM Server and systemd].
+
+[role="exclude",id="securing-apm-server"]
+=== Secure communication
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/securing-apm-server.html[Secure communication].
+
+[role="exclude",id="secure-agent-communication"]
+=== With APM agents
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/secure-agent-communication.html[With APM agents].
+
+[role="exclude",id="agent-tls"]
+=== APM agent TLS communicati
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/agent-tlson.html[APM agent TLS communicati].
+
+[role="exclude",id="api-key"]
+=== API keys
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/api-key.html[API keys].
+
+[role="exclude",id="secret-token"]
+=== Secret token
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/secret-token.html[Secret token].
+
+[role="exclude",id="anonymous-auth"]
+=== Anonymous authentication
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/anonymous-auth.html[Anonymous authentication].
+
+[role="exclude",id="secure-comms-stack"]
+=== With the Elastic Stack
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/secure-comms-stack.html[With the Elastic Stack].
+
+[role="exclude",id="privileges-to-publish-events"]
+=== Create a <em>writer</em> user
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/privileges-to-publish-events.html[Create a <em>writer</em> user].
+
+[role="exclude",id="privileges-to-publish-monitoring"]
+=== Create a <em>monitoring</em> user
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/privileges-to-publish-monitoring.html[Create a <em>monitoring</em> user].
+
+[role="exclude",id="privileges-api-key"]
+=== Create an <em>API key</em> user
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/privileges-api-key.html[Create an <em>API key</em> user].
+
+[role="exclude",id="privileges-agent-central-config"]
+=== Create a <em>central config</em> user
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/privileges-agent-central-config.html[Create a <em>central config</em> user].
+
+[role="exclude",id="privileges-rum-source-map"]
+=== Create a <em>source map</em> user
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/privileges-rum-source-map.html[Create a <em>source map</em> user].
+
+[role="exclude",id="beats-api-keys"]
+=== Grant access using API keys
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/beats-api-keys.html[Grant access using API keys].
+
+[role="exclude",id="monitor-apm"]
+=== Monitor
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/monitor-apm.html[Monitor].
+
+[role="exclude",id="monitor-apm-self-install"]
+=== Fleet-managed
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/monitor-apm-self-install.html[Fleet-managed].
+
+[role="exclude",id="monitoring"]
+=== APM Server binary
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/monitoring.html[APM Server binary].
+
+[role="exclude",id="monitoring-internal-collection"]
+=== Use internal collection
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/monitoring-internal-collection.html[Use internal collection].
+
+[role="exclude",id="monitoring-local-collection"]
+=== Use local collection
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/monitoring-local-collection.html[Use local collection].
+
+[role="exclude",id="select-metrics"]
+=== The select metrics
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/select-metrics.html[The select metrics].
+
+[role="exclude",id="monitoring-metricbeat-collection"]
+=== Use Metricbeat collection
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/monitoring-metricbeat-collection.html[Use Metricbeat collection].
+
+[role="exclude",id="api"]
+=== API
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/api.html[API].
+
+[role="exclude",id="api-info"]
+=== APM Server information A
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/api-infoPI.html[APM Server information A].
+
+[role="exclude",id="api-events"]
+=== Elastic APM events intake
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/api-eventsAPI.html[Elastic APM events intake ].
+
+[role="exclude",id="api-metadata"]
+=== Metadata
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/api-metadata.html[Metadata].
+
+[role="exclude",id="api-transaction"]
+=== Transactions
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/api-transaction.html[Transactions].
+
+[role="exclude",id="api-span"]
+=== Spans
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/api-span.html[Spans].
+
+[role="exclude",id="api-error"]
+=== Errors
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/api-error.html[Errors].
+
+[role="exclude",id="api-metricset"]
+=== Metrics
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/api-metricset.html[Metrics].
+
+[role="exclude",id="api-event-example"]
+=== Example request body
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/api-event-example.html[Example request body].
+
+[role="exclude",id="api-config"]
+=== Elastic APM agent configur
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/api-configation API.html[Elastic APM agent configur].
+
+[role="exclude",id="api-otlp"]
+=== OpenTelemetry intake API
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/api-otlp.html[OpenTelemetry intake API].
+
+[role="exclude",id="api-jaeger"]
+=== Jaeger event intake
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/api-jaeger.html[Jaeger event intake].
+
+[role="exclude",id="troubleshoot-apm"]
+=== Troubleshoot
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/troubleshoot-apm.html[Troubleshoot].
+
+[role="exclude",id="common-problems"]
+=== Common problems
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/common-problems.html[Common problems].
+
+[role="exclude",id="server-es-down"]
+=== What happens when APM Server o
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/server-es-downr Elasticsearch is down?.html[What happens when APM Server o].
+
+[role="exclude",id="common-response-codes"]
+=== APM Server response codes
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/common-response-codes.html[APM Server response codes].
+
+[role="exclude",id="processing-and-performance"]
+=== Processing and performance
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/processing-and-performance.html[Processing and performance].
+
+[role="exclude",id="enable-apm-server-debugging"]
+=== APM Server binary debugging
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/enable-apm-server-debugging.html[APM Server binary debugging].
+
+[role="exclude",id="upgrade"]
+=== Upgrade
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/upgrade.html[Upgrade].
+
+[role="exclude",id="agent-server-compatibility"]
+=== APM agent compatibility
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/agent-server-compatibility.html[APM agent compatibility].
+
+[role="exclude",id="apm-breaking"]
+=== Breaking Changes
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/apm-breaking.html[Breaking Changes].
+
+[role="exclude",id="upgrading-to-8.x"]
+=== Upgrade to version 8.12.0
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/upgrading-to-8.x.html[Upgrade to version 8.12.0].
+
+[role="exclude",id="upgrade-8.0-self-standalone"]
+=== Self-installation standalone
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/upgrade-8.0-self-standalone.html[Self-installation standalone].
+
+[role="exclude",id="upgrade-8.0-self-integration"]
+=== Self-installation APM integration
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/upgrade-8.0-self-integration.html[Self-installation APM integration].
+
+[role="exclude",id="upgrade-8.0-cloud-standalone"]
+=== Elastic Cloud standalone
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/upgrade-8.0-cloud-standalone.html[Elastic Cloud standalone].
+
+[role="exclude",id="upgrade-8.0-cloud-integration"]
+=== Elastic Cloud APM integration
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/upgrade-8.0-cloud-integration.html[Elastic Cloud APM integration].
+
+[role="exclude",id="upgrade-to-apm-integration"]
+=== Switch to the Elastic APM integration
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/upgrade-to-apm-integration.html[Switch to the Elastic APM integration].
+
+[role="exclude",id="apm-integration-upgrade-steps"]
+=== Switch a self-installation
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/apm-integration-upgrade-steps.html[Switch a self-installation].
+
+[role="exclude",id="apm-integration-upgrade-steps-ess"]
+=== Switch an Elastic Cloud cluster
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/apm-integration-upgrade-steps-ess.html[Switch an Elastic Cloud cluster].
+
+[role="exclude",id="release-notes"]
+=== Release notes
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/release-notes.html[Release notes].
+
+[role="exclude",id="release-notes-8.12"]
+=== APM version 8.12
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/release-notes-8.12.html[APM version 8.12].
+
+[role="exclude",id="release-notes-8.11"]
+=== APM version 8.11
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/release-notes-8.11.html[APM version 8.11].
+
+[role="exclude",id="release-notes-8.10"]
+=== APM version 8.10
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/release-notes-8.10.html[APM version 8.10].
+
+[role="exclude",id="release-notes-8.9"]
+=== APM version 8.9
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/release-notes-8.9.html[APM version 8.9].
+
+[role="exclude",id="release-notes-8.8"]
+=== APM version 8.8
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/release-notes-8.8.html[APM version 8.8].
+
+[role="exclude",id="release-notes-8.7"]
+=== APM version 8.7
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/release-notes-8.7.html[APM version 8.7].
+
+[role="exclude",id="release-notes-8.6"]
+=== APM version 8.6
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/release-notes-8.6.html[APM version 8.6].
+
+[role="exclude",id="release-notes-8.5"]
+=== APM version 8.5
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/release-notes-8.5.html[APM version 8.5].
+
+[role="exclude",id="release-notes-8.4"]
+=== APM version 8.4
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/release-notes-8.4.html[APM version 8.4].
+
+[role="exclude",id="release-notes-8.3"]
+=== APM version 8.3
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/release-notes-8.3.html[APM version 8.3].
+
+[role="exclude",id="release-notes-8.2"]
+=== APM version 8.2
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/release-notes-8.2.html[APM version 8.2].
+
+[role="exclude",id="release-notes-8.1"]
+=== APM version 8.1
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/release-notes-8.1.html[APM version 8.1].
+
+[role="exclude",id="release-notes-8.0"]
+=== APM version 8.0
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/release-notes-8.0.html[APM version 8.0].
+
+[role="exclude",id="known-issues"]
+=== Known issues
+
+{apm-guide-move-notice}
+
+Go to {apm-guide-ref}/known-issues.html[Known issues].

--- a/docs/en/observability/redirects.asciidoc
+++ b/docs/en/observability/redirects.asciidoc
@@ -1008,11 +1008,11 @@ Go to {apm-guide-ref}/agent-server-compatibility.html[APM agent compatibility].
 Go to {apm-guide-ref}/apm-breaking.html[Breaking Changes].
 
 [role="exclude",id="upgrading-to-8.x"]
-=== Upgrade to version 8.12.0
+=== Upgrade to version 8.11.4
 
 {apm-guide-move-notice}
 
-Go to {apm-guide-ref}/upgrading-to-8.x.html[Upgrade to version 8.12.0].
+Go to {apm-guide-ref}/upgrading-to-8.x.html[Upgrade to version 8.11.4].
 
 [role="exclude",id="upgrade-8.0-self-standalone"]
 === Self-installation standalone
@@ -1069,13 +1069,6 @@ Go to {apm-guide-ref}/apm-integration-upgrade-steps-ess.html[Switch an Elastic C
 {apm-guide-move-notice}
 
 Go to {apm-guide-ref}/release-notes.html[Release notes].
-
-[role="exclude",id="release-notes-8.12"]
-=== APM version 8.12
-
-{apm-guide-move-notice}
-
-Go to {apm-guide-ref}/release-notes-8.12.html[APM version 8.12].
 
 [role="exclude",id="release-notes-8.11"]
 === APM version 8.11

--- a/docs/en/observability/redirects.asciidoc
+++ b/docs/en/observability/redirects.asciidoc
@@ -329,11 +329,11 @@ Go to {apm-guide-ref}/data-security-delete.html[Delete sensitive data].
 Go to {apm-guide-ref}/apm-distributed-tracing.html[Distributed tracing].
 
 [role="exclude",id="apm-rum"]
-=== Real User Monitoring (R
+=== Real User Monitoring (RUM)
 
 {apm-guide-move-notice}
 
-Go to {apm-guide-ref}/apm-rumUM).html[Real User Monitoring (R].
+Go to {apm-guide-ref}/apm-rum.html[Real User Monitoring (RUM)].
 
 [role="exclude",id="sampling"]
 === Transaction sampling
@@ -389,7 +389,7 @@ Go to {apm-guide-ref}/monitoring-aws-lambda.html[Monitoring AWS Lambda Functions
 
 {apm-guide-move-notice}
 
-Go to {apm-guide-ref}/apm-k8s-attacher.html[APM K8S Attacher].
+Go to {apm-guide-ref}/apm-mutating-admission-webhook.html[APM Attacher].
 
 [role="exclude",id="how-to-guides"]
 === How-to guides
@@ -399,11 +399,11 @@ Go to {apm-guide-ref}/apm-k8s-attacher.html[APM K8S Attacher].
 Go to {apm-guide-ref}/how-to-guides.html[How-to guides].
 
 [role="exclude",id="source-map-how-to"]
-=== Create and upload source maps (RU
+=== Create and upload source maps (RUM)
 
 {apm-guide-move-notice}
 
-Go to {apm-guide-ref}/source-map-how-toM).html[Create and upload source maps (RU].
+Go to {apm-guide-ref}/source-map-how-to.html[Create and upload source maps (RUM)].
 
 [role="exclude",id="jaeger-integration"]
 === Integrate with Jaeger
@@ -413,11 +413,11 @@ Go to {apm-guide-ref}/source-map-how-toM).html[Create and upload source maps (RU
 Go to {apm-guide-ref}/jaeger-integration.html[Integrate with Jaeger].
 
 [role="exclude",id="ingest-pipelines"]
-=== Parse data using ingest pipeline
+=== Parse data using ingest pipelines
 
 {apm-guide-move-notice}
 
-Go to {apm-guide-ref}/ingest-pipeliness.html[Parse data using ingest pipeline].
+Go to {apm-guide-ref}/ingest-pipelines.html[Parse data using ingest pipelines].
 
 [role="exclude",id="custom-index-template"]
 === View the Elasticsearch index template
@@ -434,11 +434,11 @@ Go to {apm-guide-ref}/custom-index-template.html[View the Elasticsearch index te
 Go to {apm-guide-ref}/open-telemetry.html[OpenTelemetry integration].
 
 [role="exclude",id="open-telemetry-with-elastic"]
-=== OpenTelemetry API/SDK with Elastic APM agen
+=== OpenTelemetry API/SDK with Elastic APM agents
 
 {apm-guide-move-notice}
 
-Go to {apm-guide-ref}/open-telemetry-with-elasticts.html[OpenTelemetry API/SDK with Elastic APM agen].
+Go to {apm-guide-ref}/open-telemetry-with-elastic.html[OpenTelemetry API/SDK with Elastic APM agents].
 
 [role="exclude",id="open-telemetry-direct"]
 === OpenTelemetry native support
@@ -665,11 +665,11 @@ Go to {apm-guide-ref}/agent-server-ssl.html[SSL/TLS input settings].
 Go to {apm-guide-ref}/tail-based-samling-config.html[Tail-based sampling].
 
 [role="exclude",id="config-env"]
-=== Use environment variables
+=== Use environment variables in the configuration
 
 {apm-guide-move-notice}
 
-Go to {apm-guide-ref}/config-envin the configuration.html[Use environment variables ].
+Go to {apm-guide-ref}/config-env.html[Use environment variables in the configuration].
 
 [role="exclude",id="setting-up-and-running"]
 === Advanced setup
@@ -735,11 +735,11 @@ Go to {apm-guide-ref}/securing-apm-server.html[Secure communication].
 Go to {apm-guide-ref}/secure-agent-communication.html[With APM agents].
 
 [role="exclude",id="agent-tls"]
-=== APM agent TLS communicati
+=== APM agent TLS communication
 
 {apm-guide-move-notice}
 
-Go to {apm-guide-ref}/agent-tlson.html[APM agent TLS communicati].
+Go to {apm-guide-ref}/agent-tls.html[APM agent TLS communication].
 
 [role="exclude",id="api-key"]
 === API keys
@@ -868,18 +868,18 @@ Go to {apm-guide-ref}/monitoring-metricbeat-collection.html[Use Metricbeat colle
 Go to {apm-guide-ref}/api.html[API].
 
 [role="exclude",id="api-info"]
-=== APM Server information A
+=== APM Server information API
 
 {apm-guide-move-notice}
 
-Go to {apm-guide-ref}/api-infoPI.html[APM Server information A].
+Go to {apm-guide-ref}/api-info.html[APM Server information API].
 
 [role="exclude",id="api-events"]
-=== Elastic APM events intake
+=== Elastic APM events intake API
 
 {apm-guide-move-notice}
 
-Go to {apm-guide-ref}/api-eventsAPI.html[Elastic APM events intake ].
+Go to {apm-guide-ref}/api-events.html[Elastic APM events intake API].
 
 [role="exclude",id="api-metadata"]
 === Metadata
@@ -924,11 +924,11 @@ Go to {apm-guide-ref}/api-metricset.html[Metrics].
 Go to {apm-guide-ref}/api-event-example.html[Example request body].
 
 [role="exclude",id="api-config"]
-=== Elastic APM agent configur
+=== Elastic APM agent configuration API
 
 {apm-guide-move-notice}
 
-Go to {apm-guide-ref}/api-configation API.html[Elastic APM agent configur].
+Go to {apm-guide-ref}/api-config.html[Elastic APM agent configuration API].
 
 [role="exclude",id="api-otlp"]
 === OpenTelemetry intake API
@@ -959,11 +959,11 @@ Go to {apm-guide-ref}/troubleshoot-apm.html[Troubleshoot].
 Go to {apm-guide-ref}/common-problems.html[Common problems].
 
 [role="exclude",id="server-es-down"]
-=== What happens when APM Server o
+=== What happens when APM Server or Elasticsearch is down?
 
 {apm-guide-move-notice}
 
-Go to {apm-guide-ref}/server-es-downr Elasticsearch is down?.html[What happens when APM Server o].
+Go to {apm-guide-ref}/server-es-down.html[What happens when APM Server or Elasticsearch is down?].
 
 [role="exclude",id="common-response-codes"]
 === APM Server response codes


### PR DESCRIPTION
Related to https://github.com/elastic/obs-docs-projects/issues/216

From the APM team:

>With the switch to https://www.elastic.co/guide/en/observability/current/apm.html , when trying to chose a previous version, e.g. 8.11 there are no redirects and the chosen version just fails with an error for every apm subpage; only the apm overview page works and links to the previous docs. Can this be improved?

This is one approach: adding redirects from the Observability guide to the APM guide for v8.11. We'll see how it works in the preview and determine how far back we should do this. 

cc @bmorelli25 