### PR TITLE
Remove anchor from link to Kibana dashboards page

### DIFF
--- a/docs/en/observability/monitor-java-app.asciidoc
+++ b/docs/en/observability/monitor-java-app.asciidoc
@@ -1469,7 +1469,7 @@ Results show that only twenty requests were sent, which makes sense
 given the processing time.
 +
 Now let’s build a visualization using
-{kibana-ref}/dashboard.html#create-panels-with-lens[Lens] in {kib}.
+{kibana-ref}/dashboard.html[Lens] in {kib}.
 +
 [role="screenshot"]
 image:./images/monitor-java-app-metrics-kibana-create-visualization-open-files.png[Lens


### PR DESCRIPTION
This PR updates a link to unlock https://github.com/elastic/kibana/pull/191129/ that will go live for 8.16