### PR TITLE
Fixes known-issues: adds missing header, adds UI instructions

### DIFF
--- a/docs/en/observability/apm/known-issues.asciidoc
+++ b/docs/en/observability/apm/known-issues.asciidoc
@@ -37,7 +37,20 @@ This issue occurs because a non-optional parameter, `anomalyDetectorTypes` was a
 the presence of an automation migration script. This breaks pre-existing rules as they do not have this parameter
 and will fail validation. This issue is fixed in v8.14.0.
 
-It is possible to fix this error without upgrading. Follow these steps:
+It is possible to fix this error without upgrading.
+
+**Fix broken anomaly rules in the UI**
+
+. From any APM page in Kibana, select **Alerts and rules** -> **Manage rules**.
+. Filter your rules by setting **Type** to **APM Anomaly**.
+. For each anomaly rule in the list, select the pencil icon to edit the rule.
+. Add one or more **DETECTOR TYPES** to the rule.
++
+The detector type determines when the anomaly rule triggers. For example, a latency anomaly rule will
+trigger when the latency of the service being monitored is abnormal.
+Supported detector types are `latency`, `throughput`, and `failed transaction rate`.
+
+**Fix broken anomaly rules with Kibana APIs**
 
 // TODO: Add comments about how it's possible to fix this via the UI, but if you need to do it programmatically, read on for API instructions
 

--- a/docs/en/observability/apm/known-issues.asciidoc
+++ b/docs/en/observability/apm/known-issues.asciidoc
@@ -52,7 +52,6 @@ Supported detector types are `latency`, `throughput`, and `failed transaction ra
 
 **Fix broken anomaly rules with Kibana APIs**
 
-// TODO: Add comments about how it's possible to fix this via the UI, but if you need to do it programmatically, read on for API instructions
 
 . Find broken rules
 +

--- a/docs/en/observability/apm/known-issues.asciidoc
+++ b/docs/en/observability/apm/known-issues.asciidoc
@@ -53,6 +53,7 @@ There are three ways to fix this error:
 The detector type determines when the anomaly rule triggers. For example, a latency anomaly rule will
 trigger when the latency of the service being monitored is abnormal.
 Supported detector types are `latency`, `throughput`, and `failed transaction rate`.
+. Click **Save**.
 
 **Fix broken anomaly rules with Kibana APIs**
 

--- a/docs/en/observability/apm/known-issues.asciidoc
+++ b/docs/en/observability/apm/known-issues.asciidoc
@@ -38,6 +38,7 @@ the presence of an automation migration script. This breaks pre-existing rules a
 and will fail validation. This issue is fixed in v8.14.0.
 
 There are three ways to fix this error:
+
 * Upgrade to version 8.14.0 when it's released
 * Fix broken anomaly rules in the APM UI (no upgrade required)
 * Fix broken anomaly rules with Kibana APIs (no upgrade required)

--- a/docs/en/observability/apm/known-issues.asciidoc
+++ b/docs/en/observability/apm/known-issues.asciidoc
@@ -39,6 +39,8 @@ and will fail validation. This issue is fixed in v8.14.0.
 
 It is possible to fix this error without upgrading. Follow these steps:
 
+// TODO: Add comments about how it's possible to fix this via the UI, but if you need to do it programmatically, read on for API instructions
+
 . Find broken rules
 +
 ====
@@ -123,7 +125,7 @@ For each rule, submit a PUT request to the {kibana-ref}/update-rule-api.html[upd
 
 [source,shell]
 ----
-curl -u "$KIBANA_USER":"$KIBANA_PASSWORD" -XPUT "$KIBANA_URL/api/alerting/rule/046c0d4f" -H 'Content-Type: application/json' -d @046c0d4f.json
+curl -u "$KIBANA_USER":"$KIBANA_PASSWORD" -XPUT "$KIBANA_URL/api/alerting/rule/046c0d4f" -H 'Content-Type: application/json' -H 'kbn-xsrf: rule-update' -d @046c0d4f.json
 ----
 
 Once the PUT request executes successfully, the rule will no longer be broken.

--- a/docs/en/observability/apm/known-issues.asciidoc
+++ b/docs/en/observability/apm/known-issues.asciidoc
@@ -37,9 +37,12 @@ This issue occurs because a non-optional parameter, `anomalyDetectorTypes` was a
 the presence of an automation migration script. This breaks pre-existing rules as they do not have this parameter
 and will fail validation. This issue is fixed in v8.14.0.
 
-It is possible to fix this error without upgrading.
+There are three ways to fix this error:
+* Upgrade to version 8.14.0 when it's released
+* Fix broken anomaly rules in the APM UI (no upgrade required)
+* Fix broken anomaly rules with Kibana APIs (no upgrade required)
 
-**Fix broken anomaly rules in the UI**
+**Fix broken anomaly rules in the APM UI**
 
 . From any APM page in Kibana, select **Alerts and rules** -> **Manage rules**.
 . Filter your rules by setting **Type** to **APM Anomaly**.
@@ -51,7 +54,6 @@ trigger when the latency of the service being monitored is abnormal.
 Supported detector types are `latency`, `throughput`, and `failed transaction rate`.
 
 **Fix broken anomaly rules with Kibana APIs**
-
 
 . Find broken rules
 +


### PR DESCRIPTION
Hello! We just noticed that the recently added APM anomaly known issue doesn't mention the fact that this is fixable within the UI. Kevin had added [UI-based instructions](https://github.com/elastic/sdh-kibana/issues/4601#issuecomment-2046102364) earlier in the SDH comments. This seems like it would be a good idea to point out to folks who run into this problem. Can someone on the docs team help craft this messaging based on the instructions linked to in that SDH? 

Also, I've updated one of the cURL requests that was missing a required header. 