### PR TITLE
Add ESS to quickstart prereqs

### DIFF
--- a/docs/en/observability/quickstarts/monitor-hosts-with-elastic-agent.asciidoc
+++ b/docs/en/observability/quickstarts/monitor-hosts-with-elastic-agent.asciidoc
@@ -15,6 +15,7 @@ The script also generates an {agent} configuration file that you can use with yo
 [discrete]
 == Prerequisites
 
+* A deployment using our hosted {ess} on {ess-trial}[{ecloud}]. The deployment includes an {es} cluster for storing and searching your data, and {kib} for visualizing and managing your data.
 * A user with the `superuser` {ref}/built-in-roles.html[built-in role] or the privileges required to onboard data.
 +
 [%collapsible]

--- a/docs/en/observability/quickstarts/monitor-k8s-logs-metrics.asciidoc
+++ b/docs/en/observability/quickstarts/monitor-k8s-logs-metrics.asciidoc
@@ -12,6 +12,7 @@ The kubectl command installs the standalone Elastic Agent in your Kubernetes clu
 [discrete]
 == Prerequisites
 
+* A deployment using our hosted {ess} on {ess-trial}[{ecloud}]. The deployment includes an {es} cluster for storing and searching your data, and {kib} for visualizing and managing your data.
 * A user with the `superuser` {ref}/built-in-roles.html[built-in role] or the privileges required to onboard data.
 +
 [%collapsible]


### PR DESCRIPTION
Closes #4205 

Adds ESS as a prerequisite in Observability quickstarts. I borrowed language from other instructional content in the Observability guide.

## To do

- [x] ~~Product/dev review~~
- [x] Obs docs review
- [x] Open serverless PR https://github.com/elastic/observability-docs/pull/4282