### PR TITLE
[Inventory] Update EEM docs to reflect new inventory

### DIFF
--- a/docs/en/serverless/elastic-entity-model.mdx
+++ b/docs/en/serverless/elastic-entity-model.mdx
@@ -15,7 +15,7 @@ The Elastic Entity Model consists of:
 - an Entity Discovery Framework, which consists of [transforms](((ref))/transforms.html) and [Ingest pipelines](((ref))/ingest.html) that read from signal indices and write data to entity indices
 - a set of management APIs that empower entity-centric Elastic solution features and workflows
 
-In the context of Elastic Observability,
+In Elastic Observability,
 an _entity_ is an object of interest that can be associated with produced telemetry and identified as unique.
 Note that this definition is intentionally closely aligned to the work of the [OpenTelemetry Entities SIG](https://github.com/open-telemetry/oteps/blob/main/text/entities/0256-entities-data-model.md#data-model).
 Examples of entities include (but are not limited to) services, hosts, and containers.
@@ -23,8 +23,8 @@ Examples of entities include (but are not limited to) services, hosts, and conta
 The concept of an entity is important as a means to unify observability signals based on the underlying entity that the signals describe.
 
 <DocCallOut title="Notes">
-    - The Elastic Entity Model currently supports the <DocLink slug="/serverless/observability/new-experience-services">new service inventory experience</DocLink> limited to service-based entities (as identified by `service.name`) located in data identified by `logs-*` and `filebeat*` index patterns
-    - During Technical Preview, Entity Discovery Framework components are not enabled by default
+    - The Elastic Entity Model currently supports the <DocLink slug="/serverless/observability/inventory">new inventory experience</DocLink> limited to service, host, and container entities.
+    - During Technical Preview, Entity Discovery Framework components are not enabled by default.
 </DocCallOut>
 
 ## Enable the Elastic Entity Model
@@ -32,7 +32,7 @@ The concept of an entity is important as a means to unify observability signals 
 <Roles role="Admin" goal="enable the Elastic Entity Model" />
 
 During Technical Preview,
-the Elastic Entity Model is enabled when you turn on the entity-centric service inventory described in <DocLink slug="/serverless/observability/new-experience-services" />.
+the Elastic Entity Model is enabled when you turn on the entity-centric service inventory described in <DocLink slug="/serverless/observability/inventory" />.
 
 ## Disable the Elastic Entity Model
 


### PR DESCRIPTION
## Description
This PR updates the [EEM docs](https://www.elastic.co/docs/current/serverless/observability/elastic-entity-model) to:

a) include more entities: services, hosts and containers
b) remove references to the 'new service inventory' and instead mention the 'new inventory'

References to Inventory will work as soon as the new Inventory doc page is live. 

### Documentation sets edited in this PR

_Check all that apply._

- [ ] Stateful (`docs/en/observability/*`)
- [X] Serverless (`docs/en/serverless/*`)
- [ ] Integrations Developer Guide (`docs/en/integrations/*`)
- [ ] None of the above

### Related issue
Closes https://github.com/elastic/observability-docs/issues/4253

## Checklist

<!--
Add labels to:
1. Backport to other versions (`backport-*`):
    - `backport-8.x` to backport to the latest minor
    - `backport-skip` to not backport (for example, for serverless docs) 
    - `backport-main` to "backport" to `main` if the target branch is _not_ `main`
    - Individual `backport-*` labels to target specific minor versions
2. Surface blocking reviews (`needs-*-review`):
    - `needs-writer-review` for codeowners
    - `needs-dev-review` for dev team
    - `needs-product-review` for PM review
3. Build serverless preview docs: `ci:doc-build`
-->

- [X] Product/Engineering Review
- [ ] Writer Review

### Follow-up tasks
<!-- If you are updating the Integrations Developer Guide, you can delete this section -->

_Select one._

* This PR does _not_ need to be ported to another doc set because:
  - [ ] The concepts in this PR only apply to one doc set (serverless _or_ stateful)
  - [ ] The PR contains edits to both doc sets (serverless _and_ stateful)
* This PR needs to be ported to another doc set:
  - [X] Port to stateful docs: \<link to PR or tracking issue>
  - [ ] Port to serverless docs: \<link to PR or tracking issue>
