### PR TITLE
[DOCS] screenshot/video limitation

### DIFF
--- a/docs/en/observability/synthetics-create-test.asciidoc
+++ b/docs/en/observability/synthetics-create-test.asciidoc
@@ -186,6 +186,11 @@ in Elastic Synthetics including:
 * https://playwright.dev/docs/api/class-video[Videos]
 * The https://playwright.dev/docs/api/class-locatorassertions#locator-assertions-to-have-screenshot-1[`toHaveScreenshot`] and https://playwright.dev/docs/api/class-snapshotassertions[`toMatchSnapshot`] assertions
 
+[NOTE]
+====
+Captures done programmatically via https://playwright.dev/docs/api/class-page#page-screenshot[`screenshot`] or https://playwright.dev/docs/api/class-page#page-video[`video`] are not stored nor can be shown in the Synthetics application. Providing a `path` will likely make the monitor fail due to missing permissions to write local files.
+====
+
 [discrete]
 [[synthetics-make-assertions]]
 = Make assertions

--- a/docs/en/observability/synthetics-create-test.asciidoc
+++ b/docs/en/observability/synthetics-create-test.asciidoc
@@ -188,7 +188,7 @@ in Elastic Synthetics including:
 
 [NOTE]
 ====
-Captures done programmatically via https://playwright.dev/docs/api/class-page#page-screenshot[`screenshot`] or https://playwright.dev/docs/api/class-page#page-video[`video`] are not stored nor can be shown in the Synthetics application. Providing a `path` will likely make the monitor fail due to missing permissions to write local files.
+Captures done programmatically via https://playwright.dev/docs/api/class-page#page-screenshot[`screenshot`] or https://playwright.dev/docs/api/class-page#page-video[`video`] are not stored and are not shown in the Synthetics application. Providing a `path` will likely make the monitor fail due to missing permissions to write local files.
 ====
 
 [discrete]


### PR DESCRIPTION
Clarify `page.snapshot(...)` are not stored in Elasticsearch.
Clarify `page.snapshot({ path: '...',` will fail due to permissions.

This should be backported to all versions.