### PR TITLE
Add allow_restricted_indices to agentcfg privileges

### DIFF
--- a/docs/en/observability/apm/feature-roles.asciidoc
+++ b/docs/en/observability/apm/feature-roles.asciidoc
@@ -332,7 +332,7 @@ assign the user the following privileges:
 |Type | Privilege | Purpose
 
 | Index
-|`read` on `.apm-agent-configuration` index
+|`read` on `.apm-agent-configuration` index, `allow_restricted_indices: true`
 |Allow {beatname_uc} to manage central configurations in {es}
 |====
 


### PR DESCRIPTION
Update docs to reflect the required `allow_restricted_indices: true` for agent configuration role.

Closes https://github.com/elastic/apm-server/issues/12378

