### PR TITLE
profiling: add information around environment variables

### DIFF
--- a/docs/en/observability/index.asciidoc
+++ b/docs/en/observability/index.asciidoc
@@ -144,6 +144,7 @@ include::profiling-tag-data-query.asciidoc[leveloffset=+4]
 include::profiling-add-symbols.asciidoc[leveloffset=+4]
 include::profiling-use-a-proxy.asciidoc[leveloffset=+4]
 include::profiling-no-kernel-version-check.asciidoc[leveloffset=+4]
+include::profiling-envs.asciidoc[leveloffset=+4]
 
 include::profiling-upgrade.asciidoc[leveloffset=+3]
 

--- a/docs/en/observability/profiling-advanced-configuration.asciidoc
+++ b/docs/en/observability/profiling-advanced-configuration.asciidoc
@@ -8,5 +8,4 @@ See the following sections for more information:
 * <<profiling-add-symbols, Add symbols for native frames>>: Push symbols to your cluster so you can see function names and line numbers in traces of applications written in programming languages that compile to native code (C, C++, Rust, Go, etc.).
 * <<profiling-use-a-proxy,Use a proxy>>:  Set up an HTTP proxy if your infrastructure Universal Profiling Agent installation needs one to reach {ecloud}.
 * <<profiling-no-kernel-version-check, Override kernel version check >>: Configure the Universal Profiling Agent to bypass the kernel version compatibility check.
-
-
+* <<profiling-envs, Environment variables for the Universal Profiling Agent >>: Configure the Universal Profiling Agent using environment.

--- a/docs/en/observability/profiling-advanced-configuration.asciidoc
+++ b/docs/en/observability/profiling-advanced-configuration.asciidoc
@@ -8,4 +8,5 @@ See the following sections for more information:
 * <<profiling-add-symbols, Add symbols for native frames>>: Push symbols to your cluster so you can see function names and line numbers in traces of applications written in programming languages that compile to native code (C, C++, Rust, Go, etc.).
 * <<profiling-use-a-proxy,Use a proxy>>:  Set up an HTTP proxy if your infrastructure Universal Profiling Agent installation needs one to reach {ecloud}.
 * <<profiling-no-kernel-version-check, Override kernel version check >>: Configure the Universal Profiling Agent to bypass the kernel version compatibility check.
-* <<profiling-envs, Environment variables for the Universal Profiling Agent >>: Configure the Universal Profiling Agent using environment.
+* <<profiling-envs, Environment variables for the Universal Profiling Agent >>: Configure the Universal Profiling Agent using the environment.
+

--- a/docs/en/observability/profiling-envs.asciidoc
+++ b/docs/en/observability/profiling-envs.asciidoc
@@ -1,0 +1,19 @@
+[[profiling-envs]]
+= Environment variables to configure the Universal Profiling Agent
+
+The Universal Profiling Agent can be configured with environment variables.
+
+WARNING: Environment variables do have precedence over command line arguments to the Universal Profiling Agent.
+
+[options="header"]
+|==================================
+| Environment variable | Example | Description
+| `PRODFILER_VERBOSE` | `PRODFILER_VERBOSE=true` | Run the Universal Profiling Agent in verbose mode.
+| `PRODFILER_NO_KERNEL_VERSION_CHECK` | `PRODFILER_NO_KERNEL_VERSION_CHECK=true` | Disable the kernel version check. See <<profiling-no-kernel-version-check, Override kernel version check >> for more details.
+| `PRODFILER_TAGS` | `PRODFILER_TAGS="cloud_region:us-central1;env:staging"` | Set specific tags. See <<profiling-tag-data-query, Tag data for querying>> for more details.
+| `PRODFILER_PROJECT_ID` | `PRODFILER_PROJECT_ID=73` | Set project ID to 73.
+| `PRODFILER_SECRET_TOKEN` | `PRODFILER_SECRET_TOKEN=my_secret_token` | Set the secret token to `my_secret_token`.
+| `PRODFILER_COLLECTION_AGENT` | `PRODFILER_COLLECTION_AGENT=example.com:443` | Set the destination for reporting profiling information to `example.com:443`.
+| `PRODFILER_PROBABILISTIC_THRESHOLD` | `PRODFILER_PROBABILISTIC_THRESHOLD=50` | Set the probabilistic threshold to `50`. See <<profiling-probabilistic-profiling, Probabilistic profiling>> for more details.
+| `PRODFILER_PROBABILISTIC_INTERVAL` |`PRODFILER_PROBABILISTIC_INTERVAL=2m30s` | Set the probabilistic interval to `2m30s`. See <<profiling-probabilistic-profiling, Probabilistic profiling>> for more details.
+|==================================

--- a/docs/en/observability/profiling-envs.asciidoc
+++ b/docs/en/observability/profiling-envs.asciidoc
@@ -3,7 +3,7 @@
 
 The Universal Profiling Agent can be configured with environment variables.
 
-WARNING: Environment variables do have precedence over command line arguments to the Universal Profiling Agent.
+WARNING: Command line arguments to the Universal Profiling Agent do have precedence over environment variables.
 
 [options="header"]
 |==================================

--- a/docs/en/observability/profiling-envs.asciidoc
+++ b/docs/en/observability/profiling-envs.asciidoc
@@ -3,7 +3,7 @@
 
 The Universal Profiling Agent can be configured with environment variables.
 
-WARNING: Command line arguments to the Universal Profiling Agent do have precedence over environment variables.
+WARNING: Command line arguments to the Universal Profiling Agent have precedence over environment variables.
 
 [options="header"]
 |==================================

--- a/docs/en/observability/profiling-no-kernel-version-check.asciidoc
+++ b/docs/en/observability/profiling-no-kernel-version-check.asciidoc
@@ -16,4 +16,5 @@ The following example shows how to configure the `-no-kernel-version-check` in t
 sudo pf-host-agent/pf-host-agent -no-kernel-version-check=true
 ----
 
+It is also possible to use the environment variable `PRODFILER_NO_KERNEL_VERSION_CHECK=true` to set this configuration.
 

--- a/docs/en/observability/profiling-probabilistic-profiling.asciidoc
+++ b/docs/en/observability/profiling-probabilistic-profiling.asciidoc
@@ -26,3 +26,6 @@ The following example shows how to configure the Universal Profiling agent with 
 ----
 sudo pf-host-agent/pf-host-agent -probabilistic-threshold=50 -probabilistic-interval=2m30s
 ----
+
+It is also possible to use the environment variables `PRODFILER_PROBABILISTIC_THRESHOLD=50` and `PRODFILER_PROBABILISTIC_INTERVAL=2m30s` to set this configuration.
+

--- a/docs/en/observability/profiling-tag-data-query.asciidoc
+++ b/docs/en/observability/profiling-tag-data-query.asciidoc
@@ -28,3 +28,6 @@ You can then filter profiling data from the Universal Profiling Agent in Kibana 
 ----
 tags : "cloud_region:us-central1" 
 ----
+
+It is also possible to use the environment variable `PRODFILER_TAGS="cloud_region:us-central1;env:staging"` to set this configuration.
+


### PR DESCRIPTION
## Description

Document environment variables that can be used to configure the Universal Profiling Agent.

### Documentation sets edited in this PR

_Check all that apply._

- [x] Stateful (`docs/en/observability/*`)
- [ ] Serverless (`docs/en/serverless/*`)
- [ ] Integrations Developer Guide (`docs/en/integrations/*`)
- [ ] None of the above

### Related issue
https://github.com/elastic/observability-docs/issues/4360
