### PR TITLE
[synthetics] Add `fields` synthetics configuration option

### DIFF
--- a/docs/en/observability/synthetics-configuration.asciidoc
+++ b/docs/en/observability/synthetics-configuration.asciidoc
@@ -224,9 +224,24 @@ By default, monitors are automatically retested if the monitor goes from "up" to
 If the result of the retest is also "down", an error will be created, and if configured, an alert sent.
 Then the monitor will resume running according to the defined schedule.
 Using `retestOnFailure` can reduce noise related to transient problems.
+
+`fields` (`object`)::
+A list of key-value pairs that will be sent with each monitor event.
+This is useful for adding custom metadata to your monitor.
++
+For example:
++
+[source,js]
+----
+fields: {
+  foo: 'bar',
+  team: 'synthetics',
+}
+----
+
 // end::monitor-config-options[]
 
 For information on configuring monitors individually, refer to:
 
-* <<synthetics-monitor-use>> for browser monitors 
+* <<synthetics-monitor-use>> for browser monitors
 * <<synthetics-lightweight>> for lightweight monitors

--- a/docs/en/observability/synthetics-reference/lightweight-config/common.asciidoc
+++ b/docs/en/observability/synthetics-reference/lightweight-config/common.asciidoc
@@ -306,6 +306,25 @@ The value defined via the CLI takes precedence over the value defined in the lig
 and the value defined in the lightweight monitor configuration takes precedence over the value defined in _project_ configuration file.
 ====
 
+| [[monitor-fields]] *`fields`*
+a| A list of key-value pairs that will be sent with each monitor event.
+This is useful for adding custom metadata to your monitor.
+
+*Examples*:
+
+[source,yaml]
+----
+fields:
+  foo: bar
+  team: synthetics
+----
+
+[source,yaml]
+----
+fields.foo: bar
+fields.team: synthetics
+----
+
 |===
 
 :!hardbreaks-option:


### PR DESCRIPTION
## Description

Add `fields` configuration option for synthetic monitoring.

### Documentation sets edited in this PR

_Check all that apply._

- [x] Stateful (`docs/en/observability/*`)
- [ ] Serverless (`docs/en/serverless/*`)
- [ ] Integrations Developer Guide (`docs/en/integrations/*`)
- [ ] None of the above

### Related issue

Closes #4274

## Checklist

<!--
Add labels to:
1. Backport to other versions (`backport-*`):
    - `backport-8.x` to backport to the latest minor
    - `backport-skip` to not backport (for example, for serverless docs) 
    - `backport-main` to "backport" to `main` if the target branch is _not_ `main`
    - Individual `backport-*` labels to target specific minor versions
2. Surface blocking reviews (`needs-*-review`):
    - `needs-writer-review` for codeowners
    - `needs-dev-review` for dev team
    - `needs-product-review` for PM review
3. Build serverless preview docs: `ci:doc-build`
-->

- [x] Browser monitor config
- [x] Lightweight monitor config
- [ ] CLI option?
  * @shahzad31 can users also add fields via the CLI? 
- [ ] Product/Engineering Review
- [ ] Writer Review

### Follow-up tasks
<!-- If you are updating the Integrations Developer Guide, you can delete this section -->

_Select one._

* This PR does _not_ need to be ported to another doc set because:
  - [ ] The concepts in this PR only apply to one doc set (serverless _or_ stateful)
  - [ ] The PR contains edits to both doc sets (serverless _and_ stateful)
* This PR needs to be ported to another doc set:
  - [ ] Port to stateful docs: \<link to PR or tracking issue>
  - [ ] Port to serverless docs: \<link to PR or tracking issue>
