### PR TITLE
Port #4201 to serverless

### DIFF
--- a/docs/en/serverless/apm-agents/apm-agents-opentelemetry-opentelemetry-native-support.mdx
+++ b/docs/en/serverless/apm-agents/apm-agents-opentelemetry-opentelemetry-native-support.mdx
@@ -49,12 +49,15 @@ service:
   pipelines:
     traces:
       receivers: [otlp]
+      processors: [..., memory_limiter, batch]
       exporters: [logging, otlp/elastic]
     metrics:
       receivers: [otlp]
+      processors: [..., memory_limiter, batch]
       exporters: [logging, otlp/elastic]
     logs:  [^8]
       receivers: [otlp]
+      processors: [..., memory_limiter, batch]
       exporters: [logging, otlp/elastic]
 ```
 [^1]: The receivers, like the


### PR DESCRIPTION
## Description

Ports https://github.com/elastic/observability-docs/pull/4201 to serverless.

### Documentation sets edited in this PR

_Check all that apply._

- [ ] Stateful (`docs/en/observability/*`)
- [x] Serverless (`docs/en/serverless/*`)
- [ ] Integrations Developer Guide (`docs/en/integrations/*`)
- [ ] None of the above

### Related issue

N/A

## Checklist

<!--
Add labels to:
1. Backport to other versions (`backport-*`):
    - `backport-8.x` to backport to the latest minor
    - `backport-skip` to not backport (for example, for serverless docs) 
    - `backport-main` to "backport" to `main` if the target branch is _not_ `main`
    - Individual `backport-*` labels to target specific minor versions
2. Surface blocking reviews (`needs-*-review`):
    - `needs-writer-review` for codeowners
    - `needs-dev-review` for dev team
    - `needs-product-review` for PM review
3. Build serverless preview docs: `ci:doc-build`
-->

- [x] ~~Product/Engineering Review~~
- [ ] Writer Review

### Follow-up tasks

N/A (This is a port)