### PR TITLE
Add nginx tutorial to navigation

### DIFF
--- a/docs/en/observability/tutorials.asciidoc
+++ b/docs/en/observability/tutorials.asciidoc
@@ -25,4 +25,6 @@ include::monitor-gcp.asciidoc[]
 
 include::monitor-java-app.asciidoc[]
 
+include::monitor-nginx.asciidoc[leveloffset=+1]
+
 include::monitor-k8s/monitor-k8s.asciidoc[leveloffset=+1]


### PR DESCRIPTION
Replacing the nav links to the nginx tutorial.