### PR TITLE
Fix heading levels in Java tutorial

### DIFF
--- a/docs/en/observability/monitor-java-app.asciidoc
+++ b/docs/en/observability/monitor-java-app.asciidoc
@@ -1092,7 +1092,7 @@ setup got a ton easier, so whenever possible, try to directly
 write your logs as JSON.
 
 [discrete]
-== Step 5: Ingest metrics
+=== Step 5: Ingest metrics
 
 A metric is considered a point in time value that can change anytime. The
 number of current requests can change any millisecond. You could have a
@@ -1339,7 +1339,7 @@ GET metricbeat-*/_search?filter_path=**.prometheus,hits.total
 ----
 
 [discrete]
-== Step 6: View metrics in {kib}
+=== Step 6: View metrics in {kib}
 
 As this is custom data from our Javalin app, there is no predefined
 dashboard for displaying this data.
@@ -1510,7 +1510,7 @@ persisted, they reset on a JVM restart. With that in mind, it’s
 often better to log the `rate` instead of the `counter` field.
 
 [discrete]
-== Step 7: Instrument the application
+=== Step 7: Instrument the application
 
 The third piece of {observability} is Application Performance Management (APM).
 An APM setup consists of an APM server which accepts the data (and is


### PR DESCRIPTION
While I was reviewing DeDe's IA PR, I just noticed in the "On this page" that the heading levels were off in the Java tutorial. 