### PR TITLE
[APM] Document which fields are supported to create APM Service Groups

### DIFF
--- a/docs/en/observability/apm-ui/services.asciidoc
+++ b/docs/en/observability/apm-ui/services.asciidoc
@@ -41,18 +41,9 @@ To create a service group:
 . Click **Create group**.
 . Specify a name, color, and description.
 . Click **Select services**.
-. Specify a {kibana-ref}/kuery-query.html[{kib} Query Language (KQL)] query to select services for the group.
+. Specify a {kibana-ref}/kuery-query.html[{kib} Query Language (KQL)] query to filter services by one or more of the following dimensions:
+`agent.name`, `service.name`, `service.language.name`, `service.environment`, `labels.<xyz>`.
 Services that match the query within the last 24 hours will be assigned to the group.
-
-[NOTE]
-====
-Once a service group has been saved, this list of services within it is static.
-If a newly added service matches the KQL query, it will not be automatically added to the service group.
-Similarly, if a service stops matching the KQL query, it will not be removed from the group.
-
-To update the list of services within a group,
-edit the service group, click **Refresh** next to the KQL query, and click **Save group**.
-====
 
 **Examples**
 


### PR DESCRIPTION
Fixes https://github.com/elastic/observability-docs/issues/4023

Documents which fields are supported to create APM service groups and removes a note from the service groups doc.

## To do

- [x] Dev/Product review
- [x] Writer review
- [ ] Port to serverless?

cc @chrisdistasio @mielastic
