### PR TITLE
Remove unneed code marking in monitor-amazon-sqs section

### DIFF
--- a/docs/en/observability/cloud-monitoring/aws/monitor-amazon-sqs.asciidoc
+++ b/docs/en/observability/cloud-monitoring/aws/monitor-amazon-sqs.asciidoc
@@ -46,7 +46,6 @@ to {cloud}/ec-cloud-ingest-data.html[Adding data to {es}].
 [[dashboard-sqs]]
 == Dashboards
 
-{kibana-desc}
 For example, to see an overview of your SQS metrics in {kib}, go to
 the **Dashboard** app and navigate to the **[Metrics AWS] SQS Overview**
 dashboard.


### PR DESCRIPTION
https://www.elastic.co/guide/en/observability/current/monitor-amazon-sqs.html

remove unuse var marker
![image](https://github.com/elastic/observability-docs/assets/45684547/06f6ab0d-9551-41ab-ad14-304b1eafdf39)
