### PR TITLE
fix: replace ndjson.org with ndjson spec

### DIFF
--- a/docs/en/observability/apm/api-events.asciidoc
+++ b/docs/en/observability/apm/api-events.asciidoc
@@ -13,7 +13,7 @@ Events can be:
 * Metrics
 
 Each event is sent as its own line in the HTTP request body.
-This is known as http://ndjson.org[newline delimited JSON (NDJSON)].
+This is known as https://github.com/ndjson/ndjson-spec[newline delimited JSON (NDJSON)].
 
 With NDJSON, agents can open an HTTP POST request and use chunked encoding to stream events to the APM Server
 as soon as they are recorded in the agent.

--- a/docs/en/serverless/apm/apm-server-api/api-events.mdx
+++ b/docs/en/serverless/apm/apm-server-api/api-events.mdx
@@ -16,7 +16,7 @@ Events can be:
 * Metrics
 
 Each event is sent as its own line in the HTTP request body.
-This is known as [newline delimited JSON (NDJSON)](http://ndjson.org).
+This is known as [newline delimited JSON (NDJSON)](https://github.com/ndjson/ndjson-spec).
 
 With NDJSON, agents can open an HTTP POST request and use chunked encoding to stream events to the managed intake service
 as soon as they are recorded in the agent.


### PR DESCRIPTION
the original website expired and it's currently serving malicious content.

Closes https://github.com/elastic/observability-docs/issues/3981