### PR TITLE
Update Hosts documentation to reflect GA

### DIFF
--- a/docs/en/observability/monitor-infra/analyze-hosts.asciidoc
+++ b/docs/en/observability/monitor-infra/analyze-hosts.asciidoc
@@ -1,8 +1,6 @@
 [[analyze-hosts]]
 = Analyze and compare hosts
 
-beta[]
-
 We'd love to get your feedback!
 https://docs.google.com/forms/d/e/1FAIpQLScRHG8TIVb1Oq8ZhD4aks3P1TmgiM58TY123QpDCcBz83YC6w/viewform[Tell us what you think!]
 


### PR DESCRIPTION
## Description
This PR removes the BETA note as Hosts move to GA in 8.16
___________
<img width="654" alt="image" src="https://github.com/user-attachments/assets/093d0e9e-379f-4a61-9858-59e68d78dc70">
___________

### Documentation sets edited in this PR

_Check all that apply._

- [X] Stateful (`docs/en/observability/*`)
- [ ] Serverless (`docs/en/serverless/*`)
- [ ] Integrations Developer Guide (`docs/en/integrations/*`)
- [ ] None of the above

### Related issue
Closes https://github.com/elastic/observability-docs/issues/4267

## Checklist

<!--
Add labels to:
1. Backport to other versions (`backport-*`):
    - `backport-8.x` to backport to the latest minor
    - `backport-skip` to not backport (for example, for serverless docs) 
    - `backport-main` to "backport" to `main` if the target branch is _not_ `main`
    - Individual `backport-*` labels to target specific minor versions
2. Surface blocking reviews (`needs-*-review`):
    - `needs-writer-review` for codeowners
    - `needs-dev-review` for dev team
    - `needs-product-review` for PM review
3. Build serverless preview docs: `ci:doc-build`
-->

- [ ] Product/Engineering Review
- [x] Writer Review

### Follow-up tasks
<!-- If you are updating the Integrations Developer Guide, you can delete this section -->

_Select one._

* This PR does _not_ need to be ported to another doc set because:
  - [ ] The concepts in this PR only apply to one doc set (serverless _or_ stateful)
  - [ ] The PR contains edits to both doc sets (serverless _and_ stateful)
* This PR needs to be ported to another doc set:
  - [ ] Port to stateful docs: \<link to PR or tracking issue>
  - [ ] Port to serverless docs: \<link to PR or tracking issue>
