### PR TITLE
Add apm prefixed redirects

### DIFF
--- a/docs/en/observability/redirects.asciidoc
+++ b/docs/en/observability/redirects.asciidoc
@@ -161,3 +161,709 @@ For an overview of ingesting and viewing logs in {observability}, refer to <<log
 
 This page has moved.
 Please see <<apm-k8s-attacher>>.
+
+// Redirects for renaming APM IDs
+
+// Redirects for renaming APM IDs
+
+[role="exclude",id="getting-started-apm-server"]
+=== Self manage APM Server
+
+Refer to <<apm-getting-started-apm-server>>.
+
+[role="exclude",id="installing"]
+=== Step 1: Install
+
+Refer to <<apm-installing>>.
+
+[role="exclude",id="next-steps"]
+=== Step 4: Next steps
+
+Refer to <<apm-next-steps>>.
+
+[role="exclude",id="setup-repositories"]
+=== Repositories for APT and YUM
+
+Refer to <<apm-setup-repositories>>.
+
+[role="exclude",id="running-on-docker"]
+=== Run APM Server on Docker
+
+Refer to <<apm-running-on-docker>>.
+
+[role="exclude",id="data-model"]
+=== Data Model
+
+Refer to <<apm-data-model>>.
+
+[role="exclude",id="data-model-spans"]
+=== Spans
+
+Refer to <<apm-data-model-spans>>.
+
+[discrete]
+[[data-model-dropped-spans]]
+==== Dropped spans
+
+Refer to <<apm-data-model-dropped-spans>>.
+
+[role="exclude",id="data-model-transactions"]
+=== Transactions
+
+Refer to <<apm-data-model-transactions>>.
+
+[role="exclude",id="data-model-errors"]
+=== Errors
+
+Refer to <<apm-data-model-errors>>.
+
+[role="exclude",id="data-model-metrics"]
+=== Metrics
+
+Refer to <<apm-data-model-metrics>>.
+
+[role="exclude",id="data-model-metadata"]
+=== Metadata
+
+Refer to <<apm-data-model-metadata>>.
+
+[discrete]
+[[data-model-custom]]
+=== Custom context
+
+Refer to <<apm-data-model-custom>>.
+
+[discrete]
+[[data-model-labels]]
+=== Labels
+
+Refer to <<apm-data-model-labels>>.
+
+[role="exclude",id="features"]
+=== Features
+
+Refer to <<apm-features>>.
+
+[role="exclude",id="filtering"]
+=== Built-in data filters
+
+Refer to <<apm-filtering>>.
+
+[role="exclude",id="custom-filter"]
+=== Custom filters
+
+Refer to <<apm-custom-filter>>.
+
+[role="exclude",id="data-security-delete"]
+=== Delete sensitive data
+
+Refer to <<apm-data-security-delete>>.
+
+[role="exclude",id="sampling"]
+=== Transaction sampling
+
+Refer to <<apm-sampling>>.
+
+[role="exclude",id="configure-head-based-sampling"]
+=== Configure head-based sampling
+
+Refer to <<apm-configure-head-based-sampling>>.
+
+[role="exclude",id="configure-tail-based-sampling"]
+=== Configure tail-based sampling
+
+Refer to <<apm-configure-tail-based-sampling>>.
+
+[role="exclude",id="log-correlation"]
+=== Logging integration
+
+Refer to <<application-logs>>.
+
+[discrete]
+[[ingest-logs-in-es]]
+==== Ingest your logs into Elasticsearch
+
+Refer to <<application-logs>>.
+
+[role="exclude",id="cross-cluster-search"]
+=== Cross-cluster search
+
+Refer to <<apm-cross-cluster-search>>.
+
+[role="exclude",id="span-compression"]
+=== Span compression
+
+Refer to <<apm-span-compression>>.
+
+[role="exclude",id="monitoring-aws-lambda"]
+=== Monitoring AWS Lambda Functions
+
+Refer to <<apm-monitoring-aws-lambda>>.
+
+[role="exclude",id="how-to-guides"]
+=== How-to guides
+
+Refer to <<apm-how-to-guides>>.
+
+[role="exclude",id="source-map-how-to"]
+=== Create and upload source maps (RUM)
+
+Refer to <<apm-source-map-how-to>>.
+
+[discrete]
+[[source-map-rum-generate]]
+==== Generate a source map
+
+Refer to <<apm-source-map-rum-generate>>.
+
+[discrete]
+[[source-map-rum-upload]]
+==== Upload the source map
+
+Refer to <<apm-source-map-rum-upload>>.
+
+[role="exclude",id="jaeger-integration"]
+=== Integrate with Jaeger
+
+Refer to <<apm-jaeger-integration>>.
+
+[role="exclude",id="ingest-pipelines"]
+=== Parse data using ingest pipelines
+
+Refer to <<apm-ingest-pipelines>>.
+
+[role="exclude",id="custom-index-template"]
+=== View the Elasticsearch index template
+
+Refer to <<apm-custom-index-template>>.
+
+[role="exclude",id="open-telemetry"]
+=== OpenTelemetry integration
+
+Refer to <<apm-open-telemetry>>.
+
+[role="exclude",id="open-telemetry-with-elastic"]
+=== OpenTelemetry API/SDK with Elastic APM agents
+
+Refer to <<apm-open-telemetry-with-elastic>>.
+
+[role="exclude",id="open-telemetry-direct"]
+=== OpenTelemetry native support
+
+Refer to <<apm-open-telemetry-direct>>.
+
+[role="exclude",id="open-telemetry-other-env"]
+=== AWS Lambda Support
+
+Refer to <<apm-open-telemetry-other-env>>.
+
+[role="exclude",id="open-telemetry-collect-metrics"]
+=== Collect metrics
+
+Refer to <<apm-open-telemetry-collect-metrics>>.
+
+[role="exclude",id="open-telemetry-known-limitations"]
+=== Limitations
+
+Refer to <<apm-open-telemetry-known-limitations>>.
+
+[role="exclude",id="open-telemetry-resource-attributes"]
+=== Resource attributes
+
+Refer to <<apm-open-telemetry-resource-attributes>>.
+
+[role="exclude",id="manage-storage"]
+=== Manage storage
+
+Refer to <<apm-manage-storage>>.
+
+[role="exclude",id="ilm-how-to"]
+=== Index lifecycle management
+
+Refer to <<apm-ilm-how-to>>.
+
+[discrete]
+[[data-streams-custom-policy]]
+==== Configure a custom index lifecycle policy
+
+Refer to <<apm-data-streams-custom-policy>>.
+
+[role="exclude",id="storage-guide"]
+=== Storage and sizing guide
+
+Refer to <<apm-storage-guide>>.
+
+[role="exclude",id="reduce-apm-storage"]
+=== Reduce storage
+
+Refer to <<apm-reduce-apm-storage>>.
+
+[role="exclude",id="exploring-es-data"]
+=== Explore data in Elasticsearch
+
+Refer to <<apm-exploring-es-data>>.
+
+[role="exclude",id="configuring-howto-apm-server"]
+=== Configure
+
+Refer to <<apm-configuring-howto-apm-server>>.
+
+[role="exclude",id="configuration-process"]
+=== General configuration options
+
+Refer to <<apm-configuration-process>>.
+
+[discrete]
+[[max_event_size]]
+==== Max event size
+
+Refer to <<apm-max_event_size>>.
+
+[role="exclude",id="configuration-anonymous"]
+=== Anonymous authentication
+
+Refer to <<apm-configuration-anonymous>>.
+
+[role="exclude",id="configure-agent-config"]
+=== APM agent configuration
+
+Refer to <<apm-configure-agent-config>>.
+
+[role="exclude",id="configuration-instrumentation"]
+=== Instrumentation
+
+Refer to <<apm-configuration-instrumentation>>.
+
+[role="exclude",id="setup-kibana-endpoint"]
+=== Kibana endpoint
+
+Refer to <<apm-setup-kibana-endpoint>>.
+
+[role="exclude",id="configuration-logging"]
+=== Logging
+
+Refer to <<apm-configuration-logging>>.
+
+[role="exclude",id="configuring-output"]
+=== Output
+
+Refer to <<apm-configuring-output>>.
+
+[role="exclude",id="configure-cloud-id"]
+=== Elasticsearch Service
+
+Refer to <<apm-configure-cloud-id>>.
+
+[role="exclude",id="elasticsearch-output"]
+=== Elasticsearch
+
+Refer to <<apm-elasticsearch-output>>.
+
+[role="exclude",id="logstash-output"]
+=== Logstash
+
+Refer to <<apm-logstash-output>>.
+
+[role="exclude",id="kafka-output"]
+=== Kafka
+
+Refer to <<apm-kafka-output>>.
+
+[role="exclude",id="redis-output"]
+=== Redis
+
+Refer to <<apm-redis-output>>.
+
+[role="exclude",id="console-output"]
+=== Console
+
+Refer to <<apm-console-output>>.
+
+[role="exclude",id="configuration-path"]
+=== Project paths
+
+Refer to <<apm-configuration-path>>.
+
+[role="exclude",id="configuration-rum"]
+=== Real User Monitoring (RUM)
+
+Refer to <<apm-configuration-rum>>.
+
+[discrete]
+[[rum-library-pattern]]
+==== Library Frame Pattern
+
+Refer to <<apm-rum-library-pattern>>.
+
+[discrete]
+[[rum-allow-origins]]
+==== Allowed Origins
+
+Refer to <<apm-rum-allow-origins>>.
+
+[role="exclude",id="configuration-ssl-landing"]
+=== SSL/TLS settings
+
+Refer to <<apm-configuration-ssl-landing>>.
+
+[role="exclude",id="configuration-ssl"]
+=== SSL/TLS output settings
+
+Refer to <<apm-configuration-ssl>>.
+
+[role="exclude",id="agent-server-ssl"]
+=== SSL/TLS input settings
+
+Refer to <<apm-agent-server-ssl>>.
+
+[role="exclude",id="tail-based-samling-config"]
+=== Tail-based sampling
+
+Refer to <<apm-tail-based-samling-config>>.
+
+[role="exclude",id="config-env"]
+=== Use environment variables in the configuration
+
+Refer to <<apm-config-env>>.
+
+[role="exclude",id="setting-up-and-running"]
+=== Advanced setup
+
+Refer to <<apm-setting-up-and-running>>.
+
+[role="exclude",id="directory-layout"]
+=== Installation layout
+
+Refer to <<apm-directory-layout>>.
+
+[role="exclude",id="keystore"]
+=== Secrets keystore
+
+Refer to <<apm-keystore>>.
+
+[role="exclude",id="command-line-options"]
+=== Command reference
+
+Refer to <<apm-command-line-options>>.
+
+[role="exclude",id="tune-data-ingestion"]
+=== Tune data ingestion
+
+Refer to <<apm-tune-data-ingestion>>.
+
+[role="exclude",id="high-availability"]
+=== High Availability
+
+Refer to <<apm-high-availability>>.
+
+[role="exclude",id="running-with-systemd"]
+=== APM Server and systemd
+
+Refer to <<apm-running-with-systemd>>.
+
+[role="exclude",id="securing-apm-server"]
+=== Secure communication
+
+Refer to <<apm-securing-apm-server>>.
+
+[role="exclude",id="secure-agent-communication"]
+=== With APM agents
+
+Refer to <<apm-secure-agent-communication>>.
+
+[role="exclude",id="agent-tls"]
+=== APM agent TLS communication
+
+Refer to <<apm-agent-tls>>.
+
+[discrete]
+[[agent-client-cert]]
+==== Client certificate authentication
+
+Refer to <<apm-agent-client-cert>>.
+
+[role="exclude",id="api-key"]
+=== API keys
+
+Refer to <<apm-api-key>>.
+
+[role="exclude",id="secret-token"]
+=== Secret token
+
+Refer to <<apm-secret-token>>.
+
+[role="exclude",id="anonymous-auth"]
+=== Anonymous authentication
+
+Refer to <<apm-anonymous-auth>>.
+
+[role="exclude",id="secure-comms-stack"]
+=== With the Elastic Stack
+
+Refer to <<apm-secure-comms-stack>>.
+
+[role="exclude",id="privileges-to-publish-events"]
+=== Create a _writer_ user
+
+Refer to <<apm-privileges-to-publish-events>>.
+
+[role="exclude",id="privileges-to-publish-monitoring"]
+=== Create a _monitoring_ user
+
+Refer to <<apm-privileges-to-publish-monitoring>>.
+
+[role="exclude",id="privileges-api-key"]
+=== Create an _API key_ user
+
+Refer to <<apm-privileges-api-key>>.
+
+[role="exclude",id="privileges-agent-central-config"]
+=== Create a _central config_ user
+
+Refer to <<apm-privileges-agent-central-config>>.
+
+[role="exclude",id="privileges-rum-source-map"]
+=== Create a _source map_ user
+
+Refer to <<apm-privileges-rum-source-map>>.
+
+[role="exclude",id="beats-api-keys"]
+=== Grant access using API keys
+
+Refer to <<apm-beats-api-keys>>.
+
+[role="exclude",id="monitor-apm"]
+=== Monitor
+
+Refer to <<apm-monitor-apm>>.
+
+[role="exclude",id="monitor-apm-self-install"]
+=== Fleet-managed
+
+Refer to <<apm-monitor-apm-self-install>>.
+
+[role="exclude",id="monitoring"]
+=== APM Server binary
+
+Refer to <<apm-monitoring>>.
+
+[role="exclude",id="monitoring-internal-collection"]
+=== Use internal collection
+
+Refer to <<apm-monitoring-internal-collection>>.
+
+[role="exclude",id="monitoring-local-collection"]
+=== Use local collection
+
+Refer to <<apm-monitoring-local-collection>>.
+
+[role="exclude",id="select-metrics"]
+=== The select metrics
+
+Refer to <<apm-select-metrics>>.
+
+[role="exclude",id="monitoring-metricbeat-collection"]
+=== Use Metricbeat collection
+
+Refer to <<apm-monitoring-metricbeat-collection>>.
+
+[role="exclude",id="api"]
+=== API
+
+Refer to <<apm-api>>.
+
+[role="exclude",id="api-info"]
+=== APM Server information API
+
+Refer to <<apm-api-info>>.
+
+[role="exclude",id="api-events"]
+=== Elastic APM events intake API
+
+Refer to <<apm-api-events>>.
+
+[role="exclude",id="api-metadata"]
+=== Metadata
+
+Refer to <<apm-api-metadata>>.
+
+[discrete]
+[[api-metadata-schema]]
+==== Metadata scheme
+
+Refer to <<apm-api-metadata-schema>>.
+
+[role="exclude",id="api-transaction"]
+=== Transactions
+
+Refer to <<apm-api-transaction>>.
+
+[role="exclude",id="api-span"]
+=== Spans
+
+Refer to <<apm-api-span>>.
+
+[role="exclude",id="api-error"]
+=== Errors
+
+Refer to <<apm-api-error>>.
+
+[role="exclude",id="api-metricset"]
+=== Metrics
+
+Refer to <<apm-api-metricset>>.
+
+[role="exclude",id="api-event-example"]
+=== Example request body
+
+Refer to <<apm-api-event-example>>.
+
+[role="exclude",id="api-config"]
+=== Elastic APM agent configuration API
+
+Refer to <<apm-api-config>>.
+
+[role="exclude",id="api-otlp"]
+=== OpenTelemetry intake API
+
+Refer to <<apm-api-otlp>>.
+
+[role="exclude",id="api-jaeger"]
+=== Jaeger event intake
+
+Refer to <<apm-api-jaeger>>.
+
+[role="exclude",id="troubleshoot-apm"]
+=== Troubleshoot
+
+Refer to <<apm-troubleshoot-apm>>.
+
+[role="exclude",id="common-problems"]
+=== Common problems
+
+Refer to <<apm-common-problems>>.
+
+[role="exclude",id="server-es-down"]
+=== What happens when APM Server or Elasticsearch is down?
+
+Refer to <<apm-server-es-down>>.
+
+[role="exclude",id="common-response-codes"]
+=== APM Server response codes
+
+Refer to <<apm-common-response-codes>>.
+
+[role="exclude",id="processing-and-performance"]
+=== Processing and performance
+
+Refer to <<apm-processing-and-performance>>.
+
+[role="exclude",id="enable-apm-server-debugging"]
+=== APM Server binary debugging
+
+Refer to <<apm-enable-apm-server-debugging>>.
+
+[role="exclude",id="upgrade"]
+=== Upgrade
+
+Refer to <<apm-upgrade>>.
+
+[role="exclude",id="agent-server-compatibility"]
+=== APM agent compatibility
+
+Refer to <<apm-agent-server-compatibility>>.
+
+[role="exclude",id="upgrading-to-8.x"]
+=== Upgrade to version 8.11.3
+
+Refer to <<apm-upgrading-to-8.x>>.
+
+[role="exclude",id="upgrade-8.0-self-standalone"]
+=== Self-installation standalone
+
+Refer to <<apm-upgrade-8.0-self-standalone>>.
+
+[role="exclude",id="upgrade-8.0-self-integration"]
+=== Self-installation APM integration
+
+Refer to <<apm-upgrade-8.0-self-integration>>.
+
+[role="exclude",id="upgrade-8.0-cloud-standalone"]
+=== Elastic Cloud standalone
+
+Refer to <<apm-upgrade-8.0-cloud-standalone>>.
+
+[role="exclude",id="upgrade-8.0-cloud-integration"]
+=== Elastic Cloud APM integration
+
+Refer to <<apm-upgrade-8.0-cloud-integration>>.
+
+[role="exclude",id="upgrade-to-apm-integration"]
+=== Switch to the Elastic APM integration
+
+Refer to <<apm-upgrade-to-apm-integration>>.
+
+[role="exclude",id="release-notes"]
+=== Release notes
+
+Refer to <<apm-release-notes>>.
+
+[role="exclude",id="release-notes-8.11"]
+=== APM version 8.11
+
+Refer to <<apm-release-notes-8.11>>.
+
+[role="exclude",id="release-notes-8.10"]
+=== APM version 8.10
+
+Refer to <<apm-release-notes-8.10>>.
+
+[role="exclude",id="release-notes-8.9"]
+=== APM version 8.9
+
+Refer to <<apm-release-notes-8.9>>.
+
+[role="exclude",id="release-notes-8.8"]
+=== APM version 8.8
+
+Refer to <<apm-release-notes-8.8>>.
+
+[role="exclude",id="release-notes-8.7"]
+=== APM version 8.7
+
+Refer to <<apm-release-notes-8.7>>.
+
+[role="exclude",id="release-notes-8.6"]
+=== APM version 8.6
+
+Refer to <<apm-release-notes-8.6>>.
+
+[role="exclude",id="release-notes-8.5"]
+=== APM version 8.5
+
+Refer to <<apm-release-notes-8.5>>.
+
+[role="exclude",id="release-notes-8.4"]
+=== APM version 8.4
+
+Refer to <<apm-release-notes-8.4>>.
+
+[role="exclude",id="release-notes-8.3"]
+=== APM version 8.3
+
+Refer to <<apm-release-notes-8.3>>.
+
+[role="exclude",id="release-notes-8.2"]
+=== APM version 8.2
+
+Refer to <<apm-release-notes-8.2>>.
+
+[role="exclude",id="release-notes-8.1"]
+=== APM version 8.1
+
+Refer to <<apm-release-notes-8.1>>.
+
+[role="exclude",id="release-notes-8.0"]
+=== APM version 8.0
+
+Refer to <<apm-release-notes-8.0>>.


### PR DESCRIPTION
Adds redirects from old Obs URL to new Obs URL for all APM pages updated in https://github.com/elastic/observability-docs/pull/3674.