### PR TITLE
[apm/known_issues] Add known issues for ILM to DSL switch

### DIFF
--- a/docs/en/observability/apm/known-issues.asciidoc
+++ b/docs/en/observability/apm/known-issues.asciidoc
@@ -29,19 +29,20 @@ The issue does _not_ occur when creating a _new_ cluster using 8.15.0.
 The issue also does not occur if a custom ILM policy is configured using a custom component template.
 
 // Describe why it happens
-In 8.15.0, APM Server switched to use Datastream Lifecycle(DSL) to manage data retention
+In 8.15.0, APM Server switched to use Data stream Lifecycle to manage data retention
 for APM indices for new deployments as well as for upgraded deployments with default lifecycle
-configurations. Unfortunately, since any datastream created before 8.15.0 does not have DSL
-configuration, such existing datastreams become unmanaged for default lifecycle configurations.
+configurations. Unfortunately, since any data stream created before 8.15.0 does not have data
+stream lifecycle configuration, such existing data streams become unmanaged for default
+lifecycle configurations.
 
 // How to fix it
-Upgrading to 8.15.1 should fix any new indices created for the datastream. However,
+Upgrading to 8.15.1 should fix any new indices created for the data stream. However,
 indices created in version 8.15.0 would remain unmanaged if a custom ILM policy is not
 used. One of the following two approaches can be adopted to fix the unmanaged indices:
 1. Manually delete the indices when they are no longer needed.
-2. Explicitly configure APM datastreams with the default DSL config, note that using
-this approach would migrate all datastreams to DSL which should be equivalent to the
-default ILM policies:
+2. Explicitly configure APM data streams with the default data stream lifecycle config,
+note that using this approach would migrate all data streams to data stream lifecycle
+which should be equivalent to the default ILM policies:
 
 [source,txt]
 ----

--- a/docs/en/observability/apm/known-issues.asciidoc
+++ b/docs/en/observability/apm/known-issues.asciidoc
@@ -19,6 +19,80 @@ If applicable, exact error messages linked to this issue so users searching for 
 Link to fix
 ////
 
+*Upgrading to v8.15.0 may cause APM indices to become unmanaged w.r.t. lifecycle policy* +
+_Elastic Stack versions: 8.15.0_ +
+_Fixed in Elastic Stack version 8.15.1_
+
+// The conditions in which this issue occurs
+The issue occurs when Elastic Stack is upgraded to 8.15.0.
+The issue will NOT occur on a new cluster creation with version 8.15.0.
+The issue occurs because APM Server switched to Elasticsearch APM-data plugin for managing index templates.
+
+The switch also migrated us from Index Lifecycle Management (ILM) to Datastream Lifecycle (DSL) for managing
+data retention for APM indices. Due to this migration, any datastream created before 8.15.0 would be without
+datastream lifecycle configuration and, when migrated to 8.15.0, would become unmanaged (without any data 
+retention configuration). This can be fixed by explicitly configuring APM datastreams with the default
+lifecyle config:
+
+[source,txt]
+----
+
+Thanks for adding more details, we have identified a bug which is causing this issue. In 8.15.0 we migrated from using ILM to DLM (Datastream Lifecycle) and on update, the existing datastreams are not updated with the DLM settings causing Unmanaged indexes.
+
+I have created a bug report in APM-Server and we are working on a fix. For short-term mitigation, we would need to update all the APM datastream manually with the default data retention:
+
+PUT _data_stream/traces-apm-*/_lifecycle
+{
+  "data_retention": "10d"
+}
+
+PUT _data_stream/traces-apm.rum*/_lifecycle
+{
+  "data_retention": "90d"
+}
+
+PUT _data_stream/traces-apm.sampled*/_lifecycle
+{
+  "data_retention": "1h"
+}
+
+PUT _data_stream/metrics-apm.*.1m-*/_lifecycle
+{
+  "data_retention": "90d"
+}
+
+PUT _data_stream/metrics-apm.*.10m-*/_lifecycle
+{
+  "data_retention": "180d"
+}
+
+PUT _data_stream/metrics-apm.*.60m-*/_lifecycle
+{
+  "data_retention": "390d"
+}
+
+PUT _data_stream/metrics-apm.internal-*/_lifecycle
+{
+  "data_retention": "90d"
+}
+
+PUT _data_stream/metrics-apm.app.*/_lifecycle
+{
+  "data_retention": "90d"
+}
+
+PUT _data_stream/logs-apm.*/_lifecycle
+{
+  "data_retention": "10d"
+}
+----
+
+NOTE that while this issue is fixed in 8.15.1, any indices created in 8.15.0 due
+to rollovers would still be unmanaged even after upgrading. The only way to fix
+these is by configuring the datastream lifecycle explicitly as described above.
+Explicitly configuring datastream lifecycle has an added benefit of migrating
+to datastream lifecycle for all APM datastreams.
+
 [[broken-apm-anomaly-rule]]
 *Upgrading to v8.13.0 to v8.13.2 breaks APM anomaly rules* +
 _Elastic Stack versions: 8.13.0, 8.13.1, 8.13.2_ +

--- a/docs/en/observability/apm/known-issues.asciidoc
+++ b/docs/en/observability/apm/known-issues.asciidoc
@@ -29,19 +29,19 @@ The issue does _not_ occur when creating a _new_ cluster using 8.15.0.
 The issue also does not occur if a custom ILM policy is configured using a custom component template.
 
 // Describe why it happens
-In 8.15.0, APM Server switched to use Data stream Lifecycle to manage data retention
+In 8.15.0, APM Server switched to use data stream lifecycle to manage data retention
 for APM indices for new deployments as well as for upgraded deployments with default lifecycle
-configurations. Unfortunately, since any data stream created before 8.15.0 does not have data
+configurations. Unfortunately, since any data stream created before 8.15.0 does not have a data
 stream lifecycle configuration, such existing data streams become unmanaged for default
 lifecycle configurations.
 
 // How to fix it
 Upgrading to 8.15.1 should fix any new indices created for the data stream. However,
-indices created in version 8.15.0 would remain unmanaged if a custom ILM policy is not
-used. One of the following two approaches can be adopted to fix the unmanaged indices:
+indices created in version 8.15.0 would remain unmanaged if the default ILM policy is
+used. One of the following approaches can be adopted to fix the unmanaged indices:
 1. Manually delete the indices when they are no longer needed.
-2. Explicitly configure APM data streams with the default data stream lifecycle config,
-note that using this approach would migrate all data streams to data stream lifecycle
+2. Explicitly configure APM data streams with the default data stream lifecycle config.
+Using this approach would migrate all data streams to use data stream lifecycles,
 which should be equivalent to the default ILM policies:
 
 [source,txt]

--- a/docs/en/observability/apm/known-issues.asciidoc
+++ b/docs/en/observability/apm/known-issues.asciidoc
@@ -94,7 +94,7 @@ PUT _data_stream/logs-apm.*/_lifecycle
 ----
 
 // Link to fix if it exists
-This issue is fixed in 8.15.1 (https://github.com/elastic/elasticsearch/pull/112028[elastic/elasticsearch#112028]).
+This issue is fixed in 8.15.1 (https://github.com/elastic/elasticsearch/pull/112432[elastic/elasticsearch#112432]).
 
 [[broken-apm-anomaly-rule]]
 *Upgrading to v8.13.0 to v8.13.2 breaks APM anomaly rules* +

--- a/docs/en/observability/apm/known-issues.asciidoc
+++ b/docs/en/observability/apm/known-issues.asciidoc
@@ -29,12 +29,10 @@ The issue does _not_ occur when creating a _new_ cluster using 8.15.0.
 The issue also does not occur if a custom ILM policy is configured using a custom component template.
 
 // Describe why it happens
-This happens because APM Server now uses the Elasticsearch apm-data plugin to manage
-index templates, and as a result APM Server now uses datastream lifecycle (DSL) instead
-of index lifecycle management (ILM) to manage data retention for APM indices.
-This means that any datastream created before 8.15.0 does not have DSL configuration
-and, when upgraded to 8.15.0, the datastream becomes unmanaged because it has
-no DSL configuration. 
+In 8.15.0, APM Server switched to use Datastream Lifecycle(DSL) to manage data retention
+for APM indices for new deployments as well as for upgraded deployments with default lifecycle
+configurations. Unfortunately, since any datastream created before 8.15.0 does not have DSL
+configuration, such existing datastreams become unmanaged for default lifecycle configurations.
 
 // How to fix it
 Upgrading to 8.15.1 should fix any new indices created for the datastream. However,

--- a/docs/en/observability/apm/known-issues.asciidoc
+++ b/docs/en/observability/apm/known-issues.asciidoc
@@ -26,18 +26,24 @@ _Fixed in Elastic Stack version 8.15.1_
 // The conditions in which this issue occurs
 The issue only occurs when _upgrading_ the {stack} to 8.15.0.
 The issue does _not_ occur when creating a _new_ cluster using 8.15.0.
+The issue also does not occur if a custom ILM policy is configured using a custom component template.
 
 // Describe why it happens
 This happens because APM Server now uses the Elasticsearch apm-data plugin to manage
-index templates, and as a result APM Server now uses data stream lifecycle (DSL) instead
+index templates, and as a result APM Server now uses datastream lifecycle (DSL) instead
 of index lifecycle management (ILM) to manage data retention for APM indices.
-This means that any data stream created before 8.15.0 does not have DSL configuration
-and, when upgraded to 8.15.0, the data stream becomes unmanaged because it has
+This means that any datastream created before 8.15.0 does not have DSL configuration
+and, when upgraded to 8.15.0, the datastream becomes unmanaged because it has
 no DSL configuration. 
 
 // How to fix it
-This can be fixed by explicitly configuring APM data streams with the default
-DSL config:
+Upgrading to 8.15.1 should fix any new indices created for the datastream. However,
+indices created in version 8.15.0 would remain unmanaged if a custom ILM policy is not
+used. One of the following two approaches can be adopted to fix the unmanaged indices:
+1. Manually delete the indices when they are no longer needed.
+2. Explicitly configure APM datastreams with the default DSL config, note that using
+this approach would migrate all datastreams to DSL which should be equivalent to the
+default ILM policies:
 
 [source,txt]
 ----
@@ -88,11 +94,7 @@ PUT _data_stream/logs-apm.*/_lifecycle
 ----
 
 // Link to fix if it exists
-While this issue is fixed in 8.15.1 (https://github.com/elastic/elasticsearch/pull/112028[elastic/elasticsearch#112028]), any indices created in 8.15.0 due
-to rollovers would still be unmanaged even after upgrading. The only way to fix
-these is by configuring the data stream lifecycle explicitly as described above.
-Explicitly configuring data stream lifecycle has an added benefit of migrating
-to data stream lifecycle for all APM data streams.
+This issue is fixed in 8.15.1 (https://github.com/elastic/elasticsearch/pull/112028[elastic/elasticsearch#112028]).
 
 [[broken-apm-anomaly-rule]]
 *Upgrading to v8.13.0 to v8.13.2 breaks APM anomaly rules* +

--- a/docs/en/observability/apm/known-issues.asciidoc
+++ b/docs/en/observability/apm/known-issues.asciidoc
@@ -19,28 +19,28 @@ If applicable, exact error messages linked to this issue so users searching for 
 Link to fix
 ////
 
-*Upgrading to v8.15.0 may cause APM indices to become unmanaged w.r.t. lifecycle policy* +
+*Upgrading to v8.15.0 may cause APM indices to lose their lifecycle policy* +
 _Elastic Stack versions: 8.15.0_ +
 _Fixed in Elastic Stack version 8.15.1_
 
 // The conditions in which this issue occurs
-The issue occurs when Elastic Stack is upgraded to 8.15.0.
-The issue will NOT occur on a new cluster creation with version 8.15.0.
-The issue occurs because APM Server switched to Elasticsearch APM-data plugin for managing index templates.
+The issue only occurs when _upgrading_ the {stack} to 8.15.0.
+The issue does _not_ occur when creating a _new_ cluster using 8.15.0.
 
-The switch also migrated us from Index Lifecycle Management (ILM) to Datastream Lifecycle (DSL) for managing
-data retention for APM indices. Due to this migration, any datastream created before 8.15.0 would be without
-datastream lifecycle configuration and, when migrated to 8.15.0, would become unmanaged (without any data 
-retention configuration). This can be fixed by explicitly configuring APM datastreams with the default
-lifecyle config:
+// Describe why it happens
+This happens because APM Server now uses the Elasticsearch apm-data plugin to manage
+index templates, and as a result APM Server now uses data stream lifecycle (DSL) instead
+of index lifecycle management (ILM) to manage data retention for APM indices.
+This means that any data stream created before 8.15.0 does not have DSL configuration
+and, when upgraded to 8.15.0, the data stream becomes unmanaged because it has
+no DSL configuration. 
+
+// How to fix it
+This can be fixed by explicitly configuring APM data streams with the default
+DSL config:
 
 [source,txt]
 ----
-
-Thanks for adding more details, we have identified a bug which is causing this issue. In 8.15.0 we migrated from using ILM to DLM (Datastream Lifecycle) and on update, the existing datastreams are not updated with the DLM settings causing Unmanaged indexes.
-
-I have created a bug report in APM-Server and we are working on a fix. For short-term mitigation, we would need to update all the APM datastream manually with the default data retention:
-
 PUT _data_stream/traces-apm-*/_lifecycle
 {
   "data_retention": "10d"
@@ -87,11 +87,12 @@ PUT _data_stream/logs-apm.*/_lifecycle
 }
 ----
 
-NOTE that while this issue is fixed in 8.15.1, any indices created in 8.15.0 due
+// Link to fix if it exists
+While this issue is fixed in 8.15.1 (https://github.com/elastic/elasticsearch/pull/112028[elastic/elasticsearch#112028]), any indices created in 8.15.0 due
 to rollovers would still be unmanaged even after upgrading. The only way to fix
-these is by configuring the datastream lifecycle explicitly as described above.
-Explicitly configuring datastream lifecycle has an added benefit of migrating
-to datastream lifecycle for all APM datastreams.
+these is by configuring the data stream lifecycle explicitly as described above.
+Explicitly configuring data stream lifecycle has an added benefit of migrating
+to data stream lifecycle for all APM data streams.
 
 [[broken-apm-anomaly-rule]]
 *Upgrading to v8.13.0 to v8.13.2 breaks APM anomaly rules* +


### PR DESCRIPTION
APM-Server switched from Index Lifecycle Management(ILM) to Datastream Lifecycle (DSL) in v8.15.0. This switch was done when we moved from APM integration (which used ILM) to APM-data plugin (which uses DSL) in ES for managing APM datastreams. As a result of the switch, any old datastreams created before the switch would be Unmanaged because the datastream will never be updated with the DSL lifecycle -- this has to be done manually by using the [PUT API](https://www.elastic.co/guide/en/elasticsearch/reference/current/tutorial-manage-existing-data-stream.html).

Related issue: https://github.com/elastic/apm-server/issues/13898