### PR TITLE
Clarify index used in SLO privileges example

### DIFF
--- a/docs/en/observability/slo-privileges.asciidoc
+++ b/docs/en/observability/slo-privileges.asciidoc
@@ -26,8 +26,8 @@ Set the following privileges for the SLO All role:
 
 . Under *Cluster privileges* in the *Elasticsearch* section, add `manage_transform` and `manage_ingest_pipelines`.
 . Under *Index privileges*, add `.slo-*` to the *Indices* field and `all` to the *Privileges* field.
-. Click *Add index privilege*
-. Add indices you plan to create SLOs for to the *Indices* field, and add *read* and *view_index_metadata* to to the *Privileges* field.
+. Click *Add index privilege*.
+. Add indices you plan to create SLOs for to the *Indices* field, and add *read* and *view_index_metadata* to the *Privileges* field. The following example shows `logs-*`, but you can specify any indices.
 +
 [role="screenshot"]
 image::images/slo-es-priv-all.png[Cluster and index privileges for SLO All role]


### PR DESCRIPTION
Closes #3996.

Clarification is required because some users interpreted the screenshot to mean that `logs-*` was required.