### PR TITLE
Update observability AI assistant docs with latest changes

### DIFF
--- a/docs/en/observability/observability-ai-assistant.asciidoc
+++ b/docs/en/observability/observability-ai-assistant.asciidoc
@@ -180,18 +180,18 @@ The AI Assistant uses functions to include relevant context in the chat conversa
 The following table lists available functions:
 
 [horizontal]
-`summarize`:: Summarize parts of the conversation.
-`recall`:: Recall previous learning.
-`lens`:: Create custom visualizations, using {kibana-ref}/lens.html[Lens], that you can add to dashboards.
-`elasticsearch`:: Call {es} APIs on your behalf.
-`kibana`:: Call {kib} APIs on your behalf.
 `alerts`:: Get alerts for {observability}
-`get_apm_timeseries`:: Display different APM metrics (such as throughput, failure rate, or latency) for any service or all services and any or all of their dependencies. Displayed both as a time series and as a single statistic. Additionally, the function  returns any changes, such as spikes, step and trend changes, or dips. You can also use it to compare data by requesting two different time ranges, or, for example, two different service versions.
-`get_apm_error_document`:: Get a sample error document based on the grouping name. This also includes the stacktrace of the error, which might hint to the cause.
+`elasticsearch`:: Call {es} APIs on your behalf.
 `get_apm_correlations`:: Get field values that are more prominent in the foreground set than the background set. This can be useful in determining which attributes (such as `error.message`, `service.node.name`, or `transaction.name`) are contributing to, for instance, a higher latency. Another option is a time-based comparison, where you compare before and after a change point.
 `get_apm_downstream_dependencies`:: Get the downstream dependencies (services or uninstrumented backends) for a service. Map the downstream dependency name to a service by returning both `span.destination.service.resource` and `service.name`. Use this to drill down further if needed.
+`get_apm_error_document`:: Get a sample error document based on the grouping name. This also includes the stacktrace of the error, which might hint to the cause.
 `get_apm_service_summary`:: Get a summary of a single service, including the language, service version, deployments, the environments, and the infrastructure that it is running in. For example, the number of pods and a list of their downstream dependencies. It also returns active alerts and anomalies.
 `get_apm_services_list`:: Get the list of monitored services, their health statuses, and alerts.
+`get_apm_timeseries`:: Display different APM metrics (such as throughput, failure rate, or latency) for any service or all services and any or all of their dependencies. Displayed both as a time series and as a single statistic. Additionally, the function  returns any changes, such as spikes, step and trend changes, or dips. You can also use it to compare data by requesting two different time ranges, or, for example, two different service versions.
+`kibana`:: Call {kib} APIs on your behalf.
+`lens`:: Create custom visualizations, using {kibana-ref}/lens.html[Lens], that you can add to dashboards.
+`recall`:: Recall previous learning.
+`summarize`:: Summarize parts of the conversation.
 
 [discrete]
 [[obs-ai-prompts]]

--- a/docs/en/observability/observability-ai-assistant.asciidoc
+++ b/docs/en/observability/observability-ai-assistant.asciidoc
@@ -69,9 +69,6 @@ To set up the AI Assistant:
 .. In the *URL* field, enter the AI provider's API endpoint URL.
 .. Under *Authentication*, enter the API key or access key/secret you created in the previous step.
 
-//TODO: Resolve this question:
-**REVIEWERS:** What is the best link to use for AWS Bedrock security? The one I've provided above, or the link that's provided in the product? (https://docs.aws.amazon.com/IAM/latest/UserGuide/security-creds.html)
-
 [discrete]
 [[obs-ai-add-data]]
 == Add data to the AI Assistant knowledge base
@@ -190,39 +187,30 @@ beta::[]
 
 The AI Assistant uses functions to include relevant context in the chat conversation through text, data, and visual components. Both you and the AI Assistant can suggest functions. You can also edit the AI Assistant's function suggestions and inspect function responses.
 
-The following table lists available functions:
-
-//TODO: Resolve this question:
-**REVIEWERS**: Is the list of functions here correct? Only a subset are actually shown in the UI. None of the apm functions are shown in the UI right now.
-
-//TODO: Resolve this question:
-**REVIEWERS**: Should we replace this table with the UI instructions for showing the list of functions (like we did in serverless)?
-There are some good arguments for doing this, but I wonder if seeing this info might actually be useful for people who are exploring the
-docs to figure out what is possible. If so, it's better to keep the table, IMO. In not, then maybe just telling users how to see the list in the UI is good enough.
+You can suggest the following functions:
 
 [horizontal]
 `alerts`:: Get alerts for {observability}.
-`context`:: Add context based on what is shown on the screen and documents recalled from the knowledge base that match the query.
 `elasticsearch`:: Call {es} APIs on your behalf.
-`execute_query`:: Display the results of an ES|QL query.
+`kibana`:: Call {kib} APIs on your behalf.
+`summarize`:: Summarize parts of the conversation.
+`visualize_query`:: Visualize charts for ES|QL queries.
+
+Additional functions are available when your cluster has APM data:
+
+[horizontal]
 `get_apm_correlations`:: Get field values that are more prominent in the foreground set than the background set. This can be useful in determining which attributes (such as `error.message`, `service.node.name`, or `transaction.name`) are contributing to, for instance, a higher latency. Another option is a time-based comparison, where you compare before and after a change point.
 `get_apm_downstream_dependencies`:: Get the downstream dependencies (services or uninstrumented backends) for a service. Map the downstream dependency name to a service by returning both `span.destination.service.resource` and `service.name`. Use this to drill down further if needed.
 `get_apm_error_document`:: Get a sample error document based on the grouping name. This also includes the stacktrace of the error, which might hint to the cause.
 `get_apm_service_summary`:: Get a summary of a single service, including the language, service version, deployments, the environments, and the infrastructure that it is running in. For example, the number of pods and a list of their downstream dependencies. It also returns active alerts and anomalies.
 `get_apm_services_list`:: Get the list of monitored services, their health statuses, and alerts.
 `get_apm_timeseries`:: Display different APM metrics (such as throughput, failure rate, or latency) for any service or all services and any or all of their dependencies. Displayed both as a time series and as a single statistic. Additionally, the function  returns any changes, such as spikes, step and trend changes, or dips. You can also use it to compare data by requesting two different time ranges, or, for example, two different service versions.
-`get_dataset_info`:: Get information about available indices and datasets, and the fields available on them.
-`kibana`:: Call {kib} APIs on your behalf.
-`lens`:: Create custom visualizations, using {kibana-ref}/lens.html[Lens], that you can add to dashboards.
-`recall`:: Recall previous learning. This function has been renamed to `context`.
-`summarize`:: Summarize parts of the conversation.
-`query`:: Generate, execute, or visualize a query based on the user's request. This function can also explain how ES/QL works and convert queries from one language to another.
 
-//TODO: Resolve this question:
-**REVIEWERS**: Has the "recall" function really has been renamed to "context". Can we just remove the description or do we need to mention that it's been renamed here?
+TIP: Internal functions used by the AI Assistant are not shown here because they are not available for you to suggest.
+You can learn more about these functions by asking the AI Assistant about them. For example, you can ask the AI Assistant,
+"What is the context function?"
 
-//TODO: Resolve this question:
-**REVIEWERS**: Is the above description of the query function true or is the AI making stuff up? My original description said something like: "Construct and render an ES/QL query using the LLM in a multi-step process to improve the output." Also do the functions I've added here actually exist, or was AI making that up too?
+//TODO: Make sure execute_query is not an internal function.
 
 [discrete]
 [[obs-ai-prompts]]

--- a/docs/en/observability/observability-ai-assistant.asciidoc
+++ b/docs/en/observability/observability-ai-assistant.asciidoc
@@ -38,7 +38,7 @@ The AI assistant requires the following:
 * An account with a third-party generative AI provider that supports function calling. The Observability AI Assistant supports the following providers:
 ** OpenAI `gpt-4`+.
 ** Azure OpenAI Service `gpt-4`(0613) or `gpt-4-32k`(0613) with API version `2023-07-01-preview` or more recent.
-** AWS Bedrock, specifically the Anthropic Claude models.
+** AWS Bedrock, specifically the Anthropic Claude models. Note that we do not currently support Claude 3.0 models.
 * The knowledge base requires a 4 GB {ml} node.
 
 [discrete]

--- a/docs/en/observability/observability-ai-assistant.asciidoc
+++ b/docs/en/observability/observability-ai-assistant.asciidoc
@@ -1,13 +1,18 @@
 [[obs-ai-assistant]]
 = Observability AI Assistant
 
-The AI Assistant uses generative AI, powered by a {kibana-ref}/openai-action-type.html[connector] for OpenAI or Azure OpenAI Service, to provide:
+The AI Assistant uses generative AI to provide:
 
 * *Contextual insights* — open prompts throughout {observability} that explain errors and messages and suggest remediation.
 * *Chat* —  have conversations with the AI Assistant. Chat uses function calling to request, analyze, and visualize your data.
 
 [role="screenshot"]
 image::images/obs-assistant2.gif[Observability AI assistant preview]
+
+The AI Assistant integrates with your large language model (LLM) provider through our supported Elastic connectors:
+
+* {kibana-ref}/openai-action-type.html[OpenAI connector] for OpenAI or Azure OpenAI Service.
+* {kibana-ref}/bedrock-action-type.html[Amazon Bedrock connector] for Amazon Bedrock, specifically for the Claude models.
 
 [IMPORTANT]
 ====
@@ -33,6 +38,7 @@ The AI assistant requires the following:
 * An account with a third-party generative AI provider that supports function calling. The Observability AI Assistant supports the following providers:
 ** OpenAI `gpt-4`+.
 ** Azure OpenAI Service `gpt-4`(0613) or `gpt-4-32k`(0613) with API version `2023-07-01-preview` or more recent.
+** AWS Bedrock, specifically the Anthropic Claude models.
 * The knowledge base requires a 4 GB {ml} node.
 
 [discrete]
@@ -47,17 +53,24 @@ Elastic does not control third-party tools, and assumes no responsibility or lia
 [[obs-ai-set-up]]
 == Set up the AI Assistant
 
+//TODO: When we add support for additional LLMs, we might want to provide setup steps for each type of connector,
+//or make these steps more generic and rely on the UI text to help users with the setup.
+
 To set up the AI Assistant:
 
-. Create an API key from your AI provider to authenticate requests from the AI Assistant. You'll use this in the next step. Refer to your provider's documentation for information on generating API keys:
+. Create an authentication key with your AI provider to authenticate requests from the AI Assistant. You'll use this in the next step. Refer to your provider's documentation for information about creating authentication keys:
 +
-* https://platform.openai.com/docs/api-reference[OpenAI]
-* https://learn.microsoft.com/en-us/azure/cognitive-services/openai/reference[Azure OpenAI Service]
+* https://platform.openai.com/docs/api-reference[OpenAI API keys]
+* https://learn.microsoft.com/en-us/azure/cognitive-services/openai/reference[Azure OpenAI Service API keys]
+* https://docs.aws.amazon.com/bedrock/latest/userguide/security-iam.html[Amazon Bedrock authentication keys and secrets]
 
-. From *{stack-manage-app}* -> *{connectors-ui}* in {kib}, create a {kibana-ref}/openai-action-type.html[OpenAI connector].
+. From *{stack-manage-app}* -> *{connectors-ui}* in {kib}, create an {kibana-ref}/openai-action-type.html[OpenAI] or {kibana-ref}/bedrock-action-type.html[Amazon Bedrock] connector.
 . Authenticate communication between {observability} and the AI provider by providing the following information:
-.. Enter the AI provider's API endpoint URL in the *URL* field.
-.. Enter the API key you created in the previous step in the *API Key* field.
+.. In the *URL* field, enter the AI provider's API endpoint URL.
+.. Under *Authentication*, enter the API key or access key/secret you created in the previous step.
+
+//TODO: Resolve this question:
+**REVIEWERS:** What is the best link to use for AWS Bedrock security? The one I've provided above, or the link that's provided in the product? (https://docs.aws.amazon.com/IAM/latest/UserGuide/security-creds.html)
 
 [discrete]
 [[obs-ai-add-data]]
@@ -179,19 +192,40 @@ The AI Assistant uses functions to include relevant context in the chat conversa
 
 The following table lists available functions:
 
+//TODO: Resolve this question:
+**REVIEWERS**: Is the list of functions here correct? Only a subset are actually shown in the UI. None of the apm functions are shown in the UI right now.
+
+//TODO: Resolve this question:
+**REVIEWERS**: Should we replace this table with the UI instructions for showing the list of functions (like we did in serverless)?
+There are some good arguments for doing this, but I wonder if seeing this info might actually be useful for people who are exploring the
+docs to figure out what is possible. If so, it's better to keep the table, IMO. In not, then maybe just telling users how to see the list in the UI is good enough.
+
 [horizontal]
-`alerts`:: Get alerts for {observability}
+`alerts`:: Get alerts for {observability}.
+`context`:: Add context based on what is shown on the screen and documents recalled from the knowledge base that match the query.
 `elasticsearch`:: Call {es} APIs on your behalf.
+`execute_query`:: Display the results of an ES|QL query.
 `get_apm_correlations`:: Get field values that are more prominent in the foreground set than the background set. This can be useful in determining which attributes (such as `error.message`, `service.node.name`, or `transaction.name`) are contributing to, for instance, a higher latency. Another option is a time-based comparison, where you compare before and after a change point.
 `get_apm_downstream_dependencies`:: Get the downstream dependencies (services or uninstrumented backends) for a service. Map the downstream dependency name to a service by returning both `span.destination.service.resource` and `service.name`. Use this to drill down further if needed.
 `get_apm_error_document`:: Get a sample error document based on the grouping name. This also includes the stacktrace of the error, which might hint to the cause.
 `get_apm_service_summary`:: Get a summary of a single service, including the language, service version, deployments, the environments, and the infrastructure that it is running in. For example, the number of pods and a list of their downstream dependencies. It also returns active alerts and anomalies.
 `get_apm_services_list`:: Get the list of monitored services, their health statuses, and alerts.
 `get_apm_timeseries`:: Display different APM metrics (such as throughput, failure rate, or latency) for any service or all services and any or all of their dependencies. Displayed both as a time series and as a single statistic. Additionally, the function  returns any changes, such as spikes, step and trend changes, or dips. You can also use it to compare data by requesting two different time ranges, or, for example, two different service versions.
+`get_dataset_info`:: Get information about available indices and datasets, and the fields available on them.
 `kibana`:: Call {kib} APIs on your behalf.
 `lens`:: Create custom visualizations, using {kibana-ref}/lens.html[Lens], that you can add to dashboards.
-`recall`:: Recall previous learning.
+`recall`:: Recall previous learning. This function has been renamed to `context`.
 `summarize`:: Summarize parts of the conversation.
+`query`:: Generate, execute, or visualize a query based on the user's request. This function can also explain how ES/QL works and convert queries from one language to another.
+
+//TODO: Resolve this question:
+**REVIEWERS**: Has the "recall" function really has been renamed to "context". Can we just remove the description or do we need to mention that it's been renamed here?
+
+//TODO: Resolve this question:
+**REVIEWERS**: Is the above description of the query function true or is the AI making stuff up? My original description said something like: "Construct and render an ES/QL query using the LLM in a multi-step process to improve the output." Also do the functions I've added here actually exist, or was AI making that up too?
+
+//TODO: Resolve this question:
+**REVIEWERS**: Is the "recall" function deprecated? Or completely renamed and basically removed?
 
 [discrete]
 [[obs-ai-prompts]]

--- a/docs/en/observability/observability-ai-assistant.asciidoc
+++ b/docs/en/observability/observability-ai-assistant.asciidoc
@@ -206,10 +206,6 @@ Additional functions are available when your cluster has APM data:
 `get_apm_services_list`:: Get the list of monitored services, their health statuses, and alerts.
 `get_apm_timeseries`:: Display different APM metrics (such as throughput, failure rate, or latency) for any service or all services and any or all of their dependencies. Displayed both as a time series and as a single statistic. Additionally, the function  returns any changes, such as spikes, step and trend changes, or dips. You can also use it to compare data by requesting two different time ranges, or, for example, two different service versions.
 
-TIP: Internal functions used by the AI Assistant are not shown here because they are not available for you to suggest.
-You can learn more about these functions by asking the AI Assistant about them. For example, you can ask the AI Assistant,
-"What is the context function?"
-
 
 [discrete]
 [[obs-ai-prompts]]

--- a/docs/en/observability/observability-ai-assistant.asciidoc
+++ b/docs/en/observability/observability-ai-assistant.asciidoc
@@ -224,9 +224,6 @@ docs to figure out what is possible. If so, it's better to keep the table, IMO. 
 //TODO: Resolve this question:
 **REVIEWERS**: Is the above description of the query function true or is the AI making stuff up? My original description said something like: "Construct and render an ES/QL query using the LLM in a multi-step process to improve the output." Also do the functions I've added here actually exist, or was AI making that up too?
 
-//TODO: Resolve this question:
-**REVIEWERS**: Is the "recall" function deprecated? Or completely renamed and basically removed?
-
 [discrete]
 [[obs-ai-prompts]]
 === AI Assistant contextual prompts

--- a/docs/en/observability/observability-ai-assistant.asciidoc
+++ b/docs/en/observability/observability-ai-assistant.asciidoc
@@ -210,7 +210,6 @@ TIP: Internal functions used by the AI Assistant are not shown here because they
 You can learn more about these functions by asking the AI Assistant about them. For example, you can ask the AI Assistant,
 "What is the context function?"
 
-//TODO: Make sure execute_query is not an internal function.
 
 [discrete]
 [[obs-ai-prompts]]


### PR DESCRIPTION
Adds changes to stateful for #3652. Note that we decided not to document "internal" functions.

Also alphabetizes the table of functions. 

Preview link: https://observability-docs_bk_3663.docs-preview.app.elstc.co/guide/en/observability/master/obs-ai-assistant.html

Question: Why don't we alphabetize the list of functions in the UI? I know we sometimes like to put the most commonly used options first, but in my experience that kind of organizational approach falls apart over time.

TODO (after merging):

- [ ] Port changes to serverless docs.

## Open questions (these questions also appear inline in the diff):
- [x] What is the best link to use for AWS Bedrock security? The [one I’ve provided in the updated docs](https://docs.aws.amazon.com/bedrock/latest/userguide/security-iam.html), or the link that’s provided in the [AI Assistant](https://docs.aws.amazon.com/IAM/latest/UserGuide/security-creds.html)? _RESOLVED: Leaving the link as-is._
- [x] Should we replace the table of functions in the docs with the UI instructions for showing the list of functions (like we did in serverless)? There are some good arguments for doing this, but I wonder if seeing this info might actually be useful for people who are exploring the docs to figure out what is possible. If so, it’s better to keep the table, IMO. In not, then maybe just telling users how to see the list in the UI is good enough. _RESOLVED: Removing the docs for internal functions and leaving the other functions documented._
- [x] Has the "recall" function really has been renamed to "context". Can we just remove the description or do we need to mention that it’s been renamed? _RESOVLED: Removing the docs for these functions._
- [x] Is the list of functions documented in this PR correct for 8.13? Only a subset are actually shown in the UI. None of the apm functions are shown in the UI right now (maybe because I don't have APM set up?):
![image](https://github.com/elastic/observability-docs/assets/14206422/8f92e5bb-8681-4127-96d9-6066720b70ca)
  If I ask the AI Assistant what functions are available, it'll give me a long list, including context and query, but that list does not show up in the UI when I click **Select a function**. _RESOLVED: We will remove the internal functions._
- [x] Is the description of the query function  in this PR true? (Or is AI making stuff up?) _RESOVLED: Yes, but we will remove the query function because it's an LLM-only function._

