### PR TITLE
Update Sample otelcol config

### DIFF
--- a/docs/en/observability/apm/collect-application-data/open-telemetry/otel-direct.asciidoc
+++ b/docs/en/observability/apm/collect-application-data/open-telemetry/otel-direct.asciidoc
@@ -73,7 +73,7 @@ and the OTLP protocol over HTTP transport https://opentelemetry.io/docs/specs/ot
 To learn more about these exporters, see the OpenTelemetry Collector documentation:
 https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter/otlphttpexporter[OTLP/HTTP Exporter] or
 https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter/otlpexporter[OTLP/gRPC exporter].
-When adding an endpoint to an existing configuration an optional name component can be added, like `otlp/elastic`, to distinguish endpoints as described in the [OpenTelemetry Collector Configuration Basics](https://opentelemetry.io/docs/collector/configuration/#basics).
+When adding an endpoint to an existing configuration an optional name component can be added, like `otlp/elastic`, to distinguish endpoints as described in thehttps://opentelemetry.io/docs/collector/configuration/#basics[OpenTelemetry Collector Configuration Basics].
 <5> Hostname and port of the APM Server endpoint. For example, `elastic-apm-server:8200`.
 <6> Credential for Elastic APM <<apm-secret-token,secret token authorization>> (`Authorization: "Bearer a_secret_token"`) or <<apm-api-key,API key authorization>> (`Authorization: "ApiKey an_api_key"`).
 <7> Environment-specific configuration parameters can be conveniently passed in as environment variables documented https://opentelemetry.io/docs/collector/configuration/#environment-variables[here] (e.g. `ELASTIC_APM_SERVER_ENDPOINT` and `ELASTIC_APM_SECRET_TOKEN`).

--- a/docs/en/observability/apm/collect-application-data/open-telemetry/otel-direct.asciidoc
+++ b/docs/en/observability/apm/collect-application-data/open-telemetry/otel-direct.asciidoc
@@ -41,7 +41,7 @@ processors: <2>
 exporters:
   debug:
     verbosity: detailed <3>
-  otlp/elastic: <4>
+  otlp: <4>
     # Elastic APM server https endpoint without the "https://" prefix
     endpoint: "${env:ELASTIC_APM_SERVER_ENDPOINT}" <5> <7>
     headers:
@@ -53,15 +53,15 @@ service:
     traces:
       receivers: [otlp]
       processors: [..., memory_limiter, batch]
-      exporters: [debug, otlp/elastic]
+      exporters: [debug, otlp]
     metrics:
       receivers: [otlp]
       processors: [..., memory_limiter, batch]
-      exporters: [debug, otlp/elastic]
+      exporters: [debug, otlp]
     logs: <8>
       receivers: [otlp]
       processors: [..., memory_limiter, batch]
-      exporters: [debug, otlp/elastic]
+      exporters: [debug, otlp]
 ----
 <1> The receivers, like the
 https://github.com/open-telemetry/opentelemetry-collector/tree/main/receiver/otlpreceiver[OTLP receiver], that forward data emitted by APM agents, or the https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/hostmetricsreceiver[host metrics receiver].
@@ -73,6 +73,7 @@ and the OTLP protocol over HTTP transport https://opentelemetry.io/docs/specs/ot
 To learn more about these exporters, see the OpenTelemetry Collector documentation:
 https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter/otlphttpexporter[OTLP/HTTP Exporter] or
 https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter/otlpexporter[OTLP/gRPC exporter].
+When adding an endpoint to an existing configuration an optional name component can be added, like `otlp/elastic`, to distinguish endpoints as described in the [OpenTelemetry Collector Configuration Basics](https://opentelemetry.io/docs/collector/configuration/#basics).
 <5> Hostname and port of the APM Server endpoint. For example, `elastic-apm-server:8200`.
 <6> Credential for Elastic APM <<apm-secret-token,secret token authorization>> (`Authorization: "Bearer a_secret_token"`) or <<apm-api-key,API key authorization>> (`Authorization: "ApiKey an_api_key"`).
 <7> Environment-specific configuration parameters can be conveniently passed in as environment variables documented https://opentelemetry.io/docs/collector/configuration/#environment-variables[here] (e.g. `ELASTIC_APM_SERVER_ENDPOINT` and `ELASTIC_APM_SECRET_TOKEN`).

--- a/docs/en/observability/apm/collect-application-data/open-telemetry/otel-direct.asciidoc
+++ b/docs/en/observability/apm/collect-application-data/open-telemetry/otel-direct.asciidoc
@@ -26,7 +26,11 @@ Connect your OpenTelemetry Collector instances to Elastic {observability} using 
 receivers: <1>
   # ...
   otlp:
-
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
 processors: <2>
   # ...
   memory_limiter:

--- a/docs/en/observability/apm/collect-application-data/open-telemetry/otel-direct.asciidoc
+++ b/docs/en/observability/apm/collect-application-data/open-telemetry/otel-direct.asciidoc
@@ -73,7 +73,7 @@ and the OTLP protocol over HTTP transport https://opentelemetry.io/docs/specs/ot
 To learn more about these exporters, see the OpenTelemetry Collector documentation:
 https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter/otlphttpexporter[OTLP/HTTP Exporter] or
 https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter/otlpexporter[OTLP/gRPC exporter].
-When adding an endpoint to an existing configuration an optional name component can be added, like `otlp/elastic`, to distinguish endpoints as described in thehttps://opentelemetry.io/docs/collector/configuration/#basics[OpenTelemetry Collector Configuration Basics].
+When adding an endpoint to an existing configuration an optional name component can be added, like `otlp/elastic`, to distinguish endpoints as described in the https://opentelemetry.io/docs/collector/configuration/#basics[OpenTelemetry Collector Configuration Basics].
 <5> Hostname and port of the APM Server endpoint. For example, `elastic-apm-server:8200`.
 <6> Credential for Elastic APM <<apm-secret-token,secret token authorization>> (`Authorization: "Bearer a_secret_token"`) or <<apm-api-key,API key authorization>> (`Authorization: "ApiKey an_api_key"`).
 <7> Environment-specific configuration parameters can be conveniently passed in as environment variables documented https://opentelemetry.io/docs/collector/configuration/#environment-variables[here] (e.g. `ELASTIC_APM_SERVER_ENDPOINT` and `ELASTIC_APM_SECRET_TOKEN`).


### PR DESCRIPTION
## Description

Simplify otel collector sample config and make it valid.


### Documentation sets edited in this PR

_Check all that apply._

- [x] Stateful (`docs/en/observability/*`)
- [ ] Serverless (`docs/en/serverless/*`)
- [ ] Integrations Developer Guide (`docs/en/integrations/*`)
- [ ] None of the above

### Related issue
closes #13550
closes #13551

## Checklist

<!--
Add labels to:
1. Backport to other versions (`backport-*`):
    - `backport-8.x` to backport to the latest minor
    - `backport-skip` to not backport (for example, for serverless docs) 
    - `backport-main` to "backport" to `main` if the target branch is _not_ `main`
    - Individual `backport-*` labels to target specific minor versions
2. Surface blocking reviews (`needs-*-review`):
    - `needs-writer-review` for codeowners
    - `needs-dev-review` for dev team
    - `needs-product-review` for PM review
3. Build serverless preview docs: `ci:doc-build`
-->

- [ ] Product/Engineering Review
- [x] Writer Review

### Follow-up tasks
<!-- If you are updating the Integrations Developer Guide, you can delete this section -->

_Select one._

* This PR does _not_ need to be ported to another doc set because:
  - [x] The concepts in this PR only apply to one doc set (serverless _or_ stateful)
  - [ ] The PR contains edits to both doc sets (serverless _and_ stateful)
* This PR needs to be ported to another doc set:
  - [ ] Port to stateful docs: \<link to PR or tracking issue>
  - [ ] Port to serverless docs: \<link to PR or tracking issue>
