### PR TITLE
Profiling: Drop known issues section about no longer supported versions

### DIFF
--- a/docs/en/observability/profiling-get-started.asciidoc
+++ b/docs/en/observability/profiling-get-started.asciidoc
@@ -85,31 +85,6 @@ IMPORTANT: When upgrading, you must remove all existing profiling data.
 We still recommend upgrading as the latest version contains several improvements and new features.
 
 [discrete]
-[[profiling-upgrade-known-issues]]
-==== Known issue when configuring data ingestion
-
-If your {ecloud} deployment originated from version 7.x or earlier and is currently running a version between 8.9.0 and 8.10.2, you may encounter a problem while trying to enable Universal Profiling.
-
-Specifically, clicking the *Set up Universal Profiling* button triggers an error message that reads `Error while setting up Universal Profiling`.
-Upgrade to version *8.10.3* or more recent to fix this issue.
-
-
-If you previously enabled Universal Profiling in {ecloud} version 8.9.0, and you're re-executing the setup, you may also encounter
-this error. If upgrading to 8.10.3 does not solve the issue, complete the following step.
-
-
-Open *Dev Tools* from the navigation menu and execute the following command:
-
-
-WARNING: When running the following command, customizations of APM and Fleet configurations will be erased.
-
-[source,console]
-----
-POST kbn:/internal/fleet/reset_preconfigured_agent_policies/policy-elastic-agent-on-cloud
-----
-
-
-[discrete]
 [[profiling-install-profiling-agent]]
 == Install the Universal Profiling Agent
 You have the following options when installing the Universal Profiling Agent:


### PR DESCRIPTION
With 8.14 released, none of the versions listed in the known issue section is a supported version anymore.