### PR TITLE
profiling: improve self-managed section

### DIFF
--- a/docs/en/observability/profiling-self-managed.asciidoc
+++ b/docs/en/observability/profiling-self-managed.asciidoc
@@ -226,8 +226,8 @@ The next step is to run the backend applications. To do this:
 Both the collector and symbolizer need to authenticate to Elasticsearch to process profiling data.
 For this, you need to create an API key for each application.
 
-Refer to https://www.elastic.co/guide/en/kibana/current/api-keys.html#create-api-key[Create an API key] to do it via Kibana.
-You should select a "User API key", assigning the following permissions in the "Control security privileges" text area:
+Refer to {kibana-ref}/current/api-keys.html#create-api-key[Create an API key] to create an API key using {kib}.
+Select a *User API key* and assign the following permissions  under *Control security privileges*:
 
 [source,json]
 ----
@@ -377,7 +377,7 @@ output:
   elasticsearch:
     # Array of hosts to connect to.
     # Scheme and port can be left out and will be set to the default (`http` and `9200`).
-    # In case you specify and additional path, the scheme is required: `http://localhost:9200/path`.
+    # In case you specify an additional path, the scheme is required: `http://localhost:9200/path`.
     # IPv6 addresses should always be defined as: `https://[2001:db8::1]:9200`.
     hosts: ["localhost:9200"]
 

--- a/docs/en/observability/profiling-self-managed.asciidoc
+++ b/docs/en/observability/profiling-self-managed.asciidoc
@@ -226,7 +226,7 @@ The next step is to run the backend applications. To do this:
 Both the collector and symbolizer need to authenticate to Elasticsearch to process profiling data.
 For this, you need to create an API key for each application.
 
-Refer to {kibana-ref}/current/api-keys.html#create-api-key[Create an API key] to create an API key using {kib}.
+Refer to {kibana-ref}/api-keys.html#create-api-key[Create an API key] to create an API key using {kib}.
 Select a *User API key* and assign the following permissions  under *Control security privileges*:
 
 [source,json]

--- a/docs/en/observability/profiling-self-managed.asciidoc
+++ b/docs/en/observability/profiling-self-managed.asciidoc
@@ -225,34 +225,31 @@ The next step is to run the backend applications. To do this:
 
 Both the collector and symbolizer need to authenticate to Elasticsearch to process profiling data.
 For this, you need to create an API key for each application.
-The permissions needed on each application are listed below.
-You can either create a role, or assign the permissions directly to the API key.
 
-The following role definition includes the required permissions for the API keys:
+Refer to https://www.elastic.co/guide/en/kibana/current/api-keys.html#create-api-key[Create an API key] to do it via Kibana.
+You should select a "User API key", assigning the following permissions in the "Control security privileges" text area:
 
 [source,json]
 ----
 {
-  "name": "profiling",
-  "role_descriptors": {
-    "profiling": {
-      "indices": [
-        {
-          "names": [
-            "profiling-*"
-          ],
-          "privileges": [
-            "read",
-            "write"
-          ]
-        }
-      ]
-    }
+  "profiling": {
+    "indices": [
+      {
+        "names": [
+          "profiling-*"
+        ],
+        "privileges": [
+          "read",
+          "write"
+        ]
+      }
+    ]
   }
 }
 ----
 
-You will need these API keys to run the Universal Profiling backend. Continue to <<profiling-self-managed-running-linux>> or <<profiling-self-managed-running-kubernetes>> for information on running the backend applications.
+Store the "Encoded" version of the API keys, as you will need them to run the Universal Profiling backend.
+Continue to <<profiling-self-managed-running-linux>> or <<profiling-self-managed-running-kubernetes>> for information on running the backend applications.
 
 [discrete]
 [[profiling-self-managed-running-linux]]
@@ -376,81 +373,82 @@ pf-elastic-collector:
 # Configure the output to use when sending the data collected by pf-elastic-collector.
 
 #-------------------------- Elasticsearch output --------------------------
-output.elasticsearch:
-  # Array of hosts to connect to.
-  # Scheme and port can be left out and will be set to the default (`http` and `9200`).
-  # In case you specify and additional path, the scheme is required: `http://localhost:9200/path`.
-  # IPv6 addresses should always be defined as: `https://[2001:db8::1]:9200`.
-  hosts: ["localhost:9200"]
+output:
+  elasticsearch:
+    # Array of hosts to connect to.
+    # Scheme and port can be left out and will be set to the default (`http` and `9200`).
+    # In case you specify and additional path, the scheme is required: `http://localhost:9200/path`.
+    # IPv6 addresses should always be defined as: `https://[2001:db8::1]:9200`.
+    hosts: ["localhost:9200"]
 
-  # Set gzip compression level.
-  #compression_level: 0
+    # Set gzip compression level.
+    #compression_level: 0
 
-  # Protocol - either `http` (default) or `https`.
-  protocol: "https"
+    # Protocol - either `http` (default) or `https`.
+    protocol: "https"
 
-  # Authentication credentials - either API key or username/password.
-  #api_key: "id:api_key"
+    # Authentication credentials - either API key or username/password.
+    #api_key: "id:api_key"
 
-  # Optional HTTP Path.
-  #path: "/elasticsearch"
+    # Optional HTTP Path.
+    #path: "/elasticsearch"
 
-  # Proxy server url.
-  #proxy_url: http://proxy:3128
+    # Proxy server url.
+    #proxy_url: http://proxy:3128
 
-  # The number of times a particular Elasticsearch index operation is attempted. If
-  # the indexing operation doesn't succeed after this many retries, the events are
-  # dropped. The default is 3.
-  #max_retries: 3
+    # The number of times a particular Elasticsearch index operation is attempted. If
+    # the indexing operation doesn't succeed after this many retries, the events are
+    # dropped. The default is 3.
+    #max_retries: 3
 
-  # Enable custom SSL settings. Set to false to ignore custom SSL settings for secure communication.
-  #ssl.enabled: true
+    # Enable custom SSL settings. Set to false to ignore custom SSL settings for secure communication.
+    #ssl.enabled: true
 
-  # Optional SSL configuration options. SSL is off by default, change the `protocol` option if you want to enable `https`.
-  #
-  # Control the verification of Elasticsearch certificates. Valid values are:
-  # * full, which verifies that the provided certificate is signed by a trusted
-  # authority (CA) and also verifies that the server's hostname (or IP address)
-  # matches the names identified within the certificate.
-  # * strict, which verifies that the provided certificate is signed by a trusted
-  # authority (CA) and also verifies that the server's hostname (or IP address)
-  # matches the names identified within the certificate. If the Subject Alternative
-  # Name is empty, it returns an error.
-  # * certificate, which verifies that the provided certificate is signed by a
-  # trusted authority (CA), but does not perform any hostname verification.
-  #  * none, which performs no verification of the server's certificate. This
-  # mode disables many of the security benefits of SSL/TLS and should only be used
-  # after very careful consideration. It is primarily intended as a temporary
-  # diagnostic mechanism when attempting to resolve TLS errors; its use in
-  # production environments is strongly discouraged.
-  #ssl.verification_mode: full
+    # Optional SSL configuration options. SSL is off by default, change the `protocol` option if you want to enable `https`.
+    #
+    # Control the verification of Elasticsearch certificates. Valid values are:
+    # * full, which verifies that the provided certificate is signed by a trusted
+    # authority (CA) and also verifies that the server's hostname (or IP address)
+    # matches the names identified within the certificate.
+    # * strict, which verifies that the provided certificate is signed by a trusted
+    # authority (CA) and also verifies that the server's hostname (or IP address)
+    # matches the names identified within the certificate. If the Subject Alternative
+    # Name is empty, it returns an error.
+    # * certificate, which verifies that the provided certificate is signed by a
+    # trusted authority (CA), but does not perform any hostname verification.
+    #  * none, which performs no verification of the server's certificate. This
+    # mode disables many of the security benefits of SSL/TLS and should only be used
+    # after very careful consideration. It is primarily intended as a temporary
+    # diagnostic mechanism when attempting to resolve TLS errors; its use in
+    # production environments is strongly discouraged.
+    #ssl.verification_mode: full
 
-  # List of supported/valid TLS versions. By default all TLS versions 1.0 up to
-  # 1.2 are enabled.
-  #ssl.supported_protocols: [TLSv1.0, TLSv1.1, TLSv1.2]
+    # List of supported/valid TLS versions. By default all TLS versions 1.0 up to
+    # 1.2 are enabled.
+    #ssl.supported_protocols: [TLSv1.0, TLSv1.1, TLSv1.2]
 
-  # List of root certificates for HTTPS server verifications.
-  #ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
+    # List of root certificates for HTTPS server verifications.
+    #ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
 
-  # Certificate for SSL client authentication.
-  #ssl.certificate: "/etc/pki/client/cert.pem"
+    # Certificate for SSL client authentication.
+    #ssl.certificate: "/etc/pki/client/cert.pem"
 
-  # Client Certificate Key
-  #ssl.key: "/etc/pki/client/cert.key"
+    # Client Certificate Key
+    #ssl.key: "/etc/pki/client/cert.key"
 
-  # Optional passphrase for decrypting the Certificate Key.
-  # It is recommended to use the provided keystore instead of entering the passphrase in plain text.
-  #ssl.key_passphrase: ''
+    # Optional passphrase for decrypting the Certificate Key.
+    # It is recommended to use the provided keystore instead of entering the passphrase in plain text.
+    #ssl.key_passphrase: ''
 
-  # Configure cipher suites to be used for SSL connections.
-  #ssl.cipher_suites: []
+    # Configure cipher suites to be used for SSL connections.
+    #ssl.cipher_suites: []
 
-  # Configure curve types for ECDHE based cipher suites.
-  #ssl.curve_types: []
+    # Configure curve types for ECDHE based cipher suites.
+    #ssl.curve_types: []
 
-  # Configure what types of renegotiation are supported. Valid options are
-  # never, once, and freely. Default is never.
-  #ssl.renegotiation: never
+    # Configure what types of renegotiation are supported. Valid options are
+    # never, once, and freely. Default is never.
+    #ssl.renegotiation: never
 ----
 ====
 
@@ -529,81 +527,82 @@ pf-elastic-symbolizer:
 # Configure the output to use when sending the data collected by pf-elastic-symbolizer.
 
 #-------------------------- Elasticsearch output --------------------------
-output.elasticsearch:
-  # Array of hosts to connect to.
-  # Scheme and port can be left out and will be set to the default (`http` and `9200`).
-  # In case you specify an additional path, the scheme is required: `http://localhost:9200/path`.
-  # IPv6 addresses should always be defined as: `https://[2001:db8::1]:9200`.
-  hosts: ["localhost:9200"]
+output:
+  elasticsearch:
+    # Array of hosts to connect to.
+    # Scheme and port can be left out and will be set to the default (`http` and `9200`).
+    # In case you specify an additional path, the scheme is required: `http://localhost:9200/path`.
+    # IPv6 addresses should always be defined as: `https://[2001:db8::1]:9200`.
+    hosts: ["localhost:9200"]
 
-  # Set gzip compression level.
-  #compression_level: 0
+    # Set gzip compression level.
+    #compression_level: 0
 
-  # Protocol - either `http` (default) or `https`.
-  protocol: "https"
+    # Protocol - either `http` (default) or `https`.
+    protocol: "https"
 
-  # Authentication credentials - either API key or username/password.
-  #api_key: "id:api_key"
+    # Authentication credentials - either API key or username/password.
+    #api_key: "id:api_key"
 
-  # Optional HTTP Path.
-  #path: "/elasticsearch"
+    # Optional HTTP Path.
+    #path: "/elasticsearch"
 
-  # Proxy server url.
-  #proxy_url: http://proxy:3128
+    # Proxy server url.
+    #proxy_url: http://proxy:3128
 
-  # The number of times a particular Elasticsearch index operation is attempted. If
-  # the indexing operation doesn't succeed after this many retries, the events are
-  # dropped. The default is 3.
-  #max_retries: 3
+    # The number of times a particular Elasticsearch index operation is attempted. If
+    # the indexing operation doesn't succeed after this many retries, the events are
+    # dropped. The default is 3.
+    #max_retries: 3
 
-  # Enable custom SSL settings. Set to false to ignore custom SSL settings for secure communication.
-  #ssl.enabled: true
+    # Enable custom SSL settings. Set to false to ignore custom SSL settings for secure communication.
+    #ssl.enabled: true
 
-  # Optional SSL configuration options. SSL is off by default, change the `protocol` option if you want to enable `https`.
-  #
-  # Control the verification of Elasticsearch certificates. Valid values are:
-  # * full, which verifies that the provided certificate is signed by a trusted
-  # authority (CA) and also verifies that the server's hostname (or IP address)
-  # matches the names identified within the certificate.
-  # * strict, which verifies that the provided certificate is signed by a trusted
-  # authority (CA) and also verifies that the server's hostname (or IP address)
-  # matches the names identified within the certificate. If the Subject Alternative
-  # Name is empty, it returns an error.
-  # * certificate, which verifies that the provided certificate is signed by a
-  # trusted authority (CA), but does not perform any hostname verification.
-  #  * none, which performs no verification of the server's certificate. This
-  # mode disables many of the security benefits of SSL/TLS and should only be used
-  # after very careful consideration. It is primarily intended as a temporary
-  # diagnostic mechanism when attempting to resolve TLS errors; its use in
-  # production environments is strongly discouraged.
-  #ssl.verification_mode: full
+    # Optional SSL configuration options. SSL is off by default, change the `protocol` option if you want to enable `https`.
+    #
+    # Control the verification of Elasticsearch certificates. Valid values are:
+    # * full, which verifies that the provided certificate is signed by a trusted
+    # authority (CA) and also verifies that the server's hostname (or IP address)
+    # matches the names identified within the certificate.
+    # * strict, which verifies that the provided certificate is signed by a trusted
+    # authority (CA) and also verifies that the server's hostname (or IP address)
+    # matches the names identified within the certificate. If the Subject Alternative
+    # Name is empty, it returns an error.
+    # * certificate, which verifies that the provided certificate is signed by a
+    # trusted authority (CA), but does not perform any hostname verification.
+    #  * none, which performs no verification of the server's certificate. This
+    # mode disables many of the security benefits of SSL/TLS and should only be used
+    # after very careful consideration. It is primarily intended as a temporary
+    # diagnostic mechanism when attempting to resolve TLS errors; its use in
+    # production environments is strongly discouraged.
+    #ssl.verification_mode: full
 
-  # List of supported/valid TLS versions. By default all TLS versions 1.0 up to
-  # 1.2 are enabled.
-  #ssl.supported_protocols: [TLSv1.0, TLSv1.1, TLSv1.2]
+    # List of supported/valid TLS versions. By default all TLS versions 1.0 up to
+    # 1.2 are enabled.
+    #ssl.supported_protocols: [TLSv1.0, TLSv1.1, TLSv1.2]
 
-  # List of root certificates for HTTPS server verifications.
-  #ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
+    # List of root certificates for HTTPS server verifications.
+    #ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
 
-  # Certificate for SSL client authentication.
-  #ssl.certificate: "/etc/pki/client/cert.pem"
+    # Certificate for SSL client authentication.
+    #ssl.certificate: "/etc/pki/client/cert.pem"
 
-  # Client Certificate Key
-  #ssl.key: "/etc/pki/client/cert.key"
+    # Client Certificate Key
+    #ssl.key: "/etc/pki/client/cert.key"
 
-  # Optional passphrase for decrypting the Certificate Key.
-  # It is recommended to use the provided keystore instead of entering the passphrase in plain text.
-  #ssl.key_passphrase: ''
+    # Optional passphrase for decrypting the Certificate Key.
+    # It is recommended to use the provided keystore instead of entering the passphrase in plain text.
+    #ssl.key_passphrase: ''
 
-  # Configure cipher suites to be used for SSL connections.
-  #ssl.cipher_suites: []
+    # Configure cipher suites to be used for SSL connections.
+    #ssl.cipher_suites: []
 
-  # Configure curve types for ECDHE based cipher suites.
-  #ssl.curve_types: []
+    # Configure curve types for ECDHE based cipher suites.
+    #ssl.curve_types: []
 
-  # Configure what types of renegotiation are supported. Valid options are
-  # never, once, and freely. Default is never.
-  #ssl.renegotiation: never
+    # Configure what types of renegotiation are supported. Valid options are
+    # never, once, and freely. Default is never.
+    #ssl.renegotiation: never
 
 ----
 ====


### PR DESCRIPTION
### Reason for this PR

During the first customer trial using the new docs for onprem Profiling beta, we discovered 2 problems:

1. a major flaw in the config files, they cannot be re-used for k8s manifests with the dotted notation
2. the API creation instructions are unclear

### Details

Fix both points.