### PR TITLE
Document the lack of RUM global labels support in aggregations

### DIFF
--- a/docs/en/observability/apm/data-model.asciidoc
+++ b/docs/en/observability/apm/data-model.asciidoc
@@ -357,9 +357,9 @@ You can filter and group by these dimensions (some of which are optional, for ex
 * `host.name`: The user-defined name of the host or the detected hostname of the service that served the transaction
 * `host.os.platform`: The platform name of the service that served the transaction, for example `linux`
 * `kubernetes.pod.name`: The name of the Kubernetes pod running the service that served the transaction
-* `labels`: Key-value object containing string labels set globally by the APM agents.
+* `labels`: Key-value object containing string labels set globally by the APM agents except RUM agents.
 * `metricset.interval`: A string with the aggregation interval the metricset represents.
-* `numeric_labels`: Key-value object containing numeric labels set globally by the APM agents.
+* `numeric_labels`: Key-value object containing numeric labels set globally by the APM agents except RUM agents.
 * `service.environment`: The environment of the service that served the transaction
 * `service.language.name`: The language name of the service that served the transaction, for example `Go`
 * `service.language.version`: The language version of the service that served the transaction
@@ -411,9 +411,9 @@ These metric documents can be identified by searching for `metricset.name: servi
 You can filter and group by these dimensions:
 
 * `agent.name`: The name of the {apm-agent} that instrumented the operation, for example `java`
-* `labels`: Key-value object containing string labels set globally by the APM agents.
+* `labels`: Key-value object containing string labels set globally by the APM agents except RUM agents.
 * `metricset.interval`: A string with the aggregation interval the metricset represents.
-* `numeric_labels`: Key-value object containing numeric labels set globally by the APM agents.
+* `numeric_labels`: Key-value object containing numeric labels set globally by the APM agents except RUM agents.
 * `service.environment`: The environment of the service that made the request
 * `service.language.name`: The language name of the service that served the transaction, for example `Go`
 * `service.name`: The name of the service that made the request
@@ -456,9 +456,9 @@ You can filter and group by these dimensions:
 
 * `agent.name`: The name of the {apm-agent} that instrumented the operation, for example `java`
 * `event.outcome`: The outcome of the operation, for example `success`
-* `labels`: Key-value object containing string labels set globally by the APM agents.
+* `labels`: Key-value object containing string labels set globally by the APM agents except RUM agents.
 * `metricset.interval`: A string with the aggregation interval the metricset represents.
-* `numeric_labels`: Key-value object containing numeric labels set globally by the APM agents.
+* `numeric_labels`: Key-value object containing numeric labels set globally by the APM agents except RUM agents.
 * `service.environment`: The environment of the service that made the request
 * `service.language.name`: The language name of the service that served the transaction, for example `Go`
 * `service.name`: The name of the service that made the request
@@ -496,9 +496,9 @@ These metric documents can be identified by searching for `metricset.name: servi
 You can filter and group by these dimensions:
 
 * `agent.name`: The name of the {apm-agent} that instrumented the operation, for example `java`
-* `labels`: Key-value object containing string labels set globally by the APM agents.
+* `labels`: Key-value object containing string labels set globally by the APM agents except RUM agents.
 * `metricset.interval`: A string with the aggregation interval the metricset represents.
-* `numeric_labels`: Key-value object containing numeric labels set globally by the APM agents.
+* `numeric_labels`: Key-value object containing numeric labels set globally by the APM agents except RUM agents.
 * `service.environment`: The environment of the service that made the request
 * `service.language.name`: The language name of the service that served the transaction, for example `Go`
 * `service.name`: The name of the service that made the request

--- a/docs/en/observability/apm/data-model.asciidoc
+++ b/docs/en/observability/apm/data-model.asciidoc
@@ -574,7 +574,9 @@ Once this limit is reached, any new combinations of `transaction.name`, `transac
 
 This issue can be resolved by increasing memory available to APM Server, or by ensuring that the dimensions do not use values
 that are based on parameters that can change. For example, user ids, product ids, order numbers, query parameters, etc.,
-should be stripped away from the dimensions.
+should be stripped away from the dimensions. For the same reason, avoid high cardinality global labels (`labels.\*` and `numeric_labels.*`).
+
+Aggregated metrics do not consider global labels from RUM agents in order to protect APM server from using too much memory.
 
 // This heading is linked to from the APM UI section in Kibana
 [[apm-data-model-metadata]]

--- a/docs/en/observability/apm/data-model.asciidoc
+++ b/docs/en/observability/apm/data-model.asciidoc
@@ -357,9 +357,9 @@ You can filter and group by these dimensions (some of which are optional, for ex
 * `host.name`: The user-defined name of the host or the detected hostname of the service that served the transaction
 * `host.os.platform`: The platform name of the service that served the transaction, for example `linux`
 * `kubernetes.pod.name`: The name of the Kubernetes pod running the service that served the transaction
-* `labels`: Key-value object containing string labels set globally by the APM agents except RUM agents.
+* `labels`: Key-value object containing string labels set globally by the APM agents. This dimension is not present for RUM agents.
 * `metricset.interval`: A string with the aggregation interval the metricset represents.
-* `numeric_labels`: Key-value object containing numeric labels set globally by the APM agents except RUM agents.
+* `numeric_labels`: Key-value object containing numeric labels set globally by the APM agents. This dimension is not present for RUM agents.
 * `service.environment`: The environment of the service that served the transaction
 * `service.language.name`: The language name of the service that served the transaction, for example `Go`
 * `service.language.version`: The language version of the service that served the transaction
@@ -411,9 +411,9 @@ These metric documents can be identified by searching for `metricset.name: servi
 You can filter and group by these dimensions:
 
 * `agent.name`: The name of the {apm-agent} that instrumented the operation, for example `java`
-* `labels`: Key-value object containing string labels set globally by the APM agents except RUM agents.
+* `labels`: Key-value object containing string labels set globally by the APM agents. This dimension is not present for RUM agents.
 * `metricset.interval`: A string with the aggregation interval the metricset represents.
-* `numeric_labels`: Key-value object containing numeric labels set globally by the APM agents except RUM agents.
+* `numeric_labels`: Key-value object containing numeric labels set globally by the APM agents. This dimension is not present for RUM agents.
 * `service.environment`: The environment of the service that made the request
 * `service.language.name`: The language name of the service that served the transaction, for example `Go`
 * `service.name`: The name of the service that made the request
@@ -456,9 +456,9 @@ You can filter and group by these dimensions:
 
 * `agent.name`: The name of the {apm-agent} that instrumented the operation, for example `java`
 * `event.outcome`: The outcome of the operation, for example `success`
-* `labels`: Key-value object containing string labels set globally by the APM agents except RUM agents.
+* `labels`: Key-value object containing string labels set globally by the APM agents. This dimension is not present for RUM agents.
 * `metricset.interval`: A string with the aggregation interval the metricset represents.
-* `numeric_labels`: Key-value object containing numeric labels set globally by the APM agents except RUM agents.
+* `numeric_labels`: Key-value object containing numeric labels set globally by the APM agents. This dimension is not present for RUM agents.
 * `service.environment`: The environment of the service that made the request
 * `service.language.name`: The language name of the service that served the transaction, for example `Go`
 * `service.name`: The name of the service that made the request
@@ -496,9 +496,9 @@ These metric documents can be identified by searching for `metricset.name: servi
 You can filter and group by these dimensions:
 
 * `agent.name`: The name of the {apm-agent} that instrumented the operation, for example `java`
-* `labels`: Key-value object containing string labels set globally by the APM agents except RUM agents.
+* `labels`: Key-value object containing string labels set globally by the APM agents. This dimension is not present for RUM agents.
 * `metricset.interval`: A string with the aggregation interval the metricset represents.
-* `numeric_labels`: Key-value object containing numeric labels set globally by the APM agents except RUM agents.
+* `numeric_labels`: Key-value object containing numeric labels set globally by the APM agents. This dimension is not present for RUM agents.
 * `service.environment`: The environment of the service that made the request
 * `service.language.name`: The language name of the service that served the transaction, for example `Go`
 * `service.name`: The name of the service that made the request


### PR DESCRIPTION
Aggregations no longer support RUM global labels since https://github.com/elastic/apm-server/pull/10624
