### PR TITLE
Update the data set quality page

### DIFF
--- a/docs/en/observability/logs-monitor-datasets.asciidoc
+++ b/docs/en/observability/logs-monitor-datasets.asciidoc
@@ -35,19 +35,19 @@ Opening the details of a specific data set shows the degraded documents history,
 == Investigate issues
 
 The Data Set Quality page has a couple of different ways to help you find ignored fields and investigate issues.
-From the data set table, you can expand a data set's details, and view commonly ignored fields and information about those fields.
+From the data set table, you can open the data set's details page, and view commonly ignored fields and information about those fields.
 You can also open a data set in Logs Explorer to find ignored fields in individual logs.
 
 [discrete]
 [[find-ignored-fields-in-data-sets]]
 === Find ignored fields in data sets
 
-To expand the details of a data set with poor or degraded quality and view ignored fields:
+To open the details page for a data set with poor or degraded quality and view ignored fields:
 
 . From the data set table, click image:images/expand-icon.png[expand icon] next to a data set with poor or degraded quality.
-. From the details, scroll down to **Degraded fields**.
+. From the details page, scroll down to **Quality issues**.
 
-The **Degraded fields** section shows fields that have been ignored, the number of documents that contain ignored fields, and the timestamp of last occurrence of the field being ignored.
+The **Quality issues** section shows fields that were ignored during ingest, the number of documents that contain ignored fields, and the timestamp of last occurrence of the field being ignored.
 
 [discrete]
 [[find-ignored-fields-in-individual-logs]]

--- a/docs/en/serverless/logging/monitor-datasets.mdx
+++ b/docs/en/serverless/logging/monitor-datasets.mdx
@@ -34,16 +34,16 @@ Opening the details of a specific data set shows the degraded documents history,
 
 ## Investigate issues
 The Data Set Quality page has a couple of different ways to help you find ignored fields and investigate issues.
-From the data set table, you can expand a data set's details, and view commonly ignored fields and information about those fields.
+From the data set table, you can open the data set's details page, and view commonly ignored fields and information about those fields.
 You can also open a data set in Logs Explorer to find ignored fields in individual logs.
 
 ### Find ignored fields in data sets
-To expand the details of a data set with poor or degraded quality and view ignored fields:
+To open the details page for a data set with poor or degraded quality and view ignored fields:
 
 1. From the data set table, click <DocIcon type="expand" title="expand icon" /> next to a data set with poor or degraded quality.
-1. From the details, scroll down to **Degraded fields**.
+1. From the details, scroll down to **Quality issues**.
 
-The **Degraded fields** section shows fields that have been ignored, the number of documents that contain ignored fields, and the timestamp of last occurrence of the field being ignored.
+The **Quality issues** section shows fields that have been ignored, the number of documents that contain ignored fields, and the timestamp of last occurrence of the field being ignored.
 
 ### Find ignored fields in individual logs
 To use Logs Explorer to find ignored fields in individual logs:


### PR DESCRIPTION
This PR closes [Issue 4149](https://github.com/elastic/observability-docs/issues/4149).

The data set details now open in a page instead of a flyout. I've updated the language to match this and updated the name of the "Quality issues" section. 