### PR TITLE
observability/apm: reduce python specific doc for OTEL_EXPORTER_OTLP_HEADERS

### DIFF
--- a/docs/en/observability/apm/otel-direct.asciidoc
+++ b/docs/en/observability/apm/otel-direct.asciidoc
@@ -124,21 +124,14 @@ java -javaagent:/path/to/opentelemetry-javaagent-all.jar \
 For information on how to format an API key, see
 {observability-guide}/apm-api-key.html[API keys].
 
-Please note the required space between `Bearer` and `an_apm_secret_token`, and `ApiKey` and `an_api_key`.
-
-The Python OpenTelemetry agent requires the content of the header to be URL-encoded. For the `Bearer` token that would mean substituting the space between `Bearer` and the token with `%20`, e.g. `"Authorization=Bearer%20an_apm_secret_token"`, for encoding an API key you can use the following snippet:
-
-[source,python]
-----
-from urllib.parse import quote
-quote("ApiKey an_api_key")
-----
+Please note the required space between `Bearer` and `an_apm_secret_token`, and `ApiKey` and `an_api_key`. <1>
 
 | `OTEL_METRICS_EXPORTER` | Metrics exporter to use. See https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#exporter-selection[exporter selection] for more information.
 
 | `OTEL_LOGS_EXPORTER` | Logs exporter to use. See https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#exporter-selection[exporter selection] for more information.
 
 |===
+<1> preview:[] Before version 1.27.0 the Python OpenTelemetry agent required the content of the header to be URL-encoded, function `urllib.parse.quote` from Python standard library may be used for this purpose. 
 
 You are now ready to collect traces and <<apm-open-telemetry-collect-metrics,metrics>> before <<apm-open-telemetry-verify-metrics,verifying metrics>>
 and <<apm-open-telemetry-visualize,visualizing metrics>> in {kib}.


### PR DESCRIPTION
Special treatment of headers is not needed anymore since latest release so reduce the text to a note.