### PR TITLE
[apm] Update agent key privileges to include access to Kibana

### DIFF
--- a/docs/en/observability/apm-ui/api.asciidoc
+++ b/docs/en/observability/apm-ui/api.asciidoc
@@ -795,11 +795,18 @@ Create and assign this role to a user that wishes to create APM agent API keys.
 POST /_security/role/apm_agent_key_user
 {
   "cluster": ["manage_own_api_key"],
-  "applications": [{
-    "application": "apm",
-    "privileges": ["event:write", "config_agent:read"],
-    "resources": ["*"]
-  }]
+  "applications": [
+    {
+      "application": "kibana-.kibana",
+      "privileges": ["feature_apm.all"],
+      "resources": ["*"]
+    },
+    {
+      "application": "apm",
+      "privileges": ["event:write", "config_agent:read"],
+      "resources": ["*"]
+    }
+  ]
 }
 --------------------------------------------------
 


### PR DESCRIPTION
Fixes https://github.com/elastic/observability-docs/issues/3419

Updates the privileges in the [Create agent key](https://www.elastic.co/guide/en/observability/current/apm-create-agent-key.html) section's example role to include access to Kibana. 

cc @joeafari 