### PR TITLE
Fix typo and duplication

### DIFF
--- a/docs/en/integrations/quick-start.asciidoc
+++ b/docs/en/integrations/quick-start.asciidoc
@@ -71,11 +71,11 @@ cd sample
 elastic-package lint
 ----
 
-.. Format the pacakge to fix linting
+.. Format the package to fix linting
 +
 [source,console]
 ----
-elastic-package lint
+elastic-package format
 ----
 
 .. Build a `.zip` file out of the package assets


### PR DESCRIPTION
Fix typo on `package`

Update duplicated command. The second command should be `elastic-package format`, as per [documentation](https://github.com/elastic/elastic-package?tab=readme-ov-file#elastic-package-format), instead of `elastic-package lint`

![Screenshot 2024-08-08 at 17 24 53](https://github.com/user-attachments/assets/74e53e0f-b11c-4ceb-994f-890c43abc9db)
