### PR TITLE
Update elasticsearch.asciidoc

### DIFF
--- a/docs/en/apm-server/legacy/copied-from-beats/outputs/elasticsearch/docs/elasticsearch.asciidoc
+++ b/docs/en/apm-server/legacy/copied-from-beats/outputs/elasticsearch/docs/elasticsearch.asciidoc
@@ -247,7 +247,7 @@ events into different indices:
 ------------------------------------------------------------------------------
 output.elasticsearch:
   hosts: ["http://localhost:9200"]
-  index: "apm-%{[observer.version]}-%{[processor.event]}-%{+yyyy.MM.dd}\" <1>
+  index: "apm-%{[observer.version]}-%{[processor.event]}-%{+yyyy.MM.dd}" <1>
 ------------------------------------------------------------------------------
 <1> +{beat_version_key}+ is a field managed by Beats that is added to every document;
 It holds the current version of APM Server. We recommend including


### PR DESCRIPTION
Fix YAML formatting for `output.elasticsearch.index` option in example.

I don't think using `\"` is correct here, as we need to terminate the string on the line.