### PR TITLE
Update observability-overview.mdx to force a build

### DIFF
--- a/docs/en/serverless/observability-overview.mdx
+++ b/docs/en/serverless/observability-overview.mdx
@@ -6,7 +6,7 @@ description: Learn how to accelerate problem resolution with open, flexible, and
 tags: [ 'serverless', 'observability', 'overview' ]
 ---
 
-<p><DocBadge template="technical preview" /></p>
+<p><DocBadge template="technical preview" /></p> 
 
 <div id="observability-introduction"></div>
 


### PR DESCRIPTION
This is a whitespace-only change to force a build of the serverless docs. A regression was [introduced](https://github.com/elastic/observability-docs/pull/3935) when testing out the new labeling action after the migration of the serverless docs and the new serverless content has not gone live since. Merging this PR will enable the content to go live again, as a [fix](https://github.com/elastic/observability-docs/pull/3969) was recently merged. 