### PR TITLE
Update threshold-alert.asciidoc

### DIFF
--- a/docs/en/observability/threshold-alert.asciidoc
+++ b/docs/en/observability/threshold-alert.asciidoc
@@ -91,6 +91,8 @@ The shaded area shows the threshold you've set.
 [role="screenshot"]
 image::images/custom-threshold-preview-chart.png[Custom threshold preview chart,75%]
 
+If you use the **Group alerts by** option, the maximum bar size will be 3. It will only show the top 3 fields.
+
 [discrete]
 [[custom-threshold-group-by]]
 == Group alerts by (optional)


### PR DESCRIPTION
Hey, team, I'm sending this pull request because a customer asked about the bars from the preview chart. It was only showing 3 bars instead of 4, as the customer was expecting to see.  However, this is hardcoded and will only show the top 3.

## Description
<!-- Add a description here -->

### Documentation sets edited in this PR

_Check all that apply._

- [x] Stateful (`docs/en/observability/*`)
- [ ] Serverless (`docs/en/serverless/*`)
- [ ] Integrations Developer Guide (`docs/en/integrations/*`)
- [ ] None of the above

### Related issue
Closes # <!-- Add the issue this PR closes here -->

## Checklist

<!--
Add labels to:
1. Backport to other versions (`backport-*`):
    - `backport-8.x` to backport to the latest minor
    - `backport-skip` to not backport (for example, for serverless docs) 
    - `backport-main` to "backport" to `main` if the target branch is _not_ `main`
    - Individual `backport-*` labels to target specific minor versions
2. Surface blocking reviews (`needs-*-review`):
    - `needs-writer-review` for codeowners
    - `needs-dev-review` for dev team
    - `needs-product-review` for PM review
3. Build serverless preview docs: `ci:doc-build`
-->

- [ ] Product/Engineering Review
- [ ] Writer Review

### Follow-up tasks
<!-- If you are updating the Integrations Developer Guide, you can delete this section -->

_Select one._

* This PR does _not_ need to be ported to another doc set because:
  - [ ] The concepts in this PR only apply to one doc set (serverless _or_ stateful)
  - [ ] The PR contains edits to both doc sets (serverless _and_ stateful)
* This PR needs to be ported to another doc set:
  - [ ] Port to stateful docs: \<link to PR or tracking issue>
  - [x] Port to serverless docs: https://github.com/elastic/observability-docs/issues/4417 (we need to validate that this needs to be backported)
