### PR TITLE
security: add permissions block to workflows

### DIFF
--- a/.github/workflows/add-issue-to-project.yml
+++ b/.github/workflows/add-issue-to-project.yml
@@ -3,6 +3,9 @@ on:
   issues:
     types:
       - opened
+permissions:
+  contents: read
+
 jobs:
   add_issue_to_project:
     runs-on: ubuntu-latest

--- a/.github/workflows/add-pr-to-project.yml
+++ b/.github/workflows/add-pr-to-project.yml
@@ -4,6 +4,9 @@ on:
     types: [review_requested]
     branches:
       - 'main'
+permissions:
+  contents: read
+
 jobs:
   specific_review_requested:
     name: Adding

--- a/.github/workflows/add-to-dev-projects.yml
+++ b/.github/workflows/add-to-dev-projects.yml
@@ -3,6 +3,9 @@ on:
   pull_request_target:
     types:
       - labeled
+permissions:
+  contents: read
+
 jobs:
   add_to_data_plane-project:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Details

⚠️ This PR was created by an automated tool. Please review the changes carefully. ⚠️ 

We want to set the default permissions for workflows to read-only for contents. 
This is a security measure to prevent accidental changes to the repository.

This change adds a top-level permissions block to all workflows in the .github/workflows directory.
```yaml
permissions:
  contents: read
```

In some cases workflows might need more permissions than just `contents: read`.
Please checkout this branch and add the necessary permissions to the workflows.

If your workflow uses a Personal Access Token (PAT), we can still add the permissions block,
   but it will not have any effect.

Merging this PR as is might cause workflows that need more permissions to fail.

If there are any questions, please reach out to the @elastic/observablt-ci
