### PR TITLE
[serverless] Add preq to quickstarts

### DIFF
--- a/docs/en/serverless/quickstarts/k8s-logs-metrics.mdx
+++ b/docs/en/serverless/quickstarts/k8s-logs-metrics.mdx
@@ -15,6 +15,7 @@ The kubectl command installs the standalone Elastic Agent in your Kubernetes clu
 
 ## Prerequisites
 
+- An ((observability)) project. To learn more, refer to <DocLink slug="/serverless/observability/create-an-observability-project" />.
 - A user with the **Admin** role or higher—required to onboard system logs and metrics. To learn more, refer to <DocLink slug="/serverless/general/assign-user-roles" />.
 - A running Kubernetes cluster.
 - [Kubectl](https://kubernetes.io/docs/reference/kubectl/).

--- a/docs/en/serverless/quickstarts/monitor-hosts-with-elastic-agent.mdx
+++ b/docs/en/serverless/quickstarts/monitor-hosts-with-elastic-agent.mdx
@@ -18,6 +18,7 @@ The script also generates an ((agent)) configuration file that you can use with 
 
 ## Prerequisites
 
+- An ((observability)) project. To learn more, refer to <DocLink slug="/serverless/observability/create-an-observability-project" />.
 - A user with the **Admin** role or higher—required to onboard system logs and metrics. To learn more, refer to <DocLink slug="/serverless/general/assign-user-roles" />.
 - Root privileges on the host—required to run the auto-detection script used in this quickstart.
 


### PR DESCRIPTION
Related to #4205 

Ports https://github.com/elastic/observability-docs/pull/4277 to serverless docs.