### PR TITLE
Update stateful Obs docs to fix problems found during serverless testing

### DIFF
--- a/docs/en/observability/apm/aws-lambda-extension.asciidoc
+++ b/docs/en/observability/apm/aws-lambda-extension.asciidoc
@@ -2,7 +2,7 @@
 = Monitoring AWS Lambda Functions
 
 Elastic APM lets you monitor your AWS Lambda functions.
-The natural integration of <<apm-distributed-tracing,distributed tracing>> into your AWS Lambda functions provides insights into the functions' execution and runtime behavior as well as their relationships and dependencies to other services.
+The natural integration of <<apm-distributed-tracing,distributed tracing>> into your AWS Lambda functions provides insights into the function's execution and runtime behavior as well as its relationships and dependencies to other services.
 
 To get started with the setup of Elastic APM for your Lambda functions, checkout the language-specific guides:
 

--- a/docs/en/observability/apm/open-telemetry.asciidoc
+++ b/docs/en/observability/apm/open-telemetry.asciidoc
@@ -28,7 +28,7 @@ include::./diagrams/apm-otel-architecture.asciidoc[Architecture of Elastic APM w
 
 Elastic integrates with OpenTelemetry, allowing you to reuse your existing instrumentation
 to easily send observability data to the {stack}.
-There are four ways to integrate OpenTelemetry with the {stack}:
+There are several ways to integrate OpenTelemetry with the {stack}:
 
 **OpenTelemetry API/SDK with Elastic APM agents**
 

--- a/docs/en/observability/apm/otel-attrs.asciidoc
+++ b/docs/en/observability/apm/otel-attrs.asciidoc
@@ -5,7 +5,7 @@ A resource attribute is a key/value pair containing information about the entity
 Resource attributes are mapped to Elastic Common Schema (ECS) fields like `service.*`, `cloud.*`, `process.*`, etc.
 These fields describe the service and the environment that the service runs in.
 
-The examples below set the Elastic (ECS) `service.environment` field for the resource, i.e. service, that is producing trace events.
+The examples shown here set the Elastic (ECS) `service.environment` field for the resource, i.e. service, that is producing trace events.
 Note that Elastic maps the OpenTelemetry `deployment.environment` field to
 the ECS `service.environment` field on ingestion.
 


### PR DESCRIPTION
Adds fixes for https://github.com/elastic/staging-serverless-observability-docs/issues/181 (not sure why I opened this in serverless staging, but 🤷)

These changes are minor but might help make it easier when we try to keep the two sources in sync.