### PR TITLE
Revert "[8.9](backport #4030) Remove BETA mention from UP"

### DIFF
--- a/docs/en/observability/observability-introduction.asciidoc
+++ b/docs/en/observability/observability-introduction.asciidoc
@@ -88,7 +88,7 @@ For more information, see <<monitor-uptime-synthetics,Synthetic monitoring>>.
 [float]
 [[universal-profiling-overview]]
 == Universal Profiling
-Build stack traces to get visibility into your system without application source code changes or instrumentation. Use flamegraphs to explore system performance and identify the most expensive lines of code, increase CPU resource efficiency, debug performance regressions, and reduce cloud spend.
+beta[] Build stack traces to get visibility into your system without application source code changes or instrumentation. Use flamegraphs to explore system performance and identify the most expensive lines of code, increase CPU resource efficiency, debug performance regressions, and reduce cloud spend.
 
 For more information, see <<universal-profiling,Universal Profiling>>.
 


### PR DESCRIPTION
Reverts elastic/observability-docs#4031

8.9 is still marked as Beta in the main docs, so I am reverting this backport.