### PR TITLE
[apm] Add headings to APM known issues page

### DIFF
--- a/docs/en/observability/apm/known-issues.asciidoc
+++ b/docs/en/observability/apm/known-issues.asciidoc
@@ -7,19 +7,23 @@ TEMPLATE
 Note: Add known issues for newer Elastic Stack
 versions to the top of this page
 
-*Brief description* +
+[discrete]
+== Brief description
+
 _Versions: XX.XX.XX, YY.YY.YY, ZZ.ZZ.ZZ_
 
-Detailed description including:
+// Detailed description including:
 
-The conditions in which this issue occurs
-The behavior of the issue
-Why it happens
-If applicable, exact error messages linked to this issue so users searching for the error message end up here
-Link to fix
+// The conditions in which this issue occurs
+// The behavior of the issue
+// Why it happens
+// If applicable, exact error messages linked to this issue so users searching for the error message end up here
+// If applicable, link to fix
 ////
 
-*Upgrading to v8.15.0 may cause APM indices to lose their lifecycle policy* +
+[discrete]
+== Upgrading to v8.15.0 may cause APM indices to lose their lifecycle policy
+
 _Elastic Stack versions: 8.15.0_ +
 _Fixed in Elastic Stack version 8.15.1_
 
@@ -95,8 +99,10 @@ PUT _data_stream/logs-apm.*/_lifecycle
 // Link to fix if it exists
 This issue is fixed in 8.15.1 (https://github.com/elastic/elasticsearch/pull/112432[elastic/elasticsearch#112432]).
 
+[discrete]
 [[broken-apm-anomaly-rule]]
-*Upgrading to v8.13.0 to v8.13.2 breaks APM anomaly rules* +
+== Upgrading to v8.13.0 to v8.13.2 breaks APM anomaly rules
+
 _Elastic Stack versions: 8.13.0, 8.13.1, 8.13.2_ +
 _Fixed in Elastic Stack version 8.13.3_
 
@@ -223,8 +229,10 @@ curl -u "$KIBANA_USER":"$KIBANA_PASSWORD" -XPUT "$KIBANA_URL/api/alerting/rule/0
 Once the PUT request executes successfully, the rule will no longer be broken.
 ====
 
+[discrete]
 [[apm-empty-metricset-values]]
-*Upgrading APM Server to 8.11+ might break event intake from older APM Java agents* +
+== Upgrading APM Server to 8.11+ might break event intake from older APM Java agents
+
 _APM Server versions: >=8.11.0_ +
 _Elastic APM Java agent versions: < 1.43.0_
 
@@ -250,7 +258,9 @@ The fix is to upgrade the Elastic APM Java agent to a version >= 1.43.0.
 Find details in https://github.com/elastic/apm-data/pull/157[elastic/apm-data#157].
 
 
-*traces-apm@custom ingest pipeline applied to certain data streams unintentionally* +
+[discrete]
+== traces-apm@custom ingest pipeline applied to certain data streams unintentionally
+
 _APM Server versions: 8.12.0_ +
 
 // Describe the conditions in which this issue occurs
@@ -270,8 +280,9 @@ If you rely on this unintended behavior in 8.12.0, please rename your pipeline t
 // Link to fix?
 A fix was released in 8.12.1: https://github.com/elastic/kibana/pull/175448[elastic/kibana#175448].
 
+[discrete]
+== Ingesting new JVM metrics in 8.9 and 8.10 breaks upgrade to 8.11 and stops ingestion
 
-*Ingesting new JVM metrics in 8.9 and 8.10 breaks upgrade to 8.11 and stops ingestion* +
 _APM Server versions: 8.11.0, 8.11.1_ +
 _Elastic APM Java agent versions: 1.39.0+_
 
@@ -306,7 +317,9 @@ Failed installing package [apm] due to error: [ResponseError: mapper_parsing_exc
 A fix was released in 8.11.2: https://github.com/elastic/kibana/pull/171712[elastic/kibana#171712].
 
 
-*APM integration package upgrade through Fleet causes excessive data stream rollovers* +
+[discrete]
+== APM integration package upgrade through Fleet causes excessive data stream rollovers
+
 _APM Server versions: \<= 8.12.1 +_
 
 // Describe the conditions in which this issue occurs
@@ -336,7 +349,9 @@ Mappings update for metrics-apm.service_destination.10m-default failed due to Re
 A fix was released in 8.12.2: https://github.com/elastic/apm-server/pull/12219[elastic/apm-server#12219].
 
 
-*Performance regression: APM issues too many small bulk requests for Elasticsearch output* +
+[discrete]
+== Performance regression: APM issues too many small bulk requests for Elasticsearch output
+
 _APM Server versions: >=8.13.0, \<= 8.14.2_ +
 
 // Describe the conditions in which this issue occurs


### PR DESCRIPTION
Closes #4212 

Adds headings to the APM known issues page to make it easier to read. The heading text is longer than we prefer, but I think it's ok for this page only (@elastic/obs-docs let me know if you disagree).