### PR TITLE
Remove tech preview badge from docs about viewing alerts

### DIFF
--- a/docs/en/observability/view-observability-alerts.asciidoc
+++ b/docs/en/observability/view-observability-alerts.asciidoc
@@ -1,14 +1,6 @@
 [[view-observability-alerts]]
 = View alerts
 
-experimental[]
-
-****
-Given the experimental status of this feature, you may want to disable writing to specific {observability} alert indices
-or disable and remove the Alerts page altogether.
-For more information on configuring alerts, see <<create-alerts-configure>>.
-****
-
 The Alerts page lists all the alerts that have met a condition defined by a rule you created using
 one of the Observability apps.
 


### PR DESCRIPTION
Removes tech preview badge because this feature is now GA.