### PR TITLE
Add a notice that Uptime will be off by default

### DIFF
--- a/docs/en/observability/uptime-intro.asciidoc
+++ b/docs/en/observability/uptime-intro.asciidoc
@@ -13,6 +13,8 @@ infrastructure with {heartbeat} natively.
 For browser-based monitors, a richer management and reporting experience,
 and more capabilities such as triaging and responding to alerts, use the
 <<monitor-uptime-synthetics,{synthetics-app}>> instead of the {uptime-app}.
+
+Note that {uptime-app} is no longer shown by default if there is no recent Heartbeat data. If you do not see {uptime-app} in the Observability menu, this will need to be enabled. This can be done under Kibana Advanced Settings, either by switching on _Always show legacy Uptime app_ (or with the corresponding `kibana.yml` setting).
 ====
 
 The {uptime-app} uses {agent} to periodically check the status of your services and applications.

--- a/docs/en/observability/uptime-intro.asciidoc
+++ b/docs/en/observability/uptime-intro.asciidoc
@@ -14,7 +14,7 @@ For browser-based monitors, a richer management and reporting experience,
 and more capabilities such as triaging and responding to alerts, use the
 <<monitor-uptime-synthetics,{synthetics-app}>> instead of the {uptime-app}.
 
-Note that {uptime-app} is no longer shown by default if there is no recent Heartbeat data. If you do not see {uptime-app} in the Observability menu, this will need to be enabled. This can be done under Kibana Advanced Settings, either by switching on _Always show legacy Uptime app_ (or with the corresponding `kibana.yml` setting).
+Note that {uptime-app} is no longer shown by default if there is no recent Heartbeat data. If you do not see {uptime-app} in the Observability menu, this will need to be enabled. This can be done under Kibana Advanced Settings by switching on _Always show legacy Uptime app_ (`observability:enableLegacyUptimeApp`).
 ====
 
 The {uptime-app} uses {agent} to periodically check the status of your services and applications.


### PR DESCRIPTION
We don't currently clarify on the [Uptime page](https://www.elastic.co/guide/en/observability/current/uptime-intro.html) that this will not be shown in many cases, which came up recently.

I suspect the docs team may want to wordsmith what I've written (please do), but worth making it clear in the docs going back to 8.9 when this default behaviour was changed.