### PR TITLE
[DOCS] Add links in APM APIs

### DIFF
--- a/docs/en/observability/apm-ui/api.asciidoc
+++ b/docs/en/observability/apm-ui/api.asciidoc
@@ -370,7 +370,7 @@ By default, annotations are stored in a newly created `observability-annotations
 The name of this index can be changed in your `config.yml` by editing `xpack.observability.annotations.index`.
 If you change the default index name, you'll also need to <<apm-app-annotation-user-create,update your user privileges>> accordingly.
 
-NOTE: For the latest details, refer to {kibana-api}/group/endpoint-apm-annotations[APM annotations API].
+NOTE: For the latest details, refer to {api-kibana}/group/endpoint-apm-annotations[APM annotations API].
 
 [float]
 [[use-annotation-api]]
@@ -749,7 +749,7 @@ curl -X DELETE "http://localhost:5601/api/apm/sourcemaps/apm:foo-1.0.0-644fd5a9"
 
 The APM agent Key API allows you to configure APM agent keys to authorize requests from APM agents to the APM Server.
 
-NOTE: For the latest details, refer to {kibana-api}/group/endpoint-apm-agent-keys[APM agent keys API].
+NOTE: For the latest details, refer to {api-kibana}/group/endpoint-apm-agent-keys[APM agent keys API].
 
 [float]
 [[use-agent-key-api]]
@@ -768,7 +768,7 @@ include::api.asciidoc[tag=using-the-APIs]
 [[apm-create-agent-key]]
 ==== Create agent key
 
-NOTE: For the latest details, refer to {kibana-api}/group/endpoint-apm-agent-keys[APM agent keys API].
+NOTE: For the latest details, refer to {api-kibana}/group/endpoint-apm-agent-keys[APM agent keys API].
 
 Create an APM agent API key. Specify API key privileges in the request body at creation time.
 

--- a/docs/en/observability/apm-ui/api.asciidoc
+++ b/docs/en/observability/apm-ui/api.asciidoc
@@ -370,12 +370,7 @@ By default, annotations are stored in a newly created `observability-annotations
 The name of this index can be changed in your `config.yml` by editing `xpack.observability.annotations.index`.
 If you change the default index name, you'll also need to <<apm-app-annotation-user-create,update your user privileges>> accordingly.
 
-The following APIs are available:
-
-* <<apm-annotation-create>> to create an annotation for APM.
-// * <<obs-annotation-create>> POST /api/observability/annotation
-// * <<obs-annotation-get>> GET /api/observability/annotation/:id
-// * <<obs-annotation-delete>> DELETE /api/observability/annotation/:id
+NOTE: For the latest details, refer to {kibana-api}/group/endpoint-apm-annotations[APM annotations API].
 
 [float]
 [[use-annotation-api]]
@@ -393,6 +388,8 @@ include::api.asciidoc[tag=using-the-APIs]
 
 [[apm-annotation-create]]
 ==== Create or update annotation
+
+NOTE: For the latest details, refer to {kibana-api}/group/endpoint-apm-annotations[APM annotations API].
 
 [float]
 [[apm-annotation-config-req]]
@@ -752,9 +749,7 @@ curl -X DELETE "http://localhost:5601/api/apm/sourcemaps/apm:foo-1.0.0-644fd5a9"
 
 The APM agent Key API allows you to configure APM agent keys to authorize requests from APM agents to the APM Server.
 
-The following APM agent key APIs are available:
-
-* <<apm-create-agent-key>> to create an APM agent key
+NOTE: For the latest details, refer to {kibana-api}/group/endpoint-apm-agent-keys[APM agent keys API].
 
 [float]
 [[use-agent-key-api]]
@@ -772,6 +767,8 @@ include::api.asciidoc[tag=using-the-APIs]
 
 [[apm-create-agent-key]]
 ==== Create agent key
+
+NOTE: For the latest details, refer to {kibana-api}/group/endpoint-apm-agent-keys[APM agent keys API].
 
 Create an APM agent API key. Specify API key privileges in the request body at creation time.
 

--- a/docs/en/observability/apm-ui/api.asciidoc
+++ b/docs/en/observability/apm-ui/api.asciidoc
@@ -389,7 +389,7 @@ include::api.asciidoc[tag=using-the-APIs]
 [[apm-annotation-create]]
 ==== Create or update annotation
 
-NOTE: For the latest details, refer to {kibana-api}/group/endpoint-apm-annotations[APM annotations API].
+NOTE: For the latest details, refer to {api-kibana}/group/endpoint-apm-annotations[APM annotations API].
 
 [float]
 [[apm-annotation-config-req]]


### PR DESCRIPTION
This PR adds links from https://www.elastic.co/guide/en/observability/master/apm-annotation-api.html and https://www.elastic.co/guide/en/observability/master/apm-agent-key-api.html to https://www.elastic.co/docs/api/doc/kibana/group/endpoint-apm-agent-keys and https://www.elastic.co/docs/api/doc/kibana/group/endpoint-apm-annotations.
The latter pages are derived from https://github.com/elastic/kibana/blob/main/x-pack/plugins/observability_solution/apm/docs/openapi/apm.yaml

The pages in the Observability Guide can be deleted when the generated docs are satisfactory.