### PR TITLE
Add Kibana privileges for Logs Explorer

### DIFF
--- a/docs/en/observability/explore-logs.asciidoc
+++ b/docs/en/observability/explore-logs.asciidoc
@@ -13,6 +13,12 @@ From the {observability} navigation menu, click **Explorer** under the **Logs** 
 image::images/log-explorer.png[Screen capture of the Logs Explorer]
 
 [discrete]
+[[logs-explorer-privileges]]
+== Required {kib} privileges
+
+Viewing data in Logs Explorer requires `read` privileges for *Discover* and *Integrations*. For more on assigning {kib} privileges, refer to the {kibana-ref}/kibana-privileges.html[{kib} privileges] docs.
+
+[discrete]
 [[find-your-logs]]
 == Find your logs
 


### PR DESCRIPTION
This PR closes [Issue 3629](https://github.com/elastic/observability-docs/issues/3629) and adds the required privileges for viewing Logs Explorer.