### PR TITLE
Port #4130 to serverless

### DIFF
--- a/docs/en/serverless/ai-assistant/ai-assistant.mdx
+++ b/docs/en/serverless/ai-assistant/ai-assistant.mdx
@@ -41,6 +41,13 @@ The AI assistant requires the following:
     * AWS Bedrock, specifically the Anthropic Claude models.
 * The knowledge base requires a 4 GB ((ml)) node.
 
+<DocCallOut color="warning" title="Important">
+   The free tier offered by third-party generative AI providers may not be sufficient for the proper functioning of the AI assistant.
+   In most cases, a paid subscription to one of the supported providers is required.
+   The Observability AI assistant doesn't support connecting to a private LLM.
+   Elastic doesn't recommend using private LLMs with the Observability AI assistant.
+</DocCallOut>
+
 ## Your data and the AI Assistant
 
 Elastic does not use customer data for model training. This includes anything you send the model, such as alert or event data, detection rule configurations, queries, and prompts. However, any data you provide to the AI Assistant will be processed by the third-party provider you chose when setting up the OpenAI connector as part of the assistant setup.


### PR DESCRIPTION
## Description

Ports #4130 to serverless.

### Documentation sets edited in this PR

_Check all that apply._

- [ ] Stateful (`docs/en/observability/*`)
- [x] Serverless (`docs/en/serverless/*`)
- [ ] Integrations Developer Guide (`docs/en/integrations/*`)
- [ ] None of the above

### Related issue

N/A

## Checklist

<!--
Add labels to:
1. Backport to other versions (`backport-*`):
    - `backport-8.x` to backport to the latest minor
    - `backport-skip` to not backport (for example, for serverless docs) 
    - `backport-main` to "backport" to `main` if the target branch is _not_ `main`
    - Individual `backport-*` labels to target specific minor versions
2. Surface blocking reviews (`needs-*-review`):
    - `needs-writer-review` for codeowners
    - `needs-dev-review` for dev team
    - `needs-product-review` for PM review
3. Build serverless preview docs: `ci:doc-build`
-->

- [x] ~~Product/Engineering Review~~
- [ ] Writer Review

### Follow-up tasks

N/A (This is a port)
