### PR TITLE
Create OTel log and metric collection docs

### DIFF
--- a/docs/en/serverless/otel-logs-metrics.mdx
+++ b/docs/en/serverless/otel-logs-metrics.mdx
@@ -61,7 +61,7 @@ Update the `otel.yml` file to include the necessary receivers, processors, and e
 ### MacOS and Linux
 To manually collect logs and metrics on a MacOS or Linux system using OpenTelemetry:
 
-1. Download and install the standalone ((agent)) for your platform. {/* link to the download page */}
+1. Download and extract the standalone ((agent)) for your platform. For more on downloading and extracting a standalone ((agent)), refer to the first step on [Install standalone Elastic Agents](((fleet-guide))/install-standalone-elastic-agent.html).
 1. From the ((agent)) base directory, go to the `otel_samples` directory. The `platformlogs_hostmetrics.yml` file contains the receivers, processors, and exporters needed to collect logs and host metrics.
 1. Copy the contents of the `platformlogs_hostmetrics.yml`.
 1. From the ((agent)) base directory, open the `otel.yml` file and replace its contents with the contents of `platformlogs_hostmetrics.yml`.

--- a/docs/en/serverless/otel-logs-metrics.mdx
+++ b/docs/en/serverless/otel-logs-metrics.mdx
@@ -19,22 +19,53 @@ tags: [ 'serverless', 'observability', 'how-to' ]
 In this quickstart guide, you'll learn how to collect logs and metrics using the Elastic Distribution of the OpenTelemetry Collector,
 then navigate to Logs Explorer and Discover to further analyze and explore your observability data.
 
-## Overview
+## Collector components
 
 The Elastic Distribution of the OpenTelemetry Collector is made up of the following components:
 
-- Receivers collect telemetry from your host.
-- Processors take the data collected by receivers and modify or transform it before sending it to the exporters.
-- Exporters send data to the backends or destinations.
+- - <DocLink slug="/serverless/observability/quickstarts/otel-logs-metrics" section="receivers">Receivers</DocLink>: collect telemetry from your host.
+- - <DocLink slug="/serverless/observability/quickstarts/otel-logs-metrics" section="processors">Processors</DocLink>: take the data collected by receivers and modify or transform it before sending it to the exporters.
+- - <DocLink slug="/serverless/observability/quickstarts/otel-logs-metrics" section="exporters">Exporters</DocLink>: send data to the backends or destinations.
 
-The following sections explain the collector components for the different platforms.
+The Elastic Distribution of the OpenTelemetry Collector supports the following components.
 
-### MacOS and Linux
-{/* add diagrams and describe OTel components*/}
+<div id="receivers"></div>
+### Receivers
 
-### Kubernetes
-{/* add diagrams and describe components*/}
+| Component  | Description |
+|---|---|
+| [filelogreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/receiver/filelogreceiver/v0.105.0/receiver/filelogreceiver/README.md) |  |
+| [hostmetricsreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/receiver/hostmetricsreceiver/v0.105.0/receiver/hostmetricsreceiver/README.md) |  |
+| [httpcheckreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/receiver/httpcheckreceiver/v0.105.0/receiver/httpcheckreceiver/README.md) |  |
+| [k8sclusterreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/receiver/k8sclusterreceiver/v0.105.0/receiver/k8sclusterreceiver/README.md) |  |
+| [k8sobjectsreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/receiver/k8sobjectsreceiver/v0.105.0/receiver/k8sobjectsreceiver/README.md) |  |
+| [kubeletstatsreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/receiver/kubeletstatsreceiver/v0.105.0/receiver/kubeletstatsreceiver/README.md) |  |
+| [otlpreceiver](https://github.com/open-telemetry/opentelemetry-collector/blob/receiver/otlpreceiver/v0.105.0/receiver/otlpreceiver/README.md) |  |
 
+<div id="processors"></div>
+### Processors
+
+| Component  | Description |
+|---|---|
+| [elasticinframetricsprocessor](https://github.com/elastic/opentelemetry-collector-components/blob/processor/elasticinframetricsprocessor/v0.7.1/processor/elasticinframetricsprocessor/README.md)  |  |
+| [attributesprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/processor/attributesprocessor/v0.105.0/processor/attributesprocessor/README.md) |  |
+| [filterprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/processor/filterprocessor/v0.105.0/processor/filterprocessor/README.md) |  |
+| [k8sattributesprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/processor/k8sattributesprocessor/v0.105.0/processor/k8sattributesprocessor/README.md) |  |
+| [resourcedetectionprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/processor/resourcedetectionprocessor/v0.105.0/processor/resourcedetectionprocessor/README.md) |  |
+| [resourceprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/processor/resourceprocessor/v0.105.0/processor/resourceprocessor/README.md) |  |
+| [transformprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/processor/transformprocessor/v0.105.0/processor/transformprocessor/README.md) |  |
+| [batchprocessor](https://github.com/open-telemetry/opentelemetry-collector/blob/processor/batchprocessor/v0.105.0/processor/batchprocessor/README.md) |  |
+
+<div id="exporters"></div>
+### Exporters
+
+| Component  | Description |
+|---|---|
+| [elasticsearchexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/exporter/elasticsearchexporter/v0.105.0/exporter/elasticsearchexporter/README.md) |  |
+| [fileexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/exporter/fileexporter/v0.105.0/exporter/fileexporter/README.md) |  |
+| [debugexporter](https://github.com/open-telemetry/opentelemetry-collector/blob/exporter/debugexporter/v0.105.0/exporter/debugexporter/README.md) |  |
+| `[otlpexporter](https://github.com/open-telemetry/opentelemetry-collector/blob/exporter/otlpexporter/v0.105.0/exporter/otlpexporter/README.md) |  |
+| [otlphttpexporter](https://github.com/open-telemetry/opentelemetry-collector/blob/exporter/otlphttpexporter/v0.105.0/exporter/otlphttpexporter/README.md) |  |
 
 ## Collect logs and metrics using the quickstart
 
@@ -52,12 +83,15 @@ Under **Visualize your data**, you'll see links to **Logs Explorer** to view you
 
 ## Manually configure the collector
 Collecting logs and host metrics with the Elastic Distribution of the OpenTelemetry Collector without using the quickstart requires some additional configuration.
-When you download the ((agent)) package, you'll find a sample OpenTelemetry configuration file, `otel.yml`, in the package base directory.
-Refer to the following sections for more on updating the `otel.yml` file to include the necessary receivers, processors, and exporters.
+Refer to:
+- <DocLink slug="/serverless/observability/quickstarts/otel-logs-metrics" section="manual-k8s">Manual Kubernetes OpenTelemetry configuration</DocLink>.
+- <DocLink slug="/serverless/observability/quickstarts/otel-logs-metrics" section="manual-mac-linux">Manual MacOS and Linux OpenTelemetry Configuration</DocLink>.
 
+<div id="manual-k8s"></div>
 ### Kubernetes
 {/* might need some input here, not sure how/if a user would need to create a whole manifest or if we would want to recommend that. */}
 
+<div id="manual-mac-linux"></div>
 ### MacOS and Linux
 
 <DocCallOut title="Before you begin">
@@ -66,7 +100,6 @@ Refer to the following sections for more on updating the `otel.yml` file to incl
    - **Your ((es)) endpoint**: From the Observability project help menu, select **Connection details** and copy the ((es)) endpoint.
    - **API key**: From the Observability project help menu, select **Connection details** and select the **API key** tab. Give your API key a name, select **Create API key**, and copy the new API key.
 </DocCallOut>
-
 
 To manually collect logs and metrics on a MacOS or Linux system using OpenTelemetry:
 

--- a/docs/en/serverless/otel-logs-metrics.mdx
+++ b/docs/en/serverless/otel-logs-metrics.mdx
@@ -1,0 +1,95 @@
+---
+slug: /serverless/observability/quickstarts/otel-logs-metrics
+title: Use OpenTelemetry to collect logs and metrics
+description: Learn how to use the Elastic OpenTelemetry Collector to collect logs and metrics.
+tags: [ 'serverless', 'observability', 'how-to' ]
+---
+
+<p><DocBadge template="technical preview" /></p>
+
+<DocCallOut title="Before you begin">
+   This quickstart has the following requirements and limitations:
+
+   - The **Admin** role or higher is required to onboard system logs and metrics. To learn more, refer to <DocLink slug="/serverless/general/assign-user-roles" />.
+   - Root privileges on the host are required to run the OpenTelemetry collector used in this quickstart.
+   - The collectors only work on Kubernetes, Linux, and MacOS systems.
+   - See the <DocLink slug="/serverless/observability/quickstarts/otel-logs-metrics" section="limitations">Limitations section</DocLink> for known limitations when using Elastic distribution of the OpenTelemetry collector.
+</DocCallOut>
+
+In this quickstart guide, you'll learn how to collect logs and metrics using the Elastic OpenTelemetry Collector,
+then navigate to Logs Explorer and Discover to further analyze and explore your observability data.
+
+## Overview
+
+The Elastic OpenTelemetry Collector is made up of the following components:
+
+- Receivers collect telemetry from your host.
+- Processors take the data collected by receivers and modify or transform it before sending it to the exporters.
+- Exporters send data to the backends or destinations.
+
+The following sections explain the collector components for the different platforms.
+
+### MacOS and Linux
+{/* add diagrams and describe OTel components*/}
+
+### Kubernetes
+{/* add diagrams and describe components*/}
+
+
+## Collect logs and metrics using the quickstart
+
+1. <DocLink slug="/serverless/observability/create-an-observability-project">Create a new ((observability)) project</DocLink>, or open an existing one.
+1. In your ((observability)) project, go to **Add Data**.
+1. Select **Collect and analyze logs**, and then select **Elastic OpenTelemetry Collector**.
+1. Select the appropriate platform, and copy the command that's shown.
+1. Open a terminal on your host, and run the command to download and configure the OpenTelemetry collector (or download the manifest for Kubernetes).
+1. Copy the command under Step 2, and run it in your terminal to start the OpenTelemetry collector.
+
+Logs are collected from setup onward, so you won't see logs that occurred before starting the collector.
+The default log path is `/var/log/*`. To update the path, modify the `otel.yml`.
+
+Under **Visualize your data**, you'll see links to **Logs Explorer** to view your logs and **Hosts** to view your host metrics.
+
+## Manually configure the collector
+Collecting logs and host metrics with the Elastic OpenTelemetry Collector without using the quickstart requires some additional configuration.
+When you download the ((agent)) package, you'll find a sample OpenTelemetry configuration file, `otel.yml`, in the package base directory.
+Update the `otel.yml` file to include the necessary receivers, processors, and exporters.
+
+### Kubernetes
+{/* might need some input here, not sure how/if a user would need to create a whole manifest or if we would want to recommend that. */}
+
+### MacOS and Linux
+To manually collect logs and metrics on a MacOS or Linux system using OpenTelemetry:
+
+1. Download and install the standalone ((agent)) for your platform. {/* link to the download page */}
+1. From the ((agent)) base directory, go to the `otel_samples` directory. The `platformlogs_hostmetrics.yml` file contains the receivers, processors, and exporters needed to collect logs and host metrics.
+1. Copy the contents of the `platformlogs_hostmetrics.yml`.
+1. From the ((agent)) base directory, open the `otel.yml` file and replace its contents with the contents of `platformlogs_hostmetrics.yml`.
+1. Update the following in the OpenTelemetry configuration: {/* not sure if we want to actually set env vars for these or just replace them in the config */}
+    - `${env:STORAGE_DIR}`: Replace this value with the storage directory.{/* not sure what's being stored here. */}
+    - `${env:ELASTIC_ENDPOINT}`: From the Observability project help menu, select **Connection details** and copy the ((es)) endpoint. Set `elasticsearch.endpoint` to this value in the `otel.yml` file.
+    - ${env:ELASTIC_API_KEY}: From the Observability project help menu, select **Connection details** and select the **API key** tab. Give your API key a name, select **Create API key**, and copy the new API key. Set `elasticsearch.api_key` to this value in the `otel.yml` file.
+1. Run the OpenTelemetry collector with the following command:
+   ```console
+   ./elastic-agent otel --config otel.yml
+   ```
+
+Logs are collected from setup onward, so you won't see logs that occurred before starting the collector.
+The default log path is `/var/log/*`. To update the path, modify the `otel.yml`.
+
+<div id="limitations"></div>
+
+## Limitations
+
+The Elastic OpenTelemetry Collector currently has the following limitations:
+
+- `host.network.*` metrics are not present from OpenTelemetry side.
+- `process.state` is not present in the OpenTelemetry host metric. It's set to a dummy value of **Unknown** in the **State** comlumn of the host processes table.
+- The Elasticsearch exporter handles the metadata fields, but **Host OS version** and**Operating system** may show as "N/A" and **Host IP** may show different values.
+- The CPU scraper needs to be enabled to collect the `systm.load.cores` metric, which affects the **Normalized Load** column in the **Hosts** table and the **Normalized Load** visualization on the host detailed view.
+
+## Get value out of your data
+
+Use Elastic ((observability)) to gain deeper insight into your data through **Logs Explorer** and the **Hosts** page.
+
+{/* Probably want to add more here about what you can do with the data, similar to autodetect logs quickstart with next steps */}

--- a/docs/en/serverless/otel-logs-metrics.mdx
+++ b/docs/en/serverless/otel-logs-metrics.mdx
@@ -1,7 +1,7 @@
 ---
 slug: /serverless/observability/quickstarts/otel-logs-metrics
 title: Use OpenTelemetry to collect logs and metrics
-description: Learn how to use the Elastic OpenTelemetry Collector to collect logs and metrics.
+description: Learn how to use the Elastic Distribution of the OpenTelemetry Collector to collect logs and metrics.
 tags: [ 'serverless', 'observability', 'how-to' ]
 ---
 
@@ -16,12 +16,12 @@ tags: [ 'serverless', 'observability', 'how-to' ]
    - See the <DocLink slug="/serverless/observability/quickstarts/otel-logs-metrics" section="limitations">Limitations section</DocLink> for known limitations when using Elastic distribution of the OpenTelemetry collector.
 </DocCallOut>
 
-In this quickstart guide, you'll learn how to collect logs and metrics using the Elastic OpenTelemetry Collector,
+In this quickstart guide, you'll learn how to collect logs and metrics using the Elastic Distribution of the OpenTelemetry Collector,
 then navigate to Logs Explorer and Discover to further analyze and explore your observability data.
 
 ## Overview
 
-The Elastic OpenTelemetry Collector is made up of the following components:
+The Elastic Distribution of the OpenTelemetry Collector is made up of the following components:
 
 - Receivers collect telemetry from your host.
 - Processors take the data collected by receivers and modify or transform it before sending it to the exporters.
@@ -51,14 +51,23 @@ The default log path is `/var/log/*`. To update the path, modify the `otel.yml`.
 Under **Visualize your data**, you'll see links to **Logs Explorer** to view your logs and **Hosts** to view your host metrics.
 
 ## Manually configure the collector
-Collecting logs and host metrics with the Elastic OpenTelemetry Collector without using the quickstart requires some additional configuration.
+Collecting logs and host metrics with the Elastic Distribution of the OpenTelemetry Collector without using the quickstart requires some additional configuration.
 When you download the ((agent)) package, you'll find a sample OpenTelemetry configuration file, `otel.yml`, in the package base directory.
-Update the `otel.yml` file to include the necessary receivers, processors, and exporters.
+Refer to the following sections for more on updating the `otel.yml` file to include the necessary receivers, processors, and exporters.
 
 ### Kubernetes
 {/* might need some input here, not sure how/if a user would need to create a whole manifest or if we would want to recommend that. */}
 
 ### MacOS and Linux
+
+<DocCallOut title="Before you begin">
+   To manually configure the Elastic Distribution of the OpenTelemetry Collector, you'll need the following information:
+
+   - **Your ((es)) endpoint**: From the Observability project help menu, select **Connection details** and copy the ((es)) endpoint.
+   - **API key**: From the Observability project help menu, select **Connection details** and select the **API key** tab. Give your API key a name, select **Create API key**, and copy the new API key.
+</DocCallOut>
+
+
 To manually collect logs and metrics on a MacOS or Linux system using OpenTelemetry:
 
 1. Download and extract the standalone ((agent)) for your platform. For more on downloading and extracting a standalone ((agent)), refer to the first step on [Install standalone Elastic Agents](((fleet-guide))/install-standalone-elastic-agent.html).
@@ -66,9 +75,9 @@ To manually collect logs and metrics on a MacOS or Linux system using OpenTeleme
 1. Copy the contents of the `platformlogs_hostmetrics.yml`.
 1. From the ((agent)) base directory, open the `otel.yml` file and replace its contents with the contents of `platformlogs_hostmetrics.yml`.
 1. Update the following in the OpenTelemetry configuration: {/* not sure if we want to actually set env vars for these or just replace them in the config */}
-    - `${env:STORAGE_DIR}`: Replace this value with the storage directory.{/* not sure what's being stored here. */}
-    - `${env:ELASTIC_ENDPOINT}`: From the Observability project help menu, select **Connection details** and copy the ((es)) endpoint. Set `elasticsearch.endpoint` to this value in the `otel.yml` file.
-    - ${env:ELASTIC_API_KEY}: From the Observability project help menu, select **Connection details** and select the **API key** tab. Give your API key a name, select **Create API key**, and copy the new API key. Set `elasticsearch.api_key` to this value in the `otel.yml` file.
+    - `file_storage.directory`: Set to the directory where you want to store you OpenTelemetry data.{/* not sure what's being stored here. */}
+    - `elasticsearch.endpoint`: Set to your ((es)) endpoint you copied in the **Before you begin** section.
+    - `elasticsearch.api_key`: Set to the API key you created previously in the **Before you begin** section.
 1. Run the OpenTelemetry collector with the following command:
    ```console
    ./elastic-agent otel --config otel.yml
@@ -81,7 +90,7 @@ The default log path is `/var/log/*`. To update the path, modify the `otel.yml`.
 
 ## Limitations
 
-The Elastic OpenTelemetry Collector currently has the following limitations:
+The Elastic Distribution of the OpenTelemetry Collector currently has the following limitations:
 
 - `host.network.*` metrics are not present from OpenTelemetry side.
 - `process.state` is not present in the OpenTelemetry host metric. It's set to a dummy value of **Unknown** in the **State** comlumn of the host processes table.


### PR DESCRIPTION
This PR closes [Issue 240](https://github.com/elastic/opentelemetry-dev/issues/240).

This document covers users collecting logs and host metrics using the Elastic OTel collector using the new quickstart onboarding and manually through the elastic agent. 

Still working on:

- [ ] Overview section. Will include diagrams similar to otelbin.io. First draft of diagrams is [here](https://www.figma.com/design/hJYQJO9Jr5lDalLuPOD7pK/OTel-Collector-Flow?node-id=0-1&t=1S9GtV9wyn5VNX0Y-0).

Screenshot:
![image](https://github.com/user-attachments/assets/1ba2d48e-b9aa-43c9-9fec-ce1987d4be2c)

- [ ]  Finish manual config of k8s.
- [ ]  Finish next steps/getting value out of your data.
- [ ] Decide where we want the doc to go.