### PR TITLE
github-action(release automation): reviewers and use codeowners insteads

### DIFF
--- a/.github/Makefile
+++ b/.github/Makefile
@@ -18,7 +18,6 @@ BACKPORT_BRANCH_NAME = add-backport-next-$(NEXT_PROJECT_MINOR_VERSION)
 ##############################
 ## observability-docs specific
 ##############################
-PROJECT_REVIEWERS ?= elastic/obs-docs
 
 ##############################
 ## public make goals
@@ -86,7 +85,6 @@ create-prs-next-release:
 	gh pr create \
 		--title "backport: Add backport-$(PROJECT_MAJOR_VERSION).$(PROJECT_MINOR_VERSION) label" \
 		--body "Merge as soon as $(PROJECT_MAJOR_VERSION).$(PROJECT_MINOR_VERSION) branch was created." \
-		--reviewer "$(PROJECT_REVIEWERS)" \
 		--base main \
 		--label 'Team:Automation' || echo "There are no changes"
 


### PR DESCRIPTION
For some reason `gh` cannot find it

> could not request reviewer: 'elastic/obs-docs' not found

And the CODEOWNERS honour the reviewers regardless.

Hence no need to use it explicitly in the script.