### PR TITLE
[apm] Remove preview badge from EDOT Java

### DIFF
--- a/docs/en/observability/apm/open-telemetry.asciidoc
+++ b/docs/en/observability/apm/open-telemetry.asciidoc
@@ -26,7 +26,7 @@ There are several ways to integrate OpenTelemetry with the {stack}:
 [[apm-otel-elastic-distros]]
 == Elastic Distributions of OpenTelemetry language SDKs
 
-preview::[]
+preview::["Some Elastic Distributions of OpenTelemetry are not yet recommended for production use. Functionality may be changed or removed in future releases. Alpha releases are not subject to the support SLA of official GA features."]
 
 Elastic offers several distributions of OpenTelemetry language SDKs.
 A _distribution_ is a customized version of an upstream OpenTelemetry repository.
@@ -47,7 +47,7 @@ such as which sources are collected by default.
 // Where to go next
 Get started with an Elastic Distribution of OpenTelemetry language SDK:
 
-* preview:["The Elastic Distribution of OpenTelemetry Java is not yet recommended for production use. Functionality may be changed or removed in future releases. Alpha releases are not subject to the support SLA of official GA features."] https://github.com/elastic/elastic-otel-java[*Elastic Distribution of OpenTelemetry Java →*]
+* https://github.com/elastic/elastic-otel-java[*Elastic Distribution of OpenTelemetry Java →*]
 * preview:["The Elastic Distribution of OpenTelemetry .NET is not yet recommended for production use. Functionality may be changed or removed in future releases. Alpha releases are not subject to the support SLA of official GA features."] https://github.com/elastic/elastic-otel-dotnet[*Elastic Distribution of OpenTelemetry .NET →*]
 * preview:["The Elastic Distribution of OpenTelemetry Node.js is not yet recommended for production use. Functionality may be changed or removed in future releases. Alpha releases are not subject to the support SLA of official GA features."] https://github.com/elastic/elastic-otel-node[*Elastic Distribution of OpenTelemetry Node.js →*]
 * preview:["The Elastic Distribution of OpenTelemetry Python is not yet recommended for production use. Functionality may be changed or removed in future releases. Alpha releases are not subject to the support SLA of official GA features."] https://github.com/elastic/elastic-otel-python[*Elastic Distribution of OpenTelemetry Python →*]


### PR DESCRIPTION
Removes the preview badge from the link to the EDOT Java docs. 🎉 

cc @estolfo 