### PR TITLE
Update status to assign to prs

### DIFF
--- a/.github/workflows/add-pr-to-project.yml
+++ b/.github/workflows/add-pr-to-project.yml
@@ -67,3 +67,15 @@ jobs:
         env:
           PROJECT_ID: "PVT_kwDOAGc3Zs0iZw"
           GITHUB_TOKEN: ${{ steps.get_token.outputs.app_token }}
+      - name: Add label
+        uses: actions/github-script@v7
+        id: add_label
+        with:
+          github-token: ${{ steps.get_token.outputs.app_token }}
+          script: |
+            github.rest.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ['needs-writer-review']
+            })

--- a/.github/workflows/add-pr-to-project.yml
+++ b/.github/workflows/add-pr-to-project.yml
@@ -62,8 +62,8 @@ jobs:
           item: ${{ fromJSON(steps.add_pr_to_board.outputs.data).addProjectV2ItemById.item.id }}
           # This is the ID for the project "status" attribute
           field: "PVTSSF_lADOAGc3Zs0iZ84AAQIU"
-          # This is the ID for the status sub-attribute "In Review"
-          value: "2d732740"
+          # This is the ID for the status sub-attribute "In Progress"
+          value: "47fc9ee4"
         env:
           PROJECT_ID: "PVT_kwDOAGc3Zs0iZw"
           GITHUB_TOKEN: ${{ steps.get_token.outputs.app_token }}


### PR DESCRIPTION
@bmorelli25 has been reworking the "Status" field in our project. This updates the workflow that auto-assigns a "Status" when a PR is opened.

## To do

- [x] Auto-assign "In Progress" status
- [x] Auto-add `needs-writer-review` label?
- [x] Writer review