### PR TITLE
Create a logs@custom index template reference

### DIFF
--- a/docs/en/observability/index.asciidoc
+++ b/docs/en/observability/index.asciidoc
@@ -57,6 +57,8 @@ include::inspect-log-anomalies.asciidoc[leveloffset=+3]
 
 include::configure-logs-sources.asciidoc[leveloffset=+3]
 
+include::logs-index-template.asciidoc[leveloffset=+2]
+
 include::logs-troubleshooting.asciidoc[leveloffset=+2]
 
 // Infrastructure

--- a/docs/en/observability/logs-checklist.asciidoc
+++ b/docs/en/observability/logs-checklist.asciidoc
@@ -104,11 +104,19 @@ The following resources provide information on viewing and monitoring your logs:
 == Application logs
 
 Application logs provide valuable insight into events that have occurred within your services and applications.
-See <<application-logs>>.
+Refer to <<application-logs>>.
 
 [discrete]
 [[logs-alerts-checklist]]
 == Create a logs threshold alert
 
 You can create a rule to send an alert when the log aggregation exceeds a threshold.
-See <<logs-threshold-alert>>.
+
+Refer to <<logs-threshold-alert>>.
+
+[discrete]
+[[logs-template-checklist]]
+
+Configure the default `logs` template using the `logs@custom` component template.
+
+Refer to the <<logs-index-template>>.

--- a/docs/en/observability/logs-index-template.asciidoc
+++ b/docs/en/observability/logs-index-template.asciidoc
@@ -1,44 +1,47 @@
 [[logs-index-template]]
 = Logs index template reference
 
-[[custom-logs-index-template]]
-== View index templates
-
-Index templates are used to configure the backing indices of data streams as they are created.
-These index templates are composed of multiple component templates--reusable building blocks
+Index templates are used to configure the backing indices of data streams as they're created.
+These index templates are composed of multiple {ref}/indices-component-template.html[component templates]—reusable building blocks
 that configure index mappings, settings, and aliases.
 
-The default Logs index template can be viewed in {kib}.
+You can view the default `logs` index template in {kib}.
 Navigate to **{stack-manage-app}** → **Index Management** → **Index Templates**, and search for `logs`.
-Select any of the logs index templates to view their relevant component templates.
+Select the `logs` index templates to view relevant component templates.
 
 [discrete]
-[custom-logs-template-edit]
-=== Edit the {es} index template
+[[custom-logs-template-edit]]
+== Edit the `logs` index template
 
-{es} has a built-in index template for the `logs-*-*` index pattern, which is composed of component templates including:
+The default `logs` index template for the `logs-*-*` index pattern is composed of the following component templates:
 
 * `logs@mappings`
 * `logs@settings`
 * `logs@custom`
 * `ecs@mappings`
 
-You can use the `@custom` component template to customize your {es} indices. The `logs@custom` template is not installed by default, but you can create a template named `logs@custom` to override and extend default mappings or settings.
+You can use the `logs@custom` component template to customize your {es} indices. The `logs@custom` component template is not installed by default, but you can create a component template named `logs@custom` to override and extend default mappings or settings. To do this:
 
-Open {kib} and navigate to **{stack-manage-app}** → **Index Management** → **Component Templates**.
-
+. Open {kib} and navigate to **{stack-manage-app}** → **Index Management** → **Component Templates**.
 . Click *Create component template*.
 . Name the component template logs@custom.
 . Add any custom metadata, index settings, or mappings.
+
+Changes to component templates are not applied retroactively to existing indices. For changes to take effect, create a new write index for impacted data streams by triggering a rollover. Do this using the {es} {ref}/indices-rollover-index.html[Rollover API]. For example, to roll over the `logs-generic-default` data stream, run:
+
+[source,console]
+----
+POST /logs-generic-default/_rollover/
+----
 
 [discrete]
 [[custom-logs-template-default-field]]
 === Set the `default_field` using the custom template
 
-The `logs-*-*` index template uses `default_field: [*]` meaning queries without specified fields will search across all fields.
+The `logs` index template uses `default_field: [*]` meaning queries without specified fields will search across all fields.
 You can update the `default_field` to  search in the `message` field instead of all fields using the `logs@custom` component template.
 
-Either create the `logs@custom` template as detailed in the previous section, or edit the existing one to include the following in the *Index settings*:
+Either create the `logs@custom` component template as outlined in the previous section, or add the following code to the *Index settings* of the `logs` index template:
 
 [source,json]
 ----

--- a/docs/en/observability/logs-index-template.asciidoc
+++ b/docs/en/observability/logs-index-template.asciidoc
@@ -1,0 +1,54 @@
+[[logs-index-template]]
+= Logs index template reference
+
+[[custom-logs-index-template]]
+== View index templates
+
+Index templates are used to configure the backing indices of data streams as they are created.
+These index templates are composed of multiple component templates--reusable building blocks
+that configure index mappings, settings, and aliases.
+
+The default Logs index template can be viewed in {kib}.
+Navigate to **{stack-manage-app}** → **Index Management** → **Index Templates**, and search for `logs`.
+Select any of the logs index templates to view their relevant component templates.
+
+[discrete]
+[custom-logs-template-edit]
+=== Edit the {es} index template
+
+{es} has a built-in index template for the `logs-*-*` index pattern, which is composed of component templates including:
+
+* `logs@mappings`
+* `logs@settings`
+* `logs@custom`
+* `ecs@mappings`
+
+You can use the `@custom` component template to customize your {es} indices. The `logs@custom` template is not installed by default, but you can create a template named `logs@custom` to override and extend default mappings or settings.
+
+Open {kib} and navigate to **{stack-manage-app}** → **Index Management** → **Component Templates**.
+
+. Click *Create component template*.
+. Name the component template logs@custom.
+. Add any custom metadata, index settings, or mappings.
+
+[discrete]
+[[custom-logs-template-default-field]]
+=== Set the `default_field` using the custom template
+
+The `logs-*-*` index template uses `default_field: [*]` meaning queries without specified fields will search across all fields.
+You can update the `default_field` to  search in the `message` field instead of all fields using the `logs@custom` component template.
+
+Either create the `logs@custom` template as detailed in the previous section, or edit the existing one to include the following in the *Index settings*:
+
+[source,json]
+----
+{
+  "index": {
+    "query": {
+      "default_field": [
+        "message"
+      ]
+    }
+  }
+}
+----

--- a/docs/en/observability/logs-index-template.asciidoc
+++ b/docs/en/observability/logs-index-template.asciidoc
@@ -41,8 +41,13 @@ POST /logs-generic-default/_rollover/
 The `logs` index template uses `default_field: [*]` meaning queries without specified fields will search across all fields.
 You can update the `default_field` to  search in the `message` field instead of all fields using the `logs@custom` component template.
 
-Either create the `logs@custom` component template as outlined in the previous section, or add the following code to the *Index settings* of the `logs` index template:
+If you haven't already created the `logs@custom`component template, create it as outlined in the previous section. Then, follow these steps to update the *Index settings* of the component template:
 
+. Open {kib} and navigate to **{stack-manage-app}** → **Index Management** → **Component Templates**.
+. Search for `logs` and find the `logs@custom` component template.
+. Open the **Actions** menu and select **Edit**.
+. Select **Index settings** and add the following code:
++
 [source,json]
 ----
 {
@@ -55,3 +60,4 @@ Either create the `logs@custom` component template as outlined in the previous s
   }
 }
 ----
+. Click **Next** through to the **Review** page and save the component template.


### PR DESCRIPTION
this PR closes #3393 

Create a log@custom index template guide that also references how to update the `default_field` to `message` after an update has changed the default behavior to `[*]`. 