### PR TITLE
Update .mergify.yml

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -78,7 +78,7 @@ pull_request_rules:
         title: "[{{ destination_branch }}] {{ title }} (backport #{{ number }})"
         labels:
           - backport         
-   - name: backport patches to 7.16 branch
+  - name: backport patches to 7.16 branch
     conditions:
       - merged
       - base=main

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -15,104 +15,6 @@ pull_request_rules:
             git merge upstream/{{base}}
             git push upstream {{head}}
             ```
-  - name: backport patches to 8.3 branch
-    conditions:
-      - merged
-      - base=main
-      - label=backport-8.3
-    actions:
-      backport:
-        assignees:
-          - "{{ author }}"
-        branches:
-          - "8.3"
-        title: "[{{ destination_branch }}] {{ title }} (backport #{{ number }})"
-        labels:
-          - backport
-  - name: backport patches to 8.2 branch
-    conditions:
-      - merged
-      - base=main
-      - label=backport-8.2
-    actions:
-      backport:
-        assignees:
-          - "{{ author }}"
-        branches:
-          - "8.2"
-        title: "[{{ destination_branch }}] {{ title }} (backport #{{ number }})"
-        labels:
-          - backport
-  - name: backport patches to 8.1 branch
-    conditions:
-      - merged
-      - base=main
-      - label=backport-8.1
-    actions:
-      backport:
-        assignees:
-          - "{{ author }}"
-        branches:
-          - "8.1"
-        title: "[{{ destination_branch }}] {{ title }} (backport #{{ number }})"
-        labels:
-          - backport
-  - name: backport patches to 8.0 branch
-    conditions:
-      - merged
-      - base=main
-      - label=backport-8.0
-    actions:
-      backport:
-        assignees:
-          - "{{ author }}"
-        branches:
-          - "8.0"
-        title: "[{{ destination_branch }}] {{ title }} (backport #{{ number }})"
-        labels:
-          - backport
-  - name: backport patches to 7.17 branch
-    conditions:
-      - merged
-      - base=main
-      - label=backport-7.17
-    actions:
-      backport:
-        assignees:
-          - "{{ author }}"
-        branches:
-          - "7.17"
-        title: "[{{ destination_branch }}] {{ title }} (backport #{{ number }})"
-        labels:
-          - backport
-  - name: backport patches to 7.16 branch
-    conditions:
-      - merged
-      - base=main
-      - label=backport-7.16
-    actions:
-      backport:
-        assignees:
-          - "{{ author }}"
-        branches:
-          - "7.16"
-        title: "[{{ destination_branch }}] {{ title }} (backport #{{ number }})"
-        labels:
-          - backport
-  - name: backport patches to 7.15 branch
-    conditions:
-      - merged
-      - base=main
-      - label=backport-7.15
-    actions:
-      backport:
-        assignees:
-          - "{{ author }}"
-        branches:
-          - "7.15"
-        title: "[{{ destination_branch }}] {{ title }} (backport #{{ number }})"
-        labels:
-          - backport
   - name: notify the backport policy
     conditions:
       - -label~=^backport
@@ -149,6 +51,112 @@ pull_request_rules:
       comment:
         message: |
           This pull request has not been merged yet. Could you please review and merge it @{{ assignee | join(', @') }}? 🙏
+  - name: backport patches to main branch
+    conditions:
+      - merged
+      - label=backport-main
+    actions:
+      backport:
+        assignees:
+          - "{{ author }}"
+        labels:
+          - "backport"
+        branches:
+          - "main"
+        title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"
+   - name: backport patches to 7.15 branch
+    conditions:
+      - merged
+      - base=main
+      - label=backport-7.15
+    actions:
+      backport:
+        assignees:
+          - "{{ author }}"
+        branches:
+          - "7.15"
+        title: "[{{ destination_branch }}] {{ title }} (backport #{{ number }})"
+        labels:
+          - backport         
+   - name: backport patches to 7.16 branch
+    conditions:
+      - merged
+      - base=main
+      - label=backport-7.16
+    actions:
+      backport:
+        assignees:
+          - "{{ author }}"
+        branches:
+          - "7.16"
+        title: "[{{ destination_branch }}] {{ title }} (backport #{{ number }})"
+        labels:
+          - backport         
+  - name: backport patches to 7.17 branch
+    conditions:
+      - merged
+      - label=backport-7.17
+    actions:
+      backport:
+        assignees:
+          - "{{ author }}"
+        branches:
+          - "7.17"
+        title: "[{{ destination_branch }}] {{ title }} (backport #{{ number }})"
+        labels:
+          - backport
+  - name: backport patches to 8.0 branch
+    conditions:
+      - merged
+      - label=backport-8.0
+    actions:
+      backport:
+        assignees:
+          - "{{ author }}"
+        branches:
+          - "8.0"
+        title: "[{{ destination_branch }}] {{ title }} (backport #{{ number }})"
+        labels:
+          - backport
+  - name: backport patches to 8.1 branch
+    conditions:
+      - merged
+      - label=backport-8.1
+    actions:
+      backport:
+        assignees:
+          - "{{ author }}"
+        branches:
+          - "8.1"
+        title: "[{{ destination_branch }}] {{ title }} (backport #{{ number }})"
+        labels:
+          - backport
+  - name: backport patches to 8.2 branch
+    conditions:
+      - merged
+      - label=backport-8.2
+    actions:
+      backport:
+        assignees:
+          - "{{ author }}"
+        branches:
+          - "8.2"
+        title: "[{{ destination_branch }}] {{ title }} (backport #{{ number }})"
+        labels:
+          - backport
+  - name: backport patches to 8.3 branch
+    conditions:
+      - merged
+      - label=backport-8.3
+    actions:
+      backport:
+        assignees:
+          - "{{ author }}"
+        branches:
+          - "8.3"
+        title: "[{{ destination_branch }}] {{ title }} (backport #{{ number }})"
+        labels:
+          - backport
   - name: backport patches to 8.4 branch
     conditions:
       - merged
@@ -282,7 +290,6 @@ pull_request_rules:
   - name: backport patches to 8.14 branch
     conditions:
       - merged
-      - base=main
       - label=backport-8.14
     actions:
       backport:
@@ -296,7 +303,6 @@ pull_request_rules:
   - name: backport patches to 8.15 branch
     conditions:
       - merged
-      - base=main
       - label=backport-8.15
     actions:
       backport:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -64,7 +64,7 @@ pull_request_rules:
         branches:
           - "main"
         title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"
-   - name: backport patches to 7.15 branch
+  - name: backport patches to 7.15 branch
     conditions:
       - merged
       - base=main


### PR DESCRIPTION
- [x] Organizes file
- [x] Removes base=main requirement from some backport rules enabling us to backport from any branch. For example, notice how this PR didn't have all backports created: https://github.com/elastic/observability-docs/pull/3687. It will after this is merged.
- [x] Add `backport-main` label so we can backport from other branches to main when PRs are opened against version branches.