### PR TITLE
Fix typo in observability-ai-assistant.asciidoc

### DIFF
--- a/docs/en/observability/observability-ai-assistant.asciidoc
+++ b/docs/en/observability/observability-ai-assistant.asciidoc
@@ -81,7 +81,7 @@ To set up the AI Assistant:
 * https://docs.aws.amazon.com/bedrock/latest/userguide/security-iam.html[Amazon Bedrock authentication keys and secrets]
 * https://cloud.google.com/iam/docs/keys-list-get[Google Gemini service account keys]
 
-. From *{stack-manage-app}* -> *{connectors-ui}* in {kib}, create an connector for your AI provider:
+. From *{stack-manage-app}* -> *{connectors-ui}* in {kib}, create a connector for your AI provider:
 * {kibana-ref}/openai-action-type.html[OpenAI]
 * {kibana-ref}/bedrock-action-type.html[Amazon Bedrock]
 * {kibana-ref}/gemini-action-type.html[Google Gemini]


### PR DESCRIPTION
## Description
Minor typo I found while backporting.

### Documentation sets edited in this PR

_Check all that apply._

- [x] Stateful (`docs/en/observability/*`)
- [ ] Serverless (`docs/en/serverless/*`)
- [ ] Integrations Developer Guide (`docs/en/integrations/*`)
- [ ] None of the above

### Related issue
n/a

## Checklist

No backports required because I've already fixed this in the backport PRs before merging.

- [ ] Writer Review

### Follow-up tasks
<!-- If you are updating the Integrations Developer Guide, you can delete this section -->

_Select one._

* This PR does _not_ need to be ported to another doc set because:
  - [x] The concepts in this PR only apply to one doc set (serverless _or_ stateful)
  - [ ] The PR contains edits to both doc sets (serverless _and_ stateful)
* This PR needs to be ported to another doc set:
  - [ ] Port to stateful docs: \<link to PR or tracking issue>
  - [ ] Port to serverless docs: \<link to PR or tracking issue>
