### PR TITLE
Add TheHive connector for cases

### DIFF
--- a/docs/en/observability/manage-cases-settings.asciidoc
+++ b/docs/en/observability/manage-cases-settings.asciidoc
@@ -27,6 +27,7 @@ cases with that system using _connectors_. These third-party systems are support
 * {jira} (including {jira} Service Desk)
 * {ibm-r}
 * {swimlane}
+* TheHive
 * {webhook-cm}
 
 IMPORTANT: To send cases to external systems, you need the appropriate license, and your role must
@@ -43,15 +44,15 @@ After creating a connector, you can set your cases to
 === Create a connector
 
 . From the *Incident management system* list, select *Add new connector*.
-. Select the system to send cases to: *{sn}*, *{jira}*, *{ibm-r}*, *{swimlane}*,
-or *{webhook-cm}*.
+. Select the system to send cases to: *{sn}*, *{jira}*, *{ibm-r}*, *{swimlane}*, *TheHive*, or *{webhook-cm}*.
 
 . Enter your required settings. For connector configuration details, refer to
 {kibana-ref}/resilient-action-type.html[{ibm-r} connector],
 {kibana-ref}/jira-action-type.html[{jira} connector],
 {kibana-ref}/servicenow-action-type.html[{sn-itsm} connector],
 {kibana-ref}/servicenow-sir-action-type.html[{sn-sir} connector],
-{kibana-ref}/swimlane-action-type.html[{swimlane} connector], or
+{kibana-ref}/swimlane-action-type.html[{swimlane} connector], 
+{kibana-ref}/thehive-action-type.html[TheHive connector], or
 {kibana-ref}/cases-webhook-action-type.html[{webhook-cm} connector].
 
 . Click *Save*.


### PR DESCRIPTION
Relates to https://github.com/elastic/kibana/pull/180931

Observability cases can use TheHive connector in 8.16 and later releases.