### PR TITLE
[Observability AI Assistant] Add explicit text about function calling

### DIFF
--- a/docs/en/observability/observability-ai-assistant.asciidoc
+++ b/docs/en/observability/observability-ai-assistant.asciidoc
@@ -197,7 +197,7 @@ image::images/obs-ai-chat.png[Observability AI assistant chat, 60%]
 ====
 Asking questions about your data requires `function calling`, which enables LLMs to reliably interact with third-party generative AI providers to perform searches or run advanced functions using customer data.
 
-When the {observability} AI Assistant performs searches in the cluster, the queries are run with the same level of permissions of the user.
+When the {observability} AI Assistant performs searches in the cluster, the queries are run with the same level of permissions as the user.
 ====
 
 [discrete]

--- a/docs/en/observability/observability-ai-assistant.asciidoc
+++ b/docs/en/observability/observability-ai-assistant.asciidoc
@@ -193,6 +193,11 @@ This opens the AI Assistant flyout, where you can ask the assistant questions ab
 [role="screenshot"]
 image::images/obs-ai-chat.png[Observability AI assistant chat, 60%]
 
+[IMPORTANT]
+====
+Asking questions about your data requires `function calling`, which enables LLMs to reliably interact with third-party generative AI providers to perform searches or run advanced functions using customer data.
+====
+
 [discrete]
 [[obs-ai-functions]]
 === Suggest functions

--- a/docs/en/observability/observability-ai-assistant.asciidoc
+++ b/docs/en/observability/observability-ai-assistant.asciidoc
@@ -195,7 +195,7 @@ image::images/obs-ai-chat.png[Observability AI assistant chat, 60%]
 
 [IMPORTANT]
 ====
-Asking questions about your data requires `function calling`, which enables LLMs to reliably interact with third-party generative AI providers to perform searches or run advanced functions using customer data.
+Asking questions about your data requires `function calling`, which enables LLMs to reliably interact with third-party generative AI providers to perform searches or run advanced functions using customer data. When the {observability} AI Assistant is accessing data in the cluster, the queries run with the same level of permissions of the user.
 ====
 
 [discrete]

--- a/docs/en/observability/observability-ai-assistant.asciidoc
+++ b/docs/en/observability/observability-ai-assistant.asciidoc
@@ -195,7 +195,9 @@ image::images/obs-ai-chat.png[Observability AI assistant chat, 60%]
 
 [IMPORTANT]
 ====
-Asking questions about your data requires `function calling`, which enables LLMs to reliably interact with third-party generative AI providers to perform searches or run advanced functions using customer data. When the {observability} AI Assistant is accessing data in the cluster, the queries run with the same level of permissions of the user.
+Asking questions about your data requires `function calling`, which enables LLMs to reliably interact with third-party generative AI providers to perform searches or run advanced functions using customer data.
+
+When the {observability} AI Assistant performs searches in the cluster, the queries are run with the same level of permissions of the user.
 ====
 
 [discrete]


### PR DESCRIPTION
This PR adds a more explicit description of what `function calling` is and what it does by adding the following text at the end of the section [Chat with the assistant](https://www.elastic.co/guide/en/observability/current/obs-ai-assistant.html#obs-ai-chat) and just before [Suggest functions](https://www.elastic.co/guide/en/observability/current/obs-ai-assistant.html#obs-ai-functions).

Fixes https://github.com/elastic/observability-docs/issues/4206

Here is a [doc preview](https://observability-docs_bk_4211.docs-preview.app.elstc.co/guide/en/observability/master/obs-ai-assistant.html).