### PR TITLE
Remove `author_association` check in `co-docs-builder.yml`

### DIFF
--- a/.github/workflows/co-docs-builder.yml
+++ b/.github/workflows/co-docs-builder.yml
@@ -20,7 +20,7 @@ on:
 
 jobs:
   publish:
-    if: github.event.label.name == 'ci:doc-build' || github.event.pull_request.author_association == 'MEMBER'
+    if: github.event.label.name == 'ci:doc-build'
     uses: elastic/workflows/.github/workflows/docs-elastic-co-publish.yml@main
     with:
       subdirectory: 'docs/en/serverless/'


### PR DESCRIPTION
It turns out that for Elastic,  github.event.pull_request.author_association == 'NONE', so this won't work