### PR TITLE
[serverless] Add note about elastic-agent-complete

### DIFF
--- a/docs/en/serverless/synthetics/synthetics-private-location.mdx
+++ b/docs/en/serverless/synthetics/synthetics-private-location.mdx
@@ -81,6 +81,10 @@ For monitors running on ((private-location))s, you _must_ use the `elastic-agent
 Docker image to create a self-hosted ((agent)) node. The standard ((ecloud)) or self-hosted
 ((agent)) will not work.
 
+<DocCallOut color="warning" title="Important">
+  The `elastic-agent-complete` Docker image is the only way to have all available options that you see in the UI.
+</DocCallOut>
+
 <DocIf condition={ "((release-state))" === "unreleased" }>
 
 Version ((version)) has not yet been released.


### PR DESCRIPTION
I _think_ https://github.com/elastic/observability-docs/pull/4234 should be ported to serverless. (Found in the audit! https://github.com/elastic/observability-docs/issues/4235)