### PR TITLE
[DOCS] Remove obsolete section

### DIFF
--- a/docs/en/observability/manage-cases.asciidoc
+++ b/docs/en/observability/manage-cases.asciidoc
@@ -153,15 +153,3 @@ To view a case, click on its name. You can then:
 * Refresh the case to retrieve the latest updates.
 * Close the case.
 * Reopen a closed case.
-
-[discrete]
-[[observability-case-templates]]
-== Case templates
-
-preview::[]
-
-You can make the case creation process faster and more consistent by adding templates in *Cases -> Settings*.
-A template defines values for one or all of the case fields (such as severity, tags, description, and title) as well as any <<case-custom-fields,custom fields>>.
-When users create cases, they can optionally select a template and use its field values.
-
-NOTE: If you update or delete templates, existing cases are unaffected.


### PR DESCRIPTION
This PR fixes a build error related to https://github.com/elastic/observability-docs/pull/4074

In particular, the build error was:

>  INFO:build_docs:
--
  | INFO:build_docs:asciidoctor: WARNING: manage-cases-settings.asciidoc: line 78: id assigned to block already in use: observability-case-templates
  | INFO:build_docs:

