### PR TITLE
github(action): enable CI/CD observability with Opentelemetry

### DIFF
--- a/.github/workflows/opentelemetry.yml
+++ b/.github/workflows/opentelemetry.yml
@@ -1,0 +1,22 @@
+---
+# Look up results at https://ela.st/oblt-ci-cd-stats.
+# There will be one service per GitHub repository, including the org name, and one Transaction per Workflow.
+name: OpenTelemetry Export Trace
+
+on:
+  workflow_run:
+    workflows: [ "*" ]
+    types: [completed]
+
+permissions:
+  contents: read
+
+jobs:
+  otel-export-trace:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: elastic/apm-pipeline-library/.github/actions/opentelemetry@current
+        with:
+          vaultUrl: ${{ secrets.VAULT_ADDR }}
+          vaultRoleId: ${{ secrets.VAULT_ROLE_ID }}
+          vaultSecretId: ${{ secrets.VAULT_SECRET_ID }}


### PR DESCRIPTION
Send all the GitHub action steps to the APM using OpenTelemetry; this can help with analysing the CI/CD overall behaviour at a large scale.

This particular action runs independently when the other GitHub workflows have finished.