### PR TITLE
Port #4211 to serverless

### DIFF
--- a/docs/en/serverless/ai-assistant/ai-assistant.mdx
+++ b/docs/en/serverless/ai-assistant/ai-assistant.mdx
@@ -158,6 +158,12 @@ This opens the AI Assistant flyout, where you can ask the assistant questions ab
 
 ![Observability AI assistant chat](../images/ai-assistant-chat.png)
 
+<DocCallOut color="warning" title="Important">
+    Asking questions about your data requires function calling, which enables LLMs to reliably interact with third-party generative AI providers to perform searches or run advanced functions using customer data.
+
+    When the Observability AI Assistant performs searches in the cluster, the queries are run with the same level of permissions as the user.
+</DocCallOut>
+
 ### Suggest functions
 
 <DocCallOut template="beta" />


### PR DESCRIPTION
Port https://github.com/elastic/observability-docs/pull/4211 to serverless docs.

Fix https://github.com/elastic/observability-docs/issues/4257.