### PR TITLE
O11y AI Assistant -  Google Gemini support

### DIFF
--- a/docs/en/observability/observability-ai-assistant.asciidoc
+++ b/docs/en/observability/observability-ai-assistant.asciidoc
@@ -36,11 +36,11 @@ The AI assistant requires the following:
 
 * {stack} version 8.9 and later.
 * An https://www.elastic.co/pricing[Enterprise subscription].
-* An account with a third-party generative AI provider that supports function calling. The Observability AI Assistant supports the following providers:
-** OpenAI `gpt-4`+.
-** Azure OpenAI Service `gpt-4`(0613) or `gpt-4-32k`(0613) with API version `2023-07-01-preview` or more recent.
-** AWS Bedrock, specifically the Anthropic Claude models.
-** Google Gemini `gemini-1.5-pro-preview-0409` or `gemini-1.5-flash-001`, with defaulting to `gemini-1.5-pro-001`.
+* An account with a third-party generative AI provider that preferably supports function calling.
+If your AI provider does not support function calling, you can configure AI Assistant settings under **Stack Management** to simulate function calling, but this might affect performance.
++
+Refer to the {kibana-ref}/action-types.html[connector documentation] for your provider to learn about supported and default models.
+
 * The knowledge base requires a 4 GB {ml} node.
 
 [IMPORTANT]

--- a/docs/en/observability/observability-ai-assistant.asciidoc
+++ b/docs/en/observability/observability-ai-assistant.asciidoc
@@ -40,7 +40,7 @@ The AI assistant requires the following:
 ** OpenAI `gpt-4`+.
 ** Azure OpenAI Service `gpt-4`(0613) or `gpt-4-32k`(0613) with API version `2023-07-01-preview` or more recent.
 ** AWS Bedrock, specifically the Anthropic Claude models.
-** Google Gemini, with defaulting to `gemini-1.5-pro-001`.
+** Google Gemini `gemini-1.5-pro-preview-0409` or `gemini-1.5-flash-001`, with defaulting to `gemini-1.5-pro-001`.
 * The knowledge base requires a 4 GB {ml} node.
 
 [IMPORTANT]

--- a/docs/en/observability/observability-ai-assistant.asciidoc
+++ b/docs/en/observability/observability-ai-assistant.asciidoc
@@ -39,6 +39,7 @@ The AI assistant requires the following:
 ** OpenAI `gpt-4`+.
 ** Azure OpenAI Service `gpt-4`(0613) or `gpt-4-32k`(0613) with API version `2023-07-01-preview` or more recent.
 ** AWS Bedrock, specifically the Anthropic Claude models.
+** Google Gemini, with defaulting to `gemini-1.5-pro-001`
 * The knowledge base requires a 4 GB {ml} node.
 
 [IMPORTANT]

--- a/docs/en/observability/observability-ai-assistant.asciidoc
+++ b/docs/en/observability/observability-ai-assistant.asciidoc
@@ -13,6 +13,7 @@ The AI Assistant integrates with your large language model (LLM) provider throug
 
 * {kibana-ref}/openai-action-type.html[OpenAI connector] for OpenAI or Azure OpenAI Service.
 * {kibana-ref}/bedrock-action-type.html[Amazon Bedrock connector] for Amazon Bedrock, specifically for the Claude models.
+* {kibana-ref}/gemini-action-type.html[Google Gemini connector] for Google Gemini.
 
 [IMPORTANT]
 ====
@@ -39,7 +40,7 @@ The AI assistant requires the following:
 ** OpenAI `gpt-4`+.
 ** Azure OpenAI Service `gpt-4`(0613) or `gpt-4-32k`(0613) with API version `2023-07-01-preview` or more recent.
 ** AWS Bedrock, specifically the Anthropic Claude models.
-** Google Gemini, with defaulting to `gemini-1.5-pro-001`
+** Google Gemini, with defaulting to `gemini-1.5-pro-001`.
 * The knowledge base requires a 4 GB {ml} node.
 
 [IMPORTANT]
@@ -69,11 +70,15 @@ To set up the AI Assistant:
 * https://platform.openai.com/docs/api-reference[OpenAI API keys]
 * https://learn.microsoft.com/en-us/azure/cognitive-services/openai/reference[Azure OpenAI Service API keys]
 * https://docs.aws.amazon.com/bedrock/latest/userguide/security-iam.html[Amazon Bedrock authentication keys and secrets]
+* https://cloud.google.com/iam/docs/keys-list-get[Google Gemini service account keys]
 
-. From *{stack-manage-app}* -> *{connectors-ui}* in {kib}, create an {kibana-ref}/openai-action-type.html[OpenAI] or {kibana-ref}/bedrock-action-type.html[Amazon Bedrock] connector.
+. From *{stack-manage-app}* -> *{connectors-ui}* in {kib}, create an connector for your AI provider:
+* {kibana-ref}/openai-action-type.html[OpenAI]
+* {kibana-ref}/bedrock-action-type.html[Amazon Bedrock]
+* {kibana-ref}/gemini-action-type.html[Google Gemini]
 . Authenticate communication between {observability} and the AI provider by providing the following information:
 .. In the *URL* field, enter the AI provider's API endpoint URL.
-.. Under *Authentication*, enter the API key or access key/secret you created in the previous step.
+.. Under *Authentication*, enter the key or secret you created in the previous step.
 
 [discrete]
 [[obs-ai-add-data]]


### PR DESCRIPTION
We document Google Gemini in the connectors https://www.elastic.co/guide/en/kibana/current/gemini-action-type.html and in our release highlights https://www.elastic.co/guide/en/observability/current/whats-new.html, but it's missing from the o11y docs.

Add this mention to any place we list the supported connectors with the O11y AI Assistant.

TODO after merging: 
- [ ] Port to serverless