### PR TITLE
Fix URL for AWS EC2 (#3698)

### DIFF
--- a/docs/en/observability/cloud-monitoring/aws/monitor-amazon-ec2.asciidoc
+++ b/docs/en/observability/cloud-monitoring/aws/monitor-amazon-ec2.asciidoc
@@ -5,7 +5,7 @@
 <titleabbrev>Monitor EC2</titleabbrev>
 ++++
 
-https://aws.amazon.com/ec2/Amazon[Elastic Compute Cloud (Amazon EC2)] enables
+https://aws.amazon.com/ec2[Elastic Compute Cloud (Amazon EC2)] enables
 you to provision compute
 resources, on demand, in the form of virtual servers called instances. A range
 of instance types are available with different CPU, memory, storage, and


### PR DESCRIPTION
Cherry-picks https://github.com/elastic/observability-docs/pull/3698 to `main`. 