### PR TITLE
docs/otel-direct: refine python specific paragraph

### DIFF
--- a/docs/en/observability/apm/otel-direct.asciidoc
+++ b/docs/en/observability/apm/otel-direct.asciidoc
@@ -115,7 +115,7 @@ For information on how to format an API key, see
 
 Please note the required space between `Bearer` and `an_apm_secret_token`, and `ApiKey` and `an_api_key`.
 
-Some language implementations of the OpenTelemetry agent, namely Python, requires the content of the header to be URL encoded. For the `Bearer` token that would mean just substituting the space between `Bearer` an the token with `%20`, e.g. `"Authorization=Bearer%20an_apm_secret_token"`, for an API key you can use the following snippet to handle that:
+The Python OpenTelemetry agent requires the content of the header to be URL-encoded. For the `Bearer` token that would mean substituting the space between `Bearer` and the token with `%20`, e.g. `"Authorization=Bearer%20an_apm_secret_token"`, for encoding an API key you can use the following snippet:
 
 [source,python]
 ----


### PR DESCRIPTION
Simplify text, remove a `just", fix a typo.