### PR TITLE
[Host metrics] Add field calculation to serverless docs

### DIFF
--- a/docs/en/serverless/infra-monitoring/host-metrics.mdx
+++ b/docs/en/serverless/infra-monitoring/host-metrics.mdx
@@ -22,10 +22,25 @@ Learn about key host metrics displayed in the Infrastructure UI:
 
 ## Hosts metrics
 
-| Metric | Description |
-|---|---|
-| **Hosts**                 | Number of hosts returned by your search criteria. |
-|                           | Field Calculation: `count(system.cpu.cores)`      |
+<DocTable columns={[
+  {
+    "title": "Metric",
+    "width": "30%"
+  },
+  {
+    "title": "Description",
+    "width": "70%"
+  }
+]}>
+  <DocRow>
+    <DocCell>**Hosts**                </DocCell>
+    <DocCell>
+       Number of hosts returned by your search criteria.
+
+       **Field Calculation**: `count(system.cpu.cores)`
+    </DocCell>
+  </DocRow>
+</DocTable>
 
 <div id="key-metrics-cpu"></div>
 
@@ -34,11 +49,11 @@ Learn about key host metrics displayed in the Infrastructure UI:
 <DocTable columns={[
   {
     "title": "Metric",
-    "width": "50%"
+    "width": "30%"
   },
   {
     "title": "Description",
-    "width": "50%"
+    "width": "70%"
   }
 ]}>
   <DocRow>
@@ -47,67 +62,65 @@ Learn about key host metrics displayed in the Infrastructure UI:
       Percentage of CPU time spent in states other than Idle and IOWait, normalized by the number of CPU cores. This includes both time spent on user space and kernel space.
 
       100% means all CPUs of the host are busy.
+      
+      **Field Calculation**: `(average(system.cpu.user.pct) + average(system.cpu.system.pct)) / max(system.cpu.cores)`
     </DocCell>
   </DocRow>
   <DocRow>
-    <DocCell></DocCell>
-    <DocCell>**Field Calculation**: `(average(system.cpu.user.pct) + average(system.cpu.system.pct)) / max(system.cpu.cores)`</DocCell>
-  </DocRow>
-  <DocRow>
     <DocCell>**CPU Usage - iowait (%)**</DocCell>
-    <DocCell>The percentage of CPU time spent in wait (on disk).</DocCell>
-  </DocRow>
-  <DocRow>
-    <DocCell></DocCell>
-    <DocCell>**Field Calculation**: `average(system.cpu.iowait.pct) / max(system.cpu.cores)`</DocCell>
+    <DocCell>
+       The percentage of CPU time spent in wait (on disk).
+    
+       **Field Calculation**: `average(system.cpu.iowait.pct) / max(system.cpu.cores)`
+    </DocCell>
   </DocRow>
   <DocRow>
     <DocCell>**CPU Usage - irq (%)**    </DocCell>
-    <DocCell>The percentage of CPU time spent servicing and handling hardware interrupts.</DocCell>
-  </DocRow>
-  <DocRow>
-    <DocCell></DocCell>
-    <DocCell>**Field Calculation**: `average(system.cpu.irq.pct) / max(system.cpu.cores)`</DocCell>
+    <DocCell>
+       The percentage of CPU time spent servicing and handling hardware interrupts.
+    
+       **Field Calculation**: `average(system.cpu.irq.pct) / max(system.cpu.cores)`
+    </DocCell>
   </DocRow>
   <DocRow>
     <DocCell>**CPU Usage - nice (%)**  </DocCell>
-    <DocCell>The percentage of CPU time spent on low-priority processes.</DocCell>
-  </DocRow>
-  <DocRow>  
-    <DocCell></DocCell>
-    <DocCell>**Field Calculation**: `average(system.cpu.nice.pct) / max(system.cpu.cores)`</DocCell>
+    <DocCell>
+       The percentage of CPU time spent on low-priority processes.
+       
+      **Field Calculation**: `average(system.cpu.nice.pct) / max(system.cpu.cores)`
+    </DocCell>
   </DocRow>
   <DocRow>
     <DocCell>**CPU Usage - softirq (%)**</DocCell>
-    <DocCell>The percentage of CPU time spent servicing and handling software interrupts.</DocCell>
-  </DocRow>
-  <DocRow>  
-    <DocCell> </DocCell>
-    <DocCell>**Field Calculation**: `average(system.cpu.softirq.pct) / max(system.cpu.cores)`</DocCell>
+    <DocCell>
+       The percentage of CPU time spent servicing and handling software interrupts.
+       
+       **Field Calculation**: `average(system.cpu.softirq.pct) / max(system.cpu.cores)`
+    </DocCell>
   </DocRow>
   <DocRow>
     <DocCell>**CPU Usage - steal (%)**  </DocCell>
-    <DocCell>The percentage of CPU time spent in involuntary wait by the virtual CPU while the hypervisor was servicing another processor. Available only on Unix.</DocCell>
-  </DocRow>
-  <DocRow>
-    <DocCell> </DocCell>
-    <DocCell>**Field Calculation**: `average(system.cpu.steal.pct) / max(system.cpu.cores)`</DocCell>
+    <DocCell>
+       The percentage of CPU time spent in involuntary wait by the virtual CPU while the hypervisor was servicing another processor. Available only on Unix.
+       
+       **Field Calculation**: `average(system.cpu.steal.pct) / max(system.cpu.cores)`
+    </DocCell>
   </DocRow>
   <DocRow>
     <DocCell>**CPU Usage - system (%)** </DocCell>
-    <DocCell>The percentage of CPU time spent in kernel space.</DocCell>
-  </DocRow>
-  <DocRow>
-    <DocCell> </DocCell>
-    <DocCell>**Field Calculation**: `average(system.cpu.system.pct) / max(system.cpu.cores)`</DocCell>
+    <DocCell>
+       The percentage of CPU time spent in kernel space.
+    
+       **Field Calculation**: `average(system.cpu.system.pct) / max(system.cpu.cores)`
+    </DocCell>
   </DocRow>
   <DocRow>
     <DocCell>**CPU Usage - user (%)**   </DocCell>
-    <DocCell>The percentage of CPU time spent in user space. On multi-core systems, you can have percentages that are greater than 100%. For example, if 3 cores are at 60% use, then the system.cpu.user.pct will be 180%.</DocCell>
-  </DocRow>
-  <DocRow>
-    <DocCell> </DocCell>  
-    <DocCell>**Field Calculation**: `average(system.cpu.user.pct) / max(system.cpu.cores)`</DocCell>
+    <DocCell>
+       The percentage of CPU time spent in user space. On multi-core systems, you can have percentages that are greater than 100%. For example, if 3 cores are at 60% use, then the system.cpu.user.pct will be 180%.
+    
+       **Field Calculation**: `average(system.cpu.user.pct) / max(system.cpu.cores)`
+    </DocCell>
   </DocRow>
   <DocRow>
     <DocCell>**Load (1m)**             </DocCell>
@@ -115,11 +128,9 @@ Learn about key host metrics displayed in the Infrastructure UI:
       1 minute load average.
 
       Load average gives an indication of the number of threads that are runnable (either busy running on CPU, waiting to run, or waiting for a blocking IO operation to complete).
+
+      **Field Calculation**: `average(system.load.1)`
     </DocCell>
-  </DocRow>
-  <DocRow>
-    <DocCell> </DocCell>
-    <DocCell>**Field Calculation**: `average(system.load.1)`</DocCell>
   </DocRow>
   <DocRow>
     <DocCell>**Load (5m)**             </DocCell>
@@ -127,11 +138,9 @@ Learn about key host metrics displayed in the Infrastructure UI:
       5 minute load average.
 
       Load average gives an indication of the number of threads that are runnable (either busy running on CPU, waiting to run, or waiting for a blocking IO operation to complete).
+
+      **Field Calculation**: `average(system.load.5)`
     </DocCell>
-  </DocRow>
-  <DocRow>
-    <DocCell> </DocCell>
-    <DocCell>**Field Calculation**: `average(system.load.5)`</DocCell>
   </DocRow>
   <DocRow>
     <DocCell>**Load (15m)**            </DocCell>
@@ -139,11 +148,9 @@ Learn about key host metrics displayed in the Infrastructure UI:
       15 minute load average.
 
       Load average gives an indication of the number of threads that are runnable (either busy running on CPU, waiting to run, or waiting for a blocking IO operation to complete).
+
+      **Field Calculation**: `average(system.load.15)`
     </DocCell>
-  </DocRow>
-  <DocRow>
-    <DocCell> </DocCell>  
-    <DocCell>**Field Calculation**: `average(system.load.15)`</DocCell>
   </DocRow>
   <DocRow>
     <DocCell>**Normalized Load**       </DocCell>
@@ -155,11 +162,9 @@ Learn about key host metrics displayed in the Infrastructure UI:
       100% means the 1 minute load average is equal to the number of CPU cores of the host.
 
       Taking the example of a 32 CPU cores host, if the 1 minute load average is 32, the value reported here is 100%. If the 1 minute load average is 48, the value reported here is 150%.
+
+      **Field Calculation**: `average(system.load.1) / max(system.load.cores)`
     </DocCell>
-  </DocRow>
-  <DocRow>
-    <DocCell> </DocCell>
-    <DocCell>**Field Calculation**: `average(system.load.1) / max(system.load.cores)`</DocCell>
   </DocRow>
 </DocTable>
 
@@ -170,45 +175,45 @@ Learn about key host metrics displayed in the Infrastructure UI:
 <DocTable columns={[
   {
     "title": "Metric",
-    "width": "50%"
+    "width": "30%"
   },
   {
     "title": "Description",
-    "width": "50%"
+    "width": "70%"
   }
 ]}>
   <DocRow>
     <DocCell>**Memory Cache**                </DocCell>
-    <DocCell>Memory (page) cache.</DocCell>
-  </DocRow>
-  <DocRow>
-    <DocCell>  </DocCell>
-    <DocCell>**Field Calculation**: `average(system.memory.used.bytes ) - average(system.memory.actual.used.bytes)`</DocCell>
+    <DocCell>
+       Memory (page) cache.
+
+       **Field Calculation**: `average(system.memory.used.bytes ) - average(system.memory.actual.used.bytes)`
+    </DocCell>
   </DocRow>
   <DocRow>
     <DocCell>**Memory Free**                 </DocCell>
-    <DocCell>Total available memory.</DocCell>
-  </DocRow>
-  <DocRow>
-    <DocCell>  </DocCell>
-    <DocCell>**Field Calculation**: `max(system.memory.total) - average(system.memory.actual.used.bytes)`</DocCell>
+    <DocCell>
+       Total available memory.
+
+      **Field Calculation**: `max(system.memory.total) - average(system.memory.actual.used.bytes)`
+    </DocCell>
   </DocRow>
   <DocRow>
     <DocCell>**Memory Free (excluding cache)**</DocCell>
-    <DocCell>Total available memory excluding the page cache.</DocCell>
-  </DocRow>
-  <DocRow>
-    <DocCell>  </DocCell>
-    <DocCell>**Field Calculation**: `system.memory.free`</DocCell>
+    <DocCell>
+       Total available memory excluding the page cache.
+    
+       **Field Calculation**: `system.memory.free`
+    </DocCell>
   </DocRow> 
   <DocRow>
     <DocCell>**Memory Total**   </DocCell>
-    <DocCell>Total memory capacity.</DocCell>
-  </DocRow>
-  <DocRow>
-    <DocCell>  </DocCell>
-    <DocCell>**Field Calculation**: `avg(system.memory.total)`</DocCell>
-  </DocRow>  
+    <DocCell>
+       Total memory capacity.
+    
+      **Field Calculation**: `avg(system.memory.total)`
+    </DocCell>
+  </DocRow> 
   <DocRow>
     <DocCell>**Memory Usage (%)**      </DocCell>
     <DocCell>
@@ -217,60 +222,142 @@ Learn about key host metrics displayed in the Infrastructure UI:
       This includes resident memory for all processes plus memory used by the kernel structures and code apart from the page cache.
 
       A high level indicates a situation of memory saturation for the host. For example, 100% means the main memory is entirely filled with memory that can't be reclaimed, except by swapping out.
+
+      **Field Calculation**: `average(system.memory.actual.used.pct)`
     </DocCell>
-  </DocRow>
-  <DocRow>
-    <DocCell>  </DocCell>
-    <DocCell>**Field Calculation**: `average(system.memory.actual.used.pct)`</DocCell>
   </DocRow> 
   <DocRow>
     <DocCell>**Memory Used**            </DocCell>
-    <DocCell>Main memory usage excluding page cache.</DocCell>
+    <DocCell>
+       Main memory usage excluding page cache.
+       
+       **Field Calculation**: `average(system.memory.actual.used.bytes)`
+  </DocCell>
   </DocRow>
-  <DocRow>
-    <DocCell>  </DocCell>
-    <DocCell>**Field Calculation**: `average(system.memory.actual.used.bytes)`</DocCell>
-  </DocRow> 
 </DocTable>
 
 <div id="key-metrics-log"></div>
 
 ## Log metrics
 
-| Metric | Description |
-|---|---|
-| **Log Rate**                     | Derivative of the cumulative sum of the document count scaled to a 1 second rate. This metric relies on the same indices as the logs. |
-|                                  | **Field Calculation**: `cumulative_sum(doc_count)` |
+<DocTable columns={[
+  {
+    "title": "Metric",
+    "width": "30%"
+  },
+  {
+    "title": "Description",
+    "width": "70%"
+  }
+]}>
+  <DocRow>
+    <DocCell>**Log Rate**                </DocCell>
+    <DocCell>
+       Derivative of the cumulative sum of the document count scaled to a 1 second rate. This metric relies on the same indices as the logs.
+
+       **Field Calculation**: `cumulative_sum(doc_count)`
+    </DocCell>
+  </DocRow>
+</DocTable>
 
 <div id="key-metrics-network"></div>
 
 ## Network metrics
 
-| Metric | Description |
-|---|---|
-| **Network Inbound (RX)**           | Number of bytes that have been received per second on the public interfaces of the hosts. |
-|                                    | **Field Calculation**: `average(host.network.ingress.bytes) * 8 / (max(metricset.period, kql='host.network.ingress.bytes: *') / 1000)` |
-| **Network Inbound (TX)**            | Number of bytes that have been sent per second on the public interfaces of the hosts. |
-|                                     | **Field Calculation**: `average(host.network.egress.bytes) * 8 / (max(metricset.period, kql='host.network.egress.bytes: *') / 1000)` |
+<DocTable columns={[
+  {
+    "title": "Metric",
+    "width": "30%"
+  },
+  {
+    "title": "Description",
+    "width": "70%"
+  }
+]}>
+  <DocRow>
+    <DocCell>**Network Inbound (RX)**                </DocCell>
+    <DocCell>
+      Number of bytes that have been received per second on the public interfaces of the hosts.
 
-<div id="key-metrics-disk"></div>
+      **Field Calculation**: `average(host.network.ingress.bytes) * 8 / (max(metricset.period, kql='host.network.ingress.bytes: *') / 1000)`
+    </DocCell>
+  </DocRow>
+  <DocRow>
+    <DocCell>**Network Inbound (TX)**                </DocCell>
+    <DocCell>
+      Number of bytes that have been sent per second on the public interfaces of the hosts.
+
+      **Field Calculation**: `average(host.network.egress.bytes) * 8 / (max(metricset.period, kql='host.network.egress.bytes: *') / 1000)`
+    </DocCell>
+  </DocRow>
+</DocTable>
 
 ## Disk metrics
 
-| Metric | Description |
-|---|---|
-| **Disk Latency**                 | Time spent to service disk requests. |
-|                                  | **Field Calculation**: `average(system.diskio.read.time + system.diskio.write.time) / (system.diskio.read.count + system.diskio.write.count)` |
-| **Disk Read IOPS**               | Average count of read operations from the device per second. |
-|                                  | **Field Calculation**: `counter_rate(max(system.diskio.read.count), kql='system.diskio.read.count: *')` |
-| **Disk Read Throughput**         | Average number of bytes read from the device per second. |
-|                                  | **Field Calculation**: `counter_rate(max(system.diskio.read.bytes), kql='system.diskio.read.bytes: *')` |
-| **Disk Usage - Available (%)**   | Percentage of disk space available. |
-|                                  | **Field Calculation**: `1-average(system.filesystem.used.pct)` |
-| **Disk Usage - Max (%)**         | Percentage of disk space used.  A high percentage indicates that a partition on a disk is running out of space. |
-|                                  | **Field Calculation**: `max(system.filesystem.used.pct)` |
-| **Disk Write IOPS**              | Average count of write operations from the device per second. |
-|                                  | **Field Calculation**: `counter_rate(max(system.diskio.write.count), kql='system.diskio.write.count: *')` |
-| **Disk Write Throughput**        | Average number of bytes written from the device per second. |
-|                                  | **Field Calculation**: `counter_rate(max(system.diskio.write.bytes), kql='system.diskio.write.bytes: *')` |
+<DocTable columns={[
+  {
+    "title": "Metric",
+    "width": "30%"
+  },
+  {
+    "title": "Description",
+    "width": "70%"
+  }
+]}>
+  <DocRow>
+    <DocCell>**Disk Latency****                </DocCell>
+    <DocCell>
+      Time spent to service disk requests.
 
+      **Field Calculation**: `average(system.diskio.read.time + system.diskio.write.time) / (system.diskio.read.count + system.diskio.write.count)`
+    </DocCell>
+  </DocRow>
+  <DocRow>
+    <DocCell>**Disk Read IOPS**                </DocCell>
+    <DocCell>
+      Average count of read operations from the device per second.
+
+      **Field Calculation**: `counter_rate(max(system.diskio.read.count), kql='system.diskio.read.count: *')`
+    </DocCell>
+  </DocRow>
+  <DocRow>
+    <DocCell>**Disk Read Throughput**                </DocCell>
+    <DocCell>
+      Average number of bytes read from the device per second.
+
+      **Field Calculation**: `counter_rate(max(system.diskio.read.bytes), kql='system.diskio.read.bytes: *')`
+    </DocCell>
+  </DocRow>
+  <DocRow>
+    <DocCell>**Disk Usage - Available (%)**                </DocCell>
+    <DocCell>
+      Percentage of disk space available.
+
+      **Field Calculation**: `1-average(system.filesystem.used.pct)`
+    </DocCell>
+  </DocRow>
+  <DocRow>
+    <DocCell>**Disk Usage - Max (%)**                </DocCell>
+    <DocCell>
+      Percentage of disk space used.  A high percentage indicates that a partition on a disk is running out of space.
+
+      **Field Calculation**: `max(system.filesystem.used.pct)`
+    </DocCell>
+  </DocRow>
+  <DocRow>
+    <DocCell>**Disk Write IOPS**                </DocCell>
+    <DocCell>
+      Average count of write operations from the device per second.
+
+      **Field Calculation**: `counter_rate(max(system.diskio.write.count), kql='system.diskio.write.count: *')`
+    </DocCell>
+  </DocRow>
+  <DocRow>
+    <DocCell>**Disk Write Throughput**                </DocCell>
+    <DocCell>
+      Average number of bytes written from the device per second.
+
+      **Field Calculation**: `counter_rate(max(system.diskio.write.bytes), kql='system.diskio.write.bytes: *')`
+    </DocCell>
+  </DocRow>
+</DocTable>

--- a/docs/en/serverless/infra-monitoring/host-metrics.mdx
+++ b/docs/en/serverless/infra-monitoring/host-metrics.mdx
@@ -39,10 +39,6 @@ Learn about key host metrics displayed in the Infrastructure UI:
   {
     "title": "Description",
     "width": "50%"
-  },
-    {
-    "title": "Field calculation",
-    "width": "50%"
   }
 ]}>
   <DocRow>
@@ -52,42 +48,66 @@ Learn about key host metrics displayed in the Infrastructure UI:
 
       100% means all CPUs of the host are busy.
     </DocCell>
-    <DocCell>`(average(system.cpu.user.pct) + average(system.cpu.system.pct)) / max(system.cpu.cores)`</DocCell>
+  </DocRow>
+  <DocRow>
+    <DocCell></DocCell>
+    <DocCell>**Field Calculation**: `(average(system.cpu.user.pct) + average(system.cpu.system.pct)) / max(system.cpu.cores)`</DocCell>
   </DocRow>
   <DocRow>
     <DocCell>**CPU Usage - iowait (%)**</DocCell>
     <DocCell>The percentage of CPU time spent in wait (on disk).</DocCell>
-    <DocCell>`average(system.cpu.iowait.pct) / max(system.cpu.cores)`</DocCell>
+  </DocRow>
+  <DocRow>
+    <DocCell></DocCell>
+    <DocCell>**Field Calculation**: `average(system.cpu.iowait.pct) / max(system.cpu.cores)`</DocCell>
   </DocRow>
   <DocRow>
     <DocCell>**CPU Usage - irq (%)**    </DocCell>
     <DocCell>The percentage of CPU time spent servicing and handling hardware interrupts.</DocCell>
-    <DocCell>`average(system.cpu.irq.pct) / max(system.cpu.cores)`</DocCell>
+  </DocRow>
+  <DocRow>
+    <DocCell></DocCell>
+    <DocCell>**Field Calculation**: `average(system.cpu.irq.pct) / max(system.cpu.cores)`</DocCell>
   </DocRow>
   <DocRow>
     <DocCell>**CPU Usage - nice (%)**  </DocCell>
     <DocCell>The percentage of CPU time spent on low-priority processes.</DocCell>
-    <DocCell>`average(system.cpu.nice.pct) / max(system.cpu.cores)`</DocCell>
+  </DocRow>
+  <DocRow>  
+    <DocCell></DocCell>
+    <DocCell>**Field Calculation**: `average(system.cpu.nice.pct) / max(system.cpu.cores)`</DocCell>
   </DocRow>
   <DocRow>
     <DocCell>**CPU Usage - softirq (%)**</DocCell>
     <DocCell>The percentage of CPU time spent servicing and handling software interrupts.</DocCell>
-    <DocCell>`average(system.cpu.softirq.pct) / max(system.cpu.cores)`</DocCell>
+  </DocRow>
+  <DocRow>  
+    <DocCell> </DocCell>
+    <DocCell>**Field Calculation**: `average(system.cpu.softirq.pct) / max(system.cpu.cores)`</DocCell>
   </DocRow>
   <DocRow>
     <DocCell>**CPU Usage - steal (%)**  </DocCell>
     <DocCell>The percentage of CPU time spent in involuntary wait by the virtual CPU while the hypervisor was servicing another processor. Available only on Unix.</DocCell>
-    <DocCell>`average(system.cpu.steal.pct) / max(system.cpu.cores)`</DocCell>
+  </DocRow>
+  <DocRow>
+    <DocCell> </DocCell>
+    <DocCell>**Field Calculation**: `average(system.cpu.steal.pct) / max(system.cpu.cores)`</DocCell>
   </DocRow>
   <DocRow>
     <DocCell>**CPU Usage - system (%)** </DocCell>
     <DocCell>The percentage of CPU time spent in kernel space.</DocCell>
-    <DocCell>`average(system.cpu.system.pct) / max(system.cpu.cores)`</DocCell>
+  </DocRow>
+  <DocRow>
+    <DocCell> </DocCell>
+    <DocCell>**Field Calculation**: `average(system.cpu.system.pct) / max(system.cpu.cores)`</DocCell>
   </DocRow>
   <DocRow>
     <DocCell>**CPU Usage - user (%)**   </DocCell>
     <DocCell>The percentage of CPU time spent in user space. On multi-core systems, you can have percentages that are greater than 100%. For example, if 3 cores are at 60% use, then the system.cpu.user.pct will be 180%.</DocCell>
-    <DocCell>`average(system.cpu.user.pct) / max(system.cpu.cores)`</DocCell>
+  </DocRow>
+  <DocRow>
+    <DocCell> </DocCell>  
+    <DocCell>**Field Calculation**: `average(system.cpu.user.pct) / max(system.cpu.cores)`</DocCell>
   </DocRow>
   <DocRow>
     <DocCell>**Load (1m)**             </DocCell>
@@ -96,7 +116,10 @@ Learn about key host metrics displayed in the Infrastructure UI:
 
       Load average gives an indication of the number of threads that are runnable (either busy running on CPU, waiting to run, or waiting for a blocking IO operation to complete).
     </DocCell>
-    <DocCell>`average(system.load.1)`</DocCell>
+  </DocRow>
+  <DocRow>
+    <DocCell> </DocCell>
+    <DocCell>**Field Calculation**: `average(system.load.1)`</DocCell>
   </DocRow>
   <DocRow>
     <DocCell>**Load (5m)**             </DocCell>
@@ -105,7 +128,10 @@ Learn about key host metrics displayed in the Infrastructure UI:
 
       Load average gives an indication of the number of threads that are runnable (either busy running on CPU, waiting to run, or waiting for a blocking IO operation to complete).
     </DocCell>
-    <DocCell>`average(system.load.5)`</DocCell>
+  </DocRow>
+  <DocRow>
+    <DocCell> </DocCell>
+    <DocCell>**Field Calculation**: `average(system.load.5)`</DocCell>
   </DocRow>
   <DocRow>
     <DocCell>**Load (15m)**            </DocCell>
@@ -114,7 +140,10 @@ Learn about key host metrics displayed in the Infrastructure UI:
 
       Load average gives an indication of the number of threads that are runnable (either busy running on CPU, waiting to run, or waiting for a blocking IO operation to complete).
     </DocCell>
-    <DocCell>`average(system.load.15)`</DocCell>
+  </DocRow>
+  <DocRow>
+    <DocCell> </DocCell>  
+    <DocCell>**Field Calculation**: `average(system.load.15)`</DocCell>
   </DocRow>
   <DocRow>
     <DocCell>**Normalized Load**       </DocCell>
@@ -127,7 +156,10 @@ Learn about key host metrics displayed in the Infrastructure UI:
 
       Taking the example of a 32 CPU cores host, if the 1 minute load average is 32, the value reported here is 100%. If the 1 minute load average is 48, the value reported here is 150%.
     </DocCell>
-    <DocCell>`average(system.load.1) / max(system.load.cores)`</DocCell>
+  </DocRow>
+  <DocRow>
+    <DocCell> </DocCell>
+    <DocCell>**Field Calculation**: `average(system.load.1) / max(system.load.cores)`</DocCell>
   </DocRow>
 </DocTable>
 
@@ -150,17 +182,33 @@ Learn about key host metrics displayed in the Infrastructure UI:
     <DocCell>Memory (page) cache.</DocCell>
   </DocRow>
   <DocRow>
+    <DocCell>  </DocCell>
+    <DocCell>**Field Calculation**: `average(system.memory.used.bytes ) - average(system.memory.actual.used.bytes)`</DocCell>
+  </DocRow>
+  <DocRow>
     <DocCell>**Memory Free**                 </DocCell>
     <DocCell>Total available memory.</DocCell>
+  </DocRow>
+  <DocRow>
+    <DocCell>  </DocCell>
+    <DocCell>**Field Calculation**: `max(system.memory.total) - average(system.memory.actual.used.bytes)`</DocCell>
   </DocRow>
   <DocRow>
     <DocCell>**Memory Free (excluding cache)**</DocCell>
     <DocCell>Total available memory excluding the page cache.</DocCell>
   </DocRow>
   <DocRow>
+    <DocCell>  </DocCell>
+    <DocCell>**Field Calculation**: `system.memory.free`</DocCell>
+  </DocRow> 
+  <DocRow>
     <DocCell>**Memory Total**   </DocCell>
     <DocCell>Total memory capacity.</DocCell>
   </DocRow>
+  <DocRow>
+    <DocCell>  </DocCell>
+    <DocCell>**Field Calculation**: `avg(system.memory.total)`</DocCell>
+  </DocRow>  
   <DocRow>
     <DocCell>**Memory Usage (%)**      </DocCell>
     <DocCell>
@@ -172,9 +220,17 @@ Learn about key host metrics displayed in the Infrastructure UI:
     </DocCell>
   </DocRow>
   <DocRow>
+    <DocCell>  </DocCell>
+    <DocCell>**Field Calculation**: `average(system.memory.actual.used.pct)`</DocCell>
+  </DocRow> 
+  <DocRow>
     <DocCell>**Memory Used**            </DocCell>
     <DocCell>Main memory usage excluding page cache.</DocCell>
   </DocRow>
+  <DocRow>
+    <DocCell>  </DocCell>
+    <DocCell>**Field Calculation**: `average(system.memory.actual.used.bytes)`</DocCell>
+  </DocRow> 
 </DocTable>
 
 <div id="key-metrics-log"></div>
@@ -184,6 +240,7 @@ Learn about key host metrics displayed in the Infrastructure UI:
 | Metric | Description |
 |---|---|
 | **Log Rate**                     | Derivative of the cumulative sum of the document count scaled to a 1 second rate. This metric relies on the same indices as the logs. |
+|                                  | **Field Calculation**: `cumulative_sum(doc_count)` |
 
 <div id="key-metrics-network"></div>
 
@@ -192,7 +249,9 @@ Learn about key host metrics displayed in the Infrastructure UI:
 | Metric | Description |
 |---|---|
 | **Network Inbound (RX)**           | Number of bytes that have been received per second on the public interfaces of the hosts. |
+|                                    | **Field Calculation**: `average(host.network.ingress.bytes) * 8 / (max(metricset.period, kql='host.network.ingress.bytes: *') / 1000)` |
 | **Network Inbound (TX)**            | Number of bytes that have been sent per second on the public interfaces of the hosts. |
+|                                     | **Field Calculation**: `average(host.network.egress.bytes) * 8 / (max(metricset.period, kql='host.network.egress.bytes: *') / 1000)` |
 
 <div id="key-metrics-disk"></div>
 
@@ -201,10 +260,17 @@ Learn about key host metrics displayed in the Infrastructure UI:
 | Metric | Description |
 |---|---|
 | **Disk Latency**                 | Time spent to service disk requests. |
+|                                  | **Field Calculation**: `average(system.diskio.read.time + system.diskio.write.time) / (system.diskio.read.count + system.diskio.write.count)` |
 | **Disk Read IOPS**               | Average count of read operations from the device per second. |
+|                                  | **Field Calculation**: `counter_rate(max(system.diskio.read.count), kql='system.diskio.read.count: *')` |
 | **Disk Read Throughput**         | Average number of bytes read from the device per second. |
+|                                  | **Field Calculation**: `counter_rate(max(system.diskio.read.bytes), kql='system.diskio.read.bytes: *')` |
 | **Disk Usage - Available (%)**   | Percentage of disk space available. |
+|                                  | **Field Calculation**: `1-average(system.filesystem.used.pct)` |
 | **Disk Usage - Max (%)**         | Percentage of disk space used.  A high percentage indicates that a partition on a disk is running out of space. |
+|                                  | **Field Calculation**: `max(system.filesystem.used.pct)` |
 | **Disk Write IOPS**              | Average count of write operations from the device per second. |
+|                                  | **Field Calculation**: `counter_rate(max(system.diskio.write.count), kql='system.diskio.write.count: *')` |
 | **Disk Write Throughput**        | Average number of bytes written from the device per second. |
+|                                  | **Field Calculation**: `counter_rate(max(system.diskio.write.bytes), kql='system.diskio.write.bytes: *')` |
 

--- a/docs/en/serverless/infra-monitoring/host-metrics.mdx
+++ b/docs/en/serverless/infra-monitoring/host-metrics.mdx
@@ -305,7 +305,7 @@ Learn about key host metrics displayed in the Infrastructure UI:
   }
 ]}>
   <DocRow>
-    <DocCell>**Disk Latency****                </DocCell>
+    <DocCell>**Disk Latency**                </DocCell>
     <DocCell>
       Time spent to service disk requests.
 

--- a/docs/en/serverless/infra-monitoring/host-metrics.mdx
+++ b/docs/en/serverless/infra-monitoring/host-metrics.mdx
@@ -25,6 +25,7 @@ Learn about key host metrics displayed in the Infrastructure UI:
 | Metric | Description |
 |---|---|
 | **Hosts**                 | Number of hosts returned by your search criteria. |
+|                           | Field Calculation: `count(system.cpu.cores)`      |
 
 <div id="key-metrics-cpu"></div>
 
@@ -38,6 +39,10 @@ Learn about key host metrics displayed in the Infrastructure UI:
   {
     "title": "Description",
     "width": "50%"
+  },
+    {
+    "title": "Field calculation",
+    "width": "50%"
   }
 ]}>
   <DocRow>
@@ -47,34 +52,42 @@ Learn about key host metrics displayed in the Infrastructure UI:
 
       100% means all CPUs of the host are busy.
     </DocCell>
+    <DocCell>`(average(system.cpu.user.pct) + average(system.cpu.system.pct)) / max(system.cpu.cores)`</DocCell>
   </DocRow>
   <DocRow>
     <DocCell>**CPU Usage - iowait (%)**</DocCell>
     <DocCell>The percentage of CPU time spent in wait (on disk).</DocCell>
+    <DocCell>`average(system.cpu.iowait.pct) / max(system.cpu.cores)`</DocCell>
   </DocRow>
   <DocRow>
     <DocCell>**CPU Usage - irq (%)**    </DocCell>
     <DocCell>The percentage of CPU time spent servicing and handling hardware interrupts.</DocCell>
+    <DocCell>`average(system.cpu.irq.pct) / max(system.cpu.cores)`</DocCell>
   </DocRow>
   <DocRow>
     <DocCell>**CPU Usage - nice (%)**  </DocCell>
     <DocCell>The percentage of CPU time spent on low-priority processes.</DocCell>
+    <DocCell>`average(system.cpu.nice.pct) / max(system.cpu.cores)`</DocCell>
   </DocRow>
   <DocRow>
     <DocCell>**CPU Usage - softirq (%)**</DocCell>
     <DocCell>The percentage of CPU time spent servicing and handling software interrupts.</DocCell>
+    <DocCell>`average(system.cpu.softirq.pct) / max(system.cpu.cores)`</DocCell>
   </DocRow>
   <DocRow>
     <DocCell>**CPU Usage - steal (%)**  </DocCell>
     <DocCell>The percentage of CPU time spent in involuntary wait by the virtual CPU while the hypervisor was servicing another processor. Available only on Unix.</DocCell>
+    <DocCell>`average(system.cpu.steal.pct) / max(system.cpu.cores)`</DocCell>
   </DocRow>
   <DocRow>
     <DocCell>**CPU Usage - system (%)** </DocCell>
     <DocCell>The percentage of CPU time spent in kernel space.</DocCell>
+    <DocCell>`average(system.cpu.system.pct) / max(system.cpu.cores)`</DocCell>
   </DocRow>
   <DocRow>
     <DocCell>**CPU Usage - user (%)**   </DocCell>
     <DocCell>The percentage of CPU time spent in user space. On multi-core systems, you can have percentages that are greater than 100%. For example, if 3 cores are at 60% use, then the system.cpu.user.pct will be 180%.</DocCell>
+    <DocCell>`average(system.cpu.user.pct) / max(system.cpu.cores)`</DocCell>
   </DocRow>
   <DocRow>
     <DocCell>**Load (1m)**             </DocCell>
@@ -83,6 +96,7 @@ Learn about key host metrics displayed in the Infrastructure UI:
 
       Load average gives an indication of the number of threads that are runnable (either busy running on CPU, waiting to run, or waiting for a blocking IO operation to complete).
     </DocCell>
+    <DocCell>`average(system.load.1)`</DocCell>
   </DocRow>
   <DocRow>
     <DocCell>**Load (5m)**             </DocCell>
@@ -91,6 +105,7 @@ Learn about key host metrics displayed in the Infrastructure UI:
 
       Load average gives an indication of the number of threads that are runnable (either busy running on CPU, waiting to run, or waiting for a blocking IO operation to complete).
     </DocCell>
+    <DocCell>`average(system.load.5)`</DocCell>
   </DocRow>
   <DocRow>
     <DocCell>**Load (15m)**            </DocCell>
@@ -99,6 +114,7 @@ Learn about key host metrics displayed in the Infrastructure UI:
 
       Load average gives an indication of the number of threads that are runnable (either busy running on CPU, waiting to run, or waiting for a blocking IO operation to complete).
     </DocCell>
+    <DocCell>`average(system.load.15)`</DocCell>
   </DocRow>
   <DocRow>
     <DocCell>**Normalized Load**       </DocCell>
@@ -111,6 +127,7 @@ Learn about key host metrics displayed in the Infrastructure UI:
 
       Taking the example of a 32 CPU cores host, if the 1 minute load average is 32, the value reported here is 100%. If the 1 minute load average is 48, the value reported here is 150%.
     </DocCell>
+    <DocCell>`average(system.load.1) / max(system.load.cores)`</DocCell>
   </DocRow>
 </DocTable>
 


### PR DESCRIPTION
This PR adds the missing field calculations to the [serverless docs](https://docs.elastic.co/serverless/observability/host-metrics)

Fixes https://github.com/elastic/observability-docs/issues/3897

Preview link: https://elastic-dot-co-docs-production-8h6qfqwwb-elastic-dev.vercel.app/current/serverless/observability/host-metrics