### PR TITLE
[Hosts documentation] Remove callout for beta

### DIFF
--- a/docs/en/serverless/infra-monitoring/analyze-hosts.mdx
+++ b/docs/en/serverless/infra-monitoring/analyze-hosts.mdx
@@ -12,7 +12,6 @@ import ContainerDetails from '../transclusion/container-details.mdx'
 
 <div id="analyze-hosts"></div>
 
-<DocCallOut template="beta" />
 We'd love to get your feedback!
 [Tell us what you think!](https://docs.google.com/forms/d/e/1FAIpQLScRHG8TIVb1Oq8ZhD4aks3P1TmgiM58TY123QpDCcBz83YC6w/viewform)
 


### PR DESCRIPTION
This PR removes the `<DocCallOut template="beta" />` as Hosts moved to GA for serverless (9th/16th sept).

Here is a [doc preview](https://elastic-dot-co-docs-production-3ufnhcnku-elastic-dev.vercel.app/current/serverless/observability/analyze-hosts).

Fixes https://github.com/elastic/observability-docs/issues/4216.