### PR TITLE
[serverless] Update Otel doc with note

### DIFF
--- a/docs/en/serverless/apm-agents/apm-agents-opentelemetry-opentelemetry-native-support.mdx
+++ b/docs/en/serverless/apm-agents/apm-agents-opentelemetry-opentelemetry-native-support.mdx
@@ -130,6 +130,13 @@ java -javaagent:/path/to/opentelemetry-javaagent-all.jar \
     <DocCell>`OTEL_EXPORTER_OTLP_HEADERS`</DocCell>
     <DocCell>
       Authorization header that includes the Elastic APM API key: `"Authorization=ApiKey an_api_key"`.
+      Note the required space between `Bearer` and `an_apm_secret_token`, and `ApiKey` and `an_api_key`.
+
+      For information on how to format an API key, refer to <DocLink slug="/serverless/observability/apm-keep-data-secure" section="secure-communication-with-apm-agents">Secure communication with APM agents</DocLink>.
+
+      <DocCallOut title="Note">
+        If you are using a version of the Python OpenTelemetry agent _before_ 1.27.0, the content of the header _must_ be URL-encoded. You can use the Python standard library's `urllib.parse.quote` function to encode the content of the header.
+      </DocCallOut>
     </DocCell>
   </DocRow>
   <DocRow>


### PR DESCRIPTION
## Description

Ports https://github.com/elastic/observability-docs/pull/4280 to serverless.

### Documentation sets edited in this PR

_Check all that apply._

- [ ] Stateful (`docs/en/observability/*`)
- [x] Serverless (`docs/en/serverless/*`)
- [ ] Integrations Developer Guide (`docs/en/integrations/*`)
- [ ] None of the above

### Related issue

N/A

## Checklist

<!--
Add labels to:
1. Backport to other versions (`backport-*`):
    - `backport-8.x` to backport to the latest minor
    - `backport-skip` to not backport (for example, for serverless docs) 
    - `backport-main` to "backport" to `main` if the target branch is _not_ `main`
    - Individual `backport-*` labels to target specific minor versions
2. Surface blocking reviews (`needs-*-review`):
    - `needs-writer-review` for codeowners
    - `needs-dev-review` for dev team
    - `needs-product-review` for PM review
3. Build serverless preview docs: `ci:doc-build`
-->

- [x] ~~Product/Engineering Review~~
- [ ] Writer Review

### Follow-up tasks

N/A (This is a port)