### PR TITLE
Fix formatting for APM known issues doc

### DIFF
--- a/docs/en/observability/apm/known-issues.asciidoc
+++ b/docs/en/observability/apm/known-issues.asciidoc
@@ -43,11 +43,12 @@ lifecycle configurations.
 Upgrading to 8.15.1 should fix any new indices created for the data stream. However,
 indices created in version 8.15.0 would remain unmanaged if the default ILM policy is
 used. One of the following approaches can be adopted to fix the unmanaged indices:
-1. Manually delete the indices when they are no longer needed.
-2. Explicitly configure APM data streams with the default data stream lifecycle config.
+
+. Manually delete the indices when they are no longer needed.
+. Explicitly configure APM data streams with the default data stream lifecycle config.
 Using this approach would migrate all data streams to use data stream lifecycles,
 which should be equivalent to the default ILM policies:
-
++
 [source,txt]
 ----
 PUT _data_stream/traces-apm-*/_lifecycle


### PR DESCRIPTION
The formatting for the doc added using https://github.com/elastic/observability-docs/pull/4192 seems to be broken: https://www.elastic.co/guide/en/observability/current/apm-known-issues.html

The PR attempts to fix the formatting.