### PR TITLE
[Hosts docs] Remove the feedback link inline

### DIFF
--- a/docs/en/observability/monitor-infra/analyze-hosts.asciidoc
+++ b/docs/en/observability/monitor-infra/analyze-hosts.asciidoc
@@ -1,9 +1,6 @@
 [[analyze-hosts]]
 = Analyze and compare hosts
 
-We'd love to get your feedback!
-https://docs.google.com/forms/d/e/1FAIpQLScRHG8TIVb1Oq8ZhD4aks3P1TmgiM58TY123QpDCcBz83YC6w/viewform[Tell us what you think!]
-
 The **Hosts** page provides a metrics-driven view of your infrastructure backed
 by an easy-to-use interface called Lens. On the **Hosts** page, you can view
 health and performance metrics to help you quickly:


### PR DESCRIPTION
## Description
This PR removes the feedback link inline.

### Documentation sets edited in this PR

_Check all that apply._

- [X] Stateful (`docs/en/observability/*`)
- [ ] Serverless (`docs/en/serverless/*`)
- [ ] Integrations Developer Guide (`docs/en/integrations/*`)
- [ ] None of the above

### Related issue
Relates to https://github.com/elastic/observability-docs/pull/4371

## Checklist

<!--
Add labels to:
1. Backport to other versions (`backport-*`):
    - `backport-8.x` to backport to the latest minor
    - `backport-skip` to not backport (for example, for serverless docs) 
    - `backport-main` to "backport" to `main` if the target branch is _not_ `main`
    - Individual `backport-*` labels to target specific minor versions
2. Surface blocking reviews (`needs-*-review`):
    - `needs-writer-review` for codeowners
    - `needs-dev-review` for dev team
    - `needs-product-review` for PM review
3. Build serverless preview docs: `ci:doc-build`
-->

- [ ] Product/Engineering Review
- [ ] Writer Review

### Follow-up tasks
<!-- If you are updating the Integrations Developer Guide, you can delete this section -->

_Select one._

* This PR does _not_ need to be ported to another doc set because:
  - [X] The concepts in this PR only apply to one doc set (stateful)
  - [ ] The PR contains edits to both doc sets (serverless _and_ stateful)
* This PR needs to be ported to another doc set:
  - [ ] Port to stateful docs: \<link to PR or tracking issue>
  - [ ] Port to serverless docs: \<link to PR or tracking issue>
