### PR TITLE
Fix Logs Explorer naming in outdated docs

### DIFF
--- a/docs/en/observability/logs-ecs-application.asciidoc
+++ b/docs/en/observability/logs-ecs-application.asciidoc
@@ -40,7 +40,7 @@ To set up log ECS reformatting:
 
 . <<enable-log-ecs-reformatting,Enable {apm-agent} reformatting>>
 . <<ingest-ecs-logs,Ingest logs with {filebeat} or {agent}>>
-. <<view-ecs-logs,View logs in Log Explorer>>
+. <<view-ecs-logs,View logs in Logs Explorer>>
 
 [discrete]
 [[enable-log-ecs-reformatting]]

--- a/docs/en/observability/logs-filter.asciidoc
+++ b/docs/en/observability/logs-filter.asciidoc
@@ -1,7 +1,7 @@
 [[logs-filter-and-aggregate]]
 = Filter and aggregate logs
 
-Filter and aggregate your log data to find specific information, gain insight, and monitor your systems more efficiently. You can filter and aggregate based on structured fields like timestamps, log levels, and IP addresses that you've extracted from your log data. 
+Filter and aggregate your log data to find specific information, gain insight, and monitor your systems more efficiently. You can filter and aggregate based on structured fields like timestamps, log levels, and IP addresses that you've extracted from your log data.
 
 This guide shows you how to:
 
@@ -62,16 +62,16 @@ PUT _index_template/logs-example-default-template
 
 Filter your data using the fields you've extracted so you can focus on log data with specific log levels, timestamp ranges, or host IPs. You can filter your log data in different ways:
 
-- <<logs-filter-logs-explorer>> – Filter and visualize log data in {kib} using Log Explorer.
+- <<logs-filter-logs-explorer>> – Filter and visualize log data in {kib} using Logs Explorer.
 - <<logs-filter-qdsl>> – Filter log data from Dev Tools using Query DSL.
 
 [discrete]
 [[logs-filter-logs-explorer]]
-=== Filter logs in Log Explorer
+=== Filter logs in Logs Explorer
 
-Log Explorer is a {kib} tool that automatically provides views of your log data based on integrations and data streams. You can find Log Explorer in the Observability menu under *Logs*. 
+Logs Explorer is a {kib} tool that automatically provides views of your log data based on integrations and data streams. You can find Logs Explorer in the Observability menu under *Logs*.
 
-From Log Explorer, you can use the {kibana-ref}/kuery-query.html[{kib} Query Language (KQL)] in the search bar to narrow down the log data displayed in Log Explorer.
+From Logs Explorer, you can use the {kibana-ref}/kuery-query.html[{kib} Query Language (KQL)] in the search bar to narrow down the log data displayed in Logs Explorer.
 For example, you might want to look into an event that occurred within a specific time range.
 
 Add some logs with varying timestamps and log levels to your data stream:
@@ -92,7 +92,7 @@ POST logs-example-default/_bulk
 { "message": "2023-09-20T09:40:32.345Z INFO 192.168.1.106 User logout initiated." }
 ----
 
-For this example, let's look for logs with a `WARN` or `ERROR` log level that occurred on September 14th or 15th. From Log Explorer:
+For this example, let's look for logs with a `WARN` or `ERROR` log level that occurred on September 14th or 15th. From Logs Explorer:
 
 . Add the following KQL query in the search bar to filter for logs with log levels of `WARN` or `ERROR`:
 +
@@ -109,12 +109,12 @@ image::images/logs-start-date.png[Set the start date for your time range, 50%]
 [role="screenshot"]
 image::images/logs-end-date.png[Set the end date for your time range, 50%]
 
-Under the *Documents* tab, you'll see the filtered log data matching your query. 
+Under the *Documents* tab, you'll see the filtered log data matching your query.
 
 [role="screenshot"]
 image::images/logs-kql-filter.png[Filter data by log level using KQL]
 
-For more on using Log Explorer, refer to the {kibana-ref}/discover.html[Discover] documentation.
+For more on using Logs Explorer, refer to the {kibana-ref}/discover.html[Discover] documentation.
 
 [discrete]
 [[logs-filter-qdsl]]
@@ -208,7 +208,7 @@ The filtered results should show `WARN` and `ERROR` logs that occurred within th
 [discrete]
 [[logs-aggregate]]
 == Aggregate logs
-Use aggregation to analyze and summarize your log data to find patterns and gain insight. {ref}/search-aggregations-bucket.html[Bucket aggregations] organize log data into meaningful groups making it easier to identify patterns, trends, and anomalies within your logs. 
+Use aggregation to analyze and summarize your log data to find patterns and gain insight. {ref}/search-aggregations-bucket.html[Bucket aggregations] organize log data into meaningful groups making it easier to identify patterns, trends, and anomalies within your logs.
 
 For example, you might want to understand error distribution by analyzing the count of logs per log level.
 

--- a/docs/en/observability/logs-plaintext.asciidoc
+++ b/docs/en/observability/logs-plaintext.asciidoc
@@ -12,7 +12,7 @@ To ingest, parse, and correlate plaintext logs:
 
 . Ingest plaintext logs with <<ingest-plaintext-logs-with-filebeat,{filebeat}>> or <<ingest-plaintext-logs-with-the-agent,{agent}>> and parse them before indexing with an ingest pipeline.
 . <<correlate-plaintext-logs,Correlate plaintext logs with an {apm-agent}.>>
-. <<view-plaintext-logs,View logs in Log Explorer>>
+. <<view-plaintext-logs,View logs in Logs Explorer>>
 
 [discrete]
 [[ingest-plaintext-logs]]
@@ -233,4 +233,4 @@ Learn about correlating plaintext logs in the agent-specific ingestion guides:
 
 To view logs ingested by {filebeat}, go to *Discover* from the main menu and create a data view based on the `filebeat-*` index pattern. Refer to {kibana-ref}/data-views.html[Create a data view] for more information.
 
-To view logs ingested by {agent}, go to Log Explorer by clicking *Explorer* under *Logs* from the {observability} main menu. Refer to the <<logs-filter-and-aggregate>> documentation for more information on viewing and filtering your logs in {kib}.
+To view logs ingested by {agent}, go to Logs Explorer by clicking *Explorer* under *Logs* from the {observability} main menu. Refer to the <<logs-filter-and-aggregate>> documentation for more information on viewing and filtering your logs in {kib}.

--- a/docs/en/serverless/logging/view-and-monitor-logs.mdx
+++ b/docs/en/serverless/logging/view-and-monitor-logs.mdx
@@ -28,7 +28,7 @@ If you need to focus on logs from a specific integrations, select the integratio
 <DocImage size="l" url="../images/log-menu.png" alt="Screen capture of log menu" />
 
 Once you have the logs you want to focus on displayed, you can drill down further to find the information you need.
-For more on filtering your data in Logs Explorer, refer to <DocLink slug="/serverless/observability/filter-and-aggregate-logs" section="filter-logs-in-logs-explorer">Filter logs in Log Explorer</DocLink>.
+For more on filtering your data in Logs Explorer, refer to <DocLink slug="/serverless/observability/filter-and-aggregate-logs" section="filter-logs-in-logs-explorer">Filter logs in Logs Explorer</DocLink>.
 
 ## Review log data in the documents table
 


### PR DESCRIPTION
## Description
Updated the Logs Explorer name in some outdated docs.

### Documentation sets edited in this PR

_Check all that apply._

- [x] Stateful (`docs/en/observability/*`)
- [x] Serverless (`docs/en/serverless/*`)
- [ ] Integrations Developer Guide (`docs/en/integrations/*`)
- [ ] None of the above

### Follow-up tasks
<!-- If you are updating the Integrations Developer Guide, you can delete this section -->

_Select one._

* This PR does _not_ need to be ported to another doc set because:
  - [ ] The concepts in this PR only apply to one doc set (serverless _or_ stateful)
  - [x] The PR contains edits to both doc sets (serverless _and_ stateful)
