### PR TITLE
[Profiling] Update minimum X86 kernel version

### DIFF
--- a/docs/en/observability/profiling-get-started.asciidoc
+++ b/docs/en/observability/profiling-get-started.asciidoc
@@ -24,7 +24,7 @@ Before setting up Universal Profiling, make sure you meet the following requirem
 
 * An {stack} deployment on http://cloud.elastic.co[{ecloud}] at version 8.7.0 or higher. Universal Profiling is currently only available on Elastic Cloud.
 * The workloads you're profiling must be running on Linux machines with x86_64 or ARM64 CPUs.
-* The minimum supported kernel version is either 4.15 for x86_64 or 5.5 for ARM64 machines.
+* The minimum supported kernel version is either 4.19 for x86_64 or 5.5 for ARM64 machines.
 * The Integrations Server must be enabled on your {ecloud} deployment.
 * Credentials (username and password) for the `superuser` Elasticsearch role (typically, the `elastic` user).
 

--- a/docs/en/observability/profiling-troubleshooting.asciidoc
+++ b/docs/en/observability/profiling-troubleshooting.asciidoc
@@ -44,7 +44,7 @@ If the Universal Profiling Agent is running on an unsupported kernel version, th
 +
 [source,logs]
 ----
-Universal Profiling Agent requires kernel version 4.15 or newer but got 3.10.0
+Universal Profiling Agent requires kernel version 4.19 or newer but got 3.10.0
 ----
 +
 If eBPF features are not available in the kernel, the Universal Profiling Agent fails to start, and one of the following is logged:


### PR DESCRIPTION
We [bumped the minimum kernel version](https://github.com/elastic/prodfiler/pull/4764) for profiling and need to update the doc accordingly.