### PR TITLE
Fix numbering in AWS monitoring docs

### DIFF
--- a/docs/en/observability/cloud-monitoring/aws/monitor-aws-esf.asciidoc
+++ b/docs/en/observability/cloud-monitoring/aws/monitor-aws-esf.asciidoc
@@ -119,9 +119,9 @@ Elastic Serverless Forwarder uses the configuration file to know the input sourc
 
 . In Elastic Cloud, from the AWS Integrations page click *Connection details* on the upper right corner and copy your Cloud ID. 
 . Create an encoded API key for authentication. 
-
++
 You are going to reference both the Cloud ID and the newly created API key from the configuration file. Here is an example:
-
++
 [source,yml]
 ----
 inputs:


### PR DESCRIPTION
This PR fixes a wrong numbering in [Monitor AWS with Elastic Serverless Forwarder](http://localhost:8000/guide/monitor-aws-esf.html).