### PR TITLE
[Observability docs] Change 'beats' namespace to 'elastic-agent'

### DIFF
--- a/docs/en/integrations/developer-workflow-fleet.asciidoc
+++ b/docs/en/integrations/developer-workflow-fleet.asciidoc
@@ -101,7 +101,7 @@ To run the Fleet Server Docker container:
 +
 [source,terminal]
 ----
-docker run -e KIBANA_HOST=http://{YOUR-IP}:5601/{BASE-PATH} -e KIBANA_USERNAME=elastic -e KIBANA_PASSWORD=changeme -e ELASTICSEARCH_HOST=http://{YOUR-IP}:9200 -e ELASTICSEARCH_USERNAME=elastic -e ELASTICSEARCH_PASSWORD=changeme -e KIBANA_FLEET_SETUP=1 -e FLEET_SERVER_ENABLE=1 -e FLEET_SERVER_INSECURE_HTTP=1 -p 8220:8220 docker.elastic.co/beats/elastic-agent:{VERSION}
+docker run -e KIBANA_HOST=http://{YOUR-IP}:5601/{BASE-PATH} -e KIBANA_USERNAME=elastic -e KIBANA_PASSWORD=changeme -e ELASTICSEARCH_HOST=http://{YOUR-IP}:9200 -e ELASTICSEARCH_USERNAME=elastic -e ELASTICSEARCH_PASSWORD=changeme -e KIBANA_FLEET_SETUP=1 -e FLEET_SERVER_ENABLE=1 -e FLEET_SERVER_INSECURE_HTTP=1 -p 8220:8220 docker.elastic.co/elastic-agent/elastic-agent:{VERSION}
 ----
 +
 Ensure you provide the `-p 8220:8220` port mapping to map the Fleet Server container's port `8220` to your local machine's port `8220` in order for Fleet to communicate with Fleet Server.

--- a/docs/en/observability/synthetics-private-location.asciidoc
+++ b/docs/en/observability/synthetics-private-location.asciidoc
@@ -87,7 +87,7 @@ To pull the Docker image run:
 
 [source,sh,subs="attributes"]
 ----
-docker pull docker.elastic.co/beats/elastic-agent-complete:{version}
+docker pull docker.elastic.co/elastic-agent/elastic-agent-complete:{version}
 ----
 
 endif::[]
@@ -116,7 +116,7 @@ docker run \
   --env FLEET_ENROLLMENT_TOKEN={enrollment-token} \
   --cap-add=NET_RAW \
   --cap-add=SETUID \
-  --rm docker.elastic.co/beats/elastic-agent-complete:{version}
+  --rm docker.elastic.co/elastic-agent/elastic-agent-complete:{version}
 ----
 
 endif::[]

--- a/docs/en/serverless/synthetics/synthetics-private-location.mdx
+++ b/docs/en/serverless/synthetics/synthetics-private-location.mdx
@@ -92,7 +92,7 @@ Version ((version)) has not yet been released.
 To pull the Docker image run:
 
 ```sh
-docker pull docker.elastic.co/beats/elastic-agent-complete:((version))
+docker pull docker.elastic.co/elastic-agent/elastic-agent-complete:((version))
 ```
 
 </DocIf>
@@ -120,7 +120,7 @@ docker run \
   --env FLEET_ENROLLMENT_TOKEN={enrollment_token} \
   --cap-add=NET_RAW \
   --cap-add=SETUID \
-  --rm docker.elastic.co/beats/elastic-agent-complete:((version))
+  --rm docker.elastic.co/elastic-agent/elastic-agent-complete:((version))
 ```
 
 </DocIf>


### PR DESCRIPTION
Elastic Agent Docker images are currently available under both a `beats` and `elastic-agent` namespace. For 9.0 only the latter will be available, so this will update the current (8.15) docs.

Rel: https://github.com/elastic/ingest-docs/issues/1314