### PR TITLE
Update 'hide_in_deployment_modes' example to use filestream

### DIFF
--- a/docs/en/integrations/build-integration.asciidoc
+++ b/docs/en/integrations/build-integration.asciidoc
@@ -186,7 +186,7 @@ Example variable declaration:
 [source,yaml]
 ----
 streams:
-  - input: logfile
+  - input: filestream
     vars:
       - name: paths
         type: text


### PR DESCRIPTION
The [hide_in_deployment_modes](https://www.elastic.co/guide/en/integrations-developer/current/define-deployment-modes.html#hide_in_deployment_modes) example in the Integrations Developer Guide uses `logfile` input rather than the newer `filestream`.

Closes: https://github.com/elastic/ingest-docs/issues/1286
