### PR TITLE
Add link to workaround about using custom CAs in private locations

### DIFF
--- a/docs/en/observability/synthetics-private-location.asciidoc
+++ b/docs/en/observability/synthetics-private-location.asciidoc
@@ -146,7 +146,7 @@ When the {agent} is running you can add a new {private-location} in {kib}:
 . Give your new location a unique _Location name_ and select the _Agent policy_ you created above.
 . Click **Save**.
 
-IMPORTANT: It is not currently possible to use custom CAs in private locations without following a workaround. To learn more about the workaround, refer to the following GitHub issue: https://github.com/elastic/synthetics/issues/717[elastic/synthetics#717].
+IMPORTANT: It is not currently possible to use custom CAs for synthetics browser tests in private locations without following a workaround. To learn more about the workaround, refer to the following GitHub issue: https://github.com/elastic/synthetics/issues/717[elastic/synthetics#717].
 
 [discrete]
 [[synthetics-private-location-scaling]]

--- a/docs/en/observability/synthetics-private-location.asciidoc
+++ b/docs/en/observability/synthetics-private-location.asciidoc
@@ -93,7 +93,7 @@ docker pull docker.elastic.co/beats/elastic-agent-complete:{version}
 endif::[]
 
 Then enroll and run an {agent}.
-You'll need an enrollment token and the URL of the {fleet-server}. 
+You'll need an enrollment token and the URL of the {fleet-server}.
 You can use the default enrollment token for your policy or create new policies
 and {fleet-guide}/fleet-enrollment-tokens.html[enrollment tokens] as needed.
 
@@ -144,20 +144,22 @@ When the {agent} is running you can add a new {private-location} in {kib}:
 . Click **{private-location}s**.
 . Click **Add location**.
 . Give your new location a unique _Location name_ and select the _Agent policy_ you created above.
-. Click **Save**. 
+. Click **Save**.
+
+IMPORTANT: It is not currently possible to use custom CAs in private locations without following a workaround. To learn more about the workaround, refer to the following GitHub issue: https://github.com/elastic/synthetics/issues/717[elastic/synthetics#717].
 
 [discrete]
 [[synthetics-private-location-scaling]]
 = Scaling {private-location}s
 
-By default {private-location}s are configured to allow two simultaneous browser tests, and an unlimited number of lightweight checks. 
-These limits can be set via the environment variables `SYNTHETICS_LIMIT_{TYPE}`, where `{TYPE}` is one of `BROWSER`, `HTTP`, `TCP`, and `ICMP` 
-for the container running the {agent} docker image. 
+By default {private-location}s are configured to allow two simultaneous browser tests, and an unlimited number of lightweight checks.
+These limits can be set via the environment variables `SYNTHETICS_LIMIT_{TYPE}`, where `{TYPE}` is one of `BROWSER`, `HTTP`, `TCP`, and `ICMP`
+for the container running the {agent} docker image.
 
-It is critical to allocate enough memory and CPU capacity to handle configured limits. 
+It is critical to allocate enough memory and CPU capacity to handle configured limits.
 Start by allocating at least 2 GiB of memory and two cores per browser instance to ensure consistent
-performance and avoid out-of-memory errors. Then adjust as needed. Resource requirements will vary depending on workload. 
-Much less memory is needed for lightweight monitors. Start by allocating at least 512MiB of memory and two cores for 
+performance and avoid out-of-memory errors. Then adjust as needed. Resource requirements will vary depending on workload.
+Much less memory is needed for lightweight monitors. Start by allocating at least 512MiB of memory and two cores for
 lightweight checks. Then increase allocated memory and CPU based on observed usage patterns.
 
 These limits are for simultaneous tests, not total tests. For example, if


### PR DESCRIPTION
Closes #3833.

Someone who is an SME should make sure this note is accurate and in the right place. Synthetics is not my area of expertise; I'm just trying to help out.

IMO pointing to that GitHub issue may not be the best approach because the details in the issue seem speculative. It would be much better if we could be proscriptive and tell users exactly how to work around the problem. That is beyond of the scope of what was requested in #3833 and would need some effort from folks outside of the docs team. 

TODO (after merging):
- [ ] Port this change to serverless.