### PR TITLE
Fix broken image links in data quality topic

### DIFF
--- a/docs/en/observability/logs-monitor-datasets.asciidoc
+++ b/docs/en/observability/logs-monitor-datasets.asciidoc
@@ -8,7 +8,7 @@ Use this information to get an idea of your overall log data set quality and fin
 Access the Data Set Quality page from the main {kib} menu at **Stack Management** → **Data Set Quality**.
 
 [role="screenshot"]
-image::../images/logs-dataset-overview.png[Screen capture of the data set overview]
+image::images/logs-dataset-overview.png[Screen capture of the data set overview]
 
 .Requirements
 [NOTE]
@@ -24,9 +24,9 @@ For example, when the {ref}/mapping-ignored-field.html[ignore_malformed] paramet
 From the data set table, you'll find information for each data set such as its namespace, size, when the data set was last active, and the percentage of degraded docs.
 The percentage of degraded documents determines the data set's quality according to the following scale:
 
-* Good (image::../images/green-dot-icon.png[Good icon]): 0% of the documents in the data set are degraded.
-* Degraded (image::../images/yellow-dot-icon.png[Degraded icon]): Greater than 0% and up to 3% of the documents in the data set are degraded.
-* Poor (image::../images/red-dot-icon.png[Poor icon]): Greater than 3% of the documents in the data set are degraded.
+* Good (image:images/green-dot-icon.png[Good icon]): 0% of the documents in the data set are degraded.
+* Degraded (image:images/yellow-dot-icon.png[Degraded icon]): Greater than 0% and up to 3% of the documents in the data set are degraded.
+* Poor (image:images/red-dot-icon.png[Poor icon]): Greater than 3% of the documents in the data set are degraded.
 
 Opening the details of a specific data set shows the degraded documents history, a summary for the data set, and other details that can help you determine if you need to investigate any issues.
 
@@ -44,7 +44,7 @@ You can also open a data set in Logs Explorer to find ignored fields in individu
 
 To expand the details of a data set with poor or degraded quality and view ignored fields:
 
-. From the data set table, click <DocIcon type="expand" title="expand icon" /> next to a data set with poor or degraded quality.
+. From the data set table, click image:images/expand-icon.png[expand icon] next to a data set with poor or degraded quality.
 . From the details, scroll down to **Degraded fields**.
 
 The **Degraded fields** section shows fields that have been ignored, the number of documents that contain ignored fields, and the timestamp of last occurrence of the field being ignored.
@@ -59,11 +59,11 @@ To use Logs Explorer to find ignored fields in individual logs:
 . Click the percentage in the **Degraded Docs** column to open the data set in Logs Explorer.
 
 The **Documents** table in Logs Explorer is automatically filtered to show documents that were not parsed correctly.
-Under the **actions** column, you'll find the degraded document icon (<DocIcon type="indexClose" title="degraded document icon" />).
+Under the **actions** column, you'll find the degraded document icon.
 
 Now that you know which documents contain ignored fields, examine them more closely to find the origin of the issue:
 
-. Under the **actions** column, click <DocIcon type="expand" title="expand icon" /> to open the log details.
+. Under the **actions** column, click image:images/expand-icon.png[expand icon] to open the log details.
 . Select the **JSON** tab.
 . Scroll towards the end of the JSON to find the `ignored_field_values`.
 


### PR DESCRIPTION
Fixes a few broken image links that I noticed while perusing the docs.

I didn't add an image for the degraded document icon because it doesn't exist already in our images or images/icons directory. 