### PR TITLE
Update docs after migrating from apm integration package to ES apm-data plugin in 8.15

### DIFF
--- a/docs/en/observability/apm/custom-index-template.asciidoc
+++ b/docs/en/observability/apm/custom-index-template.asciidoc
@@ -22,18 +22,19 @@ Select any of the APM index templates to view their relevant component templates
 [id="index-template-view{append-legacy}"]
 === Edit the {es} index template
 
-WARNING: Custom index mappings may conflict with the mappings defined by the APM integration
+WARNING: Custom index mappings may conflict with the mappings defined by the {es} apm-data plugin
 and may break the APM integration and APM UI in {kib}.
 Do not change or customize any default mappings.
 
-When you install the APM integration, {fleet} creates a default `@custom` component template for each data stream.
-You can edit this `@custom` component template to customize your {es} indices.
+The APM index templates by default reference a non-existent `@custom` component template for each data stream.
+You can create or edit this `@custom` component template to customize your {es} indices.
 
 First, determine which <<apm-data-streams,data stream>> you'd like to edit.
 Then, open {kib} and navigate to **{stack-manage-app}** → **Index Management** → **Component Templates**.
 
 Custom component templates are named following this pattern: `<name_of_data_stream>@custom`.
 Search for the name of the data stream, like `traces-apm`, and select its custom component template.
+Create one if it does not exist.
 In this example, that'd be, `traces-apm@custom`.
 Then click **Manage** → **Edit**.
 

--- a/docs/en/observability/apm/data-streams.asciidoc
+++ b/docs/en/observability/apm/data-streams.asciidoc
@@ -109,7 +109,7 @@ For example, consider traces that would originally be indexed to `traces-apm-def
 ]
 ----
 
-For more about other ingest pipelines called by default, e.g. `traces-apm@custom`, see {fleet-guide}/data-streams.html#data-streams-pipelines[integration data streams ingest pipelines].
+For more about other ingest pipelines called by default, e.g. `traces-apm@custom`, see definition of `\*-apm*@default-pipeline` ingest pipelines from {es} apm-data plugin.
 
 For more custom APM ingest pipeline guides, see <<apm-ingest-pipelines,parse data using ingest pipelines>>.
 

--- a/docs/en/observability/apm/data-streams.asciidoc
+++ b/docs/en/observability/apm/data-streams.asciidoc
@@ -109,7 +109,7 @@ For example, consider traces that would originally be indexed to `traces-apm-def
 ]
 ----
 
-To find other ingest pipelines from the {es} apm-data plugin that are called by default, go to *Stack management* → *Ingest pipelines* {kibana-ref}/management.html[[in Kibana] and search for `apm`.
+To find other ingest pipelines from the {es} apm-data plugin that are called by default, go to *Stack management* → *Ingest pipelines* {kibana-ref}/management.html[in Kibana] and search for `apm`.
 Default APM ingest pipelines will follow the pattern `*-apm*@default-pipeline`.
 
 For more custom APM ingest pipeline guides, see <<apm-ingest-pipelines,parse data using ingest pipelines>>.

--- a/docs/en/observability/apm/data-streams.asciidoc
+++ b/docs/en/observability/apm/data-streams.asciidoc
@@ -109,7 +109,8 @@ For example, consider traces that would originally be indexed to `traces-apm-def
 ]
 ----
 
-For more about other ingest pipelines called by default, e.g. `traces-apm@custom`, see definition of `\*-apm*@default-pipeline` ingest pipelines from {es} apm-data plugin.
+To find other ingest pipelines from the {es} apm-data plugin that are called by default, go to *Stack management* → *Ingest pipelines* {kibana-ref}/management.html[[in Kibana] and search for `apm`.
+Default APM ingest pipelines will follow the pattern `*-apm*@default-pipeline`.
 
 For more custom APM ingest pipeline guides, see <<apm-ingest-pipelines,parse data using ingest pipelines>>.
 

--- a/docs/en/observability/apm/ingest-pipelines.asciidoc
+++ b/docs/en/observability/apm/ingest-pipelines.asciidoc
@@ -12,7 +12,7 @@ Ingest pipelines preprocess and enrich APM documents before indexing them.
 For example, a pipeline might define one processor that removes a field,
 one that transforms a field, and another that renames a field.
 
-The default APM pipelines are defined in index templates that {fleet} loads into {es}.
+The default APM pipelines are defined in {es} apm-data plugin index templates.
 {es} then uses the index pattern in these index templates to match pipelines to APM data streams.
 
 [discrete]
@@ -65,6 +65,5 @@ If you prefer more guidance, see one of these tutorials:
 
 * <<apm-filters-ingest-pipeline>> — Learn how to obfuscate passwords stored in the `http.request.body.original` field.
 * <<apm-data-stream-rerouting>> — Learn how to reroute APM data to user-defined APM data streams.
-* {fleet-guide}/data-streams-pipeline-tutorial.html[Transform data with custom ingest pipelines] — A basic Elastic integration tutorial where you learn how to add a custom field to incoming data.
 
 // end::ingest-pipelines[]


### PR DESCRIPTION
## Description
<!-- Add a description here -->
Remove mentions of integration packages as apm-server moved away from it in 8.15

### Documentation sets edited in this PR

_Check all that apply._

- [x] Stateful (`docs/en/observability/*`)
- [ ] Serverless (`docs/en/serverless/*`)
- [ ] Integrations Developer Guide (`docs/en/integrations/*`)
- [ ] None of the above

### Related issue
Closes # <!-- Add the issue this PR closes here -->

## Checklist

<!--
Add labels to:
1. Backport to other versions (`backport-*`):
    - `backport-8.x` to backport to the latest minor
    - `backport-skip` to not backport (for example, for serverless docs) 
    - `backport-main` to "backport" to `main` if the target branch is _not_ `main`
    - Individual `backport-*` labels to target specific minor versions
2. Surface blocking reviews (`needs-*-review`):
    - `needs-writer-review` for codeowners
    - `needs-dev-review` for dev team
    - `needs-product-review` for PM review
3. Build serverless preview docs: `ci:doc-build`
-->

- [x] Product/Engineering Review
- [ ] Writer Review

### Follow-up tasks
<!-- If you are updating the Integrations Developer Guide, you can delete this section -->

_Select one._

* This PR does _not_ need to be ported to another doc set because:
  - [ ] The concepts in this PR only apply to one doc set (serverless _or_ stateful)
  - [ ] The PR contains edits to both doc sets (serverless _and_ stateful)
* This PR needs to be ported to another doc set:
  - [ ] Port to stateful docs: \<link to PR or tracking issue>
  - [ ] Port to serverless docs: \<link to PR or tracking issue>

