### PR TITLE
Remove non-existent traces-apm.rum data stream from 7.x docs

### DIFF
--- a/docs/en/apm-server/data-streams.asciidoc
+++ b/docs/en/apm-server/data-streams.asciidoc
@@ -38,7 +38,6 @@ Traces are comprised of {apm-guide-ref}/data-model.html[spans and transactions].
 Traces are stored in the following data streams:
 
 - Application traces: `traces-apm-<namespace>`
-- RUM and iOS agent application traces: `traces-apm.rum-<namespace>`
 
 Metrics::
 


### PR DESCRIPTION
traces-apm.rum is only available since 8.x. Remove it from 7.x docs.
