### PR TITLE
Update APM anomaly known issue re: 8.13.3

### DIFF
--- a/docs/en/observability/apm/known-issues.asciidoc
+++ b/docs/en/observability/apm/known-issues.asciidoc
@@ -20,9 +20,9 @@ Link to fix
 ////
 
 [[broken-apm-anomaly-rule]]
-*Upgrading to v8.13 breaks APM anomaly rules* +
+*Upgrading to v8.13.0 to v8.13.2 breaks APM anomaly rules* +
 _Elastic Stack versions: 8.13.0, 8.13.1, 8.13.2_ +
-_Fixed in Elastic Stack version 8.14.0_
+_Fixed in Elastic Stack version 8.13.3_
 
 // The conditions in which this issue occurs
 This issue occurs when upgrading the Elastic Stack to version 8.13.0, 8.13.1, or 8.13.2.
@@ -35,11 +35,11 @@ The following log indicates the presence of this issue:
 
 This issue occurs because a non-optional parameter, `anomalyDetectorTypes` was added in 8.13.0 without
 the presence of an automation migration script. This breaks pre-existing rules as they do not have this parameter
-and will fail validation. This issue is fixed in v8.14.0.
+and will fail validation. This issue is fixed in v8.13.3.
 
 There are three ways to fix this error:
 
-* Upgrade to version 8.14.0 when it's released
+* Upgrade to version 8.13.3
 * Fix broken anomaly rules in the APM UI (no upgrade required)
 * Fix broken anomaly rules with Kibana APIs (no upgrade required)
 


### PR DESCRIPTION
Since adding this known issue doc, it was decided to ship version 8.13.3, which was subsequently [released on May 2](https://www.elastic.co/blog/elastic-stack-8-13-3-released).

You can see [the files changed in the fixing PR](https://github.com/elastic/kibana/pull/180717/files#diff-03fef972515c7d0a89727756ea3868982850651d7e2861d83797999cd3a40421L72-R74) are reflected in [the v8.13.3 tag](https://github.com/elastic/kibana/blob/v8.13.3/x-pack/plugins/apm/common/rules/schema.ts#L69).