### PR TITLE
Update Docsmobile action to fix issues

### DIFF
--- a/.github/workflows/co-docs-builder.yml
+++ b/.github/workflows/co-docs-builder.yml
@@ -20,7 +20,7 @@ on:
 
 jobs:
   publish:
-    if: contains(github.event.pull_request.labels.*.name, 'ci:doc-build')
+    if: github.event.label.name == 'ci:doc-build' || github.event.pull_request.author_association == 'MEMBER'
     uses: elastic/workflows/.github/workflows/docs-elastic-co-publish.yml@main
     with:
       subdirectory: 'docs/en/serverless/'


### PR DESCRIPTION
This PR addresses 2 issues:

1. Ensures that the build will only be run when the 'ci:doc-build' label is added instead of every time a label is added and one of the labels is 'ci:doc-build'
2. Bypasses the label requirement if the user is part of the Elastic org