### PR TITLE
Update docs to indicate that SLO burn rate rule is created automatically

### DIFF
--- a/docs/en/observability/slo-burn-rate-alert.asciidoc
+++ b/docs/en/observability/slo-burn-rate-alert.asciidoc
@@ -12,6 +12,10 @@ For example, if your long lookback period is one hour, your short lookback perio
 For each lookback period, the burn rate is computed as the error rate divided by the error budget.
 When the burn rates for both periods surpass the threshold, an alert is triggered.
 
+NOTE: When you use the UI to create an SLO, a default SLO burn rate alert rule is created automatically.
+The burn rate rule will use the default configuration and no connector.
+You must configure a connector if you want to receive alerts for SLO breaches.
+
 To create an SLO burn rate rule, go to *Observability → SLOs*. Click the more options icon to the right of the SLO you want to add a burn rate rule for, and select *Create new alert rule* from the drop-down menu:
 
 [role="screenshot"]

--- a/docs/en/observability/slo-create.asciidoc
+++ b/docs/en/observability/slo-create.asciidoc
@@ -211,9 +211,11 @@ After setting your objectives, give your SLO a name, a short description, and ad
 [[slo-alert-checkbox]]
 = Create an SLO burn rate alert rule
 
-When the *Create an SLO burn rate alert rule* checkbox is selected, the *Create rule* window opens immediately after you click the *Create SLO* button.
-Here you can define your SLO burn rate alert rule.
-For more information, see <<slo-burn-rate-alert, Create an SLO burn rate rule>>.
+When you use the UI to create an SLO, a default SLO burn rate alert rule is created automatically.
+The burn rate rule will use the default configuration and no connector.
+You must configure a connector if you want to receive alerts for SLO breaches.
+
+For more information about configuring the rule, see <<slo-burn-rate-alert, Create an SLO burn rate rule>>.
 
 [discrete]
 [[slo-dashboard]]


### PR DESCRIPTION
Adds changes to stateful for https://github.com/elastic/observability-docs/issues/3600.

TODO after merging:

- [x] Update serverless docs to reflect this change. https://github.com/elastic/staging-serverless-observability-docs/pull/228