### PR TITLE
profiling on-prem: fix kubernetes secret instructions

### DIFF
--- a/docs/en/observability/profiling-self-managed-ops.asciidoc
+++ b/docs/en/observability/profiling-self-managed-ops.asciidoc
@@ -312,18 +312,18 @@ The secrets should contain the following keys:
 
 Follow these steps to enable TLS connection from collector/symbolizer to Elasticsearch:
 
-1. Create secrets with the TLS key pairs (omit the `ca.cert` field if you are not using a self-signed CA):
+1. Create secrets with the TLS key pairs (omit the `ca.pem` field if you are not using a self-signed CA):
 +
 [source,terminal]
 ----
-kubectl create secret generic pf-collector-tls-certificate --from-file=tls.key=/path/to/key.pem \
---from-file=tls.cert=/path/to/cert.pem --from-file=ca.cert=/path/to/ca.crt
+kubectl -n universal-profiling create secret generic pf-collector-tls-certificate --from-file=tls.key=/path/to/key.pem \
+--from-file=tls.cert=/path/to/cert.pem --from-file=ca.pem=/path/to/ca.crt
 ----
 +
 [source,terminal]
 ----
-kubectl create secret generic pf-symbolizer-tls-certificate --from-file=tls.key=/path/to/key.pem \
---from-file=tls.cert=/path/to/cert.pem --from-file=ca.cert=/path/to/ca.crt
+kubectl -n universal-profiling create secret generic pf-symbolizer-tls-certificate --from-file=tls.key=/path/to/key.pem \
+--from-file=tls.cert=/path/to/cert.pem --from-file=ca.pem=/path/to/ca.crt
 ----
 
 2. Update the collector and symbolizer Helm values files to enable the use of TLS configuration, uncommenting the `output.elasticsearch.ssl` section:


### PR DESCRIPTION
### Reason for this PR

During the development of https://github.com/elastic/prodfiler/pull/4999 we noticed a mismatch in the instructions.