### PR TITLE
Update co-docs-builder.yml to fix wordlake builds

### DIFF
--- a/.github/workflows/co-docs-builder.yml
+++ b/.github/workflows/co-docs-builder.yml
@@ -20,7 +20,7 @@ on:
 
 jobs:
   publish:
-    if: github.event.label.name == 'ci:doc-build'
+    if: contains(github.event.pull_request.labels.*.name, 'ci:doc-build')
     uses: elastic/workflows/.github/workflows/docs-elastic-co-publish.yml@main
     with:
       subdirectory: 'docs/en/serverless/'


### PR DESCRIPTION
In preparing for the Docsmobile 2.0 release (and the move to elastic.co/docs) it was discovered that merges on my [fork](https://github.com/elastic/observability-docs-migration-test) to main were [not making it](https://github.com/elastic/observability-docs-migration-test/actions/runs/9392009765) to [wordlake-docs](https://github.com/elastic/wordlake-docs). It is because this `if` statement is too restrictive and only triggers when the initial label is added. 

![image](https://github.com/elastic/observability-docs/assets/1869731/3b8925f3-ff4d-4401-805e-f979688ac1b8)
