### PR TITLE
Add region doc link

### DIFF
--- a/docs/en/serverless/projects/create-an-observability-project.mdx
+++ b/docs/en/serverless/projects/create-an-observability-project.mdx
@@ -20,7 +20,7 @@ where you don't have to manage the underlying ((es)) cluster or ((kib)) instance
 1. Enter a name for your project.
 1. (Optional) Click **Edit settings** to change your project settings:
     * **Cloud provider**: The cloud platform where you’ll deploy your project. We currently support Amazon Web Services (AWS).
-    * **Region**: The region where your project will live. The region should be as close as possible to the location of your data.
+    * **Region**: The <DocLink slug="/serverless/region">region</DocLink> where your project will live. The region should be as close as possible to the location of your data.
 1. Click **Create project**. It takes a few minutes to create your project.
 1. When the project is ready, click **Continue**.
 

--- a/docs/en/serverless/projects/create-an-observability-project.mdx
+++ b/docs/en/serverless/projects/create-an-observability-project.mdx
@@ -20,7 +20,7 @@ where you don't have to manage the underlying ((es)) cluster or ((kib)) instance
 1. Enter a name for your project.
 1. (Optional) Click **Edit settings** to change your project settings:
     * **Cloud provider**: The cloud platform where you’ll deploy your project. We currently support Amazon Web Services (AWS).
-    * **Region**: The <DocLink slug="/serverless/region">region</DocLink> where your project will live. The region should be as close as possible to the location of your data.
+    * **Region**: The <DocLink slug="/serverless/region" text="region"/> where your project will live. The region should be as close as possible to the location of your data.
 1. Click **Create project**. It takes a few minutes to create your project.
 1. When the project is ready, click **Continue**.
 

--- a/docs/en/serverless/projects/create-an-observability-project.mdx
+++ b/docs/en/serverless/projects/create-an-observability-project.mdx
@@ -20,7 +20,7 @@ where you don't have to manage the underlying ((es)) cluster or ((kib)) instance
 1. Enter a name for your project.
 1. (Optional) Click **Edit settings** to change your project settings:
     * **Cloud provider**: The cloud platform where you’ll deploy your project. We currently support Amazon Web Services (AWS).
-    * **Region**: The <DocLink slug="/serverless/region" text="region"/> where your project will live. The region should be as close as possible to the location of your data.
+    * **Region**: The <DocLink slug="/serverless/regions" text="region"/> where your project will live. The region should be as close as possible to the location of your data.
 1. Click **Create project**. It takes a few minutes to create your project.
 1. When the project is ready, click **Continue**.
 

--- a/docs/en/serverless/projects/create-an-observability-project.mdx
+++ b/docs/en/serverless/projects/create-an-observability-project.mdx
@@ -20,7 +20,7 @@ where you don't have to manage the underlying ((es)) cluster or ((kib)) instance
 1. Enter a name for your project.
 1. (Optional) Click **Edit settings** to change your project settings:
     * **Cloud provider**: The cloud platform where you’ll deploy your project. We currently support Amazon Web Services (AWS).
-    * **Region**: The <DocLink slug="/serverless/regions" text="region"/> where your project will live. The region should be as close as possible to the location of your data.
+    * **Region**: The <DocLink slug="/serverless/regions" text="region"/> where your project will live.
 1. Click **Create project**. It takes a few minutes to create your project.
 1. When the project is ready, click **Continue**.
 


### PR DESCRIPTION
Added docs for serverless cloud regions [here](https://github.com/elastic/docs-content/pull/47) - this PR adds an informational link for regions to the obs project creation doc. 

I also removed the region proximity guidance from this [on request](https://github.com/elastic/docs-content/pull/47#issuecomment-2250601601). the linked region page provides some similar guidance, just a little less prescriptive

Won't merge until the core doc is merged
