### PR TITLE
[7.16] Remove non-existent traces-apm.rum data stream from 7.x docs (#3934)

### DIFF
--- a/docs/en/apm-server/data-streams.asciidoc
+++ b/docs/en/apm-server/data-streams.asciidoc
@@ -38,7 +38,6 @@ Traces are comprised of {apm-guide-ref}/data-model.html[spans and transactions].
 Traces are stored in the following data streams:
 
 - Application traces: `traces-apm-<namespace>`
-- RUM and iOS agent application traces: `traces-apm.rum-<namespace>`
 
 Metrics::
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `7.17` to `7.16`:
 - [Remove non-existent traces-apm.rum data stream from 7.x docs (#3934)](https://github.com/elastic/observability-docs/pull/3934)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)