### PR TITLE
[apm/otel] Remove limitation about host metrics in OTel docs

### DIFF
--- a/docs/en/serverless/apm-agents/apm-agents-opentelemetry-limitations.mdx
+++ b/docs/en/serverless/apm-agents/apm-agents-opentelemetry-limitations.mdx
@@ -13,18 +13,6 @@ tags: [ 'serverless', 'observability', 'overview' ]
 * Inability to see Stack traces in spans.
 * Inability in APM views to view the "Time Spent by Span Type"  (see issue [#5747](https://github.com/elastic/apm-server/issues/5747)).
 
-<div id="open-telemetry-metrics-limitations"></div>
-
-## OpenTelemetry metrics
-
-* Inability to see host metrics in the **Applications** UI when using the OpenTelemetry Collector host metrics receiver (see issue [#5310](https://github.com/elastic/apm-server/issues/5310)).
-
-    <DocCallOut title="Note">
-        Even though metrics do not show up in the **Applications** view,
-        the metrics are available in your Observability project and can be visualized using **Dashboards**.
-        See <DocLink slug="/serverless/observability/apm-agents-opentelemetry-collect-metrics" /> for more information about visualizing OpenTelemetry metrics.
-    </DocCallOut>
-
 <div id="open-telemetry-logs-intake"></div>
 
 ## OpenTelemetry logs


### PR DESCRIPTION
Port #4242 to serverless.