### PR TITLE
profiling: add documentation for the config file and CLI arguments

### DIFF
--- a/docs/en/observability/index.asciidoc
+++ b/docs/en/observability/index.asciidoc
@@ -145,6 +145,7 @@ include::profiling-add-symbols.asciidoc[leveloffset=+4]
 include::profiling-use-a-proxy.asciidoc[leveloffset=+4]
 include::profiling-no-kernel-version-check.asciidoc[leveloffset=+4]
 include::profiling-envs.asciidoc[leveloffset=+4]
+include::profiling-config-file.asciidoc[leveloffset=+4]
 
 include::profiling-upgrade.asciidoc[leveloffset=+3]
 

--- a/docs/en/observability/profiling-advanced-configuration.asciidoc
+++ b/docs/en/observability/profiling-advanced-configuration.asciidoc
@@ -10,3 +10,20 @@ See the following sections for more information:
 * <<profiling-no-kernel-version-check, Override kernel version check >>: Configure the Universal Profiling Agent to bypass the kernel version compatibility check.
 * <<profiling-envs, Environment variables for the Universal Profiling Agent >>: Configure the Universal Profiling Agent using the environment.
 
+WARNING: Command line arguments to the Universal Profiling Agent have precedence over environment variables. And environment varaibles have precedence over configuration files.
+
+The Universal Profiling Agent accepts the following CLI arguments:
+
+[options="header"]
+|==================================
+| CLI argument | Type | Example | Description
+| `-v` | `bool` | `-v` | Run the Universal Profiling Agent in verbose mode.
+| `-no-kernel-version-check` | `bool` | `-no-kernel-version-check` | Disable the kernel version check. See <<profiling-no-kernel-version-check, Override kernel version check >> for more details.
+| `-tags` | `string` | `-tags='cloud_region:us-central1;env:staging'` |  Set specific tags. See <<profiling-tag-data-query, Tag data for querying>> for more details.
+| `-project-id` | `uint` | `-project-id 73` | Splits profiling data into logical groups that you control. You can assign any non-zero, unsigned integer <= 4095.
+| `-secret-token` | `string` | `-secret-token=abc123` | Set the secret token for the communication with the Universal Profiling Collector to `abc123`.
+| `-collection-agent` | `string` | `-collection-agent=example.com:443` |  Set the destination for reporting profiling information to `example.com:443`.
+| `-probabilistic-interval` | `duration` | `-probabilistic-interval=2m30s`| Set the probabilistic interval to `2m30s`. See <<profiling-probabilistic-profiling, Probabilistic profiling>> for more details.
+| `-probabilistic-threshold` | `uint` | `-probabilistic-threshold=50` | Set the probabilistic threshold to `50`. See <<profiling-probabilistic-profiling, Probabilistic profiling>> for more details.
+| `-config` | `string` | `-config=/opt/Elastic/universal-profiling/pf-host-agent.conf` | Set the path for the configuration file of the Universal Profiling Agent. See <<profiling-config-file, Configuration file of the Universal Profiling Agent>> for more details.
+|==================================

--- a/docs/en/observability/profiling-config-file.asciidoc
+++ b/docs/en/observability/profiling-config-file.asciidoc
@@ -1,0 +1,30 @@
+[[profiling-config-file]]
+=  Configuration file of the Universal Profiling Agent
+
+The Universal Profiling Agent can be configured using a configuration file. The path to the configuration file can be specified by the CLI argument `-config`.
+By default `/etc/Elastic/universal-profiling/pf-host-agent.conf` is looked up as location for the configuration file.
+
+The expected format of the configuration file is a plaintext file, where each line holds one argument.
+
+Example:
+[source]
+----
+project-id: 73
+secret-token: abc123
+collection-agent: example.com:443
+----
+
+WARNING: Command line arguments to the Universal Profiling Agent have precedence over environment variables. And environment varaibles have precedence over configuration files.
+
+[options="header"]
+|==================================
+| Config file argument | Type | Example | Description
+| `verbose` | `bool` | `verbose: true` | Run the Universal Profiling Agent in verbose mode.
+| `no-kernel-version-check` | `bool` | `no-kernel-version-check: true` | Disable the kernel version check. See <<profiling-no-kernel-version-check, Override kernel version check >> for more details.
+| `tags` | `string` | `tags: 'cloud_region:us-central1;env:staging'` |  Set specific tags. See <<profiling-tag-data-query, Tag data for querying>> for more details.
+| `project-id` | `uint` | `project-id: 73` | Splits profiling data into logical groups that you control. You can assign any non-zero, unsigned integer <= 4095.
+| `secret-token` | `string` | `secret-token: abc123` | Set the secret token for the communication with the Universal Profiling Collector to `abc123`.
+| `collection-agent` | `string` | `collection-agent: example.com:443` |  Set the destination for reporting profiling information to `example.com:443`.
+| `probabilistic-interval` | `duration` | `probabilistic-interval: 2m30s`| Set the probabilistic interval to `2m30s`. See <<profiling-probabilistic-profiling, Probabilistic profiling>> for more details.
+| `probabilistic-threshold` | `uint` | `probabilistic-threshold: 50` | Set the probabilistic threshold to `50`. See <<profiling-probabilistic-profiling, Probabilistic profiling>> for more details.
+|==================================

--- a/docs/en/observability/profiling-envs.asciidoc
+++ b/docs/en/observability/profiling-envs.asciidoc
@@ -3,7 +3,7 @@
 
 The Universal Profiling Agent can be configured with environment variables.
 
-WARNING: Command line arguments to the Universal Profiling Agent have precedence over environment variables.
+WARNING: Command line arguments to the Universal Profiling Agent have precedence over environment variables. And environment varaibles have precedence over configuration files.
 
 [options="header"]
 |==================================
@@ -16,4 +16,5 @@ WARNING: Command line arguments to the Universal Profiling Agent have precedence
 | `PRODFILER_COLLECTION_AGENT` | `PRODFILER_COLLECTION_AGENT=example.com:443` | Set the destination for reporting profiling information to `example.com:443`.
 | `PRODFILER_PROBABILISTIC_THRESHOLD` | `PRODFILER_PROBABILISTIC_THRESHOLD=50` | Set the probabilistic threshold to `50`. See <<profiling-probabilistic-profiling, Probabilistic profiling>> for more details.
 | `PRODFILER_PROBABILISTIC_INTERVAL` |`PRODFILER_PROBABILISTIC_INTERVAL=2m30s` | Set the probabilistic interval to `2m30s`. See <<profiling-probabilistic-profiling, Probabilistic profiling>> for more details.
+| `PRODFILER_CONFIG` | `PRODFILER_CONFIG=/opt/Elastic/universal-profiling/pf-host-agent.conf` | Set the path for the configuration file of the Universal Profiling Agent. See <<profiling-config-file, Configuration file of the Universal Profiling Agent>> for more details.
 |==================================


### PR DESCRIPTION
## Description

Extend the documentation about the format of the config file and the CLI arguments.

### Documentation sets edited in this PR

_Check all that apply._

- [x] Stateful (`docs/en/observability/*`)
- [ ] Serverless (`docs/en/serverless/*`)
- [ ] Integrations Developer Guide (`docs/en/integrations/*`)
- [ ] None of the above

