### PR TITLE
Add the Firehose troubleshooting section to the new AWS monitoring docs

### DIFF
--- a/docs/en/observability/cloud-monitoring/aws/monitor-amazon-intro.asciidoc
+++ b/docs/en/observability/cloud-monitoring/aws/monitor-amazon-intro.asciidoc
@@ -36,4 +36,6 @@ include::monitor-aws-firehose.asciidoc[]
 
 include::monitor-aws-vpc-flow-logs.asciidoc[leveloffset=+2]
 
+include::monitor-aws-firehose-troubleshooting.asciidoc[leveloffset=+2]
+
 include::monitor-aws-esf.asciidoc[]

--- a/docs/en/observability/cloud-monitoring/aws/monitor-aws-firehose-troubleshooting.asciidoc
+++ b/docs/en/observability/cloud-monitoring/aws/monitor-aws-firehose-troubleshooting.asciidoc
@@ -1,0 +1,25 @@
+[[monitor-aws-firehose-troubleshooting]]
+= Troubleshooting
+
+++++
+<titleabbrev>Troubleshooting</titleabbrev>
+++++
+
+You can use the monitoring tab in the Firehose console to ensure there are incoming records and the delivery success rate is 100%. By default Firehose also logs to a Cloudwatch log group with the name /aws/kinesisfirehose/<delivery stream name>, which is automatically created when the delivery stream is created. Two log streams, DestinationDelivery and BackupDelivery, are created in this log group.
+
+The backup settings in the delivery stream specify how failed delivery requests are handled. For more details on how to configure backups to S3, refer to <<firehose-step-three>>.
+
+[discrete]
+[[aws-firehose-troubleshooting-scaling]]
+== Scaling
+
+Firehose can https://docs.aws.amazon.com/firehose/latest/dev/limits.html[automatically scale] to handle very high throughput. If your Elastic deployment is not properly configured for the data volume coming from Firehose, it could cause a bottleneck, which may lead to increased ingest times or indexing failures.
+
+There are several facets to optimizing the underlying Elasticsearch performance, but Elastic Cloud provides several ready-to-use hardware profiles which can provide a good starting point. Other factors which can impact performance are {ref}/size-your-shards.html[shard sizing], {ref}/tune-for-indexing-speed.html[indexing configuration], and {ref}/index-lifecycle-management.html[index lifecycle management (ILM)].
+
+
+[discrete]
+[[aws-firehose-troubleshooting-support]]
+== Support
+
+If you encounter further problems, please contact https://www.elastic.co/guide/en/starting-with-the-elasticsearch-platform-and-its-solutions/current/get-support-help.html[Elastic support].

--- a/docs/en/observability/cloud-monitoring/aws/monitor-aws-firehose-troubleshooting.asciidoc
+++ b/docs/en/observability/cloud-monitoring/aws/monitor-aws-firehose-troubleshooting.asciidoc
@@ -5,7 +5,7 @@
 <titleabbrev>Troubleshooting</titleabbrev>
 ++++
 
-You can use the monitoring tab in the Firehose console to ensure there are incoming records and the delivery success rate is 100%. By default Firehose also logs to a Cloudwatch log group with the name /aws/kinesisfirehose/<delivery stream name>, which is automatically created when the delivery stream is created. Two log streams, DestinationDelivery and BackupDelivery, are created in this log group.
+You can use the monitoring tab in the Firehose console to ensure there are incoming records and the delivery success rate is 100%. By default Firehose also logs to a Cloudwatch log group with the name `/aws/kinesisfirehose/<delivery stream name>`, which is automatically created when the delivery stream is created. Two log streams, `DestinationDelivery` and `BackupDelivery`, are created in this log group.
 
 The backup settings in the delivery stream specify how failed delivery requests are handled. For more details on how to configure backups to S3, refer to <<firehose-step-three>>.
 


### PR DESCRIPTION
This PR copies the [Troubleshooting](https://www.elastic.co/guide/en/kinesis/current/aws-firehose-troubleshooting.html) section under [Monitor AWS with Amazon Data Firehose](https://www.elastic.co/guide/en/observability/current/monitor-aws-firehose.html) as its original place -- the [Firehose setup guide](https://www.elastic.co/guide/en/kinesis/current/index.html) -- is going to be removed.

Fixes https://github.com/elastic/observability-docs/issues/3748 