### PR TITLE
[apm/otel] Add links to Elastic Distribution of OpenTelemetry PHP

### DIFF
--- a/docs/en/observability/apm/open-telemetry.asciidoc
+++ b/docs/en/observability/apm/open-telemetry.asciidoc
@@ -51,6 +51,7 @@ Get started with an Elastic Distribution of OpenTelemetry language SDK:
 * preview:["The Elastic Distribution of OpenTelemetry .NET is not yet recommended for production use. Functionality may be changed or removed in future releases. Alpha releases are not subject to the support SLA of official GA features."] https://github.com/elastic/elastic-otel-dotnet[*Elastic Distribution of OpenTelemetry .NET →*]
 * preview:["The Elastic Distribution of OpenTelemetry Node.js is not yet recommended for production use. Functionality may be changed or removed in future releases. Alpha releases are not subject to the support SLA of official GA features."] https://github.com/elastic/elastic-otel-node[*Elastic Distribution of OpenTelemetry Node.js →*]
 * preview:["The Elastic Distribution of OpenTelemetry Python is not yet recommended for production use. Functionality may be changed or removed in future releases. Alpha releases are not subject to the support SLA of official GA features."] https://github.com/elastic/elastic-otel-python[*Elastic Distribution of OpenTelemetry Python →*]
+* preview:["The Elastic Distribution of OpenTelemetry PHP is not yet recommended for production use. Functionality may be changed or removed in future releases. Alpha releases are not subject to the support SLA of official GA features."] https://github.com/elastic/elastic-otel-php[*Elastic Distribution of OpenTelemetry PHP →*]
 
 [NOTE]
 ====

--- a/docs/en/serverless/apm-agents/apm-agents-opentelemetry.mdx
+++ b/docs/en/serverless/apm-agents/apm-agents-opentelemetry.mdx
@@ -43,6 +43,7 @@ Get started with an Elastic Distribution of OpenTelemetry language SDK:
 * <DocBadge template="technical preview" /> [**Elastic Distribution of OpenTelemetry .NET →**](https://github.com/elastic/elastic-otel-dotnet)
 * <DocBadge template="technical preview" /> [**Elastic Distribution of OpenTelemetry Node.js →**](https://github.com/elastic/elastic-otel-node)
 * <DocBadge template="technical preview" /> [**Elastic Distribution of OpenTelemetry Python →**](https://github.com/elastic/elastic-otel-python)
+* <DocBadge template="technical preview" /> [**Elastic Distribution of OpenTelemetry PHP →**](https://github.com/elastic/elastic-otel-php)
 
 <DocCallOut title="Note">
   For more details about OpenTelemetry distributions in general, visit the [OpenTelemetry documentation](https://opentelemetry.io/docs/concepts/distributions).


### PR DESCRIPTION
Add links to the Elastic Distribution of OpenTelemetry PHP in both stateful and serverless docs.

cc @estolfo @elastic/apm-agent-php