### PR TITLE
Add limit for number of alerts per case

### DIFF
--- a/docs/en/observability/view-observability-alerts.asciidoc
+++ b/docs/en/observability/view-observability-alerts.asciidoc
@@ -92,6 +92,8 @@ You can also use the toolbar buttons in the upper-right to customize the display
 From the Alerts table, you can add one or more alerts to a case. Select image:images/action-dropdown.png[Three dots used to expand the "More actions" menu,height=22]
 to add the alert to a new case or add it to an existing case. You can add an unlimited amount of alerts from any rule type.
 
+NOTE: Each case can have a maximum of 1,000 alerts.
+
 [discrete]
 [[new-case-observability-alerts]]
 === Add an alert to a new case


### PR DESCRIPTION
This PR updates https://www.elastic.co/guide/en/observability/current/view-observability-alerts.html#cases-observability-alerts with details about the maximum number of alerts that can be attached to a case.

### Preview

https://observability-docs_bk_3738.docs-preview.app.elstc.co/guide/en/observability/master/view-observability-alerts.html#cases-observability-alerts
