### PR TITLE
Profiling: fix stack version to profiling version alignment

### DIFF
--- a/docs/en/observability/profiling-get-started.asciidoc
+++ b/docs/en/observability/profiling-get-started.asciidoc
@@ -142,4 +142,4 @@ https://container-library.elastic.co/r/observability/profiling-agent[Elastic con
 * For {k8s} deployments, the Helm chart version is already used to configure the same container image, unless
 overwritten with the `version` parameter in the Helm values file.
 
-* For {stack} version 8.8 or higher, use `v3` host agents. For version 8.7, use `v2`. `v3` host agents are incompatible with 8.7 {stack} versions.
+* For {stack} version 8.8, use `v3` host agents. For version 8.7, use `v2`. `v3` host agents are incompatible with 8.7 {stack} versions.


### PR DESCRIPTION
## Description

Only for stack version 8.8 the v3 host agent version should be used. Starting with stack version 8.9, the host agent version is aligned to the stack version.
### Documentation sets edited in this PR

_Check all that apply._

- [x] Stateful (`docs/en/observability/*`)
- [ ] Serverless (`docs/en/serverless/*`)
- [ ] Integrations Developer Guide (`docs/en/integrations/*`)
- [ ] None of the above
