### PR TITLE
Update serverless pricing link

### DIFF
--- a/docs/en/serverless/projects/billing.mdx
+++ b/docs/en/serverless/projects/billing.mdx
@@ -20,4 +20,6 @@ When you use Elastic Observability, your bill is calculated based on data volume
 Browser (journey) based tests are charged on a per-test-run basis,
 and Ping (lightweight) tests have an all-you-can-use model per location used.
 
-For detailed Observability serverless project rates, refer to the [Elastic Cloud pricing table](https://cloud.elastic.co/cloud-pricing-table?productType=serverless&project=observability).
+For more information, refer to <DocLink id="serverlessBilling" />.
+
+For detailed Observability serverless project rates, check the [Observability Serverless pricing page](https://www.elastic.co/pricing/serverless-observability).

--- a/docs/en/serverless/transclusion/synthetics/global-managed-paid-for.mdx
+++ b/docs/en/serverless/transclusion/synthetics/global-managed-paid-for.mdx
@@ -1,2 +1,2 @@
 Executing synthetic tests on Elastic's global managed testing infrastructure incurs an additional charge. Tests are charged under one of two new billing dimensions depending on the monitor type. For _browser monitor_ usage, there is a fee per test run. For _lightweight monitor_ usage, there is a fee per region in which you run any monitors regardless of the number of test runs.
-{/* For more details, refer to [full details and current pricing](https://www.elastic.co/pricing). */}
+For more details, refer to the [Observability Serverless pricing page](https://www.elastic.co/pricing/serverless-observability).


### PR DESCRIPTION
Closes https://github.com/elastic/observability-docs/issues/3635 and updates the pricing link.

(Replaces https://github.com/elastic/staging-serverless-observability-docs/pull/254)