### PR TITLE
Remove the `ecs.yml` section

### DIFF
--- a/docs/en/integrations/build-integration.asciidoc
+++ b/docs/en/integrations/build-integration.asciidoc
@@ -400,18 +400,6 @@ The `event.module` and `event.dataset` fields are defined with a fixed value spe
 - `event.dataset: apache.access`
 Field `@timestamp` is defined here as type `date`.
 
-=== ecs.yml
-This file specifies every Elastic Common Schema (ECS) field used by the integration that is not defined in the files `agent.yml` or `base-fields.yml` files. It uses `external: ecs` references.
-For example:
-+
-[source,yaml]
-----
-- external: ecs
-  name: client.ip
-- external: ecs
-  name: destination.domain
-----
-
 === fields.yml
 Here we define fields that we need in our integration and are not found in the ECS.
 The example below defines field `apache.access.ssl.protocol` in the Apache integration.


### PR DESCRIPTION
As ECS fields no longer need to be specified as part of an integration, this PR removes the ecs.yml section as requested in https://github.com/elastic/observability-docs/issues/3968.

