### PR TITLE
feat(apm/otel): include processors in pipelines example

### DIFF
--- a/docs/en/observability/apm/otel-direct.asciidoc
+++ b/docs/en/observability/apm/otel-direct.asciidoc
@@ -45,12 +45,15 @@ service:
   pipelines:
     traces:
       receivers: [otlp]
+      processors: [..., memory_limiter, batch]
       exporters: [debug, otlp/elastic]
     metrics:
       receivers: [otlp]
+      processors: [..., memory_limiter, batch]
       exporters: [debug, otlp/elastic]
     logs: <8>
       receivers: [otlp]
+      processors: [..., memory_limiter, batch]
       exporters: [debug, otlp/elastic]
 ----
 <1> The receivers, like the


### PR DESCRIPTION
since the presence _and_ order turns out to be important and most of us start with copy/pasting the example.