### PR TITLE
Deprecate the Logs Stream app

### DIFF
--- a/docs/en/observability/index.asciidoc
+++ b/docs/en/observability/index.asciidoc
@@ -186,13 +186,13 @@ include::monitor-logs.asciidoc[leveloffset=+2]
 
 include::explore-logs.asciidoc[leveloffset=+3]
 
-include::tail-logs.asciidoc[leveloffset=+3]
-
 include::categorize-logs.asciidoc[leveloffset=+3]
 
 include::inspect-log-anomalies.asciidoc[leveloffset=+3]
 
 include::configure-logs-sources.asciidoc[leveloffset=+3]
+
+include::tail-logs.asciidoc[leveloffset=+3]
 
 include::logs-add-service-name.asciidoc[leveloffset=+2]
 

--- a/docs/en/observability/tail-logs.asciidoc
+++ b/docs/en/observability/tail-logs.asciidoc
@@ -6,7 +6,7 @@
 --
 The Logs Stream app and dashboard panel are deactivated by default. We recommend viewing and inspecting your logs with <<explore-logs, Logs Explorer>> as it provides more features, better performance, and more intuitive navigation.
 
-To reactivate the Logs Stream app, refer to <<reactivate-logs-stream>>.
+To activate the Logs Stream app, refer to <<activate-logs-stream>>.
 --
 
 Within the {logs-app}, the *Stream* page enables you to monitor all of the log events flowing in from your
@@ -17,8 +17,18 @@ Click *Stream Live* to view a continuous flow of log messages in real time, or
 click *Stop streaming* to view historical logs from a specified time range.
 
 [discrete]
-[[reactivate-logs-stream]]
-== Reactivate the Logs Stream app
+[[activate-logs-stream]]
+== Activate Logs Stream
+
+As <<explore-logs, Logs Explorer>> is replacing Logs Stream, Logs Stream is disabled by default. This also means the Logs Stream panel isn't available in Dashboards.
+
+To activate Logs Stream and the Logs Stream Dashboard panel complete the following steps:
+
+. Go to **Management** → **Advanced Settings**
+. Enter _Logs Stream_ in the search bar.
+. Turn on **Enable Logs Stream**.
+
+You should now see Logs Stream in the Observability navigation, and the Logs Stream dashboard panel is available.
 
 [discrete]
 [[filter-logs]]

--- a/docs/en/observability/tail-logs.asciidoc
+++ b/docs/en/observability/tail-logs.asciidoc
@@ -20,8 +20,8 @@ click *Stop streaming* to view historical logs from a specified time range.
 [[activate-logs-stream]]
 == Activate Logs Stream
 
-Because <<explore-logs, Logs Explorer>> is replacing Logs Stream, Logs Stream is disabled by default. This also means the Logs Stream panel isn't available in Dashboards.
-To activate Logs Stream and the Logs Stream Dashboard panel complete the following steps:
+Because <<explore-logs, Logs Explorer>> is replacing Logs Stream, Logs Stream and the Logs Stream dashboard panel are disabled by default.
+To activate Logs Stream and the Logs Stream dashboard panel complete the following steps:
 
 . Go to **Management** → **Advanced Settings**
 . Enter _Logs Stream_ in the search bar.

--- a/docs/en/observability/tail-logs.asciidoc
+++ b/docs/en/observability/tail-logs.asciidoc
@@ -1,10 +1,12 @@
 [[tail-logs]]
-= Tail log files
+= Logs Stream
 
 .There's a new, better way to explore your logs!
 [sidebar]
 --
-<<explore-logs, Logs Explorer>> makes viewing and inspecting your logs easier with more features, better performance, and more intuitive navigation. We recommend switching to Logs Explorer, as it will replace Logs Stream in a future version.
+The Logs Stream app and dashboard panel are deactivated by default. We recommend viewing and inspecting your logs with <<explore-logs, Logs Explorer>> as it provides more features, better performance, and more intuitive navigation.
+
+To reactivate the Logs Stream app, refer to <<reactivate-logs-stream>>.
 --
 
 Within the {logs-app}, the *Stream* page enables you to monitor all of the log events flowing in from your
@@ -13,6 +15,10 @@ along with the power of search.
 
 Click *Stream Live* to view a continuous flow of log messages in real time, or
 click *Stop streaming* to view historical logs from a specified time range.
+
+[discrete]
+[[reactivate-logs-stream]]
+== Reactivate the Logs Stream app
 
 [discrete]
 [[filter-logs]]

--- a/docs/en/observability/tail-logs.asciidoc
+++ b/docs/en/observability/tail-logs.asciidoc
@@ -20,15 +20,14 @@ click *Stop streaming* to view historical logs from a specified time range.
 [[activate-logs-stream]]
 == Activate Logs Stream
 
-As <<explore-logs, Logs Explorer>> is replacing Logs Stream, Logs Stream is disabled by default. This also means the Logs Stream panel isn't available in Dashboards.
-
+Because <<explore-logs, Logs Explorer>> is replacing Logs Stream, Logs Stream is disabled by default. This also means the Logs Stream panel isn't available in Dashboards.
 To activate Logs Stream and the Logs Stream Dashboard panel complete the following steps:
 
 . Go to **Management** → **Advanced Settings**
 . Enter _Logs Stream_ in the search bar.
-. Turn on **Enable Logs Stream**.
+. Turn on **Logs Stream**.
 
-You should now see Logs Stream in the Observability navigation, and the Logs Stream dashboard panel is available.
+After saving your settings, you'll see Logs Stream in the Observability navigation, and the Logs Stream dashboard panel will be available.
 
 [discrete]
 [[filter-logs]]


### PR DESCRIPTION
## Description
Logs Stream is being deactivated by default. This PR addresses that, deemphasizes Logs Stream as a way to view and manage logs, but also includes instructions on activating Logs Stream if users do still want to use it.

### Documentation sets edited in this PR

_Check all that apply._

- [x] Stateful (`docs/en/observability/*`)

### Related issue
Closes #4315 

## Checklist

<!--
Add labels to:
1. Backport to other versions (`backport-*`):
    - `backport-8.x` to backport to the latest minor
    - `backport-skip` to not backport (for example, for serverless docs) 
    - `backport-main` to "backport" to `main` if the target branch is _not_ `main`
    - Individual `backport-*` labels to target specific minor versions
2. Surface blocking reviews (`needs-*-review`):
    - `needs-writer-review` for codeowners
    - `needs-dev-review` for dev team
    - `needs-product-review` for PM review
3. Build serverless preview docs: `ci:doc-build`
-->

- [x] Product/Engineering Review
- [x] Writer Review

### Follow-up tasks
<!-- If you are updating the Integrations Developer Guide, you can delete this section -->

_Select one._

* This PR does _not_ need to be ported to another doc set because:
  - [x] The concepts in this PR only apply to one doc set (serverless _or_ stateful)
