### PR TITLE
Update data-model.asciidoc

### DIFF
--- a/docs/en/observability/apm/data-model.asciidoc
+++ b/docs/en/observability/apm/data-model.asciidoc
@@ -634,7 +634,7 @@ Non-indexed information is useful for providing contextual information to help y
 quickly debug performance issues or errors.
 
 * Indexed: No
-* {es} type: {ref}/object.html[object]
+* {es} type: {ref}/flattened.html[flattened]
 * {es} fields: `transaction.custom` | `error.custom`
 * Applies to: <<apm-data-model-transactions>> | <<apm-data-model-errors>>
 


### PR DESCRIPTION
Per the PR and changelogs, the `error.custom` and `transaction.custom` fields were changed to the `flattened` type since `8.12.0`, but it does not reflect the change in this document.

- PR: [#12102](https://github.com/elastic/apm-server/pull/12102)
- Changelogs: [APM Release Notes 8.12](https://www.elastic.co/guide/en/observability/current/apm-release-notes-8.12.html#_added_7)

In addition, the documentation describes these fields as "non-indexed." In SF case 01746372, the customer reported that these fields are searchable in Discover within Kibana, indicating they may actually be indexed.