### PR TITLE
Add note about Logs Stream

### DIFF
--- a/docs/en/observability/logs-checklist.asciidoc
+++ b/docs/en/observability/logs-checklist.asciidoc
@@ -90,7 +90,7 @@ With the {logs-app} in {kib} you can search, filter, and tail all your logs inge
 
 The following resources provide information on viewing and monitoring your logs:
 
-- <<tail-logs>>: monitor all of the log events flowing in from your servers, virtual machines, and containers in a centralized view.
+- <<explore-logs>>: monitor all of your log events flowing in from your servers, virtual machines, and containers in a centralized view.
 - <<inspect-log-anomalies>>: use {ml} to detect log anomalies automatically.
 - <<categorize-logs>>: use {ml} to categorize log messages to quickly identify patterns in your log events.
 - <<configure-data-sources>>: Specify the source configuration for logs in the Logs app settings in the Kibana configuration file.

--- a/docs/en/observability/monitor-logs.asciidoc
+++ b/docs/en/observability/monitor-logs.asciidoc
@@ -8,10 +8,6 @@ directories, and tail individual files, all your logs are available in the {logs
 Logs Explorer allows you to quickly search and filter your log data, get information about the structure of log fields, and display your findings in a visualization.
 Refer to the <<explore-logs>> documentation for more on using Logs Explorer.
 
-The {logs-app} also provides:
-
-* live <<tail-logs,streaming of logs>>, filtering using auto-complete, and a logs histogram for quick navigation.
-* {ml} to detect specific <<inspect-log-anomalies,log anomalies>> automatically and <<categorize-logs, categorize log messages>> to quickly identify patterns in your
-log events.
+The {logs-app} also provides {ml} to detect specific <<inspect-log-anomalies,log anomalies>> automatically and <<categorize-logs, categorize log messages>> to quickly identify patterns in your log events.
 
 To view the {logs-app}, go to *{observability} > Logs*.

--- a/docs/en/observability/tail-logs.asciidoc
+++ b/docs/en/observability/tail-logs.asciidoc
@@ -1,6 +1,12 @@
 [[tail-logs]]
 = Tail log files
 
+.There's a new, better way to explore your logs!
+[sidebar]
+--
+<<explore-logs, Logs Explorer>> makes viewing and inspecting your logs easier with more features, better performance, and more intuitive navigation. We recommend switching to Logs Explorer, as it will replace Logs Stream in a future version.
+--
+
 Within the {logs-app}, the *Stream* page enables you to monitor all of the log events flowing in from your
 servers, virtual machines, and containers in a centralized view. You can consider this as a `tail -f` in your browser,
 along with the power of search.


### PR DESCRIPTION
This PR closes #4065.

I've added a note about switching to Logs Explorer that matches the banner in the UI.

![image](https://github.com/user-attachments/assets/a37c5e38-4968-4cca-a0e7-aa4771c2c7d6)

I've also removed references to the tail logs/logs stream page in other docs.
