### PR TITLE
apm: add 8.12.0 known issue about fleet ingest pipeline bug

### DIFF
--- a/docs/en/observability/apm/known-issues.asciidoc
+++ b/docs/en/observability/apm/known-issues.asciidoc
@@ -46,7 +46,7 @@ If you're using the Elastic APM Server v8.12.0,
 the `traces-apm@custom` ingest pipeline is now additionally applied to data streams `traces-apm.sampled-*`
 and `traces-apm.rum-*`, and applied twice for `traces-apm-*`. This bug impacts users with a non-empty `traces-apm@custom` ingest pipeline.
 
-If you rely on this unintended behavior in 8.12.0, please rename your pipeline to `traces-apm.package@custom` to preserve this behavior in later versions.
+If you rely on this unintended behavior in 8.12.0, please rename your pipeline to `traces-apm.integration@custom` to preserve this behavior in later versions.
 
 // Describe why it happens
 // This happens because...

--- a/docs/en/observability/apm/known-issues.asciidoc
+++ b/docs/en/observability/apm/known-issues.asciidoc
@@ -37,6 +37,26 @@ Failed installing package [apm] due to error: [ResponseError: mapper_parsing_exc
 // Link to fix?
 A fix was released in 8.11.2: https://github.com/elastic/kibana/pull/171712[elastic/kibana#171712].
 
+*traces-apm@custom ingest pipeline applied to certain data streams unintentionally* +
+_APM Server versions: 8.12.0_ +
+
+// Describe the conditions in which this issue occurs
+If you're using the Elastic APM Server v8.12.0,
+// Describe the behavior of the issue
+a bug has been introduced, so that `traces-apm@custom` ingest pipeline is now additionally applied to data streams `traces-apm.sampled-*`
+and `traces-apm.rum-*`, and applied twice for `traces-apm-*`. This impacts users with a non-empty `traces-apm@custom` ingest pipeline.
+
+If you rely on this unintended behavior in 8.12.0, please rename your pipeline to `traces-apm.package@custom` to preserve this behavior in 8.12.1.
+
+// Describe why it happens
+// This happens because...
+
+// Include exact error messages linked to this issue
+// so users searching for the error message end up here.
+
+// Link to fix?
+A fix was released in 8.12.1: https://github.com/elastic/kibana/pull/175448[elastic/kibana#175448].
+
 // TEMPLATE
 
 ////

--- a/docs/en/observability/apm/known-issues.asciidoc
+++ b/docs/en/observability/apm/known-issues.asciidoc
@@ -3,6 +3,27 @@
 
 APM has the following known issues:
 
+*traces-apm@custom ingest pipeline applied to certain data streams unintentionally* +
+_APM Server versions: 8.12.0_ +
+
+// Describe the conditions in which this issue occurs
+If you're using the Elastic APM Server v8.12.0,
+// Describe the behavior of the issue
+the `traces-apm@custom` ingest pipeline is now additionally applied to data streams `traces-apm.sampled-*`
+and `traces-apm.rum-*`, and applied twice for `traces-apm-*`. This bug impacts users with a non-empty `traces-apm@custom` ingest pipeline.
+
+If you rely on this unintended behavior in 8.12.0, please rename your pipeline to `traces-apm.integration@custom` to preserve this behavior in later versions.
+
+// Describe why it happens
+// This happens because...
+
+// Include exact error messages linked to this issue
+// so users searching for the error message end up here.
+
+// Link to fix?
+A fix was released in 8.12.1: https://github.com/elastic/kibana/pull/175448[elastic/kibana#175448].
+
+
 *Ingesting new JVM metrics in 8.9 and 8.10 breaks upgrade to 8.11 and stops ingestion* +
 _APM Server versions: 8.11.0, 8.11.1_ +
 _Elastic APM Java Agent versions: 1.39.0+_
@@ -36,26 +57,6 @@ Failed installing package [apm] due to error: [ResponseError: mapper_parsing_exc
 
 // Link to fix?
 A fix was released in 8.11.2: https://github.com/elastic/kibana/pull/171712[elastic/kibana#171712].
-
-*traces-apm@custom ingest pipeline applied to certain data streams unintentionally* +
-_APM Server versions: 8.12.0_ +
-
-// Describe the conditions in which this issue occurs
-If you're using the Elastic APM Server v8.12.0,
-// Describe the behavior of the issue
-the `traces-apm@custom` ingest pipeline is now additionally applied to data streams `traces-apm.sampled-*`
-and `traces-apm.rum-*`, and applied twice for `traces-apm-*`. This bug impacts users with a non-empty `traces-apm@custom` ingest pipeline.
-
-If you rely on this unintended behavior in 8.12.0, please rename your pipeline to `traces-apm.integration@custom` to preserve this behavior in later versions.
-
-// Describe why it happens
-// This happens because...
-
-// Include exact error messages linked to this issue
-// so users searching for the error message end up here.
-
-// Link to fix?
-A fix was released in 8.12.1: https://github.com/elastic/kibana/pull/175448[elastic/kibana#175448].
 
 // TEMPLATE
 

--- a/docs/en/observability/apm/known-issues.asciidoc
+++ b/docs/en/observability/apm/known-issues.asciidoc
@@ -43,8 +43,8 @@ _APM Server versions: 8.12.0_ +
 // Describe the conditions in which this issue occurs
 If you're using the Elastic APM Server v8.12.0,
 // Describe the behavior of the issue
-a bug has been introduced, so that `traces-apm@custom` ingest pipeline is now additionally applied to data streams `traces-apm.sampled-*`
-and `traces-apm.rum-*`, and applied twice for `traces-apm-*`. This impacts users with a non-empty `traces-apm@custom` ingest pipeline.
+the `traces-apm@custom` ingest pipeline is now additionally applied to data streams `traces-apm.sampled-*`
+and `traces-apm.rum-*`, and applied twice for `traces-apm-*`. This bug impacts users with a non-empty `traces-apm@custom` ingest pipeline.
 
 If you rely on this unintended behavior in 8.12.0, please rename your pipeline to `traces-apm.package@custom` to preserve this behavior in 8.12.1.
 

--- a/docs/en/observability/apm/known-issues.asciidoc
+++ b/docs/en/observability/apm/known-issues.asciidoc
@@ -46,7 +46,7 @@ If you're using the Elastic APM Server v8.12.0,
 the `traces-apm@custom` ingest pipeline is now additionally applied to data streams `traces-apm.sampled-*`
 and `traces-apm.rum-*`, and applied twice for `traces-apm-*`. This bug impacts users with a non-empty `traces-apm@custom` ingest pipeline.
 
-If you rely on this unintended behavior in 8.12.0, please rename your pipeline to `traces-apm.package@custom` to preserve this behavior in 8.12.1.
+If you rely on this unintended behavior in 8.12.0, please rename your pipeline to `traces-apm.package@custom` to preserve this behavior in later versions.
 
 // Describe why it happens
 // This happens because...


### PR DESCRIPTION
Part of https://github.com/elastic/apm-server/issues/12498
