### PR TITLE
[synthetics] Document Synthetics availability SLI

### DIFF
--- a/docs/en/observability/slo-create.asciidoc
+++ b/docs/en/observability/slo-create.asciidoc
@@ -179,6 +179,11 @@ When defining a Synthetics availability SLI, set the following fields:
 * *Tags* — One or more <<synthetics-configuration-monitor-tags,tags>> assigned to synthetic monitors.
 * *Query filter* — An optional KQL query used to filter the Synthetics checks on some relevant criteria.
 
+[NOTE]
+====
+Synthetics availability SLIs are automatically grouped by monitor and location.
+====
+
 [discrete]
 [[set-slo]]
 = Set your objectives

--- a/docs/en/observability/slo-create.asciidoc
+++ b/docs/en/observability/slo-create.asciidoc
@@ -29,6 +29,7 @@ The type of SLI to use depends on the location of your data:
 * <<timeslice-metric-sli, Timeslice metric>> — create an SLI based on a custom equation that uses multiple aggregations.
 * <<histogram-metric-sli, Histogram metric>> — create an SLI based on histogram metrics.
 * <<apm-latency-and-availability-sli, APM latency and APM availability>> — create an SLI based on services using application performance monitoring (APM).
+* <<synthetics-availability-sli>> — create an SLI based on the availability of your synthetic monitors.
 
 [discrete]
 [[custom-kql-sli]]
@@ -160,6 +161,23 @@ When defining an APM latency or APM availability SLI, set the following fields:
 * *Transaction name* — Either `all` or the specific transaction name.
 * *Threshold (APM latency only)* — The latency threshold in milliseconds (ms) to consider the request as good.
 * *Query filter* — An optional query filter on the APM data.
+
+[discrete]
+[[synthetics-availability-sli]]
+== Synthetics availability
+
+Create an indicator based on the availability of your synthetic monitors.
+Availability is determined by calculating the percentage of checks that are successful (`monitor.status : "up"`)
+out of the total number of checks.
+
+*Example*: You can define an indicator based on a HTTP monitor being "up" for at least 99% of the time.
+
+When defining a Synthetics availability SLI, set the following fields:
+
+* *Monitor name* — The name of one or more <<synthetics-configuration-monitor-name,synthetic monitors>>.
+* *Project* — The ID of one or more <<synthetics-configuration-project,projects>> containing synthetic monitors.
+* *Tags* — One or more <<synthetics-configuration-monitor-tags,tags>> assigned to synthetic monitors.
+* *Query filter* — An optional KQL query used to filter the Synthetics checks on some relevant criteria.
 
 [discrete]
 [[set-slo]]

--- a/docs/en/observability/synthetics-configuration.asciidoc
+++ b/docs/en/observability/synthetics-configuration.asciidoc
@@ -181,9 +181,9 @@ Default values to be applied to _all_ monitors when using the <<elastic-syntheti
 // tag::monitor-config-options[]
 `id` (`string`)::
 A unique identifier for this monitor.
-`name` (`string`)::
+[[synthetics-configuration-monitor-name]] `name` (`string`)::
 A human readable name for the monitor.
-`tags` (`Array<string>`)::
+[[synthetics-configuration-monitor-tags]] `tags` (`Array<string>`)::
 A list of tags that will be sent with the monitor event. Tags are displayed in the {synthetics-app} and allow you to search monitors by tag.
 `schedule` (`number`)::
 The interval (in minutes) at which the monitor should run.

--- a/docs/en/serverless/slos/create-an-slo.mdx
+++ b/docs/en/serverless/slos/create-an-slo.mdx
@@ -161,6 +161,27 @@ When defining either an APM latency or APM availability SLI, set the following f
 * **Threshold (APM latency only):** The latency threshold in milliseconds (ms) to consider the request as good.
 * **Query filter:** An optional query filter on the APM data.
 
+<div id="synthetics-availability-sli"></div>
+
+### Synthetics availability
+
+Create an indicator based on the availability of your synthetic monitors.
+Availability is determined by calculating the percentage of checks that are successful (`monitor.status : "up"`)
+out of the total number of checks.
+
+**Example**: You can define an indicator based on a HTTP monitor being "up" for at least 99% of the time.
+
+When defining a Synthetics availability SLI, set the following fields:
+
+* **Monitor name** — The name of one or more <DocLink slug="/serverless/observability/synthetics-configuration" section="monitor-name">synthetic monitors</DocLink>.
+* **Project** — The ID of one or more <DocLink slug="/serverless/observability/synthetics-configuration" section="project">projects</DocLink> containing synthetic monitors.
+* **Tags** — One or more <DocLink slug="/serverless/observability/synthetics-configuration" section="monitor-tags">tags</DocLink> assigned to synthetic monitors.
+* **Query filter** — An optional KQL query used to filter the Synthetics checks on some relevant criteria.
+
+<DocCallOut title="Note">
+  Synthetics availability SLIs are automatically grouped by monitor and location.
+</DocCallOut>
+
 <div id="set-slo"></div>
 
 ## Set your objectives

--- a/docs/en/serverless/transclusion/synthetics/configuration/monitor-config-options.mdx
+++ b/docs/en/serverless/transclusion/synthetics/configuration/monitor-config-options.mdx
@@ -6,12 +6,20 @@
     A unique identifier for this monitor.
   </DocDefDescription>
 
-  <DocDefTerm>`name` (`string`)</DocDefTerm>
+  <DocDefTerm>
+    <span id="monitor-name">
+      `name` (`string`)
+    </span>
+  </DocDefTerm>
   <DocDefDescription>
     A human readable name for the monitor.
   </DocDefDescription>
 
-  <DocDefTerm>`tags` (`Array<string>`)</DocDefTerm>
+  <DocDefTerm>
+    <span id="monitor-tags">
+      `tags` (`Array<string>`)
+    </span>
+  </DocDefTerm>
   <DocDefDescription>
     A list of tags that will be sent with the monitor event. Tags are displayed in the Synthetics UI and allow you to search monitors by tag.
   </DocDefDescription>


### PR DESCRIPTION
## Description

Document the new Synthetics availability SLI.

Preview: [Create a service-level objective (SLO) > Synthetics availability](https://observability-docs_bk_4346.docs-preview.app.elstc.co/guide/en/observability/master/slo-create.html#synthetics-availability-sli)

### Documentation sets edited in this PR

_Check all that apply._

- [x] Stateful (`docs/en/observability/*`)
- [x] Serverless (`docs/en/serverless/*`)
- [ ] Integrations Developer Guide (`docs/en/integrations/*`)
- [ ] None of the above

### Related issue

Closes #4299

## Checklist

<!--
Add labels to:
1. Backport to other versions (`backport-*`):
    - `backport-8.x` to backport to the latest minor
    - `backport-skip` to not backport (for example, for serverless docs) 
    - `backport-main` to "backport" to `main` if the target branch is _not_ `main`
    - Individual `backport-*` labels to target specific minor versions
2. Surface blocking reviews (`needs-*-review`):
    - `needs-writer-review` for codeowners
    - `needs-dev-review` for dev team
    - `needs-product-review` for PM review
3. Build serverless preview docs: `ci:doc-build`
-->

- [x] Product/Engineering Review
- [ ] Writer Review

### Follow-up tasks
<!-- If you are updating the Integrations Developer Guide, you can delete this section -->

_Select one._

* This PR does _not_ need to be ported to another doc set because:
  - [ ] The concepts in this PR only apply to one doc set (serverless _or_ stateful)
  - [x] The PR contains edits to both doc sets (serverless _and_ stateful)
* This PR needs to be ported to another doc set:
  - [ ] Port to stateful docs: \<link to PR or tracking issue>
  - [ ] Port to serverless docs: \<link to PR or tracking issue>
