### PR TITLE
Add docs on how to opt-out of complex object parsing

### DIFF
--- a/docs/en/observability/apm/configure/env.asciidoc
+++ b/docs/en/observability/apm/configure/env.asciidoc
@@ -79,7 +79,7 @@ usage in the shell. Arrays at the top-level do not require brackets (`[]`).
 
 For example, the following environment variable is set to a list:
 
-[source]
+[source,bash]
 -------------------------------------------------------------------------------
 ES_HOSTS="10.45.3.2:9220,10.45.3.1:9230"
 -------------------------------------------------------------------------------
@@ -112,7 +112,7 @@ output.elasticsearch:
 
 If the intended password is `foo,bar"baz`, to avoid parsing errors due to complex object parsing, the environment variable should be set as follows:
 
-[source]
+[source,bash]
 -------------------------------------------------------------------------------
 ES_PASSWORD='"foo,bar\"baz"'
 -------------------------------------------------------------------------------

--- a/docs/en/observability/apm/configure/env.asciidoc
+++ b/docs/en/observability/apm/configure/env.asciidoc
@@ -79,7 +79,7 @@ usage in the shell. Arrays at the top-level do not require brackets (`[]`).
 
 For example, the following environment variable is set to a list:
 
-[source,yaml]
+[source]
 -------------------------------------------------------------------------------
 ES_HOSTS="10.45.3.2:9220,10.45.3.1:9230"
 -------------------------------------------------------------------------------
@@ -95,4 +95,27 @@ output.elasticsearch:
 When APM Server loads the config file, it resolves the environment variable and
 replaces it with the specified list before reading the `hosts` setting.
 
-NOTE: Do not use double-quotes (`"`) to wrap regular expressions, or the backslash (`\`) will be interpreted as an escape character.
+[float]
+=== Opt-out of complex object parsing
+
+To opt-out of this complex object parsing behavior such that the environment variable
+is always parsed as a string, wrap the environment variable in double-quotes (`"`),
+and escape all double quotes within them.
+
+For example, given the following config:
+
+[source,yaml]
+-------------------------------------------------------------------------------
+output.elasticsearch:
+  password: '${ES_PASSWORD}'
+-------------------------------------------------------------------------------
+
+If the intended password is `foo,bar"baz`, to avoid parsing errors due to complex object parsing, the environment variable should be set as follows:
+
+[source]
+-------------------------------------------------------------------------------
+ES_PASSWORD='"foo,bar\"baz"'
+-------------------------------------------------------------------------------
+
+
+NOTE: Do not use double-quotes (`"`) to wrap regular expressions. Otherwise, the backslash (`\`) will be interpreted as an escape character.


### PR DESCRIPTION
Document a way to opt-out of complex object parsing in config parsing to avoid errors.

This is a workaround to https://github.com/elastic/apm-server/issues/13893