### PR TITLE
[Monitor AWS with Firehose] Change file name

### DIFF
--- a/docs/en/observability/cloud-monitoring/aws/ingest-aws-firehose.asciidoc
+++ b/docs/en/observability/cloud-monitoring/aws/ingest-aws-firehose.asciidoc
@@ -1,4 +1,4 @@
-[[monitor-aws-firehose]]
+[[ingest-aws-firehose]]
 == Monitor Amazon Web Services ({aws}) with Amazon Data Firehose
 
 ++++

--- a/docs/en/observability/cloud-monitoring/aws/monitor-amazon-intro.asciidoc
+++ b/docs/en/observability/cloud-monitoring/aws/monitor-amazon-intro.asciidoc
@@ -12,7 +12,7 @@ Learn how to use the Elastic Observability solution to observe and monitor a bro
 
 - <<monitor-aws-elastic-agent,Monitor {aws} with {agent}>>
 - <<monitor-aws,Monitor {aws} with {beats}>>
-- <<monitor-aws-firehose,Monitor {aws} with Amazon Data Firehose>>
+- <<ingest-aws-firehose,Monitor {aws} with Amazon Data Firehose>>
 - <<monitor-aws-esf,Monitor {aws} with Elastic Serverless Forwarder>>
 
 For a full list of supported AWS integrations, check the {integrations-docs}[Elastic
@@ -32,7 +32,7 @@ include::monitor-amazon-sqs.asciidoc[leveloffset=+2]
 
 include::monitor-aws-beats.asciidoc[]
 
-include::monitor-aws-firehose.asciidoc[]
+include::ingest-aws-firehose.asciidoc[]
 
 include::monitor-aws-vpc-flow-logs.asciidoc[leveloffset=+2]
 

--- a/docs/en/observability/cloud-monitoring/aws/monitor-aws-cloudtrail-firehose.asciidoc
+++ b/docs/en/observability/cloud-monitoring/aws/monitor-aws-cloudtrail-firehose.asciidoc
@@ -79,7 +79,7 @@ image::firehose-verify-events-cloudwatch.png[Verify events in CloudWatch]
 image::firehose-delivery-stream.png[Firehose delivery stream]
 
 You now have a CloudWatch log group with events coming from CloudTrail.
-For more information on how to set up a Amazon Data Firehose delivery stream to send data to Elastic Cloud, you can also check the <<monitor-aws-firehose,setup guide>>.
+For more information on how to set up a Amazon Data Firehose delivery stream to send data to Elastic Cloud, you can also check the <<ingest-aws-firehose,setup guide>>.
 
 . Collect {es} endpoint and API key from your deployment on Elastic Cloud.
 +


### PR DESCRIPTION
This PR changes the name of this file https://github.com/elastic/observability-docs/blob/main/docs/en/observability/cloud-monitoring/aws/monitor-aws-firehose.asciidoc from `monitor-aws-firehose` to `ingest-aws-firehose`.