### PR TITLE
Update links to search connectors docs

### DIFF
--- a/docs/en/observability/observability-ai-assistant.asciidoc
+++ b/docs/en/observability/observability-ai-assistant.asciidoc
@@ -39,7 +39,7 @@ The AI assistant requires the following:
 ** OpenAI `gpt-4`+.
 ** Azure OpenAI Service `gpt-4`(0613) or `gpt-4-32k`(0613) with API version `2023-07-01-preview` or more recent.
 ** AWS Bedrock, specifically the Anthropic Claude models.
-* An {enterprise-search-ref}/server.html[Enterprise Search] server if {enterprise-search-ref}/connectors.html[search connectors] are used to populate external data into the knowledge base.
+* An {enterprise-search-ref}/server.html[Enterprise Search] server if {ref}/es-connectors.html[search connectors] are used to populate external data into the knowledge base.
 * The knowledge base requires a 4 GB {ml} node.
 
 [IMPORTANT]
@@ -159,9 +159,9 @@ To create a connector and make its content available to the AI Assistant knowled
 If your {kib} Space doesn't include the `Search` solution you will have to create the connector from a different space or change your space *Solution view* setting to `Classic`.
 ====
 +
-For example, if you create a {enterprise-search-ref}/connectors-github.html[GitHub native connector] you have to set a `name`, attach it to a new or existing `index`, add your `personal access token` and include the `list of repositories` to synchronize.
+For example, if you create a {ref}/es-connectors-github.html[GitHub Elastic managed connector] you have to set a `name`, attach it to a new or existing `index`, add your `personal access token` and include the `list of repositories` to synchronize.
 +
-Learn more about configuring and {enterprise-search-ref}/connectors-usage.html[using connectors] in the Enterprise Search documentation.
+Learn more about configuring and {ref}/es-connectors-usage.html[using connectors] in the Elasticsearch documentation.
 +
 . Create a pipeline and process the data with ELSER.
 +

--- a/docs/en/observability/observability-ai-assistant.asciidoc
+++ b/docs/en/observability/observability-ai-assistant.asciidoc
@@ -159,7 +159,7 @@ To create a connector and make its content available to the AI Assistant knowled
 If your {kib} Space doesn't include the `Search` solution you will have to create the connector from a different space or change your space *Solution view* setting to `Classic`.
 ====
 +
-For example, if you create a {ref}/es-connectors-github.html[GitHub Elastic managed connector] you have to set a `name`, attach it to a new or existing `index`, add your `personal access token` and include the `list of repositories` to synchronize.
+For example, if you create a {ref}/es-connectors-github.html[GitHub connector] you have to set a `name`, attach it to a new or existing `index`, add your `personal access token` and include the `list of repositories` to synchronize.
 +
 Learn more about configuring and {ref}/es-connectors-usage.html[using connectors] in the Elasticsearch documentation.
 +


### PR DESCRIPTION
👋 These search connectors docs have moved to the Elasticsearch guide in 8.16.0, so updating those links. 

ℹ️ Managed or _native_ connectors still require the Enterprise Search server though so the link to the Enterprise Search docs for the _server_ is still correct. 