### PR TITLE
[Synthetics] Add client certificate reference to docs

### DIFF
--- a/docs/en/observability/synthetics-configuration.asciidoc
+++ b/docs/en/observability/synthetics-configuration.asciidoc
@@ -89,6 +89,13 @@ Below are details on a few Playwright options that are particularly relevant to 
 == TLS client authentication
 To enable TLS client authentication, set https://playwright.dev/docs/api/class-testoptions#test-options-client-certificates[`clientCertificates`] option in the configuration file:
 
+//////
+[NOTE]
+=====
+Path-based options `{certPath, keyPath, pfxPath}` are only supported on Private Locations, defer to in-memory alternatives `{cert, key, pfx}` when running on locations hosted by Elastic.
+=====
+//////
+
 [source,js]
 ----
 playwrightOptions: {
@@ -110,7 +117,7 @@ playwrightOptions: {
 ----
 
 //////
-[NOTE]
+[TIP]
 =====
 When using Synthetics monitor UI, `cert`, `key` and `pfx` can simply be specified using a string literal:
 [source,js]

--- a/docs/en/observability/synthetics-configuration.asciidoc
+++ b/docs/en/observability/synthetics-configuration.asciidoc
@@ -82,7 +82,48 @@ For all available options, refer to the https://playwright.dev/docs/test-configu
 Do not attempt to run in headful mode (using `headless:false`) when running through Elastic's global managed testing infrastructure or Private Locations as this is not supported.
 ====
 
-Below are details on a few Playwright options that are particularly relevant to Elastic Synthetics including timeouts, timezones, and device emulation.
+Below are details on a few Playwright options that are particularly relevant to Elastic Synthetics including TLS client authentication, timeouts, timezones, and device emulation.
+
+[discrete]
+[[synthetics-configuration-playwright-options-client-certificates]]
+== TLS client authentication
+To enable TLS client authentication, set https://playwright.dev/docs/api/class-testoptions#test-options-client-certificates[`clientCertificates`] option in the configuration file:
+
+[source,js]
+----
+playwrightOptions: {
+  clientCertificates: [
+    {
+      origin: 'https://example.com',
+      certPath: './cert.pem',
+      keyPath: './key.pem',
+      passphrase: 'mysecretpassword',
+    },
+    {
+      origin: 'https://example.com',
+      cert: Buffer.from("-----BEGIN CERTIFICATE-----\n..."),
+      key: Buffer.from("-----BEGIN RSA PRIVATE KEY-----\n..."),
+      passphrase: 'mysecretpassword',
+    }
+  ],
+}
+----
+
+//////
+[NOTE]
+=====
+When using Synthetics monitor UI, `cert`, `key` and `pfx` can simply be specified using a string literal:
+[source,js]
+----
+clientCertificates: [
+  {
+    cert: "-----BEGIN CERTIFICATE-----\n...",
+    // Not cert: Buffer.from("-----BEGIN CERTIFICATE-----\n..."),
+  }
+],
+----
+=====
+//////
 
 [discrete]
 [[synthetics-configuration-playwright-options-timeouts]]

--- a/docs/en/observability/synthetics-configuration.asciidoc
+++ b/docs/en/observability/synthetics-configuration.asciidoc
@@ -87,7 +87,7 @@ Below are details on a few Playwright options that are particularly relevant to 
 [discrete]
 [[synthetics-configuration-playwright-options-client-certificates]]
 == TLS client authentication
-To enable TLS client authentication, set https://playwright.dev/docs/api/class-testoptions#test-options-client-certificates[`clientCertificates`] option in the configuration file:
+To enable TLS client authentication, set the https://playwright.dev/docs/api/class-testoptions#test-options-client-certificates[`clientCertificates`] option in the configuration file:
 
 //////
 [NOTE]

--- a/docs/en/observability/synthetics-configuration.asciidoc
+++ b/docs/en/observability/synthetics-configuration.asciidoc
@@ -89,12 +89,10 @@ Below are details on a few Playwright options that are particularly relevant to 
 == TLS client authentication
 To enable TLS client authentication, set the https://playwright.dev/docs/api/class-testoptions#test-options-client-certificates[`clientCertificates`] option in the configuration file:
 
-//////
 [NOTE]
 =====
 Path-based options `{certPath, keyPath, pfxPath}` are only supported on Private Locations, defer to in-memory alternatives `{cert, key, pfx}` when running on locations hosted by Elastic.
 =====
-//////
 
 [source,js]
 ----
@@ -116,7 +114,6 @@ playwrightOptions: {
 }
 ----
 
-//////
 [TIP]
 =====
 When using Synthetics monitor UI, `cert`, `key` and `pfx` can simply be specified using a string literal:
@@ -130,7 +127,6 @@ clientCertificates: [
 ],
 ----
 =====
-//////
 
 [discrete]
 [[synthetics-configuration-playwright-options-timeouts]]

--- a/docs/en/serverless/synthetics/synthetics-configuration.mdx
+++ b/docs/en/serverless/synthetics/synthetics-configuration.mdx
@@ -91,6 +91,10 @@ Below are details on a few Playwright options that are particularly relevant to 
 ### TLS client authentication
 To enable TLS client authentication, set [`clientCertificates`](https://playwright.dev/docs/api/class-testoptions#test-options-client-certificates) option in the configuration file:
 
+<DocCallOut title="Note">
+  Path-based options `{certPath, keyPath, pfxPath}` are only supported on Private Locations, defer to in-memory alternatives `{cert, key, pfx}` when running on locations hosted by Elastic.
+</DocCallOut>
+
 ```js
 playwrightOptions: {
   clientCertificates: [
@@ -110,7 +114,7 @@ playwrightOptions: {
 }
 ```
 
-<DocCallOut title="Note">
+<DocCallOut title="Tip">
   When using Synthetics monitor UI, `cert`, `key` and `pfx` can simply be specified using a string literal:
   ```js
   clientCertificates: [

--- a/docs/en/serverless/synthetics/synthetics-configuration.mdx
+++ b/docs/en/serverless/synthetics/synthetics-configuration.mdx
@@ -89,7 +89,7 @@ Below are details on a few Playwright options that are particularly relevant to 
 <div id="synthetics-configuration-playwright-options-client-certificates"></div>
 
 ### TLS client authentication
-To enable TLS client authentication, set [`clientCertificates`](https://playwright.dev/docs/api/class-testoptions#test-options-client-certificates) option in the configuration file:
+To enable TLS client authentication, set the [`clientCertificates`](https://playwright.dev/docs/api/class-testoptions#test-options-client-certificates) option in the configuration file:
 
 <DocCallOut title="Note">
   Path-based options `{certPath, keyPath, pfxPath}` are only supported on Private Locations, defer to in-memory alternatives `{cert, key, pfx}` when running on locations hosted by Elastic.

--- a/docs/en/serverless/synthetics/synthetics-configuration.mdx
+++ b/docs/en/serverless/synthetics/synthetics-configuration.mdx
@@ -84,7 +84,43 @@ For all available options, refer to the [Playwright documentation](https://playw
   Do not attempt to run in headful mode (using `headless:false`) when running through Elastic's global managed testing infrastructure or Private Locations as this is not supported.
 </DocCallOut>
 
-Below are details on a few Playwright options that are particularly relevant to Elastic Synthetics including timeouts, timezones, and device emulation.
+Below are details on a few Playwright options that are particularly relevant to Elastic Synthetics including TLS client authentication, timeouts, timezones, and device emulation.
+
+<div id="synthetics-configuration-playwright-options-client-certificates"></div>
+
+### TLS client authentication
+To enable TLS client authentication, set [`clientCertificates`](https://playwright.dev/docs/api/class-testoptions#test-options-client-certificates) option in the configuration file:
+
+```js
+playwrightOptions: {
+  clientCertificates: [
+    {
+      origin: 'https://example.com',
+      certPath: './cert.pem',
+      keyPath: './key.pem',
+      passphrase: 'mysecretpassword',
+    },
+    {
+      origin: 'https://example.com',
+      cert: Buffer.from("-----BEGIN CERTIFICATE-----\n..."),
+      key: Buffer.from("-----BEGIN RSA PRIVATE KEY-----\n..."),
+      passphrase: 'mysecretpassword',
+    }
+  ],
+}
+```
+
+<DocCallOut title="Note">
+  When using Synthetics monitor UI, `cert`, `key` and `pfx` can simply be specified using a string literal:
+  ```js
+  clientCertificates: [
+    {
+      cert: "-----BEGIN CERTIFICATE-----\n...",
+      // Not cert: Buffer.from("-----BEGIN CERTIFICATE-----\n..."),
+    }
+  ],
+  ```
+</DocCallOut>
 
 <div id="synthetics-configuration-playwright-options-timeouts"></div>
 


### PR DESCRIPTION
## Description
<!-- Add a description here -->

Latest Synthetics version has added support for Playwright's `clientCertificates` option, which allows TLS client auth to be enabled for browser journeys. This option can be specified in project monitors or through the UI.

### Documentation sets edited in this PR

_Check all that apply._

- [x] Stateful (`docs/en/observability/*`)
- [x] Serverless (`docs/en/serverless/*`)
- [ ] Integrations Developer Guide (`docs/en/integrations/*`)
- [ ] None of the above

### Related issue
Closes #4335.

## Checklist

<!--
Add labels to:
1. Backport to other versions (`backport-*`):
    - `backport-8.x` to backport to the latest minor
    - `backport-skip` to not backport (for example, for serverless docs) 
    - `backport-main` to "backport" to `main` if the target branch is _not_ `main`
    - Individual `backport-*` labels to target specific minor versions
2. Surface blocking reviews (`needs-*-review`):
    - `needs-writer-review` for codeowners
    - `needs-dev-review` for dev team
    - `needs-product-review` for PM review
3. Build serverless preview docs: `ci:doc-build`
-->

- [ ] Product/Engineering Review
- [ ] Writer Review

### Follow-up tasks
<!-- If you are updating the Integrations Developer Guide, you can delete this section -->

_Select one._

* This PR does _not_ need to be ported to another doc set because:
  - [ ] The concepts in this PR only apply to one doc set (serverless _or_ stateful)
  - [x] The PR contains edits to both doc sets (serverless _and_ stateful)
* This PR needs to be ported to another doc set:
  - [ ] Port to stateful docs: \<link to PR or tracking issue>
  - [ ] Port to serverless docs: \<link to PR or tracking issue>
