### PR TITLE
Fix formatting in topic about logs explorer

### DIFF
--- a/docs/en/observability/monitor-logs.asciidoc
+++ b/docs/en/observability/monitor-logs.asciidoc
@@ -9,6 +9,7 @@ Logs Explorer allows you to quickly search and filter your log data, get informa
 Refer to the <<explore-logs>> documentation for more on using Logs Explorer.
 
 The {logs-app} also provides:
+
 * live <<tail-logs,streaming of logs>>, filtering using auto-complete, and a logs histogram for quick navigation.
 * {ml} to detect specific <<inspect-log-anomalies,log anomalies>> automatically and <<categorize-logs, categorize log messages>> to quickly identify patterns in your
 log events.


### PR DESCRIPTION
An empty line is required or the bulleted list does not render as expected:

![image](https://github.com/elastic/observability-docs/assets/14206422/ae1a4af5-733c-4e21-82d0-6ec2f818f3a5)
