### PR TITLE
Refactor observability attributes

### DIFF
--- a/docs/en/integrations/index.asciidoc
+++ b/docs/en/integrations/index.asciidoc
@@ -1,20 +1,6 @@
 include::{docs-root}/shared/versions/stack/{source_branch}.asciidoc[]
 include::{docs-root}/shared/attributes.asciidoc[]
 
-:doctype: book
-:forum: https://discuss.elastic.co/
-
-:package-spec-repo: https://github.com/elastic/package-spec
-
-// Access package spec files with {package-spec-root}
-:package-spec: {package-spec-root}/spec
-
-// repos
-:integrations-repo-link: https://github.com/elastic/integrations
-:package-registry-repo-link: https://github.com/elastic/package-registry
-:package-spec-repo-link: https://github.com/elastic/package-spec
-:package-storage-repo-link: https://github.com/elastic/package-storage
-
 // Additional information that hasn't been copied over yet
 // https://github.com/elastic/integrations/blob/main/docs/definitions.md
 // https://github.com/elastic/integrations/blob/main/docs/definitions.md

--- a/docs/en/integrations/package-spec.asciidoc
+++ b/docs/en/integrations/package-spec.asciidoc
@@ -77,7 +77,7 @@ Included from the package-spec repository. This will update when the spec is upd
 
 [source,yaml]
 ----
-include::{package-spec}/integration/spec.yml[]
+include::{package-spec-root}/spec/integration/spec.yml[]
 ----
 
 [[dev-spec]]
@@ -91,7 +91,7 @@ Included from the package-spec repository. This will update when the spec is upd
 
 [source,yaml]
 ----
-include::{package-spec}/integration/_dev/spec.yml[]
+include::{package-spec-root}/spec/integration/_dev/spec.yml[]
 ----
 
 [[data-stream-spec]]
@@ -105,7 +105,7 @@ Included from the package-spec repository. This will update when the spec is upd
 
 [source,yaml]
 ----
-include::{package-spec}/integration/data_stream/spec.yml[]
+include::{package-spec-root}/spec/integration/data_stream/spec.yml[]
 ----
 
 [[docs-spec]]
@@ -119,7 +119,7 @@ Included from the package-spec repository. This will update when the spec is upd
 
 [source,yaml]
 ----
-include::{package-spec}/integration/docs/spec.yml[]
+include::{package-spec-root}/spec/integration/docs/spec.yml[]
 ----
 
 [[kibana-spec]]
@@ -133,7 +133,7 @@ Included from the package-spec repository. This will update when the spec is upd
 
 [source,yaml]
 ----
-include::{package-spec}/integration/kibana/spec.yml[]
+include::{package-spec-root}/spec/integration/kibana/spec.yml[]
 ----
 
 [[changelog-spec]]
@@ -147,7 +147,7 @@ Included from the package-spec repository. This will update when the spec is upd
 
 [source,yaml]
 ----
-include::{package-spec}/integration/changelog.spec.yml[]
+include::{package-spec-root}/spec/integration/changelog.spec.yml[]
 ----
 
 [[manifest-spec]]
@@ -162,5 +162,5 @@ Included from the package-spec repository. This will update when the spec is upd
 
 [source,yaml]
 ----
-include::{package-spec}/integration/manifest.spec.yml[]
+include::{package-spec-root}/spec/integration/manifest.spec.yml[]
 ----

--- a/docs/en/integrations/what-is-an-integration.asciidoc
+++ b/docs/en/integrations/what-is-an-integration.asciidoc
@@ -24,14 +24,14 @@ Integrations have a strict, well-defined structure, and offer a number of benefi
 . Create a source package
 +
 All integrations start as a source package.
-You'll find most Elastic integrations in the {integrations-repo-link}[`elastic/integrations`] repository,
+You'll find most Elastic integrations in the https://github.com/elastic/integrations[`elastic/integrations`] repository,
 but a package can live anywhere.
 +
 All packages must adhere to the <<package-spec,package specification>> -- a formal spec used for the creation and validation of new or updated integrations.
 
 . Publish the integration to the package registry
 +
-Once an integration (package) has been created, it needs to be built. Built integrations are stored in the {package-storage-repo-link}[Package Storage repository] and served up via the {package-registry-repo-link}[{package-registry}].
+Once an integration (package) has been created, it needs to be built. Built integrations are stored in the https://github.com/elastic/package-storage[Package Storage repository] and served up via the https://github.com/elastic/package-registry[{package-registry}].
 The {fleet} UI in {kib} connects to the {package-registry} and allows users to discover, install, and configure Elastic Packages.
 The {package-registry} can also be {fleet-guide}/air-gapped.html#air-gapped-diy-epr[deployed on-premise in air-gapped environments].
 

--- a/docs/en/observability/apm.asciidoc
+++ b/docs/en/observability/apm.asciidoc
@@ -1,37 +1,8 @@
 [[apm]]
 = Application performance monitoring (APM)
 
-:apm-integration-docs:
-:obs-repo-dir:           {observability-docs-root}/docs/en
-
-:github_repo_link: https://github.com/elastic/apm-server/blob/v{version}
-ifeval::["{version}" == "8.0.0"]
-:github_repo_link: https://github.com/elastic/apm-server/blob/main
-endif::[]
-
-
 // OTHER ATTRS
 // TODO: Check that these are still relevant
-:version: {apm_server_version}
-:beatname_lc: apm-server
-:beatname_uc: APM Server
-:beatname_pkg: {beatname_lc}
-:beat_kib_app: APM app
-:beat_monitoring_user: apm_system
-:beat_monitoring_user_version: 6.5.0
-:beat_monitoring_version: 6.5
-:beat_default_index_prefix: apm
-:access_role: {beat_default_index_prefix}_user
-:beat_version_key: observer.version
-:dockerimage: docker.elastic.co/apm/{beatname_lc}:{version}
-:dockergithub: https://github.com/elastic/apm-server-docker/tree/{branch}
-:dockerconfig: https://raw.githubusercontent.com/elastic/apm-server/{branch}/apm-server.docker.yml
-:discuss_forum: apm
-:github_repo_name: apm-server
-:sample_date_0: 2019.10.20
-:sample_date_1: 2019.10.21
-:sample_date_2: 2019.10.22
-:repo: apm-server
 :no_kibana:
 :no_ilm:
 :no-pipeline:
@@ -75,34 +46,32 @@ like JVM metrics in the Java Agent, and Go runtime metrics in the Go Agent.
 Use <<traces-get-started,Get started with application traces and APM>> to quickly spin up an APM deployment.
 Want to host everything yourself instead? See <<getting-started-apm-server>>.
 
-include::{apm-server-dir}/getting-started-apm-server.asciidoc[]
+include::{observability-docs-root}/docs/en/observability/apm/getting-started-apm-server.asciidoc[]
 
-include::{apm-server-dir}/data-model.asciidoc[]
+include::{observability-docs-root}/docs/en/observability/apm/data-model.asciidoc[]
 
-include::{apm-server-dir}/features.asciidoc[]
+include::{observability-docs-root}/docs/en/observability/apm/features.asciidoc[]
 
-include::{apm-server-dir}/how-to.asciidoc[]
+include::{observability-docs-root}/docs/en/observability/apm/how-to.asciidoc[]
 
-include::{apm-server-dir}/open-telemetry.asciidoc[]
+include::{observability-docs-root}/docs/en/observability/apm/open-telemetry.asciidoc[]
 
-include::{apm-server-dir}/manage-storage.asciidoc[]
+include::{observability-docs-root}/docs/en/observability/apm/manage-storage.asciidoc[]
 
-include::{apm-server-dir}/configure/index.asciidoc[leveloffset=+1]
+include::{observability-docs-root}/docs/en/observability/apm/configure/index.asciidoc[leveloffset=+1]
 
-include::{apm-server-dir}/setting-up-and-running.asciidoc[]
+include::{observability-docs-root}/docs/en/observability/apm/setting-up-and-running.asciidoc[]
 
-include::{apm-server-dir}/secure-comms.asciidoc[]
+include::{observability-docs-root}/docs/en/observability/apm/secure-comms.asciidoc[]
 
-include::{apm-server-dir}/monitor-apm-server.asciidoc[]
+include::{observability-docs-root}/docs/en/observability/apm/monitor-apm-server.asciidoc[]
 
-include::{apm-server-dir}/api.asciidoc[]
+include::{observability-docs-root}/docs/en/observability/apm/api.asciidoc[]
 
-include::{apm-server-dir}/troubleshoot-apm.asciidoc[]
+include::{observability-docs-root}/docs/en/observability/apm/troubleshoot-apm.asciidoc[]
 
-include::{apm-server-dir}/upgrading.asciidoc[]
+include::{observability-docs-root}/docs/en/observability/apm/upgrading.asciidoc[]
 
-include::{apm-server-dir}/release-notes.asciidoc[leveloffset=+1]
+include::{observability-docs-root}/docs/en/observability/apm/release-notes.asciidoc[leveloffset=+1]
 
-include::{apm-server-dir}/known-issues.asciidoc[leveloffset=+1]
-
-:which-guide: observability
+include::{observability-docs-root}/docs/en/observability/apm/known-issues.asciidoc[leveloffset=+1]

--- a/docs/en/observability/apm/access-api-keys.asciidoc
+++ b/docs/en/observability/apm/access-api-keys.asciidoc
@@ -29,15 +29,15 @@ In the role descriptors box, assign the appropriate privileges to the new API ke
 [source,json,subs="attributes,callouts"]
 ----
 {
-    "{beat_default_index_prefix}_writer": {
+    "apm_writer": {
         "index": [
             {
-                "names": ["{beat_default_index_prefix}-*"],
+                "names": ["apm-*"],
                 "privileges": ["create_index", "create_doc"]
             }
         ]
     },
-    "{beat_default_index_prefix}_sourcemap": {
+    "apm_sourcemap": {
         "index": [
             {
                 "names": [".apm-source-map"],
@@ -45,7 +45,7 @@ In the role descriptors box, assign the appropriate privileges to the new API ke
             }
         ]
     },
-    "{beat_default_index_prefix}_agentcfg": {
+    "apm_agentcfg": {
         "index": [
             {
                 "names": [".apm-agent-configuration"],
@@ -89,7 +89,7 @@ For example:
 [source,json,subs="attributes,callouts"]
 ----
 {
-    "{beat_default_index_prefix}_monitoring": {
+    "apm_monitoring": {
         "index": [
             {
                 "names": [".monitoring-beats-*"],
@@ -128,17 +128,17 @@ For example:
 ------------------------------------------------------------
 POST /_security/api_key
 {
-  "name": "{beat_default_index_prefix}_host001", <1>
+  "name": "apm_host001", <1>
   "role_descriptors": {
-    "{beat_default_index_prefix}_writer": { <2>
+    "apm_writer": { <2>
       "index": [
         {
-          "names": ["{beat_default_index_prefix}-*"],
+          "names": ["apm-*"],
           "privileges": ["create_index", "create_doc"]
         }
       ]
     },
-    "{beat_default_index_prefix}_sourcemap": {
+    "apm_sourcemap": {
       "index": [
         {
           "names": [".apm-source-map"],
@@ -146,7 +146,7 @@ POST /_security/api_key
         }
       ]
     },
-    "{beat_default_index_prefix}_agentcfg": {
+    "apm_agentcfg": {
       "index": [
         {
           "names": [".apm-agent-configuration"],

--- a/docs/en/observability/apm/access-api-keys.asciidoc
+++ b/docs/en/observability/apm/access-api-keys.asciidoc
@@ -7,11 +7,11 @@ access to {es} resources. You can set API keys to expire at a certain time,
 and you can explicitly invalidate them. Any user with the `manage_api_key`
 or `manage_own_api_key` cluster privilege can create API keys.
 
-{beatname_uc} instances typically send both collected data and monitoring
+APM Server instances typically send both collected data and monitoring
 information to {es}. If you are sending both to the same cluster, you can use the same
 API key. For different clusters, you need to use an API key per cluster.
 
-NOTE: For security reasons, we recommend using a unique API key per {beatname_uc} instance.
+NOTE: For security reasons, we recommend using a unique API key per APM Server instance.
 You can create as many API keys per user as necessary.
 
 [float]
@@ -64,7 +64,7 @@ and input the lifetime of the API key in days.
 
 Click **Create API key**. In the dropdown, switch to **{beats}** and copy the API key.
 
-You can now use this API key in your +{beatname_lc}.yml+ configuration file:
+You can now use this API key in your +apm-server.yml+ configuration file:
 
 ["source","yml",subs="attributes"]
 --------------------
@@ -108,7 +108,7 @@ and input the lifetime of the API key in days.
 
 Click **Create API key**. In the dropdown, switch to **{beats}** and copy the API key.
 
-You can now use this API key in your +{beatname_lc}.yml+ configuration file like this:
+You can now use this API key in your +apm-server.yml+ configuration file like this:
 
 ["source","yml",subs="attributes"]
 --------------------

--- a/docs/en/observability/apm/anonymous-auth.asciidoc
+++ b/docs/en/observability/apm/anonymous-auth.asciidoc
@@ -30,7 +30,7 @@ You can only enable and configure anonymous authentication if an <<api-key,API k
 <<secret-token,secret token>> is configured. If neither are configured, these settings will be ignored.
 ====
 
-include::{apm-server-dir}/tab-widgets/anonymous-auth-widget.asciidoc[]
+include::{observability-docs-root}/docs/en/observability/apm/tab-widgets/anonymous-auth-widget.asciidoc[]
 
 [float]
 [[derive-client-ip]]

--- a/docs/en/observability/apm/api-error.asciidoc
+++ b/docs/en/observability/apm/api-error.asciidoc
@@ -8,7 +8,7 @@ An error or a logged error message captured by an agent occurring in a monitored
 ==== Error Schema
 
 APM Server uses JSON Schema to validate requests. The specification for errors is defined on
-{github_repo_link}/docs/spec/v2/error.json[GitHub] and included below:
+https://github.com/elastic/apm-server/blob/{version}/docs/spec/v2/error.json[GitHub] and included below:
 
 [source,json]
 ----

--- a/docs/en/observability/apm/api-error.asciidoc
+++ b/docs/en/observability/apm/api-error.asciidoc
@@ -8,7 +8,7 @@ An error or a logged error message captured by an agent occurring in a monitored
 ==== Error Schema
 
 APM Server uses JSON Schema to validate requests. The specification for errors is defined on
-https://github.com/elastic/apm-server/blob/{version}/docs/spec/v2/error.json[GitHub] and included below:
+https://github.com/elastic/apm-server/blob/{minor-version}/docs/spec/v2/error.json[GitHub] and included below:
 
 [source,json]
 ----

--- a/docs/en/observability/apm/api-info.asciidoc
+++ b/docs/en/observability/apm/api-info.asciidoc
@@ -68,6 +68,6 @@ curl -X POST http://127.0.0.1:8200/ \
   "build_date": "2021-12-18T19:59:06Z",
   "build_sha": "24fe620eeff5a19e2133c940c7e5ce1ceddb1445",
   "publish_ready": true,
-  "version": "{version}"
+  "version": "{apm_server_version}"
 }
 ---------------------------------------------------------------------------

--- a/docs/en/observability/apm/api-keys.asciidoc
+++ b/docs/en/observability/apm/api-keys.asciidoc
@@ -26,7 +26,7 @@ make sure <<agent-tls,TLS>> is enabled, then complete these steps:
 [float]
 === Enable API keys
 
-include::{apm-server-dir}/tab-widgets/api-key-widget.asciidoc[]
+include::{observability-docs-root}/docs/en/observability/apm/tab-widgets/api-key-widget.asciidoc[]
 
 [[create-api-key-user]]
 [float]
@@ -133,7 +133,7 @@ Keys created using this method can only be used for communication with APM Serve
 [float]
 ===== `apikey` subcommands
 
-include::{apm-server-dir}/command-reference.asciidoc[tag=apikey-subcommands]
+include::{observability-docs-root}/docs/en/observability/apm/command-reference.asciidoc[tag=apikey-subcommands]
 
 [[create-api-key-privileges]]
 [float]
@@ -156,7 +156,7 @@ and gives the "agent configuration" and "ingest" privileges.
 
 ["source","sh",subs="attributes"]
 -----
-{beatname_lc} apikey create --ingest --agent-config --name java-001
+apm-server apikey create --ingest --agent-config --name java-001
 -----
 
 The response will look similar to this:
@@ -177,7 +177,7 @@ The following example verifies that the `java-001` API key has the "agent config
 
 ["source","sh",subs="attributes"]
 -----
-{beatname_lc} apikey verify --agent-config --ingest --credentials cVQ0dHoyOEIxZzU5ekMzdUFYZlc6ckg1NXpLZDVRVDZ3dnMzVWJia3hPQQ==
+apm-server apikey verify --agent-config --ingest --credentials cVQ0dHoyOEIxZzU5ekMzdUFYZlc6ckg1NXpLZDVRVDZ3dnMzVWJia3hPQQ==
 -----
 
 If the API key has the requested privileges, the response will look similar to this:
@@ -195,7 +195,7 @@ The following example invalidates the `java-001` API key.
 
 ["source","sh",subs="attributes"]
 -----
-{beatname_lc} apikey invalidate --name java-001
+apm-server apikey invalidate --name java-001
 -----
 
 The response will look similar to this:
@@ -310,7 +310,7 @@ You can then use the APM Server CLI to verify that the API key has the requested
 
 ["source","sh",subs="attributes"]
 -----
-{beatname_lc} apikey verify --credentials R25yVVQzUUI3eVpiU054S0VUNmQ6UmhIS2lzVG1RMWFQQ0hDX1RQd092dw==
+apm-server apikey verify --credentials R25yVVQzUUI3eVpiU054S0VUNmQ6UmhIS2lzVG1RMWFQQ0hDX1RQd092dw==
 -----
 
 If the API key has the requested privileges, the response will look similar to this:

--- a/docs/en/observability/apm/api-metadata.asciidoc
+++ b/docs/en/observability/apm/api-metadata.asciidoc
@@ -58,7 +58,7 @@ The table below maps these environment variables to the APM metadata event field
 ==== Metadata Schema
 
 APM Server uses JSON Schema to validate requests. The specification for metadata is defined on
-https://github.com/elastic/apm-server/blob/{version}/docs/spec/v2/metadata.json[GitHub] and included below:
+https://github.com/elastic/apm-server/blob/{minor-version}/docs/spec/v2/metadata.json[GitHub] and included below:
 
 [source,json]
 ----

--- a/docs/en/observability/apm/api-metadata.asciidoc
+++ b/docs/en/observability/apm/api-metadata.asciidoc
@@ -58,7 +58,7 @@ The table below maps these environment variables to the APM metadata event field
 ==== Metadata Schema
 
 APM Server uses JSON Schema to validate requests. The specification for metadata is defined on
-{github_repo_link}/docs/spec/v2/metadata.json[GitHub] and included below:
+https://github.com/elastic/apm-server/blob/{version}/docs/spec/v2/metadata.json[GitHub] and included below:
 
 [source,json]
 ----

--- a/docs/en/observability/apm/api-metricset.asciidoc
+++ b/docs/en/observability/apm/api-metricset.asciidoc
@@ -8,7 +8,7 @@ Metrics contain application metric data captured by an {apm-agent}.
 ==== Metric Schema
 
 APM Server uses JSON Schema to validate requests. The specification for metrics is defined on
-{github_repo_link}/docs/spec/v2/metricset.json[GitHub] and included below:
+https://github.com/elastic/apm-server/blob/{version}/docs/spec/v2/metricset.json[GitHub] and included below:
 
 [source,json]
 ----

--- a/docs/en/observability/apm/api-metricset.asciidoc
+++ b/docs/en/observability/apm/api-metricset.asciidoc
@@ -8,7 +8,7 @@ Metrics contain application metric data captured by an {apm-agent}.
 ==== Metric Schema
 
 APM Server uses JSON Schema to validate requests. The specification for metrics is defined on
-https://github.com/elastic/apm-server/blob/{version}/docs/spec/v2/metricset.json[GitHub] and included below:
+https://github.com/elastic/apm-server/blob/{minor-version}/docs/spec/v2/metricset.json[GitHub] and included below:
 
 [source,json]
 ----

--- a/docs/en/observability/apm/api-span.asciidoc
+++ b/docs/en/observability/apm/api-span.asciidoc
@@ -8,7 +8,7 @@ Spans are events captured by an agent occurring in a monitored service.
 ==== Span Schema
 
 APM Server uses JSON Schema to validate requests. The specification for spans is defined on
-{github_repo_link}/docs/spec/v2/span.json[GitHub] and included below:
+https://github.com/elastic/apm-server/blob/{version}/docs/spec/v2/span.json[GitHub] and included below:
 
 [source,json]
 ----

--- a/docs/en/observability/apm/api-span.asciidoc
+++ b/docs/en/observability/apm/api-span.asciidoc
@@ -8,7 +8,7 @@ Spans are events captured by an agent occurring in a monitored service.
 ==== Span Schema
 
 APM Server uses JSON Schema to validate requests. The specification for spans is defined on
-https://github.com/elastic/apm-server/blob/{version}/docs/spec/v2/span.json[GitHub] and included below:
+https://github.com/elastic/apm-server/blob/{minor-version}/docs/spec/v2/span.json[GitHub] and included below:
 
 [source,json]
 ----

--- a/docs/en/observability/apm/api-transaction.asciidoc
+++ b/docs/en/observability/apm/api-transaction.asciidoc
@@ -8,7 +8,7 @@ Transactions are events corresponding to an incoming request or similar task occ
 ==== Transaction Schema
 
 APM Server uses JSON Schema to validate requests. The specification for transactions is defined on
-https://github.com/elastic/apm-server/blob/{version}/docs/spec/v2/transaction.json[GitHub] and included below:
+https://github.com/elastic/apm-server/blob/{minor-version}/docs/spec/v2/transaction.json[GitHub] and included below:
 
 [source,json]
 ----

--- a/docs/en/observability/apm/api-transaction.asciidoc
+++ b/docs/en/observability/apm/api-transaction.asciidoc
@@ -8,7 +8,7 @@ Transactions are events corresponding to an incoming request or similar task occ
 ==== Transaction Schema
 
 APM Server uses JSON Schema to validate requests. The specification for transactions is defined on
-{github_repo_link}/docs/spec/v2/transaction.json[GitHub] and included below:
+https://github.com/elastic/apm-server/blob/{version}/docs/spec/v2/transaction.json[GitHub] and included below:
 
 [source,json]
 ----

--- a/docs/en/observability/apm/apm-distributed-tracing.asciidoc
+++ b/docs/en/observability/apm/apm-distributed-tracing.asciidoc
@@ -106,7 +106,7 @@ with each agent's API.
 Sending services must add the `traceparent` header to outgoing requests.
 
 --
-include::{apm-server-dir}/tab-widgets/distributed-trace-send-widget.asciidoc[]
+include::{observability-docs-root}/docs/en/observability/apm/tab-widgets/distributed-trace-send-widget.asciidoc[]
 --
 
 [float]
@@ -117,7 +117,7 @@ Receiving services must parse the incoming `traceparent` header,
 and start a new transaction or span as a child of the received context.
 
 --
-include::{apm-server-dir}/tab-widgets/distributed-trace-receive-widget.asciidoc[]
+include::{observability-docs-root}/docs/en/observability/apm/tab-widgets/distributed-trace-receive-widget.asciidoc[]
 --
 
 [float]

--- a/docs/en/observability/apm/apm-quick-start.asciidoc
+++ b/docs/en/observability/apm/apm-quick-start.asciidoc
@@ -20,4 +20,4 @@ simply spin-up your instance and point your *APM agents* towards it.
 [float]
 == What will I learn in this guide?
 
-include::{obs-repo-dir}/observability/traces-get-started.asciidoc[tag=apm-quick-start]
+include::{observability-docs-root}/docs/en/observability/traces-get-started.asciidoc[tag=apm-quick-start]

--- a/docs/en/observability/apm/command-reference.asciidoc
+++ b/docs/en/observability/apm/command-reference.asciidoc
@@ -1,18 +1,3 @@
-//////////////////////////////////////////////////////////////////////////
-//// This content is shared by all Elastic Beats. Make sure you keep the
-//// descriptions here generic enough to work for all Beats that include
-//// this file. When using cross references, make sure that the cross
-//// references resolve correctly for any files that include this one.
-//// Use the appropriate variables defined in the index.asciidoc file to
-//// resolve Beat names: beatname_uc and beatname_lc
-//// Use the following include to pull this content into a doc file:
-//// include::../../libbeat/docs/command-reference.asciidoc[]
-//////////////////////////////////////////////////////////////////////////
-
-
-// These attributes are used to resolve short descriptions
-// tag::attributes[]
-
 :global-flags: Also see <<global-flags,Global flags>>.
 
 :deploy-command-short-desc: Deploys the specified function to your serverless environment
@@ -20,13 +5,7 @@
 :apikey-command-short-desc: Manage API Keys for communication between APM agents and server.
 
 ifndef::serverless[]
-ifndef::no_dashboards[]
-:export-command-short-desc: Exports the configuration, index template, {ilm-init} policy, or a dashboard to stdout
-endif::no_dashboards[]
-
-ifdef::no_dashboards[]
 :export-command-short-desc: Exports the configuration, index template, or {ilm-init} policy to stdout
-endif::no_dashboards[]
 endif::serverless[]
 
 ifdef::serverless[]
@@ -38,19 +17,7 @@ endif::serverless[]
 :modules-command-short-desc: Manages configured modules
 :package-command-short-desc: Packages the configuration and executable into a zip file
 :remove-command-short-desc: Removes the specified function from your serverless environment
-:run-command-short-desc: Runs {beatname_uc}. This command is used by default if you start {beatname_uc} without specifying a command
-
-ifdef::has_ml_jobs[]
-:setup-command-short-desc: Sets up the initial environment, including the index template, {ilm-init} policy and write alias, {kib} dashboards (when available), and {ml} jobs (when available)
-endif::[]
-
-ifdef::no_dashboards[]
-:setup-command-short-desc: Sets up the initial environment, including the ES index template, and {ilm-init} policy and write alias
-endif::no_dashboards[]
-
-ifndef::has_ml_jobs,no_dashboards[]
-:setup-command-short-desc: Sets up the initial environment, including the index template, {ilm-init} policy and write alias, and {kib} dashboards (when available)
-endif::[]
+:run-command-short-desc: Runs APM Server. This command is used by default if you start APM Server without specifying a command
 
 :update-command-short-desc: Updates the specified function
 :test-command-short-desc: Tests the configuration
@@ -59,7 +26,7 @@ endif::[]
 // end::attributes[]
 
 [[command-line-options]]
-=== {beatname_uc} command reference
+=== APM Server command reference
 
 ++++
 <titleabbrev>Command reference</titleabbrev>
@@ -67,29 +34,20 @@ endif::[]
 
 IMPORTANT: These commands only apply to the APM Server binary installation method.
 
-ifndef::no_dashboards[]
-{beatname_uc} provides a command-line interface for starting {beatname_uc} and
-performing common tasks, like testing configuration files and loading dashboards.
-endif::no_dashboards[]
-
-ifdef::no_dashboards[]
-{beatname_uc} provides a command-line interface for starting {beatname_uc} and
+APM Server provides a command-line interface for starting APM Server and
 performing common tasks, like testing configuration files.
-endif::no_dashboards[]
 
 The command-line also supports <<global-flags,global flags>>
 for controlling global behaviors.
 
-ifeval::["{beatname_lc}"!="winlogbeat"]
 [TIP]
 =========================
 Use `sudo` to run the following commands if:
 
 * the config file is owned by `root`, or
-* {beatname_uc} is configured to capture data that requires `root` access
+* APM Server is configured to capture data that requires `root` access
 
 =========================
-endif::[]
 
 Some of the features described here require an Elastic license. For
 more information, see https://www.elastic.co/subscriptions and
@@ -99,40 +57,21 @@ more information, see https://www.elastic.co/subscriptions and
 [options="header"]
 |=======================
 |Commands |
-ifeval::["{beatname_lc}"=="functionbeat"]
-|<<deploy-command,`deploy`>> | {deploy-command-short-desc}.
-endif::[]
-ifdef::apm-server[]
 |<<apikey-command,`apikey`>> |{apikey-command-short-desc}.
-endif::[]
 |<<export-command,`export`>> |{export-command-short-desc}.
 |<<help-command,`help`>> |{help-command-short-desc}.
 ifndef::serverless[]
 |<<keystore-command,`keystore`>> |{keystore-command-short-desc}.
 endif::[]
-ifeval::["{beatname_lc}"=="functionbeat"]
-|<<package-command,`package`>> |{package-command-short-desc}.
-|<<remove-command,`remove`>> |{remove-command-short-desc}.
-endif::[]
-ifdef::has_modules_command[]
-|<<modules-command,`modules`>> |{modules-command-short-desc}.
-endif::[]
 ifndef::serverless[]
 |<<run-command,`run`>> |{run-command-short-desc}.
 endif::[]
-ifndef::apm-server[]
-|<<setup-command,`setup`>> |{setup-command-short-desc}.
-endif::apm-server[]
 |<<test-command,`test`>> |{test-command-short-desc}.
-ifeval::["{beatname_lc}"=="functionbeat"]
-|<<update-command,`update`>> |{update-command-short-desc}.
-endif::[]
 |<<version-command,`version`>> |{version-command-short-desc}.
 |=======================
 
 Also see <<global-flags,Global flags>>.
 
-ifdef::apm-server[]
 [float]
 [[apikey-command]]
 ==== `apikey` command
@@ -152,7 +91,7 @@ and you must ensure that `apm-server.api_key` or `output.elasticsearch` are conf
 
 ["source","sh",subs="attributes"]
 ----
-{beatname_lc} apikey SUBCOMMAND [FLAGS]
+apm-server apikey SUBCOMMAND [FLAGS]
 ----
 
 *`SUBCOMMAND`*
@@ -224,64 +163,21 @@ When used with `info`, only returns valid API Keys (not expired or invalidated).
 
 ["source","sh",subs="attributes"]
 -----
-{beatname_lc} apikey create --ingest --agent-config --name example-001
-{beatname_lc} apikey info --name example-001 --valid-only
-{beatname_lc} apikey invalidate --name example-001
+apm-server apikey create --ingest --agent-config --name example-001
+apm-server apikey info --name example-001 --valid-only
+apm-server apikey invalidate --name example-001
 -----
 
 For more information, see <<api-key>>.
-
-endif::[]
-
-ifeval::["{beatname_lc}"=="functionbeat"]
-[[deploy-command]]
-==== `deploy` command
-
-{deploy-command-short-desc}. Before deploying functions, make sure the user has
-the credentials required by your cloud service provider.
-
-*SYNOPSIS*
-
-["source","sh",subs="attributes"]
-----
-{beatname_lc} deploy FUNCTION_NAME [FLAGS]
-----
-
-*`FUNCTION_NAME`*::
-Specifies the name of the function to deploy.
-
-*FLAGS*
-
-*`-h, --help`*::
-Shows help for the `deploy` command.
-
-{global-flags}
-
-*EXAMPLES*
-
-["source","sh",subs="attributes"]
------
-{beatname_lc} deploy cloudwatch
-{beatname_lc} deploy sqs
------
-endif::[]
 
 [float]
 [[export-command]]
 ==== `export` command
 
 ifndef::serverless[]
-ifndef::no_dashboards[]
-{export-command-short-desc}. You can use this
-command to quickly view your configuration, see the contents of the index
-template and the {ilm-init} policy, or export a dashboard from {kib}.
-endif::no_dashboards[]
-
-ifdef::no_dashboards[]
 {export-command-short-desc}. You can use this
 command to quickly view your configuration or see the contents of the index
 template or the {ilm-init} policy.
-endif::no_dashboards[]
 endif::serverless[]
 
 ifdef::serverless[]
@@ -294,7 +190,7 @@ endif::serverless[]
 
 ["source","sh",subs="attributes"]
 ----
-{beatname_lc} export SUBCOMMAND [FLAGS]
+apm-server export SUBCOMMAND [FLAGS]
 ----
 
 *`SUBCOMMAND`*
@@ -302,31 +198,6 @@ endif::serverless[]
 *`config`*::
 Exports the current configuration to stdout. If you use the `-c` flag, this
 command exports the configuration that's defined in the specified file.
-
-ifndef::no_dashboards[]
-[[dashboard-subcommand]]*`dashboard`*::
-Exports a dashboard. You can use this option to store a dashboard on disk in a
-module and load it automatically. For example, to export the dashboard to a JSON
-file, run:
-+
-["source","shell",subs="attributes"]
-----
-{beatname_lc} export dashboard --id="DASHBOARD_ID" > dashboard.json
-----
-+
-To find the `DASHBOARD_ID`, look at the URL for the dashboard in {kib}. By
-default, `export dashboard` writes the dashboard to stdout. The example shows
-how to write the dashboard to a JSON file so that you can import it later. The
-JSON file will contain the dashboard with all visualizations and searches. You
-must load the index pattern separately for {beatname_uc}.
-+
-To load the dashboard, copy the generated `dashboard.json` file into the
-`kibana/6/dashboard` directory of {beatname_uc}, and run
-+{beatname_lc} setup --dashboards+ to import the dashboard.
-+
-If {kib} is not running on `localhost:5061`, you must also adjust the
-{beatname_uc} configuration under `setup.kibana`.
-endif::no_dashboards[]
 
 [[template-subcommand]]*`template`*::
 Exports the index template to stdout. You can specify the `--es.version` and
@@ -358,46 +229,30 @@ Shows help for the `export` command.
 *`--index BASE_NAME`*::
 When used with <<template-subcommand,`template`>>, sets the base name to use for
 the index template. If this flag is not specified, the default base name is
-+{beatname_lc}+.
++apm-server+.
 
 *`--dir DIRNAME`*::
 Define a directory to which the template and {ilm-init} policy should be exported to
 as files instead of printing them to `stdout`.
-
-ifndef::no_dashboards[]
-*`--id DASHBOARD_ID`*::
-When used with <<dashboard-subcommand,`dashboard`>>, specifies the dashboard ID.
-endif::no_dashboards[]
 
 {global-flags}
 
 *EXAMPLES*
 
 ifndef::serverless[]
-ifndef::no_dashboards[]
 ["source","sh",subs="attributes"]
 -----
-{beatname_lc} export config
-{beatname_lc} export template --es.version {version} --index myindexname
-{beatname_lc} export dashboard --id="a7b35890-8baa-11e8-9676-ef67484126fb" > dashboard.json
+apm-server export config
+apm-server export template --es.version {version} --index myindexname
 -----
-endif::no_dashboards[]
-
-ifdef::no_dashboards[]
-["source","sh",subs="attributes"]
------
-{beatname_lc} export config
-{beatname_lc} export template --es.version {version} --index myindexname
------
-endif::no_dashboards[]
 endif::serverless[]
 
 ifdef::serverless[]
 ["source","sh",subs="attributes"]
 -----
-{beatname_lc} export config
-{beatname_lc} export template --es.version {version} --index myindexname
-{beatname_lc} export function cloudwatch
+apm-server export config
+apm-server export template --es.version {version} --index myindexname
+apm-server export function cloudwatch
 -----
 endif::serverless[]
 
@@ -414,9 +269,8 @@ endif::[]
 
 ["source","sh",subs="attributes"]
 ----
-{beatname_lc} help COMMAND_NAME [FLAGS]
+apm-server help COMMAND_NAME [FLAGS]
 ----
-
 
 *`COMMAND_NAME`*::
 Specifies the name of the command to show help for.
@@ -431,7 +285,7 @@ Specifies the name of the command to show help for.
 
 ["source","sh",subs="attributes"]
 -----
-{beatname_lc} help export
+apm-server help export
 -----
 
 ifndef::serverless[]
@@ -445,7 +299,7 @@ ifndef::serverless[]
 
 ["source","sh",subs="attributes"]
 ----
-{beatname_lc} keystore SUBCOMMAND [FLAGS]
+apm-server keystore SUBCOMMAND [FLAGS]
 ----
 
 *`SUBCOMMAND`*
@@ -483,135 +337,14 @@ Shows help for the `keystore` command.
 
 ["source","sh",subs="attributes"]
 -----
-{beatname_lc} keystore create
-{beatname_lc} keystore add ES_PWD
-{beatname_lc} keystore remove ES_PWD
-{beatname_lc} keystore list
+apm-server keystore create
+apm-server keystore add ES_PWD
+apm-server keystore remove ES_PWD
+apm-server keystore list
 -----
 
 See <<keystore>> for more examples.
 
-endif::[]
-
-ifeval::["{beatname_lc}"=="functionbeat"]
-[float]
-[[package-command]]
-==== `package` command
-
-{package-command-short-desc}.
-
-*SYNOPSIS*
-
-["source","sh",subs="attributes"]
-----
-{beatname_lc} package [FLAGS]
-----
-
-*FLAGS*
-
-*`-h, --help`*::
-Shows help for the `package` command.
-
-*`-o, --output`*::
-Specifies the full path pattern to use when creating the packages.
-
-{global-flags}
-
-*EXAMPLES*
-
-["source","sh",subs="attributes"]
------
-{beatname_lc} package --output /path/to/folder/package-{{.Provider}}.zip
------
-
-[[remove-command]]
-==== `remove` command
-
-{remove-command-short-desc}. Before removing functions, make sure the user has
-the credentials required by your cloud service provider.
-
-*SYNOPSIS*
-
-["source","sh",subs="attributes"]
-----
-{beatname_lc} remove FUNCTION_NAME [FLAGS]
-----
-
-*`FUNCTION_NAME`*::
-Specifies the name of the function to remove.
-
-*FLAGS*
-
-*`-h, --help`*::
-Shows help for the `remove` command.
-
-{global-flags}
-
-*EXAMPLES*
-
-["source","sh",subs="attributes"]
------
-{beatname_lc} remove cloudwatch
-{beatname_lc} remove sqs
------
-endif::[]
-
-ifdef::has_modules_command[]
-[[modules-command]]
-==== `modules` command
-
-{modules-command-short-desc}. You can use this command to enable and disable
-specific module configurations defined in the `modules.d` directory. The
-changes you make with this command are persisted and used for subsequent
-runs of {beatname_uc}.
-
-To see which modules are enabled and disabled, run the `list` subcommand.
-
-*SYNOPSIS*
-
-["source","sh",subs="attributes"]
-----
-{beatname_lc} modules SUBCOMMAND [FLAGS]
-----
-
-
-*`SUBCOMMAND`*
-
-*`disable MODULE_LIST`*::
-Disables the modules specified in the space-separated list.
-
-*`enable MODULE_LIST`*::
-Enables the modules specified in the space-separated list.
-
-*`list`*::
-Lists the modules that are currently enabled and disabled.
-
-
-*FLAGS*
-
-*`-h, --help`*::
-Shows help for the `export` command.
-
-
-{global-flags}
-
-*EXAMPLES*
-
-ifeval::["{beatname_lc}"=="filebeat"]
-["source","sh",subs="attributes"]
------
-{beatname_lc} modules list
-{beatname_lc} modules enable apache2 auditd mysql
------
-endif::[]
-
-ifeval::["{beatname_lc}"=="metricbeat"]
-["source","sh",subs="attributes"]
------
-{beatname_lc} modules list
-{beatname_lc} modules enable apache nginx system
------
-endif::[]
 endif::[]
 
 ifndef::serverless[]
@@ -625,105 +358,33 @@ ifndef::serverless[]
 
 ["source","sh",subs="attributes"]
 -----
-{beatname_lc} run [FLAGS]
+apm-server run [FLAGS]
 -----
 
 Or:
 
 ["source","sh",subs="attributes"]
 -----
-{beatname_lc} [FLAGS]
+apm-server [FLAGS]
 -----
 
 *FLAGS*
 
-ifeval::["{beatname_lc}"=="packetbeat"]
-*`-I, --I FILE`*::
-Reads packet data from the specified file instead of reading packets from the
-network. This option is useful only for testing {beatname_uc}.
-+
-["source","sh",subs="attributes"]
------
-{beatname_lc} run -I ~/pcaps/network_traffic.pcap
------
-endif::[]
-
 *`-N, --N`*:: Disables publishing for testing purposes.
-
-ifeval::["{beatname_lc}"=="packetbeat"]
-*`-O, --O`*::
-Read packets one by one by pressing _Enter_ after each. This option is useful
-only for testing {beatname_uc}.
-endif::[]
 
 *`--cpuprofile FILE`*::
 Writes CPU profile data to the specified file. This option is useful for
-troubleshooting {beatname_uc}.
-
-ifeval::["{beatname_lc}"=="packetbeat"]
-*`-devices`*::
-Prints the list of devices that are available for sniffing and then exits.
-endif::[]
-
-ifeval::["{beatname_lc}"=="packetbeat"]
-*`-dump FILE`*::
-Writes all captured packets to the specified file. This option is useful for
-troubleshooting {beatname_uc}.
-endif::[]
+troubleshooting APM Server.
 
 *`-h, --help`*::
 Shows help for the `run` command.
 
 *`--httpprof [HOST]:PORT`*::
 Starts an HTTP server for profiling. This option is useful for troubleshooting
-and profiling {beatname_uc}.
-
-ifeval::["{beatname_lc}"=="packetbeat"]
-*`-l N`*::
-Reads the pcap file `N` number of times. The default is 1. Use this option in
-combination with the `-I` option. For an infinite loop, use _0_. The `-l`
-option is useful only for testing {beatname_uc}.
-endif::[]
-
-*`--memprofile FILE`*::
-Writes memory profile data to the specified output file. This option is useful
-for troubleshooting {beatname_uc}.
-
-ifeval::["{beatname_lc}"=="filebeat"]
-*`--modules MODULE_LIST`*::
-Specifies a comma-separated list of modules to run. For example:
-+
-["source","sh",subs="attributes"]
------
-{beatname_lc} run --modules nginx,mysql,system
------
-+
-Rather than specifying the list of modules every time you run {beatname_uc},
-you can use the <<modules-command,`modules`>> command to enable and disable
-specific modules. Then when you run {beatname_uc}, it will run any modules
-that are enabled.
-endif::[]
-
-ifeval::["{beatname_lc}"=="filebeat"]
-*`--once`*::
-When the `--once` flag is used, {beatname_uc} starts all configured harvesters
-and inputs, and runs each input until the harvesters are closed. If you set the
-`--once` flag, you should also set `close_eof` so the harvester is closed when
-the end of the file is reached. By default harvesters are closed after
-`close_inactive` is reached.
-endif::[]
+and profiling APM Server.
 
 *`--system.hostfs MOUNT_POINT`*::
-
 Specifies the mount point of the host's file system for use in monitoring a host.
-
-
-ifeval::["{beatname_lc}"=="packetbeat"]
-*`-t`*::
-Reads packets from the pcap file as fast as possible without sleeping. Use this
-option in combination with the `-I` option. The `-t` option is useful only for
-testing Packetbeat.
-endif::[]
 
 {global-flags}
 
@@ -731,144 +392,16 @@ endif::[]
 
 ["source","sh",subs="attributes"]
 -----
-{beatname_lc} run -e
+apm-server run -e
 -----
 
 Or:
 
 ["source","sh",subs="attributes"]
 -----
-{beatname_lc} -e
+apm-server -e
 -----
 endif::[]
-
-ifndef::apm-server[]
-[float]
-[[setup-command]]
-==== `setup` command
-
-{setup-command-short-desc}
-
-* The index template ensures that fields are mapped correctly in {es}.
-If {ilm} is enabled it also ensures that the defined {ilm-init} policy
-and write alias are connected to the indices matching the index template.
-The {ilm-init} policy takes care of the lifecycle of an index, when to do a rollover,
-when to move an index from the hot phase to the next phase, etc.
-
-ifndef::no_dashboards[]
-* The {kib} dashboards make it easier for you to visualize {beatname_uc} data
-in {kib}.
-endif::no_dashboards[]
-
-ifdef::has_ml_jobs[]
-* The {ml} jobs contain the configuration information and metadata
-necessary to analyze data for anomalies.
-endif::[]
-
-This command sets up the environment without actually running
-{beatname_uc} and ingesting data.
-
-*SYNOPSIS*
-
-// tag::setup-command-tag[]
-["source","sh",subs="attributes"]
-----
-{beatname_lc} setup [FLAGS]
-----
-
-
-*FLAGS*
-
-ifndef::no_dashboards[]
-*`--dashboards`*::
-Sets up the {kib} dashboards (when available). This option loads the dashboards
-from the {beatname_uc} package. For more options, such as loading customized
-dashboards, see {beatsdevguide}/import-dashboards.html[Importing Existing Beat
-Dashboards] in the _{beats} Developer Guide_.
-endif::no_dashboards[]
-
-*`-h, --help`*::
-Shows help for the `setup` command.
-
-ifeval::["{beatname_lc}"=="filebeat"]
-*`--modules MODULE_LIST`*::
-Specifies a comma-separated list of modules. Use this flag to avoid errors when
-there are no modules defined in the +{beatname_lc}.yml+ file.
-
-*`--pipelines`*::
-Sets up ingest pipelines for configured filesets. {beatname_uc} looks for
-enabled modules in the +{beatname_lc}.yml+ file. If you used the
-<<modules-command,`modules`>> command to enable modules in the `modules.d`
-directory, also specify the `--modules` flag.
-endif::[]
-
-*`--index-management`*::
-Sets up components related to {es} index management including
-template, {ilm-init} policy, and write alias (if supported and configured).
-
-ifdef::apm-server[]
-*`--pipelines`*::
-Registers the <<ingest-pipelines,pipeline>> definitions set in `ingest/pipeline/definition.json`.
-endif::apm-server[]
-
-*`--template`*::
-deprecated:[7.2]
-Sets up the index template only.
-It is recommended to use `--index-management` instead.
-
-*`--ilm-policy`*::
-deprecated:[7.2]
-Sets up the {ilm} policy.
-It is recommended to use `--index-management` instead.
-
-{global-flags}
-
-*EXAMPLES*
-
-ifeval::["{beatname_lc}"=="filebeat"]
-["source","sh",subs="attributes"]
------
-{beatname_lc} setup --dashboards
-{beatname_lc} setup --pipelines
-{beatname_lc} setup --pipelines --modules system,nginx,mysql <1>
-{beatname_lc} setup --index-management
------
-<1> If you used the <<modules-command,`modules`>> command to enable modules in
-the `modules.d` directory, also specify the `--modules` flag to indicate which
-modules to load pipelines for.
-endif::[]
-
-ifeval::["{beatname_lc}"!="filebeat"]
-
-ifndef::no_dashboards[]
-["source","sh",subs="attributes"]
------
-{beatname_lc} setup --dashboards
-{beatname_lc} setup --index-management
------
-endif::no_dashboards[]
-
-ifndef::apm-server[]
-ifdef::no_dashboards[]
-["source","sh",subs="attributes"]
------
-{beatname_lc} setup --index-management
------
-endif::no_dashboards[]
-endif::apm-server[]
-
-ifdef::apm-server[]
-["source","sh",subs="attributes"]
------
-{beatname_lc} setup --index-management
-{beatname_lc} setup --pipelines
------
-endif::apm-server[]
-
-endif::[]
-// end::setup-command-tag[]
-
-endif::apm-server[]
 
 [float]
 [[test-command]]
@@ -880,7 +413,7 @@ endif::apm-server[]
 
 ["source","sh",subs="attributes"]
 ----
-{beatname_lc} test SUBCOMMAND [FLAGS]
+apm-server test SUBCOMMAND [FLAGS]
 ----
 
 *`SUBCOMMAND`*
@@ -888,17 +421,8 @@ endif::apm-server[]
 *`config`*::
 Tests the configuration settings.
 
-ifeval::["{beatname_lc}"=="metricbeat"]
-*`modules [MODULE_NAME] [METRICSET_NAME]`*::
-Tests module settings for all configured modules. When you run this command,
-{beatname_uc} does a test run that applies the current settings, retrieves the
-metrics, and shows them as output. To test the settings for a specific module,
-specify `MODULE_NAME`. To test the settings for a specific metricset in the
-module, also specify `METRICSET_NAME`.
-endif::[]
-
 *`output`*::
-Tests that {beatname_uc} can connect to the output by using the
+Tests that APM Server can connect to the output by using the
 current settings.
 
 *FLAGS*
@@ -907,57 +431,12 @@ current settings.
 
 {global-flags}
 
-ifeval::["{beatname_lc}"!="metricbeat"]
 *EXAMPLE*
 
 ["source","sh",subs="attributes"]
 -----
-{beatname_lc} test config
+apm-server test config
 -----
-endif::[]
-
-ifeval::["{beatname_lc}"=="metricbeat"]
-*EXAMPLES*
-
-["source","sh",subs="attributes"]
------
-{beatname_lc} test config
-{beatname_lc} test modules system cpu
------
-endif::[]
-
-ifeval::["{beatname_lc}"=="functionbeat"]
-[[update-command]]
-==== `update` command
-
-{update-command-short-desc}. Before updating functions, make sure the user has
-the credentials required by your cloud service provider.
-
-*SYNOPSIS*
-
-["source","sh",subs="attributes"]
-----
-{beatname_lc} update FUNCTION_NAME [FLAGS]
-----
-
-*`FUNCTION_NAME`*::
-Specifies the name of the function to update.
-
-*FLAGS*
-
-*`-h, --help`*::
-Shows help for the `update` command.
-
-{global-flags}
-
-*EXAMPLES*
-
-["source","sh",subs="attributes"]
------
-{beatname_lc} update cloudwatch
-{beatname_lc} update sqs
------
-endif::[]
 
 [float]
 [[version-command]]
@@ -969,7 +448,7 @@ endif::[]
 
 ["source","sh",subs="attributes"]
 ----
-{beatname_lc} version [FLAGS]
+apm-server version [FLAGS]
 ----
 
 
@@ -983,7 +462,7 @@ endif::[]
 
 ["source","sh",subs="attributes"]
 -----
-{beatname_lc} version
+apm-server version
 -----
 
 
@@ -991,7 +470,7 @@ endif::[]
 [[global-flags]]
 === Global flags
 
-These global flags are available whenever you run {beatname_uc}.
+These global flags are available whenever you run APM Server.
 
 *`-E, --E "SETTING_NAME=VALUE"`*::
 Overrides a specific configuration setting. You can specify multiple overrides.
@@ -999,26 +478,16 @@ For example:
 +
 ["source","sh",subs="attributes"]
 ----------------------------------------------------------------------
-{beatname_lc} -E "name=mybeat" -E "output.elasticsearch.hosts=['http://myhost:9200']"
+apm-server -E "name=mybeat" -E "output.elasticsearch.hosts=['http://myhost:9200']"
 ----------------------------------------------------------------------
 +
-This setting is applied to the currently running {beatname_uc} process.
-The {beatname_uc} configuration file is not changed.
-
-ifeval::["{beatname_lc}"=="filebeat"]
-*`-M, --M "VAR_NAME=VALUE"`*:: Overrides the default configuration for a
-{beatname_uc} module. You can specify multiple variable overrides. For example:
-+
-["source","sh",subs="attributes"]
-----------------------------------------------------------------------
-{beatname_lc} -modules=nginx -M "nginx.access.var.paths=['/var/log/nginx/access.log*']" -M "nginx.access.var.pipeline=no_plugins"
-----------------------------------------------------------------------
-endif::[]
+This setting is applied to the currently running APM Server process.
+The APM Server configuration file is not changed.
 
 *`-c, --c FILE`*::
-Specifies the configuration file to use for {beatname_uc}. The file you specify
+Specifies the configuration file to use for APM Server. The file you specify
 here is relative to `path.config`. If the `-c` flag is not specified, the
-default config file, +{beatname_lc}.yml+, is used.
+default config file, +apm-server.yml+, is used.
 
 *`-d, --d SELECTORS`*::
 Enables debugging for the specified selectors. For the selectors, you can
@@ -1031,10 +500,10 @@ messages.
 Logs to stderr and disables syslog/file output.
 
 *`-environment`*::
-For logging purposes, specifies the environment that {beatname_uc} is running in.
+For logging purposes, specifies the environment that APM Server is running in.
 This setting is used to select a default log output when no log output is configured.
 Supported values are: `systemd`, `container`, `macos_service`, and `windows_service`.
-If `systemd` or `container` is specified, {beatname_uc} will log to stdout and stderr
+If `systemd` or `container` is specified, APM Server will log to stdout and stderr
 by default.
 
 *`--path.config`*::
@@ -1053,13 +522,7 @@ Sets the path for log files. See the <<directory-layout>> section for details.
 
 *`--strict.perms`*::
 Sets strict permission checking on configuration files. The default is `-strict.perms=true`.
-ifndef::apm-server[]
-See {beats-ref}/config-file-permissions.html[Config file ownership and permissions]
-for more information.
-endif::[]
-ifdef::apm-server[]
 See <<config-file-ownership>> for more information.
-endif::[]
 
 *`-v, --v`*::
 Logs INFO-level messages.
@@ -1076,9 +539,6 @@ Logs INFO-level messages.
 :!package-command-short-desc:
 :!remove-command-short-desc:
 :!run-command-short-desc:
-:!setup-command-short-desc:
-:!setup-command-short-desc:
-:!setup-command-short-desc:
 :!update-command-short-desc:
 :!test-command-short-desc:
 :!version-command-short-desc:

--- a/docs/en/observability/apm/command-reference.asciidoc
+++ b/docs/en/observability/apm/command-reference.asciidoc
@@ -383,6 +383,10 @@ Shows help for the `run` command.
 Starts an HTTP server for profiling. This option is useful for troubleshooting
 and profiling APM Server.
 
+*`--memprofile FILE`*::
+Writes memory profile data to the specified output file. This option is useful
+for troubleshooting APM Server.
+
 *`--system.hostfs MOUNT_POINT`*::
 Specifies the mount point of the host's file system for use in monitoring a host.
 

--- a/docs/en/observability/apm/command-reference.asciidoc
+++ b/docs/en/observability/apm/command-reference.asciidoc
@@ -1063,3 +1063,22 @@ endif::[]
 
 *`-v, --v`*::
 Logs INFO-level messages.
+
+:!global-flags:
+:!deploy-command-short-desc:
+:!apikey-command-short-desc:
+:!export-command-short-desc:
+:!export-command-short-desc:
+:!export-command-short-desc:
+:!help-command-short-desc:
+:!keystore-command-short-desc:
+:!modules-command-short-desc:
+:!package-command-short-desc:
+:!remove-command-short-desc:
+:!run-command-short-desc:
+:!setup-command-short-desc:
+:!setup-command-short-desc:
+:!setup-command-short-desc:
+:!update-command-short-desc:
+:!test-command-short-desc:
+:!version-command-short-desc:

--- a/docs/en/observability/apm/common-problems.asciidoc
+++ b/docs/en/observability/apm/common-problems.asciidoc
@@ -16,7 +16,7 @@ This section describes common problems you might encounter when using a Fleet-ma
 
 If no data shows up in {es}, first make sure that your APM components are properly connected.
 
-include::{apm-server-dir}/tab-widgets/no-data-indexed-widget.asciidoc[]
+include::{observability-docs-root}/docs/en/observability/apm/tab-widgets/no-data-indexed-widget.asciidoc[]
 
 [[data-indexed-no-apm]]
 [float]
@@ -57,7 +57,7 @@ If the `mapping.name.type` is `"text"`, your APM indices were not set up correct
 To fix this problem, install the APM integration by following these steps:
 
 --
-include::{apm-server-dir}/getting-started-apm-server.asciidoc[tag=install-apm-integration]
+include::{observability-docs-root}/docs/en/observability/apm/getting-started-apm-server.asciidoc[tag=install-apm-integration]
 --
 
 This will reinstall the APM index templates and trigger a data stream index rollover.

--- a/docs/en/observability/apm/config-ownership.asciidoc
+++ b/docs/en/observability/apm/config-ownership.asciidoc
@@ -3,38 +3,38 @@
 ==== Configuration file ownership
 
 On systems with POSIX file permissions,
-the {beatname_uc} configuration file is subject to ownership and file permission checks.
-These checks prevent unauthorized users from providing or modifying configurations that are run by {beatname_uc}.
+the APM Server configuration file is subject to ownership and file permission checks.
+These checks prevent unauthorized users from providing or modifying configurations that are run by APM Server.
 
 When installed via an RPM or DEB package,
-the configuration file at +/etc/{beatname_lc}/{beatname_lc}.yml+ will be owned by +{beatname_lc}+,
+the configuration file at +/etc/apm-server/apm-server.yml+ will be owned by +apm-server+,
 and have file permissions of `0600` (`-rw-------`).
 
-{beatname_uc} will only start if the configuration file is owned by the user running the process,
+APM Server will only start if the configuration file is owned by the user running the process,
 or by running as root with configuration ownership set to `root:root`
 
 You may encounter the following errors if your configuration file fails these checks:
 
 ["source", "systemd", subs="attributes"]
 -----
-Exiting: error loading config file: config file ("/etc/{beatname_lc}/{beatname_lc}.yml")
+Exiting: error loading config file: config file ("/etc/apm-server/apm-server.yml")
 must be owned by the user identifier (uid=1000) or root
 -----
 
 To correct this problem you can change the ownership of the configuration file with:
-+chown {beatname_lc}:{beatname_lc} /etc/{beatname_lc}/{beatname_lc}.yml+.
++chown apm-server:apm-server /etc/apm-server/apm-server.yml+.
 
 You can also make root the config owner, although this is not recommended:
-+sudo chown root:root /etc/{beatname_lc}/{beatname_lc}.yml+.
++sudo chown root:root /etc/apm-server/apm-server.yml+.
 
 ["source", "systemd", subs="attributes"]
 -----
-Exiting: error loading config file: config file ("/etc/{beatname_lc}/{beatname_lc}.yml")
+Exiting: error loading config file: config file ("/etc/apm-server/apm-server.yml")
 can only be writable by the owner but the permissions are "-rw-rw-r--"
-(to fix the permissions use: 'chmod go-w /etc/{beatname_lc}/{beatname_lc}.yml')
+(to fix the permissions use: 'chmod go-w /etc/apm-server/apm-server.yml')
 -----
 
-To correct this problem, use +chmod go-w /etc/{beatname_lc}/{beatname_lc}.yml+ to
+To correct this problem, use +chmod go-w /etc/apm-server/apm-server.yml+ to
 remove write privileges from anyone other than the owner.
 
 [float]

--- a/docs/en/observability/apm/configure/agent-config.asciidoc
+++ b/docs/en/observability/apm/configure/agent-config.asciidoc
@@ -29,7 +29,7 @@ apm-server.agent.config.elasticsearch.api_key: TiNAGG4BaaMdaH1tRfuU:KnR6yE41RrSo
 
 The following options are only supported for APM Server binary users.
 You can specify these options in the `apm-server.agent.config` section of the
-+{beatname_lc}.yml+ config file:
++apm-server.yml+ config file:
 
 [float]
 [[agent-config-cache]]
@@ -71,4 +71,4 @@ rejecting fetch request: no valid elasticsearch config
 This occurs because the user or API key set in either `apm-server.agent.config.elasticsearch` or `output.elasticsearch`
 (if `apm-server.agent.config.elasticsearch` is not set) does not have adequate permissions to read source maps from {es}.
 
-To fix this error, ensure that {beatname_uc} has all the required privileges. See <<privileges-agent-central-config-server>> for more details.
+To fix this error, ensure that APM Server has all the required privileges. See <<privileges-agent-central-config-server>> for more details.

--- a/docs/en/observability/apm/configure/env.asciidoc
+++ b/docs/en/observability/apm/configure/env.asciidoc
@@ -37,7 +37,7 @@ If you need to use a literal `${` in your configuration file then you can write
 `$${` to escape the expansion.
 
 After changing the value of an environment variable, you need to restart
-{beatname_uc} to pick up the new value.
+APM Server to pick up the new value.
 
 [NOTE]
 ==================================
@@ -92,7 +92,7 @@ output.elasticsearch:
   hosts: '${ES_HOSTS}'
 -------------------------------------------------------------------------------
 
-When {beatname_uc} loads the config file, it resolves the environment variable and
+When APM Server loads the config file, it resolves the environment variable and
 replaces it with the specified list before reading the `hosts` setting.
 
 NOTE: Do not use double-quotes (`"`) to wrap regular expressions, or the backslash (`\`) will be interpreted as an escape character.

--- a/docs/en/observability/apm/configure/instrumentation.asciidoc
+++ b/docs/en/observability/apm/configure/instrumentation.asciidoc
@@ -12,7 +12,7 @@ Instrumentation of APM Server is not yet supported for Fleet-managed APM.
 ****
 
 APM Server uses the Elastic APM Go Agent to instrument its publishing pipeline.
-To gain insight into the performance of {beatname_uc}, you can enable this instrumentation and send trace data to APM Server.
+To gain insight into the performance of APM Server, you can enable this instrumentation and send trace data to APM Server.
 Currently, only the {es} output is instrumented.
 
 Example configuration with instrumentation enabled:
@@ -30,18 +30,18 @@ instrumentation:
 [float]
 == Configuration options
 
-You can specify the following options in the `instrumentation` section of the +{beatname_lc}.yml+ config file:
+You can specify the following options in the `instrumentation` section of the +apm-server.yml+ config file:
 
 [float]
 === `enabled`
 
-Set to `true` to enable instrumentation of {beatname_uc}.
+Set to `true` to enable instrumentation of APM Server.
 Defaults to `false`.
 
 [float]
 === `environment`
 
-Set the environment in which {beatname_uc} is running, for example, `staging`, `production`, `dev`, etc.
+Set the environment in which APM Server is running, for example, `staging`, `production`, `dev`, etc.
 Environments can be filtered in the {kibana-ref}/xpack-apm.html[{apm-app}].
 
 [float]

--- a/docs/en/observability/apm/configure/kibana.asciidoc
+++ b/docs/en/observability/apm/configure/kibana.asciidoc
@@ -30,7 +30,7 @@ apm-server.kibana.host: "http://localhost:5601"
 == {kib} endpoint configuration options
 
 You can specify the following options in the `apm-server.kibana` section of the
-+{beatname_lc}.yml+ config file. These options are not required for a Fleet-managed APM Server.
++apm-server.yml+ config file. These options are not required for a Fleet-managed APM Server.
 
 [float]
 [[kibana-enabled]]
@@ -97,9 +97,9 @@ under a custom prefix.
 [float]
 === `apm-server.kibana.ssl.enabled`
 
-Enables {beatname_uc} to use SSL settings when connecting to {kib} via HTTPS.
-If you configure {beatname_uc} to connect over HTTPS, this setting defaults to
-`true` and {beatname_uc} uses the default SSL settings.
+Enables APM Server to use SSL settings when connecting to {kib} via HTTPS.
+If you configure APM Server to connect over HTTPS, this setting defaults to
+`true` and APM Server uses the default SSL settings.
 
 Example configuration:
 

--- a/docs/en/observability/apm/configure/logging.asciidoc
+++ b/docs/en/observability/apm/configure/logging.asciidoc
@@ -14,7 +14,7 @@ Fleet-managed users should see {fleet-guide}/monitor-elastic-agent.html[View {ag
 to learn how to view logs and change the logging level of {agent}.
 ****
 
-The `logging` section of the +{beatname_lc}.yml+ config file contains options
+The `logging` section of the +apm-server.yml+ config file contains options
 for configuring the logging output.
 
 The logging system can write logs to the syslog or rotate log files. If logging
@@ -25,8 +25,8 @@ is not explicitly configured the file output is used.
 logging.level: info
 logging.to_files: true
 logging.files:
-  path: /var/log/{beatname_lc}
-  name: {beatname_lc}
+  path: /var/log/apm-server
+  name: apm-server
   keepfiles: 7
   permissions: 0640
 ----
@@ -37,7 +37,7 @@ TIP: In addition to setting logging options in the config file, you can modify
 the logging output configuration from the command line. See
 <<command-line-options>>.
 
-WARNING: When {beatname_uc} is running on a Linux system with systemd, it uses
+WARNING: When APM Server is running on a Linux system with systemd, it uses
 by default the `-e` command line option, that makes it write all the logging output
 to stderr so it can be captured by journald. Other outputs are disabled. See
 <<running-with-systemd>> to know more and learn how to change this.
@@ -46,7 +46,7 @@ to stderr so it can be captured by journald. Other outputs are disabled. See
 == Configuration options
 
 You can specify the following options in the `logging` section of the
-+{beatname_lc}.yml+ config file:
++apm-server.yml+ config file:
 
 ifndef::serverless[]
 [float]
@@ -73,7 +73,7 @@ When true, writes all logging output to the Windows Event Log.
 When true, writes all logging output to files. The log files are automatically
 rotated when the log file size limit is reached.
 
-NOTE: {beatname_uc} only creates a log file if there is logging output. For
+NOTE: APM Server only creates a log file if there is logging output. For
 example, if you set the log <<level,`level`>> to `error` and there are no
 errors, there will be no log file in the directory specified for logs.
 endif::serverless[]
@@ -103,7 +103,7 @@ published. Also logs any warnings, errors, or critical errors.
 [[selectors]]
 === `logging.selectors`
 
-The list of debugging-only selector tags used by different {beatname_uc} components.
+The list of debugging-only selector tags used by different APM Server components.
 Use `*` to enable debug output for all components. Use `publisher` to display
 debug messages related to event publishing.
 
@@ -112,7 +112,7 @@ debug messages related to event publishing.
 The list of available selectors may change between releases, so avoid creating
 tests that depend on specific selectors.
 
-To see which selectors are available, run {beatname_uc} in debug mode
+To see which selectors are available, run APM Server in debug mode
 (set `logging.level: debug` in the configuration). The selector name appears
 after the log level and is enclosed in brackets.
 =====
@@ -131,7 +131,7 @@ endif::serverless[]
 [float]
 === `logging.metrics.enabled`
 
-By default, {beatname_uc} periodically logs its internal metrics that have
+By default, APM Server periodically logs its internal metrics that have
 changed in the last period. For each metric that changed, the delta from the
 value at the beginning of the period is logged. Also, the total values for all
 non-zero internal metrics are logged on shutdown. Set this to false to disable
@@ -162,7 +162,7 @@ the <<directory-layout>> section for details.
 [float]
 === `logging.files.name`
 
-The name of the file that logs are written to. The default is '{beatname_lc}'.
+The name of the file that logs are written to. The default is 'apm-server'.
 
 [float]
 === `logging.files.rotateeverybytes`
@@ -214,9 +214,9 @@ ifndef::serverless[]
 [float]
 === `logging.files.redirect_stderr` experimental[]
 
-When true, diagnostic messages printed to {beatname_uc}'s standard error output
+When true, diagnostic messages printed to APM Server's standard error output
 will also be logged to the log file. This can be helpful in situations were
-{beatname_uc} terminates unexpectedly because an error has been detected by
+APM Server terminates unexpectedly because an error has been detected by
 Go's runtime but diagnostic information is not present in the log file.
 This feature is only available when logging to files (`logging.to_files` is true).
 Disabled by default.

--- a/docs/en/observability/apm/configure/output.asciidoc
+++ b/docs/en/observability/apm/configure/output.asciidoc
@@ -7,12 +7,12 @@
 
 Output configuration options.
 
-// You configure {beatname_uc} to write to a specific output by setting options
-// in the Outputs section of the +{beatname_lc}.yml+ config file. Only a single
+// You configure APM Server to write to a specific output by setting options
+// in the Outputs section of the +apm-server.yml+ config file. Only a single
 // output may be defined.
 
 // The following topics describe how to configure each supported output. If you've
-// secured the {stack}, also read <<securing-{beatname_lc}>> for more about
+// secured the {stack}, also read <<securing-apm-server>> for more about
 // security-related configuration options.
 
 include::outputs/outputs-list.asciidoc[tag=outputs-list]

--- a/docs/en/observability/apm/configure/outputs/console.asciidoc
+++ b/docs/en/observability/apm/configure/outputs/console.asciidoc
@@ -15,7 +15,7 @@ The Console output writes events in JSON format to stdout.
 
 WARNING: The Console output should be used only for debugging issues as it can produce a large amount of logging data.
 
-To use this output, edit the {beatname_uc} configuration file to disable the {es}
+To use this output, edit the APM Server configuration file to disable the {es}
 output by commenting it out, and enable the console output by adding `output.console`.
 
 Example configuration:
@@ -35,7 +35,7 @@ endif::[]
 
 === Configuration options
 
-You can specify the following `output.console` options in the +{beatname_lc}.yml+ config file:
+You can specify the following `output.console` options in the +apm-server.yml+ config file:
 
 ==== `enabled`
 

--- a/docs/en/observability/apm/configure/outputs/elasticsearch.asciidoc
+++ b/docs/en/observability/apm/configure/outputs/elasticsearch.asciidoc
@@ -24,7 +24,7 @@ output.elasticsearch:
 <1> To enable SSL, add `https` to all URLs defined under __hosts__.
 
 When sending data to a secured cluster through the `elasticsearch`
-output, {beatname_uc} can use any of the following authentication methods:
+output, APM Server can use any of the following authentication methods:
 
 * Basic authentication credentials (username and password).
 * Token-based (API key) authentication.
@@ -36,7 +36,7 @@ output, {beatname_uc} can use any of the following authentication methods:
 ----
 output.elasticsearch:
   hosts: ["https://myEShost:9200"]
-  username: "{beat_default_index_prefix}_writer"
+  username: "apm_writer"
   password: "{pwd}"
 ----
 
@@ -69,7 +69,7 @@ Matrix].
 
 === Configuration options
 
-You can specify the following options in the `elasticsearch` section of the +{beatname_lc}.yml+ config file:
+You can specify the following options in the `elasticsearch` section of the +apm-server.yml+ config file:
 
 ==== `enabled`
 
@@ -177,131 +177,6 @@ then proxy environment variables are used. See the
 https://golang.org/pkg/net/http/#ProxyFromEnvironment[Go documentation]
 for more information about the environment variables.
 
-// output.elasticsearch.index has been removed from APM Server
-ifndef::apm-server[]
-
-[[index-option-es]]
-==== `index`
-
-The index name to write events to when you're using daily indices. The default is
-+"{beatname_lc}-%{[{beat_version_key}]}-%{+yyyy.MM.dd}"+, for example,
-+"{beatname_lc}-{version}-{localdate}"+. If you change this setting, you also
-need to configure the `setup.template.name` and `setup.template.pattern` options
-(see <<configuration-template>>).
-
-ifndef::no_dashboards[]
-If you are using the pre-built {kib}
-dashboards, you also need to set the `setup.dashboards.index` option (see
-<<configuration-dashboards>>).
-endif::no_dashboards[]
-
-ifndef::no_ilm[]
-When <<ilm,{ilm} ({ilm-init})>> is enabled, the default `index` is
-+"{beatname_lc}-%{[{beat_version_key}]}-%{+yyyy.MM.dd}-%{index_num}"+, for example,
-+"{beatname_lc}-{version}-{localdate}-000001"+. Custom `index` settings are ignored
-when {ilm-init} is enabled. If you’re sending events to a cluster that supports index
-lifecycle management, see <<ilm>> to learn how to change the index name.
-endif::no_ilm[]
-
-You can set the index dynamically by using a format string to access any event
-field. For example, this configuration uses a custom field, `fields.log_type`,
-to set the index:
-
-["source","yaml",subs="attributes"]
-------------------------------------------------------------------------------
-output.elasticsearch:
-  hosts: ["http://localhost:9200"]
-  index: "%{[fields.log_type]}-%{[{beat_version_key}]}-%{+yyyy.MM.dd}" <1>
-------------------------------------------------------------------------------
-
-<1> We recommend including +{beat_version_key}+ in the name to avoid mapping issues
-when you upgrade.
-
-With this configuration, all events with `log_type: normal` are sent to an
-index named +normal-{version}-{localdate}+, and all events with
-`log_type: critical` are sent to an index named
-+critical-{version}-{localdate}+.
-
-See the <<indices-option-es,`indices`>> setting for other ways to set the index
-dynamically.
-endif::apm-server[]
-
-// output.elasticsearch.indices has been removed from APM Server
-ifndef::apm-server[]
-
-[[indices-option-es]]
-==== `indices`
-
-An array of index selector rules. Each rule specifies the index to use for
-events that match the rule. During publishing, {beatname_uc} uses the first
-matching rule in the array. Rules can contain conditionals, format string-based
-fields, and name mappings. If the `indices` setting is missing or no rule
-matches, the <<index-option-es,`index`>> setting is used.
-
-ifndef::no_ilm[]
-Similar to `index`, defining custom `indices` will disable <<ilm>>.
-endif::no_ilm[]
-
-Rule settings:
-
-*`index`*:: The index format string to use. If this string contains field
-references, such as `%{[fields.name]}`, the fields must exist, or the rule fails.
-
-*`mappings`*:: A dictionary that takes the value returned by `index` and maps it
-to a new name.
-
-*`default`*:: The default string value to use if `mappings` does not find a
-match.
-
-*`when`*:: A condition that must succeed in order to execute the current rule.
-ifndef::no-processors[]
-All the <<conditions,conditions>> supported by processors are also supported
-here.
-endif::no-processors[]
-
-The following example sets the index based on whether the `message` field
-contains the specified string:
-
-["source","yaml",subs="attributes"]
-------------------------------------------------------------------------------
-output.elasticsearch:
-  hosts: ["http://localhost:9200"]
-  indices:
-    - index: "warning-%{[{beat_version_key}]}-%{+yyyy.MM.dd}"
-      when.contains:
-        message: "WARN"
-    - index: "error-%{[{beat_version_key}]}-%{+yyyy.MM.dd}"
-      when.contains:
-        message: "ERR"
-------------------------------------------------------------------------------
-
-
-This configuration results in indices named +warning-{version}-{localdate}+
-and +error-{version}-{localdate}+ (plus the default index if no matches are
-found).
-
-The following example sets the index by taking the name returned by the `index`
-format string and mapping it to a new name that's used for the index:
-
-["source","yaml"]
-------------------------------------------------------------------------------
-output.elasticsearch:
-  hosts: ["http://localhost:9200"]
-  indices:
-    - index: "%{[fields.log_type]}"
-      mappings:
-        critical: "sev1"
-        normal: "sev2"
-      default: "sev3"
-------------------------------------------------------------------------------
-
-
-This configuration results in indices named `sev1`, `sev2`, and `sev3`.
-
-The `mappings` setting simplifies the configuration, but is limited to string
-values. You cannot specify format strings within the mapping pairs.
-endif::apm-server[]
-
 ifndef::no_ilm[]
 [[ilm-es]]
 ==== `ilm`
@@ -351,7 +226,7 @@ ingest node pipeline dynamically.
 ==== `pipelines`
 
 An array of pipeline selector rules. Each rule specifies the ingest node
-pipeline to use for events that match the rule. During publishing, {beatname_uc}
+pipeline to use for events that match the rule. During publishing, APM Server
 uses the first matching rule in the array. Rules can contain conditionals,
 format string-based fields, and name mappings. If the `pipelines` setting is
 missing or no rule matches, the <<pipeline-option-es,`pipeline`>> setting is
@@ -421,7 +296,7 @@ endif::[]
 ==== `max_retries`
 
 ifdef::ignores_max_retries[]
-{beatname_uc} ignores the `max_retries` setting and retries indefinitely.
+APM Server ignores the `max_retries` setting and retries indefinitely.
 endif::[]
 
 ifndef::ignores_max_retries[]
@@ -446,7 +321,7 @@ The value must have a duration suffix, e.g. `"5s"`. The default is `1s`.
 ==== `backoff.init`
 
 The number of seconds to wait before trying to reconnect to {es} after
-a network error. After waiting `backoff.init` seconds, {beatname_uc} tries to
+a network error. After waiting `backoff.init` seconds, APM Server tries to
 reconnect. If the attempt fails, the backoff timer is increased exponentially up
 to `backoff.max`. After a successful connection, the backoff timer is reset. The
 default is `1s`.

--- a/docs/en/observability/apm/configure/outputs/kafka.asciidoc
+++ b/docs/en/observability/apm/configure/outputs/kafka.asciidoc
@@ -13,7 +13,7 @@ The Kafka output is not yet supported by {fleet}-managed APM Server.
 
 The Kafka output sends events to Apache Kafka.
 
-To use this output, edit the {beatname_uc} configuration file to disable the {es}
+To use this output, edit the APM Server configuration file to disable the {es}
 output by commenting it out, and enable the Kafka output by uncommenting the
 Kafka section.
 
@@ -35,14 +35,12 @@ output.kafka:
   max_message_bytes: 1000000
 ------------------------------------------------------------------------------
 
-NOTE: Events bigger than <<kafka-max_message_bytes,`max_message_bytes`>> will be dropped. To avoid this problem, make sure {beatname_uc} does not generate events bigger than <<kafka-max_message_bytes,`max_message_bytes`>>.
+NOTE: Events bigger than <<kafka-max_message_bytes,`max_message_bytes`>> will be dropped. To avoid this problem, make sure APM Server does not generate events bigger than <<kafka-max_message_bytes,`max_message_bytes`>>.
 
-ifdef::apm-server[]
 [float]
 === {kib} configuration
 
 include::../../shared-kibana-endpoint.asciidoc[tag=shared-kibana-config]
-endif::[]
 
 [[kafka-compatibility]]
 === Compatibility
@@ -52,19 +50,14 @@ might work as well, but are not supported.
 
 === Configuration options
 
-You can specify the following options in the `kafka` section of the +{beatname_lc}.yml+ config file:
+You can specify the following options in the `kafka` section of the +apm-server.yml+ config file:
 
 ==== `enabled`
 
 The `enabled` config is a boolean setting to enable or disable the output. If set
 to false, the output is disabled.
 
-ifndef::apm-server[]
-The default value is `true`.
-endif::[]
-ifdef::apm-server[]
 The default value is `false`.
-endif::[]
 
 ==== `hosts`
 
@@ -73,7 +66,7 @@ The cluster metadata contain the actual Kafka brokers events are published to.
 
 ==== `version`
 
-Kafka version {beatname_lc} is assumed to run against. Defaults to 1.0.0.
+Kafka version apm-server is assumed to run against. Defaults to 1.0.0.
 
 Event timestamps will be added, if version 0.10.0.0+ is enabled.
 
@@ -125,7 +118,7 @@ topic dynamically.
 ==== `topics`
 
 An array of topic selector rules. Each rule specifies the `topic` to use for
-events that match the rule. During publishing, {beatname_uc} sets the `topic`
+events that match the rule. During publishing, APM Server sets the `topic`
 for each event based on the first matching rule in the array. Rules
 can contain conditionals, format string-based fields, and name mappings. If the
 `topics` setting is missing or no rule matches, the
@@ -236,7 +229,7 @@ metadata for the configured topics. The default is false.
 ==== `max_retries`
 
 ifdef::ignores_max_retries[]
-{beatname_uc} ignores the `max_retries` setting and retries indefinitely.
+APM Server ignores the `max_retries` setting and retries indefinitely.
 endif::[]
 
 ifndef::ignores_max_retries[]
@@ -251,7 +244,7 @@ endif::[]
 ==== `backoff.init`
 
 The number of seconds to wait before trying to republish to Kafka
-after a network error. After waiting `backoff.init` seconds, {beatname_uc}
+after a network error. After waiting `backoff.init` seconds, APM Server
 tries to republish. If the attempt fails, the backoff timer is increased
 exponentially up to `backoff.max`. After a successful publish, the backoff
 timer is reset. The default is `1s`.

--- a/docs/en/observability/apm/configure/outputs/logstash.asciidoc
+++ b/docs/en/observability/apm/configure/outputs/logstash.asciidoc
@@ -274,8 +274,8 @@ that when a proxy is used the name resolution occurs on the proxy server.
 ==== `index`
 
 The index root name to write events to. The default is `apm-server`. For
-example +"{beat_default_index_prefix}"+ generates +"[{beat_default_index_prefix}-]{version}-YYYY.MM.DD"+
-indices (for example, +"{beat_default_index_prefix}-{version}-2017.04.26"+).
+example +"apm"+ generates +"[apm-]{version}-YYYY.MM.DD"+
+indices (for example, +"apm-{version}-2017.04.26"+).
 
 NOTE: This parameter's value will be assigned to the `metadata.beat` field. It
 can then be accessed in {ls}'s output section as `%{[@metadata][beat]}`.

--- a/docs/en/observability/apm/configure/outputs/logstash.asciidoc
+++ b/docs/en/observability/apm/configure/outputs/logstash.asciidoc
@@ -169,7 +169,7 @@ Matrix].
 === Configuration options
 
 You can specify the following options in the `logstash` section of the
-+{beatname_lc}.yml+ config file:
++apm-server.yml+ config file:
 
 ==== `enabled`
 
@@ -221,7 +221,7 @@ will switch to another host if the selected one becomes unresponsive. The defaul
 output.logstash:
   hosts: ["localhost:5044", "localhost:5045"]
   loadbalance: true
-  index: {beatname_lc}
+  index: apm-server
 ------------------------------------------------------------------------------
 
 ==== `ttl`
@@ -327,7 +327,7 @@ The default is `false`.
 ==== `backoff.init`
 
 The number of seconds to wait before trying to reconnect to {ls} after
-a network error. After waiting `backoff.init` seconds, {beatname_uc} tries to
+a network error. After waiting `backoff.init` seconds, APM Server tries to
 reconnect. If the attempt fails, the backoff timer is increased exponentially up
 to `backoff.max`. After a successful connection, the backoff timer is reset. The
 default is `1s`.
@@ -338,4 +338,4 @@ The maximum number of seconds to wait before attempting to connect to
 {ls} after a network error. The default is `60s`.
 
 // Logstash security
-include::{apm-server-dir}/shared-ssl-logstash-config.asciidoc[]
+include::{observability-docs-root}/docs/en/observability/apm/shared-ssl-logstash-config.asciidoc[]

--- a/docs/en/observability/apm/configure/outputs/output-cloud.asciidoc
+++ b/docs/en/observability/apm/configure/outputs/output-cloud.asciidoc
@@ -20,7 +20,7 @@ If you want to use APM on {ess}, see:
 {cloud}/ec-manage-apm-settings.html[Add APM user settings].
 endif::apm-server[]
 
-{beatname_uc} comes with two settings that simplify the output configuration
+APM Server comes with two settings that simplify the output configuration
 when used together with {ess-product}[{ess}]. When defined,
 these setting overwrite settings from other parts in the configuration.
 
@@ -37,7 +37,7 @@ These settings can be also specified at the command line, like this:
 
 ["source","sh",subs="attributes"]
 ------------------------------------------------------------------------------
-{beatname_lc} -e -E cloud.id="<cloud-id>" -E cloud.auth="<cloud.auth>"
+apm-server -e -E cloud.id="<cloud-id>" -E cloud.auth="<cloud.auth>"
 ------------------------------------------------------------------------------
 
 

--- a/docs/en/observability/apm/configure/outputs/output-cloud.asciidoc
+++ b/docs/en/observability/apm/configure/outputs/output-cloud.asciidoc
@@ -44,7 +44,7 @@ These settings can be also specified at the command line, like this:
 === `cloud.id`
 
 The Cloud ID, which can be found in the {ess} web console, is used by
-{beatname_uc} to resolve the {es} and {kib} URLs. This setting
+APM Server to resolve the {es} and {kib} URLs. This setting
 overwrites the `output.elasticsearch.hosts` and `setup.kibana.host` settings.
 
 === `cloud.auth`

--- a/docs/en/observability/apm/configure/outputs/redis.asciidoc
+++ b/docs/en/observability/apm/configure/outputs/redis.asciidoc
@@ -15,7 +15,7 @@ The Redis output inserts the events into a Redis list or a Redis channel.
 This output plugin is compatible with
 the {logstash-ref}/plugins-inputs-redis.html[Redis input plugin] for {ls}.
 
-To use this output, edit the {beatname_uc} configuration file to disable the {es}
+To use this output, edit the APM Server configuration file to disable the {es}
 output by commenting it out, and enable the Redis output by adding `output.redis`.
 
 Example configuration:
@@ -25,17 +25,15 @@ Example configuration:
 output.redis:
   hosts: ["localhost"]
   password: "my_password"
-  key: "{beatname_lc}"
+  key: "apm-server"
   db: 0
   timeout: 5
 ------------------------------------------------------------------------------
 
-ifdef::apm-server[]
 [float]
 === {kib} configuration
 
 include::../../shared-kibana-endpoint.asciidoc[tag=shared-kibana-config]
-endif::[]
 
 === Compatibility
 
@@ -44,7 +42,7 @@ but are not supported.
 
 === Configuration options
 
-You can specify the following `output.redis` options in the +{beatname_lc}.yml+ config file:
+You can specify the following `output.redis` options in the +apm-server.yml+ config file:
 
 ==== `enabled`
 
@@ -69,7 +67,7 @@ configured, the output uses the system certificate store.
 
 ==== `index`
 
-The index name added to the events metadata for use by {ls}. The default is "{beatname_lc}".
+The index name added to the events metadata for use by {ls}. The default is "apm-server".
 
 [[key-option-redis]]
 ==== `key`
@@ -95,7 +93,7 @@ dynamically.
 ==== `keys`
 
 An array of key selector rules. Each rule specifies the `key` to use for events
-that match the rule. During publishing, {beatname_uc} uses the first matching
+that match the rule. During publishing, APM Server uses the first matching
 rule in the array. Rules can contain conditionals, format string-based fields,
 and name mappings. If the `keys` setting is missing or no rule matches, the
 <<key-option-redis,`key`>> setting is used.
@@ -178,7 +176,7 @@ The Redis connection timeout in seconds. The default is 5 seconds.
 ==== `backoff.init`
 
 The number of seconds to wait before trying to reconnect to Redis after
-a network error. After waiting `backoff.init` seconds, {beatname_uc} tries to
+a network error. After waiting `backoff.init` seconds, APM Server tries to
 reconnect. If the attempt fails, the backoff timer is increased exponentially up
 to `backoff.max`. After a successful connection, the backoff timer is reset. The
 default is `1s`.
@@ -191,7 +189,7 @@ Redis after a network error. The default is `60s`.
 ==== `max_retries`
 
 ifdef::ignores_max_retries[]
-{beatname_uc} ignores the `max_retries` setting and retries indefinitely.
+APM Server ignores the `max_retries` setting and retries indefinitely.
 endif::[]
 
 ifndef::ignores_max_retries[]

--- a/docs/en/observability/apm/configure/path.asciidoc
+++ b/docs/en/observability/apm/configure/path.asciidoc
@@ -12,12 +12,12 @@ This documentation is only relevant for APM Server binary users.
 Fleet-managed paths are defined in <<directory-layout>>.
 ****
 
-The `path` section of the +{beatname_lc}.yml+ config file contains configuration
-options that define where {beatname_uc} looks for its files. For example, {beatname_uc}
+The `path` section of the +apm-server.yml+ config file contains configuration
+options that define where APM Server looks for its files. For example, APM Server
 looks for the {es} template file in the configuration path and writes
 log files in the logs path.
 ifdef::has_registry[]
-{beatname_uc} looks for its registry files in the data path.
+APM Server looks for its registry files in the data path.
 endif::[]
 
 Please see the <<directory-layout>> section for more details.
@@ -37,15 +37,15 @@ Note that it is possible to override these options by using command line flags.
 [float]
 == Configuration options
 
-You can specify the following options in the `path` section of the +{beatname_lc}.yml+ config file:
+You can specify the following options in the `path` section of the +apm-server.yml+ config file:
 
 [float]
 === `home`
 
-The home path for the {beatname_uc} installation. This is the default base path for all
+The home path for the APM Server installation. This is the default base path for all
 other path settings and for miscellaneous files that come with the distribution (for example, the
 sample dashboards). If not set by a CLI flag or in the configuration file, the default
-for the home path is the location of the {beatname_uc} binary.
+for the home path is the location of the APM Server binary.
 
 Example:
 
@@ -57,7 +57,7 @@ path.home: /usr/share/beats
 [float]
 === `config`
 
-The configuration path for the {beatname_uc} installation. This is the default base path
+The configuration path for the APM Server installation. This is the default base path
 for configuration files, including the main YAML configuration file and the
 {es} template file. If not set by a CLI flag or in the configuration file, the default for the
 configuration path is the home path.
@@ -72,8 +72,8 @@ path.config: /usr/share/beats/config
 [float]
 === `data`
 
-The data path for the {beatname_uc} installation. This is the default base path for all
-the files in which {beatname_uc} needs to store its data. If not set by a CLI
+The data path for the APM Server installation. This is the default base path for all
+the files in which APM Server needs to store its data. If not set by a CLI
 flag or in the configuration file, the default for the data path is a `data`
 subdirectory inside the home path.
 
@@ -85,13 +85,13 @@ Example:
 path.data: /var/lib/beats
 ------------------------------------------------------------------------------
 
-TIP: When running multiple {beatname_uc} instances on the same host, make sure they
+TIP: When running multiple APM Server instances on the same host, make sure they
 each have a distinct `path.data` value.
 
 [float]
 === `logs`
 
-The logs path for a {beatname_uc} installation. This is the default location for {beatname_uc}'s
+The logs path for a APM Server installation. This is the default location for APM Server's
 log files. If not set by a CLI flag or in the configuration file, the default
 for the logs path is a `logs` subdirectory inside the home path.
 
@@ -107,7 +107,7 @@ path.logs: /var/log/beats
 
 Specifies the mount point of the host's file system for use in monitoring a host.
 This can either be set in the config, or with the `--system.hostfs` CLI flag. This is used for cgroup self-monitoring.
-ifeval::["{beatname_lc}"=="metricbeat"]
+ifeval::["apm-server"=="metricbeat"]
 This is also used by the system module to read files from `/proc` and `/sys`.
 endif::[]
 

--- a/docs/en/observability/apm/configure/tls.asciidoc
+++ b/docs/en/observability/apm/configure/tls.asciidoc
@@ -9,7 +9,7 @@ SSL/TLS is available for:
 Additional information on getting started with SSL/TLS is available in <<securing-apm-server>>.
 
 // :leveloffset: +2
-include::{apm-server-dir}/shared-ssl-config.asciidoc[]
+include::{observability-docs-root}/docs/en/observability/apm/shared-ssl-config.asciidoc[]
 // :leveloffset: -2
 
-include::{apm-server-dir}/ssl-input-settings.asciidoc[leveloffset=-1]
+include::{observability-docs-root}/docs/en/observability/apm/ssl-input-settings.asciidoc[leveloffset=-1]

--- a/docs/en/observability/apm/debugging.asciidoc
+++ b/docs/en/observability/apm/debugging.asciidoc
@@ -1,14 +1,3 @@
-//////////////////////////////////////////////////////////////////////////
-//// This content is shared by all Elastic Beats. Make sure you keep the
-//// descriptions here generic enough to work for all Beats that include
-//// this file. When using cross references, make sure that the cross
-//// references resolve correctly for any files that include this one.
-//// Use the appropriate variables defined in the index.asciidoc file to
-//// resolve Beat names: beatname_uc and beatname_lc.
-//// Use the following include to pull this content into a doc file:
-//// include::../../libbeat/docs/debugging.asciidoc[]
-//////////////////////////////////////////////////////////////////////////
-
 [[enable-apm-server-debugging]]
 === Enable APM Server binary debugging
 
@@ -19,30 +8,30 @@
 NOTE: Fleet-managed users should see {fleet-guide}/monitor-elastic-agent.html[View {agent} logs]
 to learn how to view logs and change the logging level of {agent}.
 
-By default, {beatname_uc} sends all its output to syslog. When you run {beatname_uc} in
+By default, APM Server sends all its output to syslog. When you run APM Server in
 the foreground, you can use the `-e` command line flag to redirect the output to
 standard error instead. For example:
 
 ["source","sh",subs="attributes"]
 -----------------------------------------------
-{beatname_lc} -e
+apm-server -e
 -----------------------------------------------
 
-The default configuration file is {beatname_lc}.yml (the location of the file varies by
+The default configuration file is apm-server.yml (the location of the file varies by
 platform). You can use a different configuration file by specifying the `-c` flag. For example:
 
 ["source","sh",subs="attributes"]
 ------------------------------------------------------------
-{beatname_lc} -e -c my{beatname_lc}config.yml
+apm-server -e -c myapm-serverconfig.yml
 ------------------------------------------------------------
 
 You can increase the verbosity of debug messages by enabling one or more debug
-selectors. For example, to view publisher-related messages, start {beatname_uc}
+selectors. For example, to view publisher-related messages, start APM Server
 with the `publisher` selector:
 
 ["source","sh",subs="attributes"]
 ------------------------------------------------------------
-{beatname_lc} -e -d "publisher"
+apm-server -e -d "publisher"
 ------------------------------------------------------------
 
 If you want all the debugging output (fair warning, it's quite a lot), you can
@@ -50,5 +39,5 @@ use `*`, like this:
 
 ["source","sh",subs="attributes"]
 ------------------------------------------------------------
-{beatname_lc} -e -d "*"
+apm-server -e -d "*"
 ------------------------------------------------------------

--- a/docs/en/observability/apm/feature-roles.asciidoc
+++ b/docs/en/observability/apm/feature-roles.asciidoc
@@ -148,7 +148,7 @@ If you don't use the +apm_system+ user:
 
 --
 . Create a *monitoring role*, called something like
-+{beat_default_index_prefix}_monitoring_writer+, that has the following privileges:
++apm_monitoring_writer+, that has the following privileges:
 +
 [options="header"]
 |====
@@ -211,7 +211,7 @@ information. Assign the following roles to the *monitoring user*:
 To grant users the required privileges for viewing monitoring data:
 
 . Create a *monitoring role*, called something like
-+{beat_default_index_prefix}_monitoring_viewer+, that has the following privileges:
++apm_monitoring_viewer+, that has the following privileges:
 +
 [options="header"]
 |====

--- a/docs/en/observability/apm/feature-roles.asciidoc
+++ b/docs/en/observability/apm/feature-roles.asciidoc
@@ -39,7 +39,7 @@ requirements and the minimum privileges required to use specific features.
 
 Typically, you need to create the following separate roles:
 
-* <<privileges-to-publish-events,Writer role>>: To publish events collected by {beatname_uc}.
+* <<privileges-to-publish-events,Writer role>>: To publish events collected by APM Server.
 * <<privileges-to-publish-monitoring,Monitoring role>>: One for sending monitoring
 information, and another for viewing it.
 * <<privileges-api-key,API key role>>: To create and manage API keys.
@@ -133,18 +133,18 @@ Monitoring on {ecloud} is enabled by clicking the *Enable* button in the *Monito
 ===== Internal collection
 
 If you're using <<monitoring-internal-collection,internal collection>> to
-collect metrics about {beatname_uc}, {security-features} provides
-the +{beat_monitoring_user}+ {ref}/built-in-users.html[built-in user] and
-+{beat_monitoring_user}+ {ref}/built-in-roles.html[built-in role] to send
+collect metrics about APM Server, {security-features} provides
+the +apm_system+ {ref}/built-in-users.html[built-in user] and
++apm_system+ {ref}/built-in-roles.html[built-in role] to send
 monitoring information. You can use the built-in user, if it's available in your
 environment, or create a user who has the built-in role assigned,
 or create a user and manually assign the privileges needed to send monitoring
 information.
 
-If you use the built-in +{beat_monitoring_user}+ user,
+If you use the built-in +apm_system+ user,
 make sure you set the password before using it.
 
-If you don't use the +{beat_monitoring_user}+ user:
+If you don't use the +apm_system+ user:
 
 --
 . Create a *monitoring role*, called something like
@@ -176,7 +176,7 @@ See <<monitoring-metricbeat-collection>>
 for complete details on setting up {metricbeat} collection.
 
 If you're <<monitoring-metricbeat-collection,using {metricbeat}>> to collect
-metrics about {beatname_uc}, {security-features} provides the `remote_monitoring_user`
+metrics about APM Server, {security-features} provides the `remote_monitoring_user`
 {ref}/built-in-users.html[built-in user], and the `remote_monitoring_collector`
 and `remote_monitoring_agent` {ref}/built-in-roles.html[built-in roles] for
 collecting and sending monitoring information. You can use the built-in user, if
@@ -197,7 +197,7 @@ information. Assign the following roles to the *monitoring user*:
 |Role | Purpose
 
 |`remote_monitoring_collector`
-|Collect monitoring metrics from {beatname_uc}
+|Collect monitoring metrics from APM Server
 
 |`remote_monitoring_agent`
 |Send monitoring data to the monitoring cluster
@@ -227,14 +227,14 @@ To grant users the required privileges for viewing monitoring data:
 |====
 +
 . Assign the *monitoring role*, along with the following built-in roles, to users who
-need to view monitoring data for {beatname_uc}:
+need to view monitoring data for APM Server:
 +
 [options="header"]
 |====
 |Role | Purpose
 
 |`monitoring_user`
-|Grants access to monitoring indices for {beatname_uc}
+|Grants access to monitoring indices for APM Server
 |====
 
 ////
@@ -260,7 +260,7 @@ that has the following `cluster` level privileges:
 | Privilege | Purpose
 
 |`manage_own_api_key`
-|Allow {beatname_uc} to create, retrieve, and invalidate API keys
+|Allow APM Server to create, retrieve, and invalidate API keys
 |====
 
 . Depending on what the **API key role** will be used for,
@@ -333,11 +333,11 @@ assign the user the following privileges:
 
 | Index
 |`read` on `.apm-agent-configuration` index, `allow_restricted_indices: true`
-|Allow {beatname_uc} to manage central configurations in {es}
+|Allow APM Server to manage central configurations in {es}
 |====
 
 The above privileges should be sufficient for APM agent central configuration to work properly
-as long as {beatname_uc} communicates with {es} successfully.
+as long as APM Server communicates with {es} successfully.
 If it fails, it may fallback to read agent central configuration via {kib} if configured,
 which requires the following privileges:
 
@@ -346,8 +346,8 @@ which requires the following privileges:
 |Type | Privilege | Purpose
 
 | Spaces
-|`Read` on {beat_kib_app}
-|Allow {beatname_uc} to manage central configurations via the {beat_kib_app}
+|`Read` on {apm-app}
+|Allow APM Server to manage central configurations via the {apm-app}
 |====
 
 TIP: Looking for privileges and roles needed to use central configuration from the {apm-app} or {apm-app} API?
@@ -374,11 +374,11 @@ assign the user the following privileges:
 
 |Index
 |`read` on `.apm-source-map` index
-|Allow {beatname_uc} to read RUM source maps from {es}
+|Allow APM Server to read RUM source maps from {es}
 |====
 
 The above privileges should be sufficient for RUM source mapping to work properly
-as long as {beatname_uc} communicates with {es} successfully.
+as long as APM Server communicates with {es} successfully.
 If it fails, it may fallback to read source maps via {kib} if configured,
 which requires additional {kib} privileges.
 See {kibana-ref}/rum-sourcemap-api.html[RUM source map API] for more details.

--- a/docs/en/observability/apm/getting-started-apm-server.asciidoc
+++ b/docs/en/observability/apm/getting-started-apm-server.asciidoc
@@ -139,7 +139,7 @@ image::./images/fm-ov.png[APM Server fleet overview]
 Use the decision tree below to help determine which method of configuring and running the APM Server is best for your use case.
 
 [subs=attributes+]
-include::{apm-server-dir}/diagrams/apm-decision-tree.asciidoc[APM Server decision tree]
+include::{observability-docs-root}/docs/en/observability/apm/diagrams/apm-decision-tree.asciidoc[APM Server decision tree]
 
 
 === APM Server binary
@@ -189,7 +189,7 @@ endif::[]
 
 ifeval::["{release-state}"=="unreleased"]
 
-Version {version} of APM Server has not yet been released.
+Version {apm_server_version} of APM Server has not yet been released.
 
 endif::[]
 
@@ -197,8 +197,8 @@ ifeval::["{release-state}"!="unreleased"]
 
 ["source","sh",subs="attributes"]
 ----------------------------------------------------------------------
-curl -L -O {downloads}/apm-server-{version}-amd64.deb
-sudo dpkg -i apm-server-{version}-amd64.deb
+curl -L -O https://artifacts.elastic.co/downloads/apm-server/apm-server-{apm_server_version}-amd64.deb
+sudo dpkg -i apm-server-{apm_server_version}-amd64.deb
 ----------------------------------------------------------------------
 
 endif::[]
@@ -208,7 +208,7 @@ endif::[]
 
 ifeval::["{release-state}"=="unreleased"]
 
-Version {version} of APM Server has not yet been released.
+Version {apm_server_version} of APM Server has not yet been released.
 
 endif::[]
 
@@ -216,8 +216,8 @@ ifeval::["{release-state}"!="unreleased"]
 
 ["source","sh",subs="attributes"]
 ----------------------------------------------------------------------
-curl -L -O {downloads}/apm-server-{version}-x86_64.rpm
-sudo rpm -vi apm-server-{version}-x86_64.rpm
+curl -L -O https://artifacts.elastic.co/downloads/apm-server/apm-server-{apm_server_version}-x86_64.rpm
+sudo rpm -vi apm-server-{apm_server_version}-x86_64.rpm
 ----------------------------------------------------------------------
 
 endif::[]
@@ -227,7 +227,7 @@ endif::[]
 
 ifeval::["{release-state}"=="unreleased"]
 
-Version {version} of APM Server has not yet been released.
+Version {apm_server_version} of APM Server has not yet been released.
 
 endif::[]
 
@@ -235,8 +235,8 @@ ifeval::["{release-state}"!="unreleased"]
 
 ["source","sh",subs="attributes"]
 ------------------------------------------------
-curl -L -O {downloads}/apm-server-{version}-linux-x86_64.tar.gz
-tar xzvf apm-server-{version}-linux-x86_64.tar.gz
+curl -L -O https://artifacts.elastic.co/downloads/apm-server/apm-server-{apm_server_version}-linux-x86_64.tar.gz
+tar xzvf apm-server-{apm_server_version}-linux-x86_64.tar.gz
 ------------------------------------------------
 endif::[]
 
@@ -245,7 +245,7 @@ endif::[]
 
 ifeval::["{release-state}"=="unreleased"]
 
-Version {version} of APM Server has not yet been released.
+Version {apm_server_version} of APM Server has not yet been released.
 
 endif::[]
 
@@ -253,8 +253,8 @@ ifeval::["{release-state}"!="unreleased"]
 
 ["source","sh",subs="attributes"]
 ------------------------------------------------
-curl -L -O {downloads}/apm-server-{version}-darwin-x86_64.tar.gz
-tar xzvf apm-server-{version}-darwin-x86_64.tar.gz
+curl -L -O https://artifacts.elastic.co/downloads/apm-server/apm-server-{apm_server_version}-darwin-x86_64.tar.gz
+tar xzvf apm-server-{apm_server_version}-darwin-x86_64.tar.gz
 ------------------------------------------------
 
 endif::[]
@@ -264,7 +264,7 @@ endif::[]
 
 ifeval::["{release-state}"=="unreleased"]
 
-Version {version} of APM Server has not yet been released.
+Version {apm_server_version} of APM Server has not yet been released.
 
 endif::[]
 
@@ -357,7 +357,7 @@ API, not the {es} API.
 +
 ["source","yaml",subs="attributes"]
 ----
-POST kbn:/api/fleet/epm/packages/apm/{version}
+POST kbn:/api/fleet/epm/packages/apm/{apm_server_version}
 { "force": true }
 ----
 +
@@ -470,10 +470,10 @@ you can start visualizing your data in the {kibana-ref}/xpack-apm.html[{apm-app}
 If you're migrating from Jaeger, see <<jaeger-integration>>.
 
 // Shared APM & YUM
-include::{apm-server-dir}/repositories.asciidoc[]
+include::{observability-docs-root}/docs/en/observability/apm/repositories.asciidoc[]
 
 // Shared docker
-include::{apm-server-dir}/shared-docker.asciidoc[]
+include::{observability-docs-root}/docs/en/observability/apm/shared-docker.asciidoc[]
 
 
 === Fleet-managed APM Server
@@ -500,13 +500,13 @@ For more information, refer to {fleet-guide}/fleet-server.html[{fleet-server}].
 
 ==== Step 2: Add and configure the APM integration
 
-include::{obs-repo-dir}/observability/tab-widgets/add-apm-integration/content.asciidoc[tag=self-managed]
+include::{observability-docs-root}/docs/en/observability/tab-widgets/add-apm-integration/content.asciidoc[tag=self-managed]
 
 ****
 An internet connection is required to install the APM integration via the Fleet UI in Kibana.
 
 --
-include::{apm-server-dir}/getting-started-apm-server.asciidoc[tag=install-apm-integration-no-internet]
+include::{observability-docs-root}/docs/en/observability/apm/getting-started-apm-server.asciidoc[tag=install-apm-integration-no-internet]
 --
 ****
 
@@ -531,7 +531,7 @@ This should match the secret token defined when setting up the APM integration.
 TIP: You can edit your APM integration settings if you need to change the APM Server URL
 or secret token to match your APM agents.
 
-include::{apm-server-dir}/tab-widgets/install-agents-widget.asciidoc[]
+include::{observability-docs-root}/docs/en/observability/apm/tab-widgets/install-agents-widget.asciidoc[]
 
 ==== Step 4: View your data
 

--- a/docs/en/observability/apm/getting-started-apm-server.asciidoc
+++ b/docs/en/observability/apm/getting-started-apm-server.asciidoc
@@ -175,8 +175,8 @@ NOTE: *Before you begin*: If you haven't installed the {stack}, do that now.
 See {stack-ref}/installing-elastic-stack.html[Learn how to install the
 {stack} on your own hardware].
 
-To download and install {beatname_uc}, use the commands below that work with your system.
-If you use `apt` or `yum`, you can <<setup-repositories,install {beatname_uc} from our repositories>>
+To download and install APM Server, use the commands below that work with your system.
+If you use `apt` or `yum`, you can <<setup-repositories,install APM Server from our repositories>>
 to update to the newest version more easily.
 
 ifeval::["{release-state}"!="unreleased"]
@@ -430,7 +430,7 @@ You can change the defaults in `apm-server.yml` or by supplying a different addr
 
 For Debian package and RPM installations, we recommend the `apm-server` process runs as a non-root user.
 Therefore, these installation methods create an `apm-server` user which you can use to start the process.
-In addition, {beatname_uc} will only start if the configuration file is
+In addition, APM Server will only start if the configuration file is
 <<config-file-ownership,owned by the user running the process>>.
 
 To start the APM Server in this case, run:

--- a/docs/en/observability/apm/https.asciidoc
+++ b/docs/en/observability/apm/https.asciidoc
@@ -19,7 +19,7 @@ For example:
 ----------------------------------------------------------------------
 output.elasticsearch:
   hosts: ["https://myEShost:9200"]
-  username: "{beat_default_index_prefix}_writer" <1>
+  username: "apm_writer" <1>
   password: "{pwd}"
 ----------------------------------------------------------------------
 <1> This user needs the privileges required to publish events to {es}.
@@ -115,7 +115,7 @@ For example, specify a unique username and password to connect to {kib} like thi
 ----
 setup.kibana:
   host: "mykibanahost:5601"
-  username: "{beat_default_index_prefix}_kib_setup" <1>
+  username: "apm_kib_setup" <1>
   password: "{pwd}"
 ----
 <1> This user needs privileges required to set up dashboards

--- a/docs/en/observability/apm/https.asciidoc
+++ b/docs/en/observability/apm/https.asciidoc
@@ -1,27 +1,15 @@
-//////////////////////////////////////////////////////////////////////////
-//// This content is shared by all Elastic Beats. Make sure you keep the
-//// descriptions here generic enough to work for all Beats that include
-//// this file. When using cross references, make sure that the cross
-//// references resolve correctly for any files that include this one.
-//// Use the appropriate variables defined in the index.asciidoc file to
-//// resolve Beat names: beatname_uc and beatname_lc.
-//// Use the following include to pull this content into a doc file:
-//// include::../../libbeat/docs/https.asciidoc[]
-//// This content is structured to be included as a whole file.
-//////////////////////////////////////////////////////////////////////////
-
 [float]
 [[securing-communication-elasticsearch]]
 == Secure communication with {es}
 
 When sending data to a secured cluster through the `elasticsearch`
-output, {beatname_uc} can use any of the following authentication methods:
+output, APM Server can use any of the following authentication methods:
 
 * Basic authentication credentials (username and password).
 * Token-based API authentication.
 * A client certificate.
 
-Authentication is specified in the {beatname_uc} configuration file:
+Authentication is specified in the APM Server configuration file:
 
 * To use *basic authentication*, specify the `username` and `password` settings under `output.elasticsearch`.
 For example:
@@ -75,11 +63,11 @@ the `role_mapping.yml` file on each node in the {es} cluster. For more
 information, see {ref}/mapping-roles.html#mapping-roles-file[Using role
 mapping files].
 +
-By default, {beatname_uc} uses the list of trusted certificate authorities (CA) from the
-operating system where {beatname_uc} is running. If the certificate authority that signed your node certificates
+By default, APM Server uses the list of trusted certificate authorities (CA) from the
+operating system where APM Server is running. If the certificate authority that signed your node certificates
 is not in the host system's trusted certificate authorities list, you need
 to add the path to the `.pem` file that contains your CA's certificate to the
-{beatname_uc} configuration. This will configure {beatname_uc} to use a specific list of
+APM Server configuration. This will configure APM Server to use a specific list of
 CA certificates instead of the default list from the OS.
 +
 Here is an example configuration:

--- a/docs/en/observability/apm/jaeger-integration.asciidoc
+++ b/docs/en/observability/apm/jaeger-integration.asciidoc
@@ -47,7 +47,7 @@ IMPORTANT: There are <<caveats-jaeger,caveats>> to this integration.
 
 The APM integration serves Jaeger gRPC over the same host and port as the Elastic {apm-agent} protocol.
 
-include::{apm-server-dir}/tab-widgets/jaeger-widget.asciidoc[]
+include::{observability-docs-root}/docs/en/observability/apm/tab-widgets/jaeger-widget.asciidoc[]
 
 [float]
 [[configure-sampling-jaeger]]

--- a/docs/en/observability/apm/manage-storage.asciidoc
+++ b/docs/en/observability/apm/manage-storage.asciidoc
@@ -207,4 +207,4 @@ POST /.ds-*-apm*/_update_by_query?expand_wildcards=all
 
 TIP: Remember to also change the service name in the {apm-agents-ref}/index.html[{apm-agent} configuration].
 
-include::{apm-server-dir}/exploring-es-data.asciidoc[leveloffset=+2]
+include::{observability-docs-root}/docs/en/observability/apm/exploring-es-data.asciidoc[leveloffset=+2]

--- a/docs/en/observability/apm/metadata-api.asciidoc
+++ b/docs/en/observability/apm/metadata-api.asciidoc
@@ -58,7 +58,7 @@ The table below maps these environment variables to the APM metadata event field
 ==== Metadata Schema
 
 APM Server uses JSON Schema to validate requests. The specification for metadata is defined on
-{github_repo_link}/docs/spec/v2/metadata.json[GitHub] and included below:
+https://github.com/elastic/apm-server/blob/{version}/docs/spec/v2/metadata.json[GitHub] and included below:
 
 [source,json]
 ----

--- a/docs/en/observability/apm/metricset-api.asciidoc
+++ b/docs/en/observability/apm/metricset-api.asciidoc
@@ -8,7 +8,7 @@ Metrics contain application metric data captured by an {apm-agent}.
 ==== Metric Schema
 
 APM Server uses JSON Schema to validate requests. The specification for metrics is defined on
-{github_repo_link}/docs/spec/v2/metricset.json[GitHub] and included below:
+https://github.com/elastic/apm-server/blob/{version}/docs/spec/v2/metricset.json[GitHub] and included below:
 
 [source,json]
 ----

--- a/docs/en/observability/apm/metricset-api.asciidoc
+++ b/docs/en/observability/apm/metricset-api.asciidoc
@@ -8,7 +8,7 @@ Metrics contain application metric data captured by an {apm-agent}.
 ==== Metric Schema
 
 APM Server uses JSON Schema to validate requests. The specification for metrics is defined on
-https://github.com/elastic/apm-server/blob/{version}/docs/spec/v2/metricset.json[GitHub] and included below:
+https://github.com/elastic/apm-server/blob/{minor-version}/docs/spec/v2/metricset.json[GitHub] and included below:
 
 [source,json]
 ----

--- a/docs/en/observability/apm/monitor-apm-server.asciidoc
+++ b/docs/en/observability/apm/monitor-apm-server.asciidoc
@@ -28,4 +28,4 @@ all you have to do is flip a switch and watch the data pour in.
 
 include::./monitor.asciidoc[]
 
-include::{apm-server-dir}/monitoring/monitoring-beats.asciidoc[leveloffset=+2]
+include::{observability-docs-root}/docs/en/observability/apm/monitoring/monitoring-beats.asciidoc[leveloffset=+2]

--- a/docs/en/observability/apm/monitoring/monitoring-beats.asciidoc
+++ b/docs/en/observability/apm/monitoring/monitoring-beats.asciidoc
@@ -7,13 +7,13 @@
 
 There are two methods to monitor the APM Server binary.
 Make sure monitoring is enabled on your {es} cluster,
-then configure one of these methods to collect {beatname_uc} metrics:
+then configure one of these methods to collect APM Server metrics:
 
 * <<monitoring-internal-collection,Internal collection>> - Internal
 collectors send monitoring data directly to your monitoring cluster.
 ifndef::serverless[]
 * <<monitoring-metricbeat-collection, {metricbeat} collection>> -
-{metricbeat} collects monitoring data from your {beatname_uc} instance
+{metricbeat} collects monitoring data from your APM Server instance
 and sends it directly to your monitoring cluster.
 * <<monitoring-local-collection, Local collection>> - Local collection sends
 select monitoring data directly to the standard indices of your monitoring

--- a/docs/en/observability/apm/monitoring/monitoring-internal-collection.asciidoc
+++ b/docs/en/observability/apm/monitoring/monitoring-internal-collection.asciidoc
@@ -1,14 +1,3 @@
-//////////////////////////////////////////////////////////////////////////
-//// This content is shared by all Elastic Beats. Make sure you keep the
-//// descriptions here generic enough to work for all Beats that include
-//// this file. When using cross references, make sure that the cross
-//// references resolve correctly for any files that include this one.
-//// Use the appropriate variables defined in the index.asciidoc file to
-//// resolve Beat names: beatname_uc and beatname_lc.
-//// Use the following include to pull this content into a doc file:
-//// include::../../libbeat/docs/monitoring/monitoring-internal-collection.asciidoc[]
-//////////////////////////////////////////////////////////////////////////
-
 [role="xpack"]
 [[monitoring-internal-collection]]
 == Use internal collection to send monitoring data
@@ -31,13 +20,13 @@ endif::[]
 //{ref}/monitor-elasticsearch-cluster.html[Monitor a cluster].
 
 . Create an API key or user that has appropriate authority to send system-level monitoring
-data to {es}. For example, you can use the built-in +{beat_monitoring_user}+ user or
-assign the built-in +{beat_monitoring_user}+ role to another user. For more
+data to {es}. For example, you can use the built-in +apm_system+ user or
+assign the built-in +apm_system+ role to another user. For more
 information on the required privileges, see <<privileges-to-publish-monitoring>>.
 For more information on how to use API keys, see <<beats-api-keys>>.
 
-. Add the `monitoring` settings in the {beatname_uc} configuration file. If you
-configured the {es} output and want to send {beatname_uc} monitoring events to
+. Add the `monitoring` settings in the APM Server configuration file. If you
+configured the {es} output and want to send APM Server monitoring events to
 the same {es} cluster, specify the following minimal configuration:
 +
 ["source","yml",subs="attributes"]
@@ -46,7 +35,7 @@ monitoring:
   enabled: true
   elasticsearch:
     api_key:  id:api_key <1>
-    username: {beat_monitoring_user}
+    username: apm_system
     password: somepassword
 --------------------
 <1> Specify one of `api_key` or `username`/`password`.
@@ -67,7 +56,7 @@ If you
 ifndef::no-output-logstash[]
 configured a different output, such as {ls} or you
 endif::[]
-want to send {beatname_uc} monitoring events to a separate {es} cluster
+want to send APM Server monitoring events to a separate {es} cluster
 (referred to as the _monitoring cluster_), you must specify additional
 configuration options. For example:
 +
@@ -79,11 +68,11 @@ monitoring:
   elasticsearch:
     hosts: ["https://example.com:9200", "https://example2.com:9200"] <2>
     api_key:  id:api_key <3>
-    username: {beat_monitoring_user}
+    username: apm_system
     password: somepassword
 --------------------
 <1> This setting identifies the {es} cluster under which the
-monitoring data for this {beatname_uc} instance will appear in the
+monitoring data for this APM Server instance will appear in the
 {stack-monitor-app} UI. To get a cluster's `cluster_uuid`,
 call the `GET /` API against that cluster.
 <2> This setting identifies the hosts and port numbers of {es} nodes
@@ -112,11 +101,11 @@ the username from the client certificate (`CN`) is used. See
 <<configuration-ssl>> for more information about SSL settings.
 
 ifndef::serverless[]
-. Start {beatname_uc}.
+. Start APM Server.
 endif::[]
 
 ifdef::serverless[]
-. Deploy {beatname_uc}.
+. Deploy APM Server.
 endif::[]
 
 . {kibana-ref}/monitoring-data.html[View the monitoring data in {kib}].

--- a/docs/en/observability/apm/monitoring/monitoring-metricbeat.asciidoc
+++ b/docs/en/observability/apm/monitoring/monitoring-metricbeat.asciidoc
@@ -6,25 +6,10 @@
 <titleabbrev>Use {metricbeat} collection</titleabbrev>
 ++++
 
-In 7.3 and later, you can use {metricbeat} to collect data about {beatname_uc}
+In 7.3 and later, you can use {metricbeat} to collect data about APM Server
 and ship it to the monitoring cluster. The benefit of using {metricbeat} instead
 of internal collection is that the monitoring agent remains active even if the
-{beatname_uc} instance dies.
-
-ifeval::["{beatname_lc}"=="metricbeat"]
-Because you'll be using {metricbeat} to _monitor_ {beatname_uc}, you'll need to
-run two instances of {beatname_uc}: a main instance that collects metrics from
-the system and services running on the server, and a second instance that
-collects metrics from {beatname_uc} only. Using a separate instance as a
-monitoring agent allows you to send monitoring data to a dedicated monitoring
-cluster. If the main agent goes down, the monitoring agent remains active.
-
-If you're running {beatname_uc} as a service, this approach requires extra work
-because you need to run two instances of the same installed  service
-concurrently. If you don't want to run two instances concurrently, use
-<<monitoring-internal-collection,internal collection>> instead of using
-{metricbeat}.
-endif::[]
+APM Server instance dies.
 
 //Commenting out this link temporarily until the general monitoring docs can be
 //updated.
@@ -47,8 +32,8 @@ To collect and ship monitoring data:
 +
 --
 // tag::enable-http-endpoint[]
-Add the following setting in the {beatname_uc} configuration file
-(+{beatname_lc}.yml+):
+Add the following setting in the APM Server configuration file
+(+apm-server.yml+):
 
 [source,yaml]
 ----------------------------------
@@ -66,12 +51,12 @@ http.port: 5067
 // end::enable-http-endpoint[]
 --
 
-. Disable the default collection of {beatname_uc} monitoring metrics. +
+. Disable the default collection of APM Server monitoring metrics. +
 +
 --
 // tag::disable-beat-collection[]
-Add the following setting in the {beatname_uc} configuration file
-(+{beatname_lc}.yml+):
+Add the following setting in the APM Server configuration file
+(+apm-server.yml+):
 
 [source,yaml]
 ----------------------------------
@@ -87,7 +72,7 @@ For more information, see
 +
 --
 // tag::set-http-host[]
-If you intend to get metrics using {metricbeat} installed on another server, you need to bind the {beatname_uc} to host's IP:
+If you intend to get metrics using {metricbeat} installed on another server, you need to bind the APM Server to host's IP:
 
 [source,yaml]
 ----------------------------------
@@ -100,7 +85,7 @@ http.host: xxx.xxx.xxx.xxx
 +
 --
 // tag::set-cluster-uuid[]
-To see the {beats} monitoring section in {kib} if you have a cluster, you need to associate the {beatname_uc} with cluster UUID:
+To see the {beats} monitoring section in {kib} if you have a cluster, you need to associate the APM Server with cluster UUID:
 
 [source,yaml]
 ----------------------------------
@@ -110,29 +95,16 @@ monitoring.cluster_uuid: "cluster-uuid"
 --
 
 ifndef::serverless[]
-. Start {beatname_uc}.
+. Start APM Server.
 endif::[]
 
 [float]
 [[configure-metricbeat]]
 === Install and configure {metricbeat} to collect monitoring data
 
-ifeval::["{beatname_lc}"!="metricbeat"]
-. Install {metricbeat} on the same server as {beatname_uc}. To learn how, see
+. Install {metricbeat} on the same server as APM Server. To learn how, see
 {metricbeat-ref}/metricbeat-installation-configuration.html[Get started with {metricbeat}].
 If you already have {metricbeat} installed on the server, skip this step.
-endif::[]
-ifeval::["{beatname_lc}"=="metricbeat"]
-. The next step depends on how you want to run {metricbeat}:
-* If you're running as a service and want to run a separate monitoring instance,
-take the steps required for your environment to run two instances of
-{metricbeat} as a service. The steps for doing this vary by platform and are
-beyond the scope of this documentation.
-* If you're running the binary directly in the foreground and want to run a
-separate monitoring instance, install {metricbeat} to a different path. If
-necessary, set `path.config`, `path.data`, and `path.log` to point to the
-correct directories. See <<directory-layout>> for the default locations.
-endif::[]
 
 . Enable the `beat-xpack` module in {metricbeat}. +
 +
@@ -175,7 +147,7 @@ Set the `hosts`, `username`, and `password` settings as required by your
 environment. For other module settings, it's recommended that you accept the
 defaults.
 
-By default, the module collects {beatname_uc} monitoring data from
+By default, the module collects APM Server monitoring data from
 `localhost:5066`. If you exposed the metrics on a different host or port when
 you enabled the HTTP endpoint, update the `hosts` setting.
 
@@ -193,7 +165,7 @@ specify a list of hosts, for example:
 hosts: ["http://localhost:5066","http://localhost:5067","http://localhost:5068"]
 ----------------------------------
 
-If you configured {beatname_uc} to use encrypted communications, you must access
+If you configured APM Server to use encrypted communications, you must access
 it via HTTPS. For example, use a `hosts` setting like `https://localhost:5066`.
 // end::configure-beat-module[]
 

--- a/docs/en/observability/apm/monitoring/shared-monitor-config.asciidoc
+++ b/docs/en/observability/apm/monitoring/shared-monitor-config.asciidoc
@@ -1,15 +1,3 @@
-//////////////////////////////////////////////////////////////////////////
-//// This content is shared by all Elastic Beats. Make sure you keep the
-//// descriptions here generic enough to work for all Beats that include
-//// this file. When using cross references, make sure that the cross
-//// references resolve correctly for any files that include this one.
-//// Use the appropriate variables defined in the index.asciidoc file to
-//// resolve Beat names: beatname_uc and beatname_lc.
-//// Use the following include to pull this content into a doc file:
-//// include::../../libbeat/docs/monitoring/shared-monitor-config.asciidoc[]
-//// Make sure this content appears below a level 2 heading.
-//////////////////////////////////////////////////////////////////////////
-
 [float]
 [[configuration-monitor]]
 === Settings for internal collection
@@ -18,7 +6,7 @@ Use the following settings to configure internal collection when you are not
 using {metricbeat} to collect monitoring data.
 
 You specify these settings in the X-Pack monitoring section of the
-+{beatname_lc}.yml+ config file:
++apm-server.yml+ config file:
 
 [float]
 ==== `monitoring.enabled`
@@ -31,7 +19,7 @@ The default value is `false`.
 [float]
 ==== `monitoring.elasticsearch`
 
-The {es} instances that you want to ship your {beatname_uc} metrics to. This
+The {es} instances that you want to ship your APM Server metrics to. This
 configuration option contains the following fields:
 
 [float]
@@ -50,7 +38,7 @@ The default is `50`. For more information, see <<elasticsearch-output>>.
 ===== `backoff.init`
 
 The number of seconds to wait before trying to reconnect to {es} after
-a network error. After waiting `backoff.init` seconds, {beatname_uc} tries to
+a network error. After waiting `backoff.init` seconds, APM Server tries to
 reconnect. If the attempt fails, the backoff timer is increased exponentially up
 to `backoff.max`. After a successful connection, the backoff timer is reset. The
 default is `1s`.
@@ -97,21 +85,21 @@ Dictionary of HTTP parameters to pass within the URL with index operations.
 [float]
 ===== `password`
 
-The password that {beatname_uc} uses to authenticate with the {es} instances for
+The password that APM Server uses to authenticate with the {es} instances for
 shipping monitoring data.
 
 [float]
 ===== `metrics.period`
 
 The time interval (in seconds) when metrics are sent to the {es} cluster. A new
-snapshot of {beatname_uc} metrics is generated and scheduled for publishing each
+snapshot of APM Server metrics is generated and scheduled for publishing each
 period. The default value is 10 * time.Second.
 
 [float]
 ===== `state.period`
 
 The time interval (in seconds) when state information are sent to the {es} cluster. A new
-snapshot of {beatname_uc} state is generated and scheduled for publishing each
+snapshot of APM Server state is generated and scheduled for publishing each
 period. The default value is 60 * time.Second.
 
 [float]
@@ -143,5 +131,5 @@ HTTPS connections to {es}. For more information, see <<configuration-ssl>>.
 [float]
 ===== `username`
 
-The user ID that {beatname_uc} uses to authenticate with the {es} instances for
+The user ID that APM Server uses to authenticate with the {es} instances for
 shipping monitoring data.

--- a/docs/en/observability/apm/open-telemetry.asciidoc
+++ b/docs/en/observability/apm/open-telemetry.asciidoc
@@ -1,24 +1,9 @@
 [[open-telemetry]]
 == OpenTelemetry integration
 
-:ot-what:       https://opentelemetry.io/docs/concepts/what-is-opentelemetry/
-:ot-spec:       https://github.com/open-telemetry/opentelemetry-specification/blob/master/README.md
-:ot-grpc:       https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/otlp.md#otlpgrpc
-:ot-http:       https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/otlp.md#otlphttp
-:ot-contrib:    https://github.com/open-telemetry/opentelemetry-collector-contrib
-:ot-resource:   {ot-contrib}/tree/main/processor/resourceprocessor
-:ot-attr:       {ot-contrib}/blob/main/processor/attributesprocessor
-:ot-repo:       https://github.com/open-telemetry/opentelemetry-collector
-:ot-pipelines:  https://opentelemetry.io/docs/collector/configuration/#service
-:ot-extension:  {ot-repo}/blob/master/extension/README.md
-:ot-scaling:    {ot-repo}/blob/master/docs/performance.md
-
-:ot-collector:  https://opentelemetry.io/docs/collector/getting-started/
-:ot-dockerhub:  https://hub.docker.com/r/otel/opentelemetry-collector-contrib
-
-{ot-what}[OpenTelemetry] is a set of APIs, SDKs, tooling, and integrations that enable the capture and management of
+https://opentelemetry.io/docs/concepts/what-is-opentelemetry/[OpenTelemetry] is a set of APIs, SDKs, tooling, and integrations that enable the capture and management of
 telemetry data from your services and applications. For more information about the
-OpenTelemetry project, see the {ot-spec}[spec].
+OpenTelemetry project, see the https://github.com/open-telemetry/opentelemetry-specification/blob/master/README.md[spec].
 
 [float]
 == OpenTelemetry and the {stack}

--- a/docs/en/observability/apm/otel-attrs.asciidoc
+++ b/docs/en/observability/apm/otel-attrs.asciidoc
@@ -20,7 +20,7 @@ export OTEL_RESOURCE_ATTRIBUTES=deployment.environment=production
 
 **OpenTelemetry collector**
 
-Use the {ot-resource}[resource processor] to set or apply changes to resource attributes.
+Use the https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/resourceprocessor[resource processor] to set or apply changes to resource attributes.
 
 [source,yaml]
 ----
@@ -38,5 +38,5 @@ processors:
 --
 Need to add event attributes instead?
 Use attributes--not to be confused with resource attributes--to add data to span, log, or metric events.
-Attributes can be added as a part of the OpenTelemetry instrumentation process or with the {ot-attr}[attributes processor].
+Attributes can be added as a part of the OpenTelemetry instrumentation process or with the https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/attributesprocessor[attributes processor].
 --

--- a/docs/en/observability/apm/otel-direct.asciidoc
+++ b/docs/en/observability/apm/otel-direct.asciidoc
@@ -58,8 +58,8 @@ https://github.com/open-telemetry/opentelemetry-collector/tree/main/receiver/otl
 <2> We recommend using the https://github.com/open-telemetry/opentelemetry-collector/blob/main/processor/batchprocessor/README.md[Batch processor] and the https://github.com/open-telemetry/opentelemetry-collector/blob/main/processor/memorylimiterprocessor/README.md[memory limiter processor]. For more information, see https://github.com/open-telemetry/opentelemetry-collector/blob/main/processor/README.md#recommended-processors[recommended processors].
 <3> The https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter/debugexporter[debug exporter] is helpful for troubleshooting, and supports configurable verbosity levels: `basic` (default), `normal`, and `detailed`.
 <4> Elastic {observability} endpoint configuration.
-APM Server supports a ProtoBuf payload via both the OTLP protocol over gRPC transport {ot-grpc}[(OTLP/gRPC)]
-and the OTLP protocol over HTTP transport {ot-http}[(OTLP/HTTP)].
+APM Server supports a ProtoBuf payload via both the OTLP protocol over gRPC transport https://opentelemetry.io/docs/specs/otlp/#otlpgrpc[(OTLP/gRPC)]
+and the OTLP protocol over HTTP transport https://opentelemetry.io/docs/specs/otlp/#otlphttp[(OTLP/HTTP)].
 To learn more about these exporters, see the OpenTelemetry Collector documentation:
 https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter/otlphttpexporter[OTLP/HTTP Exporter] or
 https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter/otlpexporter[OTLP/gRPC exporter].
@@ -128,7 +128,7 @@ and <<open-telemetry-visualize,visualizing metrics>> in {kib}.
 [[open-telemetry-proxy-apm]]
 ==== Proxy requests to APM Server
 
-APM Server supports both the {ot-grpc}[OTLP/gRPC] and {ot-http}[OTLP/HTTP] protocol on the same port as Elastic APM agent requests. For ease of setup, we recommend using OTLP/HTTP when proxying or load balancing requests to the APM Server.
+APM Server supports both the https://opentelemetry.io/docs/specs/otlp/#otlpgrpc[OTLP/gRPC] and https://opentelemetry.io/docs/specs/otlp/#otlphttp[OTLP/HTTP] protocol on the same port as Elastic APM agent requests. For ease of setup, we recommend using OTLP/HTTP when proxying or load balancing requests to the APM Server.
 
 If you use the OTLP/gRPC protocol, requests to the APM Server must use either HTTP/2 over TLS or HTTP/2 Cleartext (H2C). No matter which protocol is used, OTLP/gRPC requests will have the header: `"Content-Type: application/grpc"`.
 

--- a/docs/en/observability/apm/otel-limitations.asciidoc
+++ b/docs/en/observability/apm/otel-limitations.asciidoc
@@ -26,7 +26,7 @@
 [[open-telemetry-otlp-limitations]]
 ==== OpenTelemetry Line Protocol (OTLP)
 
-APM Server supports both the {ot-grpc}[(OTLP/gRPC)] and {ot-http}[(OTLP/HTTP)] protocol with ProtoBuf payload.
+APM Server supports both the  https://opentelemetry.io/docs/specs/otlp/#otlpgrpc[OTLP/gRPC] and https://opentelemetry.io/docs/specs/otlp/#otlphttp[OTLP/HTTP] protocol with ProtoBuf payload.
 APM Server does not yet support JSON Encoding for OTLP/HTTP.
 
 [float]
@@ -55,4 +55,4 @@ When using OpenTelemetry with Elastic APM, there are two different implementatio
 Using the https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/tailsamplingprocessor[tailsamplingprocessor] in the OpenTelemetry Collector comes with an important limitation. Elastic's APM backend calculates span and transaction metrics based on the incoming span events.
 These metrics are accurate for 100% sampling scenarios. In scenarios with probabilistic sampling, Elastic's APM backend is being informed about the sampling rate of spans and can extrapolate throughput metrics based on the incoming, partial data. However, with tail-based sampling there's no clear probability for sampling decisions as the rules can be more complex and the OpenTelemetry Collector does not provide sampling probability information to the Elastic backend that could be used for extrapolation of data. Therefore, there's no way for Elastic APM to properly extrapolate throughput and count metrics that are derived from span events that have been tail-based sampled in the OpenTelemetry Collector. In these scenarios, derived throughput and count metrics are likely to be inaccurate.
 
-Therefore, we recommend using Elastic's native tail-based smapling when integrating with OpenTelemetry. 
+Therefore, we recommend using Elastic's native tail-based sampling when integrating with OpenTelemetry.

--- a/docs/en/observability/apm/otel-metrics.asciidoc
+++ b/docs/en/observability/apm/otel-metrics.asciidoc
@@ -33,7 +33,7 @@ Use *Discover* to validate that metrics are successfully reported to {kib}.
 . Launch {kib}:
 +
 --
-include::{apm-server-dir}/tab-widgets/open-kibana-widget.asciidoc[]
+include::{observability-docs-root}/docs/en/observability/apm/tab-widgets/open-kibana-widget.asciidoc[]
 --
 
 . Open the main menu, then click *Discover*.

--- a/docs/en/observability/apm/repositories.asciidoc
+++ b/docs/en/observability/apm/repositories.asciidoc
@@ -1,14 +1,3 @@
-//////////////////////////////////////////////////////////////////////////
-//// This content is shared by all Elastic Beats. Make sure you keep the
-//// descriptions here generic enough to work for all Beats that include
-//// this file. When using cross references, make sure that the cross
-//// references resolve correctly for any files that include this one.
-//// Use the appropriate variables defined in the index.asciidoc file to
-//// resolve Beat names: beatname_uc and beatname_lc.
-//// Use the following include to pull this content into a doc file:
-//// include::../../libbeat/docs/setup-repositories.asciidoc[]
-//////////////////////////////////////////////////////////////////////////
-
 [[setup-repositories]]
 ==== Repositories for APT and YUM
 
@@ -27,13 +16,13 @@ to sign all our packages. It is available from https://pgp.mit.edu.
 
 ifeval::["{release-state}"=="unreleased"]
 
-Version {version} of {repo} has not yet been released.
+Version {version} of apm-server has not yet been released.
 
 endif::[]
 
 ifeval::["{release-state}"!="unreleased"]
 
-To add the {repo} repository for APT:
+To add the apm-server repository for APT:
 
 . Download and install the Public Signing Key:
 +
@@ -86,18 +75,18 @@ Simply delete the `deb-src` entry from the `/etc/apt/sources.list` file, and the
 ==================================================
 
 . Run `apt-get update`, and the repository is ready for use. For example, you can
-install {beatname_uc} by running:
+install APM Server by running:
 +
 ["source","sh",subs="attributes"]
 --------------------------------------------------
-sudo apt-get update && sudo apt-get install {beatname_pkg}
+sudo apt-get update && sudo apt-get install apm-server
 --------------------------------------------------
 
-. To configure {beatname_uc} to start automatically during boot, run:
+. To configure APM Server to start automatically during boot, run:
 +
 ["source","sh",subs="attributes"]
 --------------------------------------------------
-sudo systemctl enable {beatname_pkg}
+sudo systemctl enable apm-server
 --------------------------------------------------
 
 endif::[]
@@ -107,13 +96,13 @@ endif::[]
 
 ifeval::["{release-state}"=="unreleased"]
 
-Version {version} of {repo} has not yet been released.
+Version {version} of apm-server has not yet been released.
 
 endif::[]
 
 ifeval::["{release-state}"!="unreleased"]
 
-To add the {repo} repository for YUM:
+To add the apm-server repository for YUM:
 
 . Download and install the public signing key:
 +
@@ -152,19 +141,19 @@ type=rpm-md
 --------------------------------------------------
 endif::[]
 +
-Your repository is ready to use. For example, you can install {beatname_uc} by
+Your repository is ready to use. For example, you can install APM Server by
 running:
 +
 ["source","sh",subs="attributes"]
 --------------------------------------------------
-sudo yum install {beatname_pkg}
+sudo yum install apm-server
 --------------------------------------------------
 
-. To configure {beatname_uc} to start automatically during boot, run:
+. To configure APM Server to start automatically during boot, run:
 +
 ["source","sh",subs="attributes"]
 --------------------------------------------------
-sudo systemctl enable {beatname_pkg}
+sudo systemctl enable apm-server
 --------------------------------------------------
 
 endif::[]

--- a/docs/en/observability/apm/secret-token.asciidoc
+++ b/docs/en/observability/apm/secret-token.asciidoc
@@ -24,7 +24,7 @@ as there is no way to prevent them from being publicly exposed.
 NOTE: {ess} and {ece} deployments provision a secret token when the deployment is created.
 The secret token can be found and reset in the {ecloud} console under **Deployments** -- **APM & Fleet**.
 
-include::{apm-server-dir}/tab-widgets/secret-token-widget.asciidoc[]
+include::{observability-docs-root}/docs/en/observability/apm/tab-widgets/secret-token-widget.asciidoc[]
 
 [[configure-secret-token]]
 [float]

--- a/docs/en/observability/apm/secure-comms.asciidoc
+++ b/docs/en/observability/apm/secure-comms.asciidoc
@@ -16,8 +16,8 @@ process and connecting securely to APM agents and the {stack}.
 include::secure-agent-communication.asciidoc[]
 
 // APM privileges
-include::{apm-server-dir}/feature-roles.asciidoc[]
+include::{observability-docs-root}/docs/en/observability/apm/feature-roles.asciidoc[]
 
 // APM API keys
-include::{apm-server-dir}/access-api-keys.asciidoc[]
+include::{observability-docs-root}/docs/en/observability/apm/access-api-keys.asciidoc[]
 :leveloffset: -1

--- a/docs/en/observability/apm/setting-up-and-running.asciidoc
+++ b/docs/en/observability/apm/setting-up-and-running.asciidoc
@@ -18,14 +18,14 @@ This section includes additional information on how to set up and run APM Server
 * <<high-availability>>
 * <<running-on-docker>>
 
-include::{apm-server-dir}/shared-directory-layout.asciidoc[]
+include::{observability-docs-root}/docs/en/observability/apm/shared-directory-layout.asciidoc[]
 
-include::{apm-server-dir}/keystore.asciidoc[]
+include::{observability-docs-root}/docs/en/observability/apm/keystore.asciidoc[]
 
-include::{apm-server-dir}/command-reference.asciidoc[]
+include::{observability-docs-root}/docs/en/observability/apm/command-reference.asciidoc[]
 
-include::{apm-server-dir}/data-ingestion.asciidoc[]
+include::{observability-docs-root}/docs/en/observability/apm/data-ingestion.asciidoc[]
 
-include::{apm-server-dir}/high-availability.asciidoc[]
+include::{observability-docs-root}/docs/en/observability/apm/high-availability.asciidoc[]
 
-include::{apm-server-dir}/shared-systemd.asciidoc[]
+include::{observability-docs-root}/docs/en/observability/apm/shared-systemd.asciidoc[]

--- a/docs/en/observability/apm/shared-directory-layout.asciidoc
+++ b/docs/en/observability/apm/shared-directory-layout.asciidoc
@@ -30,5 +30,5 @@ include::{ingest-docs-root}/docs/en/ingest-management/tab-widgets/install-layout
 APM Server uses the following default paths unless you explicitly change them.
 
 --
-include::{apm-server-dir}/tab-widgets/directory-layout-widget.asciidoc[]
+include::{observability-docs-root}/docs/en/observability/apm/tab-widgets/directory-layout-widget.asciidoc[]
 --

--- a/docs/en/observability/apm/shared-docker.asciidoc
+++ b/docs/en/observability/apm/shared-docker.asciidoc
@@ -33,7 +33,7 @@ ifeval::["{release-state}"!="unreleased"]
 +
 ["source", "sh", subs="attributes"]
 ------------------------------------------------
-docker pull docker.elastic.co/apm/apm_server:{version}
+docker pull docker.elastic.co/apm/apm-server:{version}
 ------------------------------------------------
 
 . Verify the Docker image:
@@ -41,14 +41,14 @@ docker pull docker.elastic.co/apm/apm_server:{version}
 ["source", "sh", subs="attributes"]
 ----
 wget https://artifacts.elastic.co/cosign.pub
-cosign verify --key cosign.pub docker.elastic.co/apm/apm_server:{version}
+cosign verify --key cosign.pub docker.elastic.co/apm/apm-server:{version}
 ----
 +
 The `cosign` command prints the check results and the signature payload in JSON format:
 +
 [source,sh,subs="attributes"]
 ----
-Verification for docker.elastic.co/apm/apm_server:{version} --
+Verification for docker.elastic.co/apm/apm-server:{version} --
 The following checks were performed on each of these signatures:
   - The cosign claims were validated
   - Existence of the claims in the transparency log was verified offline
@@ -88,7 +88,7 @@ docker run -d \
   --name=apm-server \
   --user=apm-server \
   --volume="$(pwd)/apm-server.docker.yml:/usr/share/apm-server/apm-server.yml:ro" \
-  docker.elastic.co/apm/apm_server:{version} \
+  docker.elastic.co/apm/apm-server:{version} \
   --strict.perms=false -e \
   -E output.elasticsearch.hosts=["elasticsearch:9200"] <1> <2>
 --------------------------------------------
@@ -132,6 +132,6 @@ Here is an example Dockerfile to achieve this:
 
 ["source", "dockerfile", subs="attributes"]
 --------------------------------------------
-FROM docker.elastic.co/apm/apm_server:{version}
+FROM docker.elastic.co/apm/apm-server:{version}
 COPY --chmod=0644 --chown=1000:1000 apm-server.yml /usr/share/apm-server/apm-server.yml
 --------------------------------------------

--- a/docs/en/observability/apm/shared-docker.asciidoc
+++ b/docs/en/observability/apm/shared-docker.asciidoc
@@ -1,8 +1,6 @@
 [[running-on-docker]]
 ==== Run APM Server on Docker
 
-:dockerimage: docker.elastic.co/apm/{beatname_lc}:{version}
-
 Docker images for APM Server are available from the Elastic Docker
 registry. The base image is https://hub.docker.com/_/ubuntu[ubuntu:22.04].
 
@@ -35,7 +33,7 @@ ifeval::["{release-state}"!="unreleased"]
 +
 ["source", "sh", subs="attributes"]
 ------------------------------------------------
-docker pull {dockerimage}
+docker pull docker.elastic.co/apm/apm_server:{version}
 ------------------------------------------------
 
 . Verify the Docker image:
@@ -43,14 +41,14 @@ docker pull {dockerimage}
 ["source", "sh", subs="attributes"]
 ----
 wget https://artifacts.elastic.co/cosign.pub
-cosign verify --key cosign.pub {dockerimage}
+cosign verify --key cosign.pub docker.elastic.co/apm/apm_server:{version}
 ----
 +
 The `cosign` command prints the check results and the signature payload in JSON format:
 +
 [source,sh,subs="attributes"]
 ----
-Verification for {dockerimage} --
+Verification for docker.elastic.co/apm/apm_server:{version} --
 The following checks were performed on each of these signatures:
   - The cosign claims were validated
   - Existence of the claims in the transparency log was verified offline
@@ -90,7 +88,7 @@ docker run -d \
   --name=apm-server \
   --user=apm-server \
   --volume="$(pwd)/apm-server.docker.yml:/usr/share/apm-server/apm-server.yml:ro" \
-  {dockerimage} \
+  docker.elastic.co/apm/apm_server:{version} \
   --strict.perms=false -e \
   -E output.elasticsearch.hosts=["elasticsearch:9200"] <1> <2>
 --------------------------------------------
@@ -134,8 +132,6 @@ Here is an example Dockerfile to achieve this:
 
 ["source", "dockerfile", subs="attributes"]
 --------------------------------------------
-FROM {dockerimage}
+FROM docker.elastic.co/apm/apm_server:{version}
 COPY --chmod=0644 --chown=1000:1000 apm-server.yml /usr/share/apm-server/apm-server.yml
 --------------------------------------------
-
-:!dockerimage:

--- a/docs/en/observability/apm/shared-docker.asciidoc
+++ b/docs/en/observability/apm/shared-docker.asciidoc
@@ -1,6 +1,8 @@
 [[running-on-docker]]
 ==== Run APM Server on Docker
 
+:dockerimage: docker.elastic.co/apm/{beatname_lc}:{version}
+
 Docker images for APM Server are available from the Elastic Docker
 registry. The base image is https://hub.docker.com/_/ubuntu[ubuntu:22.04].
 
@@ -135,3 +137,5 @@ Here is an example Dockerfile to achieve this:
 FROM {dockerimage}
 COPY --chmod=0644 --chown=1000:1000 apm-server.yml /usr/share/apm-server/apm-server.yml
 --------------------------------------------
+
+:!dockerimage:

--- a/docs/en/observability/apm/shared-docker.asciidoc
+++ b/docs/en/observability/apm/shared-docker.asciidoc
@@ -1,7 +1,7 @@
 [[running-on-docker]]
-==== Run {beatname_uc} on Docker
+==== Run APM Server on Docker
 
-Docker images for {beatname_uc} are available from the Elastic Docker
+Docker images for APM Server are available from the Elastic Docker
 registry. The base image is https://hub.docker.com/_/ubuntu[ubuntu:22.04].
 
 A list of all published Docker images and tags is available at
@@ -17,12 +17,12 @@ Elastic license levels.
 [float]
 ===== Pull the image
 
-Obtaining {beatname_uc} for Docker is as simple as issuing a +docker pull+ command
+Obtaining APM Server for Docker is as simple as issuing a +docker pull+ command
 against the Elastic Docker registry and then, optionally, verifying the image.
 
 ifeval::["{release-state}"=="unreleased"]
 
-However, version {version} of {beatname_uc} has not yet been
+However, version {version} of APM Server has not yet been
 released, so no Docker image is currently available for this version.
 
 endif::[]
@@ -57,98 +57,10 @@ The following checks were performed on each of these signatures:
 
 endif::[]
 
-ifndef::apm-server[]
-
 [float]
-===== Run the {beatname_uc} setup
+===== Configure APM Server on Docker
 
-Running {beatname_uc} with the setup command will create the index pattern and
-load visualizations
-ifndef::no_dashboards[]
-, dashboards,
-endif::no_dashboards[]
-and {ml} jobs.  Run this command:
-
-ifeval::["{beatname_lc}"=="filebeat"]
-["source", "sh", subs="attributes"]
---------------------------------------------
-docker run \
-{dockerimage} \
-setup -E setup.kibana.host=kibana:5601 \
--E output.elasticsearch.hosts=["elasticsearch:9200"] <1> <2>
---------------------------------------------
-endif::[]
-
-ifeval::["{beatname_lc}"=="metricbeat"]
-["source", "sh", subs="attributes"]
---------------------------------------------
-docker run \
-{dockerimage} \
-setup -E setup.kibana.host=kibana:5601 \
--E output.elasticsearch.hosts=["elasticsearch:9200"] <1> <2>
---------------------------------------------
-endif::[]
-
-ifeval::["{beatname_lc}"=="heartbeat"]
-["source", "sh", subs="attributes"]
---------------------------------------------
-docker run \
-{dockerimage} \
-setup -E setup.kibana.host=kibana:5601 \
--E output.elasticsearch.hosts=["elasticsearch:9200"] <1> <2>
---------------------------------------------
-endif::[]
-
-ifeval::["{beatname_lc}"=="journalbeat"]
-["source", "sh", subs="attributes"]
---------------------------------------------
-docker run \
-{dockerimage} \
-setup -E setup.kibana.host=kibana:5601 \
--E output.elasticsearch.hosts=["elasticsearch:9200"] <1> <2>
---------------------------------------------
-endif::[]
-
-ifeval::["{beatname_lc}"=="packetbeat"]
-["source", "sh", subs="attributes"]
---------------------------------------------
-docker run \
---cap-add=NET_ADMIN \
-{dockerimage} \
-setup -E setup.kibana.host=kibana:5601 \
--E output.elasticsearch.hosts=["elasticsearch:9200"] <1> <2>
---------------------------------------------
-endif::[]
-
-ifeval::["{beatname_lc}"=="auditbeat"]
-["source", "sh", subs="attributes"]
---------------------------------------------
-docker run \
-  --cap-add="AUDIT_CONTROL" \
-  --cap-add="AUDIT_READ" \
-  {dockerimage} \
-  setup -E setup.kibana.host=kibana:5601 \
-  -E output.elasticsearch.hosts=["elasticsearch:9200"] <1> <2>
---------------------------------------------
-endif::[]
-
-<1> Substitute your {kib} and {es} hosts and ports.
-<2> If you are using the hosted {ess} in {ecloud}, replace
-the `-E output.elasticsearch.hosts` line with the Cloud ID and elastic password
-using this syntax:
-
-[source,shell]
---------------------------------------------
--E cloud.id=<Cloud ID from Elasticsearch Service> \
--E cloud.auth=elastic:<elastic password>
---------------------------------------------
-
-endif::apm-server[]
-
-[float]
-===== Configure {beatname_uc} on Docker
-
-The Docker image provides several methods for configuring {beatname_uc}. The
+The Docker image provides several methods for configuring APM Server. The
 conventional approach is to provide a configuration file via a volume mount, but
 it's also possible to create a custom image with your
 configuration included.
@@ -160,121 +72,26 @@ Download this example configuration file as a starting point:
 
 ["source","sh",subs="attributes,callouts"]
 ------------------------------------------------
-curl -L -O {dockerconfig}
+curl -L -O https://raw.githubusercontent.com/elastic/apm-server/{branch}/apm-server.docker.yml
 ------------------------------------------------
 
 [float]
 ====== Volume-mounted configuration
 
-One way to configure {beatname_uc} on Docker is to provide +{beatname_lc}.docker.yml+ via a volume mount.
+One way to configure APM Server on Docker is to provide +apm-server.docker.yml+ via a volume mount.
 With +docker run+, the volume mount can be specified like this.
 
-ifeval::["{beatname_lc}"=="filebeat"]
-["source", "sh", subs="attributes"]
---------------------------------------------
-docker run -d \
-  --name={beatname_lc} \
-  --user=root \
-  --volume="$(pwd)/{beatname_lc}.docker.yml:/usr/share/{beatname_lc}/{beatname_lc}.yml:ro" \
-  --volume="/var/lib/docker/containers:/var/lib/docker/containers:ro" \
-  --volume="/var/run/docker.sock:/var/run/docker.sock:ro" \
-  {dockerimage} {beatname_lc} -e -strict.perms=false \
-  -E output.elasticsearch.hosts=["elasticsearch:9200"] <1> <2>
---------------------------------------------
-endif::[]
-
-ifeval::["{beatname_lc}"=="journalbeat"]
-Make sure you include the path to the host's journal. The path might be
-`/var/log/journal` or `/run/log/journal`.
-
-["source", "sh", subs="attributes"]
---------------------------------------------
-sudo docker run -d \
-  --name={beatname_lc} \
-  --user=root \
-  --volume="/var/log/journal:/var/log/journal" \
-  --volume="/etc/machine-id:/etc/machine-id" \
-  --volume="/run/systemd:/run/systemd" \
-  --volume="/etc/hostname:/etc/hostname:ro" \
-  {dockerimage} {beatname_lc} -e -strict.perms=false \
-  -E output.elasticsearch.hosts=["elasticsearch:9200"] <1> <2>
---------------------------------------------
-endif::[]
-
-ifeval::["{beatname_lc}"=="metricbeat"]
-["source", "sh", subs="attributes"]
---------------------------------------------
-docker run -d \
-  --name={beatname_lc} \
-  --user=root \
-  --volume="$(pwd)/{beatname_lc}.docker.yml:/usr/share/{beatname_lc}/{beatname_lc}.yml:ro" \
-  --volume="/var/run/docker.sock:/var/run/docker.sock:ro" \
-  --volume="/sys/fs/cgroup:/hostfs/sys/fs/cgroup:ro" \
-  --volume="/proc:/hostfs/proc:ro" \
-  --volume="/:/hostfs:ro" \
-  {dockerimage} {beatname_lc} -e \
-  -E output.elasticsearch.hosts=["elasticsearch:9200"] <1> <2>
---------------------------------------------
-endif::[]
-
-ifeval::["{beatname_lc}"=="packetbeat"]
-["source", "sh", subs="attributes"]
---------------------------------------------
-docker run -d \
-  --name={beatname_lc} \
-  --user={beatname_lc} \
-  --volume="$(pwd)/{beatname_lc}.docker.yml:/usr/share/{beatname_lc}/{beatname_lc}.yml:ro" \
-  --cap-add="NET_RAW" \
-  --cap-add="NET_ADMIN" \
-  --network=host \
-  {dockerimage} \
-  --strict.perms=false -e \
-  -E output.elasticsearch.hosts=["elasticsearch:9200"] <1> <2>
---------------------------------------------
-endif::[]
-
-ifeval::["{beatname_lc}"=="auditbeat"]
-["source", "sh", subs="attributes"]
---------------------------------------------
-docker run -d \
-  --name={beatname_lc} \
-  --user=root \
-  --volume="$(pwd)/{beatname_lc}.docker.yml:/usr/share/{beatname_lc}/{beatname_lc}.yml:ro" \
-  --cap-add="AUDIT_CONTROL" \
-  --cap-add="AUDIT_READ" \
-  --pid=host \
-  {dockerimage} -e \
-  --strict.perms=false \
-  -E output.elasticsearch.hosts=["elasticsearch:9200"] <1> <2>
---------------------------------------------
-endif::[]
-
-ifeval::["{beatname_lc}"=="heartbeat"]
-["source", "sh", subs="attributes"]
---------------------------------------------
-docker run -d \
-  --name={beatname_lc} \
-  --user={beatname_lc} \
-  --volume="$(pwd)/{beatname_lc}.docker.yml:/usr/share/{beatname_lc}/{beatname_lc}.yml:ro" \
-  {dockerimage} \
-  --strict.perms=false -e \
-  -E output.elasticsearch.hosts=["elasticsearch:9200"] <1> <2>
---------------------------------------------
-endif::[]
-
-ifeval::["{beatname_lc}"=="apm-server"]
 ["source", "sh", subs="attributes"]
 --------------------------------------------
 docker run -d \
   -p 8200:8200 \
-  --name={beatname_lc} \
-  --user={beatname_lc} \
-  --volume="$(pwd)/{beatname_lc}.docker.yml:/usr/share/{beatname_lc}/{beatname_lc}.yml:ro" \
+  --name=apm-server \
+  --user=apm-server \
+  --volume="$(pwd)/apm-server.docker.yml:/usr/share/apm-server/apm-server.yml:ro" \
   {dockerimage} \
   --strict.perms=false -e \
   -E output.elasticsearch.hosts=["elasticsearch:9200"] <1> <2>
 --------------------------------------------
-endif::[]
 
 <1> Substitute your {es} hosts and ports.
 <2> If you are using the hosted {ess} in {ecloud}, replace
@@ -285,7 +102,7 @@ using the syntax shown earlier.
 ====== Customize your configuration
 
 ifdef::has_docker_label_ex[]
-The +{beatname_lc}.docker.yml+ file you downloaded earlier is configured to deploy {beats} modules based on the Docker labels applied to your containers.  See <<configuration-autodiscover-hints>> for more details. Add labels to your application Docker containers, and they will be picked up by the {beats} autodiscover feature when they are deployed.  Here is an example command for an Apache HTTP Server container with labels to configure the {filebeat} and {metricbeat} modules for the Apache HTTP Server:
+The +apm-server.docker.yml+ file you downloaded earlier is configured to deploy {beats} modules based on the Docker labels applied to your containers.  See <<configuration-autodiscover-hints>> for more details. Add labels to your application Docker containers, and they will be picked up by the {beats} autodiscover feature when they are deployed.  Here is an example command for an Apache HTTP Server container with labels to configure the {filebeat} and {metricbeat} modules for the Apache HTTP Server:
 
 ["source", "sh", subs="attributes"]
 --------------------------------------------
@@ -304,31 +121,17 @@ docker run \
 endif::[]
 
 ifndef::has_docker_label_ex[]
-The +{beatname_lc}.docker.yml+ downloaded earlier should be customized for your environment. See <<configuring-howto-{beatname_lc}>> for more details. Edit the configuration file and customize it to match your environment then re-deploy your {beatname_uc} container.
+The +apm-server.docker.yml+ downloaded earlier should be customized for your environment. See <<configuring-howto-apm-server>> for more details. Edit the configuration file and customize it to match your environment then re-deploy your APM Server container.
 endif::[]
 
 [float]
 ====== Custom image configuration
 
-It's possible to embed your {beatname_uc} configuration in a custom image.
+It's possible to embed your APM Server configuration in a custom image.
 Here is an example Dockerfile to achieve this:
 
-ifeval::["{beatname_lc}"!="auditbeat"]
-
 ["source", "dockerfile", subs="attributes"]
 --------------------------------------------
 FROM {dockerimage}
-COPY --chmod=0644 --chown=1000:1000 {beatname_lc}.yml /usr/share/{beatname_lc}/{beatname_lc}.yml
+COPY --chmod=0644 --chown=1000:1000 apm-server.yml /usr/share/apm-server/apm-server.yml
 --------------------------------------------
-
-endif::[]
-
-ifeval::["{beatname_lc}"=="auditbeat"]
-
-["source", "dockerfile", subs="attributes"]
---------------------------------------------
-FROM {dockerimage}
-COPY {beatname_lc}.yml /usr/share/{beatname_lc}/{beatname_lc}.yml
---------------------------------------------
-
-endif::[]

--- a/docs/en/observability/apm/shared-ssl-config.asciidoc
+++ b/docs/en/observability/apm/shared-ssl-config.asciidoc
@@ -167,7 +167,7 @@ The list of root certificates for verifications is required.
 If `certificate_authorities` is self-signed, the host system
 needs to trust that CA cert as well.
 
-By default you can specify a list of files that +{beatname_lc}+ will read, but you
+By default you can specify a list of files that +apm-server+ will read, but you
 can also embed a certificate directly in the `YAML` configuration:
 
 [source,yaml]
@@ -326,7 +326,7 @@ The list of root certificates for client verifications is only required if
 `client_authentication` is configured, the system keystore is used.
 
 If `certificate_authorities` is self-signed, the host system needs to trust that CA cert as well.
-By default you can specify a list of files that +{beatname_lc}+ will read, but you can also embed a certificate
+By default you can specify a list of files that +apm-server+ will read, but you can also embed a certificate
 directly in the `YAML` configuration:
 
 [source,yaml]

--- a/docs/en/observability/apm/shared-ssl-logstash-config.asciidoc
+++ b/docs/en/observability/apm/shared-ssl-logstash-config.asciidoc
@@ -1,38 +1,27 @@
-//////////////////////////////////////////////////////////////////////////
-//// This content is shared by all Elastic Beats. Make sure you keep the
-//// descriptions here generic enough to work for all Beats that include
-//// this file. When using cross references, make sure that the cross
-//// references resolve correctly for any files that include this one.
-//// Use the appropriate variables defined in the index.asciidoc file to
-//// resolve Beat names: beatname_uc and beatname_lc.
-//// Use the following include to pull this content into a doc file:
-//// include::../../libbeat/docs/shared-ssl-logstash-config.asciidoc[]
-//////////////////////////////////////////////////////////////////////////
-
 [float]
 [[configuring-ssl-logstash]]
 == Secure communication with {ls}
 
-You can use SSL mutual authentication to secure connections between {beatname_uc} and {ls}. This ensures that
-{beatname_uc} sends encrypted data to trusted {ls} servers only, and that the {ls} server receives data from
-trusted {beatname_uc} clients only.
+You can use SSL mutual authentication to secure connections between APM Server and {ls}. This ensures that
+APM Server sends encrypted data to trusted {ls} servers only, and that the {ls} server receives data from
+trusted APM Server clients only.
 
 To use SSL mutual authentication:
 
 . Create a certificate authority (CA) and use it to sign the certificates that you plan to use for
-{beatname_uc} and {ls}. Creating a correct SSL/TLS infrastructure is outside the scope of this
+APM Server and {ls}. Creating a correct SSL/TLS infrastructure is outside the scope of this
 document. There are many online resources available that describe how to create certificates.
 +
 TIP: If you are using {security-features}, you can use the
 {ref}/certutil.html[`elasticsearch-certutil` tool] to generate certificates.
 
-. Configure {beatname_uc} to use SSL. In the +{beatname_lc}.yml+ config file, specify the following settings under
+. Configure APM Server to use SSL. In the +apm-server.yml+ config file, specify the following settings under
 `ssl`:
 +
-* `certificate_authorities`: Configures {beatname_uc} to trust any certificates signed by the specified CA. If
+* `certificate_authorities`: Configures APM Server to trust any certificates signed by the specified CA. If
 `certificate_authorities` is empty or not set, the trusted certificate authorities of the host system are used.
 
-* `certificate` and `key`: Specifies the certificate and key that {beatname_uc} uses to authenticate with
+* `certificate` and `key`: Specifies the certificate and key that APM Server uses to authenticate with
 {ls}.
 +
 For example:
@@ -55,7 +44,7 @@ For more information about these configuration options, see <<configuration-ssl>
 * `ssl_certificate` and `ssl_key`: Specify the certificate and key that {ls} uses to authenticate with the client.
 * `ssl_verify_mode`: Specifies whether the {ls} server verifies the client certificate against the CA. You
 need to specify either `peer` or `force_peer` to make the server ask for the certificate and validate it. If you
-specify `force_peer`, and {beatname_uc} doesn't provide a certificate, the {ls} connection will be closed. If you choose not to use {ref}/certutil.html[`certutil`], the certificates that you obtain must allow for both `clientAuth` and `serverAuth` if the extended key usage extension is present.
+specify `force_peer`, and APM Server doesn't provide a certificate, the {ls} connection will be closed. If you choose not to use {ref}/certutil.html[`certutil`], the certificates that you obtain must allow for both `clientAuth` and `serverAuth` if the extended key usage extension is present.
 +
 For example:
 +
@@ -80,7 +69,7 @@ For more information about these options, see the
 [[testing-ssl-logstash]]
 === Validate the {ls} server's certificate
 
-Before running {beatname_uc}, you should validate the {ls} server's certificate. You can use `curl` to validate the certificate even though the protocol used to communicate with {ls} is not based on HTTP. For example:
+Before running APM Server, you should validate the {ls} server's certificate. You can use `curl` to validate the certificate even though the protocol used to communicate with {ls} is not based on HTTP. For example:
 
 [source,shell]
 ------------------------------------------------------------------------------
@@ -130,14 +119,14 @@ curl: (51) SSL: certificate verification failed (result: 5)
 See the <<ssl-client-fails,troubleshooting docs>> for info about resolving this issue.
 
 [float]
-=== Test the {beatname_uc} to {ls} connection
+=== Test the APM Server to {ls} connection
 
-If you have {beatname_uc} running as a service, first stop the service. Then test your setup by running {beatname_uc} in
+If you have APM Server running as a service, first stop the service. Then test your setup by running APM Server in
 the foreground so you can quickly see any errors that occur:
 
 ["source","sh",subs="attributes,callouts"]
 ------------------------------------------------------------------------------
-{beatname_lc} -c {beatname_lc}.yml -e -v
+apm-server -c apm-server.yml -e -v
 ------------------------------------------------------------------------------
 
 Any errors will be printed to the console. See the <<ssl-client-fails,troubleshooting docs>> for info about

--- a/docs/en/observability/apm/shared-systemd.asciidoc
+++ b/docs/en/observability/apm/shared-systemd.asciidoc
@@ -1,65 +1,63 @@
 [[running-with-systemd]]
-=== {beatname_uc} and systemd
+=== APM Server and systemd
 
 IMPORTANT: These commands only apply to the APM Server binary installation method.
 Fleet-managed users should see {fleet-guide}/start-stop-elastic-agent.html[Start and stop {agent}s on edge hosts].
 
 The DEB and RPM packages include a service unit for Linux systems with
-systemd. On these systems, you can manage {beatname_uc} by using the usual
+systemd. On these systems, you can manage APM Server by using the usual
 systemd commands.
 
-ifdef::apm-server[]
-We recommend that the {beatname_pkg} process is run as a non-root user.
-Therefore, that is the default setup for {beatname_uc}'s DEB package and RPM installation.
-endif::apm-server[]
+We recommend that the apm-server process is run as a non-root user.
+Therefore, that is the default setup for APM Server's DEB package and RPM installation.
 
 [float]
-==== Start and stop {beatname_uc}
+==== Start and stop APM Server
 
-Use `systemctl` to start or stop {beatname_uc}:
-
-["source", "sh", subs="attributes"]
-------------------------------------------------
-sudo systemctl start {beatname_pkg}
-------------------------------------------------
+Use `systemctl` to start or stop APM Server:
 
 ["source", "sh", subs="attributes"]
 ------------------------------------------------
-sudo systemctl stop {beatname_pkg}
+sudo systemctl start apm-server
 ------------------------------------------------
 
-By default, the {beatname_uc} service starts automatically when the system
+["source", "sh", subs="attributes"]
+------------------------------------------------
+sudo systemctl stop apm-server
+------------------------------------------------
+
+By default, the APM Server service starts automatically when the system
 boots. To enable or disable auto start use:
 
 ["source", "sh", subs="attributes"]
 ------------------------------------------------
-sudo systemctl enable {beatname_pkg}
+sudo systemctl enable apm-server
 ------------------------------------------------
 
 ["source", "sh", subs="attributes"]
 ------------------------------------------------
-sudo systemctl disable {beatname_pkg}
+sudo systemctl disable apm-server
 ------------------------------------------------
 
 [float]
-==== {beatname_uc} status and logs
+==== APM Server status and logs
 
 To get the service status, use `systemctl`:
 
 ["source", "sh", subs="attributes"]
 ------------------------------------------------
-systemctl status {beatname_pkg}
+systemctl status apm-server
 ------------------------------------------------
 
 Logs are stored by default in journald. To view the Logs, use `journalctl`:
 
 ["source", "sh", subs="attributes"]
 ------------------------------------------------
-journalctl -u {beatname_pkg}.service
+journalctl -u apm-server.service
 ------------------------------------------------
 
 [float]
-=== Customize systemd unit for {beatname_uc}
+=== Customize systemd unit for APM Server
 
 The systemd service unit file includes environment variables that you can
 override to change the default options.
@@ -69,8 +67,8 @@ override to change the default options.
 |=======================================
 | Variable | Description | Default value
 | `BEAT_LOG_OPTS` | Log options |
-| `BEAT_CONFIG_OPTS` | Flags for configuration file path | +-c /etc/{beatname_lc}/{beatname_lc}.yml+
-| `BEAT_PATH_OPTS` | Other paths | +-path.home /usr/share/{beatname_lc} -path.config /etc/{beatname_lc} -path.data /var/lib/{beatname_lc} -path.logs /var/log/{beatname_lc}+
+| `BEAT_CONFIG_OPTS` | Flags for configuration file path | +-c /etc/apm-server/apm-server.yml+
+| `BEAT_PATH_OPTS` | Other paths | +-path.home /usr/share/apm-server -path.config /etc/apm-server -path.data /var/lib/apm-server -path.logs /var/log/apm-server+
 |=======================================
 
 NOTE: You can use `BEAT_LOG_OPTS` to set debug selectors for logging. However,
@@ -78,10 +76,10 @@ to configure logging behavior, set the logging options described in
 <<configuration-logging,Configure logging>>.
 
 To override these variables, create a drop-in unit file in the
-+/etc/systemd/system/{beatname_pkg}.service.d+ directory.
++/etc/systemd/system/apm-server.service.d+ directory.
 
 For example a file with the following content placed in
-+/etc/systemd/system/{beatname_pkg}.service.d/debug.conf+
++/etc/systemd/system/apm-server.service.d/debug.conf+
 would override `BEAT_LOG_OPTS` to enable debug for {es} output.
 
 ["source", "systemd", subs="attributes"]
@@ -96,13 +94,11 @@ the service:
 ["source", "sh", subs="attributes"]
 ------------------------------------------------
 systemctl daemon-reload
-systemctl restart {beatname_pkg}
+systemctl restart apm-server
 ------------------------------------------------
 
 NOTE: It is recommended that you use a configuration management tool to
 include drop-in unit files. If you need to add a drop-in manually, use
-+systemctl edit {beatname_pkg}.service+.
++systemctl edit apm-server.service+.
 
-ifdef::apm-server[]
-include::{apm-server-dir}/config-ownership.asciidoc[]
-endif::apm-server[]
+include::{observability-docs-root}/docs/en/observability/apm/config-ownership.asciidoc[]

--- a/docs/en/observability/apm/ssl-input-settings.asciidoc
+++ b/docs/en/observability/apm/ssl-input-settings.asciidoc
@@ -10,7 +10,7 @@ Most options on this page are supported by all APM Server deployment methods.
 These settings apply to SSL/TLS communication between the APM Server and APM Agents.
 See <<agent-tls>> to learn more.
 
-include::{apm-server-dir}/tab-widgets/tls-widget.asciidoc[]
+include::{observability-docs-root}/docs/en/observability/apm/tab-widgets/tls-widget.asciidoc[]
 
 [float]
 ==== Enable TLS
@@ -79,7 +79,7 @@ individually configurable in Go, so they are not included in this list.
 | Fleet-managed     | `Cipher suites for TLS connections`
 |====
 
-include::{apm-server-dir}/shared-ssl-config.asciidoc[tag=cipher_suites]
+include::{observability-docs-root}/docs/en/observability/apm/shared-ssl-config.asciidoc[tag=cipher_suites]
 
 [float]
 ==== Curve types for ECDHE based cipher suites

--- a/docs/en/observability/apm/tab-widgets/api-key.asciidoc
+++ b/docs/en/observability/apm/tab-widgets/api-key.asciidoc
@@ -6,7 +6,7 @@ this value should be the number of unique API keys configured in your monitored 
 
 // tag::binary[]
 API keys are disabled by default. Enable and configure this feature in the `apm-server.auth.api_key`
-section of the +{beatname_lc}.yml+ configuration file.
+section of the +apm-server.yml+ configuration file.
 
 At a minimum, you must enable API keys,
 and should set a limit on the number of unique API keys that APM Server allows per minute.

--- a/docs/en/observability/apm/tab-widgets/directory-layout.asciidoc
+++ b/docs/en/observability/apm/tab-widgets/directory-layout.asciidoc
@@ -3,23 +3,23 @@
 [cols="<h,<,<m",options="header",]
 |=======================================================================
 | Type   | Description | Location
-| home   | Home of the {beatname_uc} installation. | {extract.path}
+| home   | Home of the APM Server installation. | {extract.path}
 | bin    | The location for the binary files. | {extract.path}
 | config | The location for configuration files. | {extract.path}
 | data   | The location for persistent data files. | {extract.path}/data
-| logs   | The location for the logs created by {beatname_uc}. | {extract.path}/logs
+| logs   | The location for the logs created by APM Server. | {extract.path}/logs
 ifdef::serverless[]
 | pkg    | The location for the binary uploaded to your serverless provider. | {extract.path}/pkg
 endif::serverless[]
 |=======================================================================
 
 For the ZIP, tar.gz, or TGZ distributions, these paths are based on the location
-of the extracted binary file. This means that if you start {beatname_uc} with
+of the extracted binary file. This means that if you start APM Server with
 the following simple command, all paths are set correctly:
 
 ["source","sh",subs="attributes"]
 ----------------------------------------------------------------------
-./{beatname_lc}
+./apm-server
 ----------------------------------------------------------------------
 
 // end::zip[]
@@ -29,11 +29,11 @@ the following simple command, all paths are set correctly:
 [cols="<h,<,<m",options="header",]
 |=======================================================================
 | Type   | Description | Location
-| home   | Home of the {beatname_uc} installation. | /usr/share/{beatname_lc}
-| bin    | The location for the binary files. | /usr/share/{beatname_lc}
-| config | The location for configuration files. | /usr/share/{beatname_lc}
-| data   | The location for persistent data files. | /usr/share/{beatname_lc}/data
-| logs   | The location for the logs created by {beatname_uc}. | /usr/share/{beatname_lc}/logs
+| home   | Home of the APM Server installation. | /usr/share/apm-server
+| bin    | The location for the binary files. | /usr/share/apm-server
+| config | The location for configuration files. | /usr/share/apm-server
+| data   | The location for persistent data files. | /usr/share/apm-server/data
+| logs   | The location for the logs created by APM Server. | /usr/share/apm-server/logs
 |=======================================================================
 
 // end::docker[]
@@ -43,15 +43,15 @@ the following simple command, all paths are set correctly:
 [cols="<h,<,<m",options="header",]
 |=======================================================================
 | Type   | Description | Location
-| home   | Home of the {beatname_uc} installation. | /usr/share/{beatname_lc}
-| bin    | The location for the binary files. | /usr/share/{beatname_lc}/bin
-| config | The location for configuration files. | /etc/{beatname_lc}
-| data   | The location for persistent data files. | /var/lib/{beatname_lc}
-| logs   | The location for the logs created by {beatname_uc}. | /var/log/{beatname_lc}
+| home   | Home of the APM Server installation. | /usr/share/apm-server
+| bin    | The location for the binary files. | /usr/share/apm-server/bin
+| config | The location for configuration files. | /etc/apm-server
+| data   | The location for persistent data files. | /var/lib/apm-server
+| logs   | The location for the logs created by APM Server. | /var/log/apm-server
 |=======================================================================
 
 For the deb and rpm distributions, these paths are set in the init script or in
-the systemd unit file.  Make sure that you start the {beatname_uc} service by using
+the systemd unit file.  Make sure that you start the APM Server service by using
 the preferred operating system method (init scripts or `systemctl`).
 Otherwise the paths might be set incorrectly.
 

--- a/docs/en/observability/apm/tls-comms.asciidoc
+++ b/docs/en/observability/apm/tls-comms.asciidoc
@@ -32,7 +32,7 @@ location of the output zip archive containing the certificate and the private ke
 
 Enable TLS and configure the APM Server to point to the extracted certificate and key:
 
-include::{apm-server-dir}/tab-widgets/tls-widget.asciidoc[]
+include::{observability-docs-root}/docs/en/observability/apm/tab-widgets/tls-widget.asciidoc[]
 
 [float]
 [[agent-self-sign-3]]

--- a/docs/en/observability/apm/troubleshoot-apm.asciidoc
+++ b/docs/en/observability/apm/troubleshoot-apm.asciidoc
@@ -54,4 +54,4 @@ include::apm-response-codes.asciidoc[]
 
 include::processing-performance.asciidoc[]
 
-include::{apm-server-dir}/debugging.asciidoc[]
+include::{observability-docs-root}/docs/en/observability/apm/debugging.asciidoc[]

--- a/docs/en/observability/apm/upgrading-to-8.x.asciidoc
+++ b/docs/en/observability/apm/upgrading-to-8.x.asciidoc
@@ -81,10 +81,10 @@ See the {stack-ref}/upgrading-elastic-stack.html[{stack} Installation and Upgrad
 
 . **Install the APM integration via the {fleet} UI**
 +
-include::{apm-server-dir}/getting-started-apm-server.asciidoc[tag=why-apm-integration]
+include::{observability-docs-root}/docs/en/observability/apm/getting-started-apm-server.asciidoc[tag=why-apm-integration]
 +
 --
-include::{apm-server-dir}/getting-started-apm-server.asciidoc[tag=install-apm-integration]
+include::{observability-docs-root}/docs/en/observability/apm/getting-started-apm-server.asciidoc[tag=install-apm-integration]
 --
 
 . **Install the {version} APM Server release**

--- a/docs/en/observability/gcp-topic.asciidoc
+++ b/docs/en/observability/gcp-topic.asciidoc
@@ -1,7 +1,7 @@
 There are three available filesets:
 `audit`, `vpcflow`, `firewall`. This tutorial covers the `audit` fileset.
 
-. Go to the *Logs Router* page to configure {gcp} to export logs to a Pub/Sub
+. Go to the *Logs Router* page to configure GCP to export logs to a Pub/Sub
 topic. Use the search bar to find the page:
 +
 image::monitor-gcp-navigate-logs-router.png[Navigate to Logs Router page]

--- a/docs/en/observability/grant-cases-access.asciidoc
+++ b/docs/en/observability/grant-cases-access.asciidoc
@@ -1,11 +1,6 @@
 [[grant-cases-access]]
 = Configure access to cases
 
-:frontmatter-description: Learn about the {kib} feature privileges required to access {observability} cases. 
-:frontmatter-tags-products: [observability]
-:frontmatter-tags-content-type: [how-to] 
-:frontmatter-tags-user-goals: [configure]
-
 // lint ignore observability
 To access and send cases to external systems, you need the {subscriptions}[appropriate license],
 and your role must have the *Cases* {kib} privilege as a user for the *{observability}* feature.
@@ -14,7 +9,7 @@ Here are the minimum required privileges:
 
 // lint disable observability
 [options="header"]
-|=== 
+|===
 
 | Action | {kib} Privileges
 | Give full access to manage cases and settings
@@ -47,12 +42,12 @@ a|
 
 | Revoke all access to cases | `None` for the *Cases* feature under *{observability}*.
 
-|=== 
+|===
 // lint enable observability
 
 NOTE: If you are using an on-premises {kib} deployment and want your email
 notifications and external incident management systems to contain links back
-to {kib}, configure the 
+to {kib}, configure the
 {kibana-ref}/settings.html#server-publicBaseUrl[server.publicBaseUrl] setting.
 
 For more details, refer to {kibana-ref}/xpack-spaces.html#spaces-control-user-access[feature access based on user privileges].

--- a/docs/en/observability/index.asciidoc
+++ b/docs/en/observability/index.asciidoc
@@ -83,9 +83,6 @@ include::cloud-monitoring/aws/monitor-amazon-intro.asciidoc[leveloffset=+1]
 // Synthetics
 include::synthetics-intro.asciidoc[leveloffset=+1]
 
-:playwright-url:      https://playwright.dev/
-:playwright-api-docs: https://playwright.dev/docs/api/class-playwright
-
 include::synthetics-get-started.asciidoc[leveloffset=+2]
 include::synthetics-get-started-project.asciidoc[leveloffset=+3]
 include::synthetics-get-started-ui.asciidoc[leveloffset=+3]

--- a/docs/en/observability/monitor-aws-agent.asciidoc
+++ b/docs/en/observability/monitor-aws-agent.asciidoc
@@ -1,7 +1,5 @@
-:aws: AWS
-
 [[monitor-aws-elastic-agent]]
-== Monitor Amazon Web Services ({aws}) with {agent}
+== Monitor Amazon Web Services (AWS) with {agent}
 
 ****
 **New to Elastic?** Follow the steps in our {estc-welcome}/getting-started-observability.html[getting started guide] instead
@@ -10,7 +8,7 @@ basics.
 ****
 
 
-In this tutorial, you’ll learn how to deploy {agent} and monitor your {aws}
+In this tutorial, you’ll learn how to deploy {agent} and monitor your AWS
 infrastructure with Elastic {observability}.
 
 [discrete]
@@ -118,7 +116,7 @@ queue.
 }
 ----
 <1> Replace `<sqs-arn>` with the ARN of the SQS queue.
-<2> Replace `<source-account>` with your AWS account number. 
+<2> Replace `<source-account>` with your AWS account number.
 <3> Replace `<s3-bucket-arn>` with the ARN of the S3 bucket containing your VPC
 flow logs.
 +
@@ -154,7 +152,7 @@ contains inputs for collecting a variety of logs and metrics from AWS. You'll
 start out by configuring the integration to collect VPC flow logs.
 After you get that working, you'll learn how to add S3 access logs.
 
-To add the integration: 
+To add the integration:
 
 . Go to the {kib} home page and click **Add integrations**.
 +
@@ -175,7 +173,7 @@ this tutorial when you're ready to configure the integration.
 . Specify the AWS credentials required to connect to AWS and read log files.
 Here we show how to use an AWS access key ID and secret, but there are a few
 other ways to provide AWS credentials. To learn more, refer to the
-{integrations-docs}/aws[{aws} integration] documentation.
+{integrations-docs}/aws[AWS integration] documentation.
 +
 [role="screenshot"]
 image::images/agent-tut-aws-credentials.png[Screenshot of the VPC flow configuration with credentials specified]
@@ -205,7 +203,7 @@ The account you specify must have at least the following privileges:
 **Collect VPC flow logs from S3**.
 
 . Change defaults and in the **Queue URL** field, specify
-the URL of the SQS queue you created earlier. 
+the URL of the SQS queue you created earlier.
 +
 [role="screenshot"]
 image::images/agent-tut-config-vpc-logs.png[Screenshot of the VPC flow configuration with the Queue URL specified]
@@ -289,7 +287,7 @@ image::agent-tut-two-buckets-archi.png[Diagram of the logging architecture with 
 
 To create the new bucket and queue for S3 access logs:
 
-. In the https://s3.console.aws.amazon.com/s3[{aws} S3 console], click
+. In the https://s3.console.aws.amazon.com/s3[AWS S3 console], click
 **Create bucket**. Give the bucket a **name** and specify the **region** where
 you want it deployed.
 +
@@ -328,7 +326,7 @@ Now you need to edit the agent policy and configure the integration to collect
 S3 access logs.
 
 . From the main menu in {kib}, go to **{fleet} -> Agents** and click the policy
-your agent is using. 
+your agent is using.
 
 . Edit the AWS integration policy and turn on the
 **Collect S3 access logs from S3** selector.
@@ -368,17 +366,17 @@ image::images/agent-tut-s3accesslog-dashboard.png[Screenshot of the S3 Server Ac
 
 [discrete]
 [[aws-elastic-agent-collect-metrics]]
-=== Step 6: Collect {aws} metrics
+=== Step 6: Collect AWS metrics
 
 In this step, you configure the AWS integration to periodically fetch monitoring
-metrics from AWS CloudWatch using **GetMetricData** API for {aws} services.
+metrics from AWS CloudWatch using **GetMetricData** API for AWS services.
 Specifically you'll learn how to stream and process billing and EC2 metrics.
 
 IMPORTANT: Extra AWS charges on CloudWatch API requests may be generated if you
 configure the AWS integration to collect metrics. To learn more, refer to the
 https://aws.amazon.com/cloudwatch/pricing/[Amazon CloudWatch pricing] page.
 
-. Make sure the {aws} account used to collect metrics from CloudWatch has at
+. Make sure the AWS account used to collect metrics from CloudWatch has at
 least the following permissions:
 +
 [source,yml]
@@ -405,7 +403,7 @@ least the following permissions:
 ----
 
 . From the main menu in {kib}, go to **{fleet} -> Agents** and click the policy
-your agent is using. 
+your agent is using.
 
 . Edit the AWS integration policy and turn on the **Collect billing metrics**
 selector. You can accept the defaults.

--- a/docs/en/observability/monitor-aws-beats.asciidoc
+++ b/docs/en/observability/monitor-aws-beats.asciidoc
@@ -1,10 +1,7 @@
-:tutorial: tutorial
-:aws: AWS
-
 [[monitor-aws]]
-== Monitor Amazon Web Services ({aws}) with {beats}
+== Monitor Amazon Web Services (AWS) with {beats}
 
-In this tutorial, you’ll learn how to monitor your {aws} infrastructure using
+In this tutorial, you’ll learn how to monitor your AWS infrastructure using
 Elastic {observability}: Logs and Infrastructure metrics.
 
 [discrete]
@@ -31,10 +28,10 @@ and {kib} for visualizing and managing your data.
 With this tutorial, we assume that your logs and your infrastructure
 data are already shipped to CloudWatch. We are going to show you how you can
 stream your data from CloudWatch to {es}. If you don’t know how to put
-your {aws} logs and infrastructure data in CloudWatch, Amazon provides a lot of
+your AWS logs and infrastructure data in CloudWatch, Amazon provides a lot of
 documentation around this specific topic:
 
-* Collect your logs and infrastructure data from specific https://www.youtube.com/watch?v=vAnIhIwE5hY[{aws} services]
+* Collect your logs and infrastructure data from specific https://www.youtube.com/watch?v=vAnIhIwE5hY[AWS services]
 * Export your logs https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/S3ExportTasksConsole.html[to an S3 bucket]
 
 
@@ -45,7 +42,7 @@ documentation around this specific topic:
 To centralize your logs in {es}, you need to have an S3 bucket.
 {filebeat}, the agent you'll use to collect logs, has an input for S3.
 
-In the https://s3.console.aws.amazon.com/s3[{aws} S3 console], click on *Create
+In the https://s3.console.aws.amazon.com/s3[AWS S3 console], click on *Create
 bucket*. Give the bucket a *name* and specify the *region* in which you want it
 deployed.
 
@@ -130,7 +127,7 @@ image::configure-notification-output.png[Event Notification Setting]
 [[aws-step-four]]
 === Step 4: Install and configure {filebeat}
 
-To monitor {aws} using the {stack}, you need two main components:
+To monitor AWS using the {stack}, you need two main components:
 an Elastic deployment to store and analyze the data and an agent to collect and
 ship the data.
 
@@ -140,11 +137,11 @@ include::{observability-docs-root}/docs/en/shared/install-configure-filebeat.asc
 
 [discrete]
 [[aws-step-five]]
-=== Step 5: Configure the {aws} Module
+=== Step 5: Configure the AWS Module
 
 Now that the output is working, you can set up the
-{filebeat-ref}/filebeat-module-aws.html[{filebeat} {aws}] module which
-will automatically create the {aws} input. This
+{filebeat-ref}/filebeat-module-aws.html[{filebeat} AWS] module which
+will automatically create the AWS input. This
 module checks SQS for new messages regarding the new object created in the S3
 bucket and uses the information in these messages to retrieve logs from S3
 buckets. With this setup, periodic polling from each S3 bucket is not needed.
@@ -161,7 +158,7 @@ access logs are useful for many applications. For example, access log
 information can be useful in security and access audits. It can also help you
 learn about your customer base and understand your Amazon S3 bill.
 
-Let's enable the {aws} module in {filebeat}.
+Let's enable the AWS module in {filebeat}.
 
 [source,bash]
 ----
@@ -192,7 +189,7 @@ Edit the `modules.d/aws.yml` file with the following configurations.
 <2> This is the AWS profile defined following the https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html[AWS standard].
 <3> Add the URL to the queue containing notifications around the bucket containing the EC2 logs
 
-Make sure that the {aws} user used to collect the logs from S3 has at least the
+Make sure that the AWS user used to collect the logs from S3 has at least the
 following permissions attached to it:
 
 [source,yml]
@@ -215,7 +212,7 @@ following permissions attached to it:
 ----
 
 You can now upload your logs to the S3 bucket. If you are using CloudWatch,
-make sure to edit the policy of your bucket as shown in https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/S3ExportTasksConsole.html[step 3 of the {aws} user guide].
+make sure to edit the policy of your bucket as shown in https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/S3ExportTasksConsole.html[step 3 of the AWS user guide].
 This will help you avoid permissions issues.
 
 Start {filebeat} to collect the logs.
@@ -306,11 +303,11 @@ This gives you an overview of how your S3 buckets are being accessed.
 [[aws-step-seven]]
 === Step 7: Collect Infrastructure metrics
 
-To monitor your {aws} infrastructure you will need to first make sure your
+To monitor your AWS infrastructure you will need to first make sure your
 infrastructure data are being shipped to CloudWatch. To ship the data to
-{es} we are going to use the {aws} module from {metricbeat}. This module
+{es} we are going to use the AWS module from {metricbeat}. This module
 periodically fetches monitoring metrics from AWS CloudWatch using
-**GetMetricData** API for {aws} services.
+**GetMetricData** API for AWS services.
 
 [IMPORTANT]
 ====
@@ -328,20 +325,20 @@ In a new terminal window, run the following commands.
 include::{observability-docs-root}/docs/en/shared/install-configure-metricbeat.asciidoc[]
 :leveloffset: -3
 
-Now that the output is working, you are going to set up the {aws} module.
+Now that the output is working, you are going to set up the AWS module.
 
 [discrete]
 [[aws-step-nine]]
-=== Step 9: Configure the {aws} module
+=== Step 9: Configure the AWS module
 
-To collect metrics from your {aws} infrastructure, we'll use the
-{metricbeat-ref}/metricbeat-module-aws.html[{metricbeat} {aws}] module. This module
+To collect metrics from your AWS infrastructure, we'll use the
+{metricbeat-ref}/metricbeat-module-aws.html[{metricbeat} AWS] module. This module
 contains many metricsets: `billing`, `cloudwatch`, `dynamodb`, `ebs`,
 `ec2`, `elb`, `lambda`, and many more. Each metricset is created to help you
 stream and process your data. In this tutorial, we're going to show you a
 few examples using the `ec2` and the `billing` metricsets.
 
-. Let's enable the {aws} module in {metricbeat}.
+. Let's enable the AWS module in {metricbeat}.
 +
 [source,bash]
 ----
@@ -376,7 +373,7 @@ few examples using the `ec2` and the `billing` metricsets.
 <3> Defines the metricset that is going to be used.
 <4> This is the AWS profile defined following the https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html[AWS standard].
 
-Make sure that the {aws} user used to collect the metrics from CloudWatch has at
+Make sure that the AWS user used to collect the metrics from CloudWatch has at
 least the following permissions attached to it:
 
 [source,yml]
@@ -415,7 +412,7 @@ You can now start {metricbeat}:
 
 Now that the metrics are being streamed to {es} we can visualize them in
 {kib}. In {kib}, open the main menu and click
-**Infrastructure**. Make sure to show the **{aws}** source and the **EC2 Instances**:
+**Infrastructure**. Make sure to show the **AWS** source and the **EC2 Instances**:
 
 image::EC2-instances.png[Your EC2 Infrastructure]
 
@@ -428,7 +425,7 @@ AWS] EC2 Overview**:
 image::ec2-dashboard.png[EC2 Overview]
 
 // lint ignore metricbeat
-If you want to track your billings on {aws}, you can also check the
+If you want to track your billings on AWS, you can also check the
 **[Metricbeat AWS] Billing Overview** dashboard:
 
 image::aws-billing.png[Billing Overview]

--- a/docs/en/observability/monitor-azure-beats.asciidoc
+++ b/docs/en/observability/monitor-azure-beats.asciidoc
@@ -1,5 +1,3 @@
-:tutorial: tutorial
-
 [[monitor-azure]]
 == Monitor Microsoft Azure with {beats}
 
@@ -11,7 +9,7 @@ agents centrally in {fleet}. To learn how to use {agent}, refer to
 <<monitor-azure-elastic-agent>>.
 ****
 
-In this {tutorial}, you'll learn how to monitor your Microsoft Azure deployments
+In this tutorial, you'll learn how to monitor your Microsoft Azure deployments
 using Elastic {observability}: Logs and Infrastructure metrics.
 
 [discrete]
@@ -182,7 +180,7 @@ Active Directory (Azure AD).
 You can create the service principal using the https://docs.microsoft.com/en-us/azure/active-directory/develop/howto-create-service-principal-portal[Azure portal]
 or https://docs.microsoft.com/en-us/powershell/azure/create-azure-service-principal-azureps?view=azps-2.7.0[Azure PowerShell].
 Then, you need to grant access permission, which is detailed https://docs.microsoft.com/en-us/azure/role-based-access-control/built-in-roles[here].
-This {tutorial} uses the Azure portal.
+This tutorial uses the Azure portal.
 
 [discrete]
 ==== Create an Azure service principal
@@ -198,7 +196,7 @@ Directory and then click on *New registration*.
 +
 image:monitor-azure-click-app-registration.png[Click on App registrations]
 +
-. Type the name of your application (this {tutorial} uses `monitor-azure`) and
+. Type the name of your application (this tutorial uses `monitor-azure`) and
 click on *Register* (leave all the other options with the default value).
 +
 image:monitor-azure-register-app.png[Register an application]
@@ -268,7 +266,7 @@ password. Keep it safe as you will use it later.
 [role="screenshot"]
 image:monitor-azure-kibana-security.png[{ecloud} security]
 
-You can run {metricbeat} on any machine. This {tutorial} uses a small
+You can run {metricbeat} on any machine. This tutorial uses a small
 Azure VM, *B2s* (2 vCPUs, 4 GB memory), with an Ubuntu distribution.
 
 :leveloffset: +3

--- a/docs/en/observability/monitor-gcp.asciidoc
+++ b/docs/en/observability/monitor-gcp.asciidoc
@@ -1,10 +1,7 @@
-:tutorial: tutorial
-:gcp: GCP
-
 [[monitor-gcp]]
 == Monitor Google Cloud Platform
 
-In this tutorial, you'll learn how to monitor your Google Cloud Platform ({gcp})
+In this tutorial, you'll learn how to monitor your Google Cloud Platform (GCP)
 deployments using Elastic {observability}: Logs and Infrastructure metrics.
 
 [NOTE]
@@ -20,7 +17,7 @@ link:gcp-dataflow.html[GCP Dataflow Templates].
 
 You'll learn how to:
 
-- Set up a {gcp} Service Account.
+- Set up a GCP Service Account.
 - Ingest metrics using the {metricbeat-ref}/metricbeat-module-gcp.html[{metricbeat}
 Google Cloud Platform module] and view those metrics in {kib}.
 - Export GCP audit logs through Pub/Sub topics.
@@ -38,11 +35,11 @@ and {kib} for visualizing and managing your data.
 === Step 1: Setup a Service Account
 
 Google Cloud Platform implements https://cloud.google.com/compute/docs/access/service-accounts[service
-accounts] as a way to access APIs securely. To monitor {gcp} with
+accounts] as a way to access APIs securely. To monitor GCP with
 Elastic, you will need a service account. The easiest way is to use a predefined
-service account that {gcp} https://cloud.google.com/compute/docs/access/service-accounts?hl=en#default_service_account[creates automatically].
+service account that GCP https://cloud.google.com/compute/docs/access/service-accounts?hl=en#default_service_account[creates automatically].
 Alternatively, you can create a new service account.
-This {tutorial} creates a new one.
+This tutorial creates a new one.
 
 First, to access the service account menu, click
 *Menu* -> *IAM & Admin* -> *Service Accounts*.
@@ -51,7 +48,7 @@ image::monitor-gcp-service-account-menu.png[Service account menu]
 
 Next, click *Create Service Account*. Define the new service account
 name (for example, "gcp-monitor") and the description (for example, "Service
-account to monitor {gcp} services using the {stack}").
+account to monitor GCP services using the {stack}").
 
 image::monitor-gcp-service-account-name.png[Service account name]
 
@@ -60,7 +57,7 @@ image::monitor-gcp-service-account-name.png[Service account name]
 Make sure to select the correct roles.
 ====
 
-To monitor {gcp} services, you need to add these roles to the
+To monitor GCP services, you need to add these roles to the
 service account:
 
 *Compute Viewer*:
@@ -98,16 +95,16 @@ Keep this file in an accessible place to use later.
 
 [NOTE]
 ====
-This {tutorial} assumes the Elastic cluster is already running. Make sure you have your *cloud ID* and your *credentials* on hand.
+This tutorial assumes the Elastic cluster is already running. Make sure you have your *cloud ID* and your *credentials* on hand.
 ====
 
-To monitor {gcp} using the {stack}, you need two main components:
+To monitor GCP using the {stack}, you need two main components:
 an Elastic deployment to store and analyze the data and an agent to collect
 and ship the data.
 
-Two agents can be used to monitor {gcp}: {metricbeat} is used to
+Two agents can be used to monitor GCP: {metricbeat} is used to
 monitor metrics, and {filebeat} to monitor logs. You can run the agents on any
-machine. This {tutorial} uses a small {gcp} instance, e2-small (2 vCPUs,
+machine. This tutorial uses a small GCP instance, e2-small (2 vCPUs,
 2 GB memory), with an Ubuntu distribution.
 
 :leveloffset: +3
@@ -171,7 +168,7 @@ following command:
 ./metricbeat test modules gcp
 ----
 +
-{metricbeat} will print {gcp} metrics to the terminal, if the setup is correct.
+{metricbeat} will print GCP metrics to the terminal, if the setup is correct.
 
 . When the input and output are ready, start {metricbeat} to collect the data.
 +
@@ -195,7 +192,7 @@ collect Google Cloud logs.
 include::{observability-docs-root}/docs/en/shared/install-configure-filebeat.asciidoc[]
 :leveloffset: -3
 
-Now that the output is working, you are going to set up the input ({gcp}).
+Now that the output is working, you are going to set up the input (GCP).
 
 [discrete]
 === Step 5: Configure {filebeat} Google Cloud module

--- a/docs/en/observability/splunk-get-started.asciidoc
+++ b/docs/en/observability/splunk-get-started.asciidoc
@@ -1,8 +1,3 @@
-[chapter, role="xpack"]
-[[splunk-get-started]]
-
-:modulename: system nginx mysql
-
 [[splunk-get-started]]
 = Get started with data from Splunk
 
@@ -42,7 +37,7 @@ include::{observability-docs-root}/docs/en/observability/logs-metrics-get-starte
 == Step 1: Add integration
 
 // lint ignore add-nginx-integration
-Find the Nginx integration and begin adding it as described in 
+Find the Nginx integration and begin adding it as described in
 <<add-nginx-integration,Ingest logs, metrics, and uptime data>>.
 
 [discrete]

--- a/docs/en/observability/synthetics-create-test.asciidoc
+++ b/docs/en/observability/synthetics-create-test.asciidoc
@@ -9,9 +9,9 @@ on your site.
 = Syntax overview
 
 To write synthetic tests for your application, you'll need to know basic JavaScript and
-{playwright-url}[Playwright] syntax.
+https://playwright.dev/[Playwright] syntax.
 
-TIP: {playwright-url}[Playwright] is a browser testing library developed by Microsoft.
+TIP: https://playwright.dev/[Playwright] is a browser testing library developed by Microsoft.
 It's fast, reliable, and features a modern API that automatically waits for page elements to be ready.
 
 The synthetics agent exposes an API for creating and running tests, including:
@@ -82,8 +82,8 @@ a| A function where you will add steps.
 
 `page`::        A https://playwright.dev/docs/api/class-page[page] object from Playwright
                 that lets you control the browser's current page.
-`browser`::     A {playwright-api-docs}[browser] object created by Playwright.
-`context`::     A https://playwright.dev/docs/api/class-browsercontext[browser context] 
+`browser`::     A https://playwright.dev/docs/api/class-playwright[browser] object created by Playwright.
+`context`::     A https://playwright.dev/docs/api/class-browsercontext[browser context]
                 that doesn't share cookies or cache with other browser contexts.
 `params`::      User-defined variables that allow you to invoke the Synthetics suite with custom parameters.
                 For example, if you want to use a different homepage depending on the `env`
@@ -322,7 +322,7 @@ external NPM packages, those packages will be bundled along with the
 journey code when the `push` command is invoked.
 
 However there are some limitations when using external packages:
-	
+
 * Bundled journeys after compression should not be more than 800 Kilobytes.
 * Native node modules will not work as expected due to platform inconsistency.
 

--- a/docs/en/observability/traces-get-started.asciidoc
+++ b/docs/en/observability/traces-get-started.asciidoc
@@ -60,7 +60,7 @@ include::apm/tab-widgets/install-agents-widget.asciidoc[]
 endif::[]
 
 ifdef::apm-integration-docs[]
-include::{apm-server-dir}/tab-widgets/install-agents-widget.asciidoc[]
+include::{observability-docs-root}/docs/en/observability/apm/tab-widgets/install-agents-widget.asciidoc[]
 endif::[]
 --
 

--- a/docs/en/shared/copied-from-beats/start-filebeat/start-filebeat.asciidoc
+++ b/docs/en/shared/copied-from-beats/start-filebeat/start-filebeat.asciidoc
@@ -54,3 +54,5 @@ PS C:{backslash}Program Files{backslash}{beatname_lc}> Start-Service {beatname_l
 By default, Windows log files are stored in +C:{backslash}ProgramData{backslash}{beatname_lc}\Logs+.
 
 // end::win[]
+
+:!beatname_url:


### PR DESCRIPTION
Refactor book-scoped attributes in the observability docs. This PR closes [Issue 228](https://github.com/elastic/obs-docs-team/issues/228).

The following docs have book-scoped attributes:

- [x] command-reference.asciidoc - I believe these just need to be unset
https://docs.asciidoctor.org/asciidoc/latest/attributes/unset-attributes/
- [x]  docs/en/integrations/index.asciidoc
- [x]  grant-cases-access.asciidoc - another that might just need to be unset. make sure there aren't any other pages included.
- [x]  docs/en/observability/index.asciidoc - playwright stuff for synthetics
- [x]  monitor-azure-beats.asciidoc
- [x] monitor-aws-agent.asciidoc
- [x] monitor-aws-beats.asciidoc
- [x] monitor-gcp.asciidoc
- [x] splunk-get-started.asciidoc
- [x] docs/en/observabiltiy/apm/open-telemetry.asciidoc - hardcode the URLs here.
- [x]  apm.asciidoc
- [x] docs/en/observability/apm/release-notes.asciidoc
- [x] docs/en/observability/apm/version.asciidoc
- [x]  Update all APM docs that currently use attributes
