### PR TITLE
Add Firehose redirects

### DIFF
--- a/docs/en/observability/redirects.asciidoc
+++ b/docs/en/observability/redirects.asciidoc
@@ -867,3 +867,19 @@ Refer to <<apm-release-notes-8.1>>.
 === APM version 8.0
 
 Refer to <<apm-release-notes-8.0>>.
+
+[role="exclude",id="aws-firehose"]
+=== Amazon Kinesis Data Firehose overview
+
+Refer to <<monitor-aws-firehose>>.
+
+[role="exclude",id="aws-firehose-setup-guide"]
+=== Amazon Kinesis Data Firehose setup guide
+
+Refer to <<monitor-aws-firehose>>.
+
+[role="exclude",id="aws-firehose-troubleshooting"]
+=== Amazon Kinesis Data Firehose troubleshooting
+
+Refer to <<monitor-aws-firehose-troubleshooting>>.
+


### PR DESCRIPTION
Adds redirects for the Firehose pages removed with https://github.com/elastic/docs/pull/2970.

Relates to https://github.com/elastic/observability-docs/issues/3749