### PR TITLE
Profiling: update backend API role permissions

### DIFF
--- a/docs/en/observability/profiling-self-managed.asciidoc
+++ b/docs/en/observability/profiling-self-managed.asciidoc
@@ -233,6 +233,9 @@ Select a *User API key* and assign the following permissions  under *Control sec
 ----
 {
   "profiling": {
+    "cluster": [
+      "monitor"
+    ],
     "indices": [
       {
         "names": [


### PR DESCRIPTION

In 8.15 we introduced a check on permissions performed by the collector.
This requires a new cluster privilege that is not included in the role.