### PR TITLE
Add missing ServiceNow connectors to list in alerting docs

### DIFF
--- a/docs/en/observability/create-alerts.asciidoc
+++ b/docs/en/observability/create-alerts.asciidoc
@@ -50,9 +50,9 @@ preview:[] To temporarily suppress notifications for _all_ rules, create a {kiba
 
 
 Extend your rules by connecting them to actions that use built-in *connectors* for email,
-{ibm-r}, Index, JIRA, Microsoft Teams, PagerDuty, Server log, {sn} ITSM, Opsgenie, and Slack.
-Also supported is a powerful webhook output letting you tie into other third-party systems.
-Connectors allow actions to talk to these services and integrations.
+{ibm-r}, Index, JIRA, Microsoft Teams, PagerDuty, Server log, {sn} ITSM, {sn} SecOps,
+{sn} ITOM, Opsgenie, and Slack. Also supported is a powerful webhook output letting you
+tie into other third-party systems. Connectors allow actions to talk to these services and integrations.
 
 Learn how to create specific types of rules:
 


### PR DESCRIPTION
Closes #2382.

~Should we also link to the docs about these connectors? We could in the changed paragraph that's part of this PR, but it might be better to link to the connectors documentation from the topics where we show the connector configuration. WDYT?~ Gonna defer this until later when I make other updates to the alerting docs.