### PR TITLE
Add note about legacy summary transforms that can be removed

### DIFF
--- a/docs/en/observability/slo-overview.asciidoc
+++ b/docs/en/observability/slo-overview.asciidoc
@@ -92,6 +92,39 @@ The Reset API loads the outdated SLO definition and resets it to the new format 
 Once an SLO is reset, it will start to regenerate SLIs and summary data.
 ====
 
+[%collapsible]
+.Remove legacy summary transforms
+====
+After migrating to 8.12+, you might have some legacy SLO summary transforms running. 
+The following legacy summary transforms can be deleted safely, but make sure you don't delete new summary transforms used by your migrated SLOs.
+
+```
+# Stop all legacy summary transforms
+POST _transform/slo-summary-occurrences-30d-rolling/_stop?force=true
+POST _transform/slo-summary-occurrences-7d-rolling/_stop?force=true
+POST _transform/slo-summary-occurrences-90d-rolling/_stop?force=true
+POST _transform/slo-summary-occurrences-monthly-aligned/_stop?force=true
+POST _transform/slo-summary-occurrences-weekly-aligned/_stop?force=true
+POST _transform/slo-summary-timeslices-30d-rolling/_stop?force=true
+POST _transform/slo-summary-timeslices-7d-rolling/_stop?force=true
+POST _transform/slo-summary-timeslices-90d-rolling/_stop?force=true
+POST _transform/slo-summary-timeslices-monthly-aligned/_stop?force=true
+POST _transform/slo-summary-timeslices-weekly-aligned/_stop?force=true
+
+# Delete all legacy summary transforms
+DELETE _transform/slo-summary-occurrences-30d-rolling?force=true
+DELETE _transform/slo-summary-occurrences-7d-rolling?force=true
+DELETE _transform/slo-summary-occurrences-90d-rolling?force=true
+DELETE _transform/slo-summary-occurrences-monthly-aligned?force=true
+DELETE _transform/slo-summary-occurrences-weekly-aligned?force=true
+DELETE _transform/slo-summary-timeslices-30d-rolling?force=true
+DELETE _transform/slo-summary-timeslices-7d-rolling?force=true
+DELETE _transform/slo-summary-timeslices-90d-rolling?force=true
+DELETE _transform/slo-summary-timeslices-monthly-aligned?force=true
+DELETE _transform/slo-summary-timeslices-weekly-aligned?force=true
+```
+====
+
 [discrete]
 [[slo-overview-next-steps]]
 == Next steps


### PR DESCRIPTION
## Summary

This PR adds some instructions about cleaning legacy summary transforms after migrating to 8.12+ as requested here: https://docs.google.com/document/d/1WorAwfybTTnqB667TmxVEPCPLX5XJpZncxCkhdwE4T4/edit#heading=h.rlbm0ze0wbwn


