### PR TITLE
Ports #3975 to serverless

### DIFF
--- a/docs/en/serverless/ai-assistant/ai-assistant.mdx
+++ b/docs/en/serverless/ai-assistant/ai-assistant.mdx
@@ -283,7 +283,7 @@ The AI Assistant runs the tasks requested in the message and creates a conversat
 It might take a minute or two for the AI Assistant to process the message and create the conversation.
 
 Note that overly broad prompts may result in the request exceeding token limits.
-For more information, refer to <DocLink slug="/serverless/observability/ai-assistant" section="token-limits" />
+For more information, refer to <DocLink slug="/serverless/observability/ai-assistant" section="token-limits" />.
 Also, attempting to analyze several alerts in a single connector execution may cause you to exceed the function call limit.
 If this happens, modify the message specified in the connector configuration to avoid exceeding limits.
 

--- a/docs/en/serverless/ai-assistant/ai-assistant.mdx
+++ b/docs/en/serverless/ai-assistant/ai-assistant.mdx
@@ -247,7 +247,7 @@ You can continue a conversation from a contextual prompt by clicking **Start cha
 
 ### Add the AI Assistant connector to alerting workflows
 
-You can use the Observability AI Assistant connector to add AI-generated insights and custom actions to your alerting workflows.
+You can use the [Observability AI Assistant connector](((kibana-ref))/obs-ai-assistant-action-type.html) to add AI-generated insights and custom actions to your alerting workflows.
 To do this:
 
 1. <DocLink slug="/serverless/observability/create-manage-rules" text="Create (or edit) an alerting rule" /> and specify the conditions that must be met for the alert to fire.


### PR DESCRIPTION
## Description
Ports #3957 to serverless.

Also adds a missing period.

### Documentation sets edited in this PR

_Check all that apply._

- [ ] Stateful (`docs/en/observability/*`)
- [x] Serverless (`docs/en/serverless/*`)
- [ ] Integrations Developer Guide (`docs/en/integrations/*`)
- [ ] None of the above

### Related issue
n/a

## Checklist

<!--
Add labels to:
1. Backport to other versions (`backport-*`):
    - `backport-8.x` to backport to the latest minor
    - `backport-skip` to not backport (for example, for serverless docs) 
    - `backport-main` to "backport" to `main` if the target branch is _not_ `main`
    - Individual `backport-*` labels to target specific minor versions
2. Surface blocking reviews (`needs-*-review`):
    - `needs-writer-review` for codeowners
    - `needs-dev-review` for dev team
    - `needs-product-review` for PM review
3. Build serverless preview docs: `ci:doc-build`
-->

- [ ] Product/Engineering Review
- [x] Writer Review

### Follow-up tasks
<!-- If you are updating the Integrations Developer Guide, you can delete this section -->

_Select one._

* This PR does _not_ need to be ported to another doc set because:
  - [ ] The concepts in this PR only apply to one doc set (serverless _or_ stateful)
  - [ ] The PR contains edits to both doc sets (serverless _and_ stateful)
  - [x] This PR _is_ a port.
* This PR needs to be ported to another doc set:
  - [ ] Port to stateful docs: \<link to PR or tracking issue>
  - [ ] Port to serverless docs: \<link to PR or tracking issue>
