### PR TITLE
add synthetics multi factor authentication docs

### DIFF
--- a/docs/en/observability/index.asciidoc
+++ b/docs/en/observability/index.asciidoc
@@ -56,6 +56,8 @@ include::synthetics-command-reference.asciidoc[leveloffset=+3]
 
 include::synthetics-configuration.asciidoc[leveloffset=+3]
 
+include::synthetics-mfa.asciidoc[leveloffset=+3]
+
 include::synthetics-settings.asciidoc[leveloffset=+3]
 
 include::synthetics-roles.asciidoc[leveloffset=+3]

--- a/docs/en/observability/synthetics-command-reference.asciidoc
+++ b/docs/en/observability/synthetics-command-reference.asciidoc
@@ -333,3 +333,26 @@ and you do _not_ include `--url` and `--auth`, all global locations managed by E
 However, you will not be able to push to these locations with your API key and will see an error:
 _You don't have permission to use Elastic managed global locations_. For more details, refer to the
 <<synthetics-troubleshooting-public-locations-disabled,troubleshooting docs>>.
+
+[discrete]
+[[elastic-synthetics-totp-command]]
+= `@elastic/synthetics totp <secret>`
+
+Generate a Time-based One-Time Password (TOTP) for multifactor authentication (MFA) in Synthetics.
+
+[source, sh]
+----
+npx @elastic/synthetics totp <secret>
+npx @elastic/synthetics totp <secret> --issuer <string> --label <string>
+----
+
+`<secret>`::
+The encoded secret key used to generate the TOTP.
+
+`--issuer <string>`::
+
+Name of the provider or service that is assocaited with the account.
+
+`--label <string>`::
+
+Identifier for the account. Defaults to `SyntheticsTOTP`

--- a/docs/en/observability/synthetics-mfa.asciidoc
+++ b/docs/en/observability/synthetics-mfa.asciidoc
@@ -8,7 +8,7 @@
 Multi-factor Authentication (MFA) adds an essential layer of security to
 applications login processes, protecting against unauthorized access. A very
 common usecase in Synthetics is testing user journeys that involves websites
-behind protected behind MFA.
+protected behind MFA.
 
 Synthetics supports testing websites secured by Time-based One-Time Password
 (TOTP), a common MFA method that provides short lived One Time tokens that are
@@ -29,7 +29,7 @@ OTP Token: 123456
 
 == Using TOTP token inside the journeys
 
-Once the Synhetics TOTP Authentication is configured in your application, you
+Once the Synthetics TOTP Authentication is configured in your application, you
 can now use the OTP token in the synthetics browser journeys using the `mfa`
 object imported from `@elastic/synthetics`.
 

--- a/docs/en/observability/synthetics-mfa.asciidoc
+++ b/docs/en/observability/synthetics-mfa.asciidoc
@@ -1,0 +1,60 @@
+[[synthetics-mfa]]
+= Multi-factor Authentication (MFA) for browser monitors
+
+++++
+<titleabbrev>Multi-factor Authentication</titleabbrev>
+++++
+
+Multi-factor Authentication (MFA) adds an essential layer of security to
+applications login processes, protecting against unauthorized access. A very
+common usecase in Synthetics is testing user journeys that involves websites
+behind protected behind MFA.
+
+Synthetics supports testing websites secured by Time-based One-Time Password
+(TOTP), a common MFA method that provides short lived One Time tokens that are
+desirable for enhancing security.
+
+== Configuring using TOTP
+
+To test a browser journey that uses TOTP for MFA, you need to first configure the
+Synthetics authenticator token in the target application. To do that, you can generate a One
+Time Password (OTP) using the Synthetics CLI, refer to <<elastic-synthetics-totp-command>>.
+
+```sh
+npx @elastic/synthetics totp <secret>
+
+// prints
+OTP Token: 123456
+```
+
+== Using TOTP token inside the journeys
+
+Once the Synhetics TOTP Authentication is configured in your application, you
+can now use the OTP token in the synthetics browser journeys using the `mfa`
+object imported from `@elastic/synthetics`.
+
+```ts
+import { journey, step, mfa} from '@elastic/synthetics';
+
+journey('MFA Test', ({ page, params }) => {
+  step('Login using TOTP token', async () => {
+    // login using username and pass and go to 2FA in next page
+    const token = mfa.token(params.MFA_GH_SECRET);
+    await page.getByPlaceholder("token-input").fill(token)
+  });
+});
+```
+
+For monitors that are created from the Synthetics UI using the Script editor, `mfa` object can be accessed as shown below:
+
+```ts
+step('Login using 2FA', async () => {
+  const token = mfa.token(params.MFA_GH_SECRET);
+  await page.getByPlaceholder("token-input").fill(token)
+});
+```
+
+[NOTE]
+====
+`params.MFA_GH_SECRET` would be the encoded secret that was used for registering the Synthetics Authentication in your web application.
+====

--- a/docs/en/observability/synthetics-mfa.asciidoc
+++ b/docs/en/observability/synthetics-mfa.asciidoc
@@ -7,18 +7,18 @@
 
 Multi-factor Authentication (MFA) adds an essential layer of security to
 applications login processes, protecting against unauthorized access. A very
-common usecase in Synthetics is testing user journeys that involves websites
-protected behind MFA.
+common use case in Synthetics is testing user journeys involving websites
+protected by MFA.
 
 Synthetics supports testing websites secured by Time-based One-Time Password
-(TOTP), a common MFA method that provides short lived One Time tokens that are
-desirable for enhancing security.
+(TOTP), a common MFA method that provides short-lived one-time tokens to
+enhance security.
 
 == Configuring using TOTP
 
-To test a browser journey that uses TOTP for MFA, you need to first configure the
-Synthetics authenticator token in the target application. To do that, you can generate a One
-Time Password (OTP) using the Synthetics CLI, refer to <<elastic-synthetics-totp-command>>.
+To test a browser journey that uses TOTP for MFA, first configure the
+Synthetics authenticator token in the target application. To do this, generate a One-Time
+Password (OTP) using the Synthetics CLI; refer to <<elastic-synthetics-totp-command>>.
 
 ```sh
 npx @elastic/synthetics totp <secret>
@@ -27,7 +27,8 @@ npx @elastic/synthetics totp <secret>
 OTP Token: 123456
 ```
 
-== Using TOTP token inside the journeys
+[discrete]
+== Applying the TOTP Token in Browser Journeys
 
 Once the Synthetics TOTP Authentication is configured in your application, you
 can now use the OTP token in the synthetics browser journeys using the `mfa`
@@ -45,7 +46,7 @@ journey('MFA Test', ({ page, params }) => {
 });
 ```
 
-For monitors that are created from the Synthetics UI using the Script editor, `mfa` object can be accessed as shown below:
+For monitors created in the Synthetics UI using the Script editor, the `mfa` object can be accessed as shown below:
 
 ```ts
 step('Login using 2FA', async () => {

--- a/docs/en/observability/synthetics-mfa.asciidoc
+++ b/docs/en/observability/synthetics-mfa.asciidoc
@@ -14,7 +14,8 @@ Synthetics supports testing websites secured by Time-based One-Time Password
 (TOTP), a common MFA method that provides short-lived one-time tokens to
 enhance security.
 
-== Configuring using TOTP
+[discrete]
+== Configuring TOTP for MFA
 
 To test a browser journey that uses TOTP for MFA, first configure the
 Synthetics authenticator token in the target application. To do this, generate a One-Time

--- a/docs/en/serverless/serverless-observability.docnav.json
+++ b/docs/en/serverless/serverless-observability.docnav.json
@@ -485,6 +485,11 @@
           "classic-sources": ["enObservabilitySyntheticsConfiguration"]
         },
         {
+          "label": "Multifactor Authentication for browser monitors",
+          "slug": "/serverless/observability/synthetics-mfa",
+          "classic-sources": ["enObservabilitySyntheticsMFA"]
+        },
+        {
           "label": "Configure Synthetics settings",
           "slug": "/serverless/observability/synthetics-settings",
           "classic-sources": ["enObservabilitySyntheticsSettings"]

--- a/docs/en/serverless/synthetics/synthetics-command-reference.mdx
+++ b/docs/en/serverless/synthetics/synthetics-command-reference.mdx
@@ -366,3 +366,28 @@ To list both locations on Elastic's global managed infrastructure and ((private-
   _You don't have permission to use Elastic managed global locations_. For more details, refer to the
   <DocLink slug="/serverless/observability/synthetics-troubleshooting" section="you-do-not-have-permission-to-use-elastic-managed-locations">troubleshooting docs</DocLink>.
 </DocCallOut> */}
+
+## `@elastic/synthetics totp <secret>`
+
+Generate a Time-based One-Time Password (TOTP) for multifactor authentication(MFA) in Synthetics.
+
+```sh
+npx @elastic/synthetics totp <secret> --issuer <issuer> --label <label>
+```
+
+<DocDefList>
+  <DocDefTerm>`secret`</DocDefTerm>
+  <DocDefDescription>
+    The encoded secret key used to generate the TOTP.
+  </DocDefDescription>
+
+  <DocDefTerm>`--issuer <string>`</DocDefTerm>
+  <DocDefDescription>
+    Name of the provider or service that is assocaited with the account.
+  </DocDefDescription>
+
+  <DocDefTerm>`--label <string>`</DocDefTerm>
+  <DocDefDescription>
+    Identifier for the account. Defaults to `SyntheticsTOTP`
+  </DocDefDescription>
+</DocDefList>

--- a/docs/en/serverless/synthetics/synthetics-mfa.mdx
+++ b/docs/en/serverless/synthetics/synthetics-mfa.mdx
@@ -14,7 +14,7 @@ tags: []
 Multi-factor Authentication (MFA) adds an essential layer of security to
 applications login processes, protecting against unauthorized access. A very
 common usecase in Synthetics is testing user journeys that involves websites
-behind protected behind MFA.
+protected behind MFA.
 
 Synthetics supports testing websites secured by Time-based One-Time Password
 (TOTP), a common MFA method that provides short lived One Time tokens that are
@@ -35,7 +35,7 @@ OTP Token: 123456
 
 ## Using TOTP token inside the journeys
 
-Once the Synhetics TOTP Authentication is configured in your application, you can now use the OTP token in the synthetics browser
+Once the Synthetics TOTP Authentication is configured in your application, you can now use the OTP token in the synthetics browser
 journeys using the `mfa` object imported from `@elastic/synthetics`.
 
 ```ts

--- a/docs/en/serverless/synthetics/synthetics-mfa.mdx
+++ b/docs/en/serverless/synthetics/synthetics-mfa.mdx
@@ -13,18 +13,18 @@ tags: []
 
 Multi-factor Authentication (MFA) adds an essential layer of security to
 applications login processes, protecting against unauthorized access. A very
-common usecase in Synthetics is testing user journeys that involves websites
-protected behind MFA.
+common use case in Synthetics is testing user journeys involving websites
+protected by MFA.
 
 Synthetics supports testing websites secured by Time-based One-Time Password
-(TOTP), a common MFA method that provides short lived One Time tokens that are
-desirable for enhancing security. 
+(TOTP), a common MFA method that provides short-lived one-time tokens to
+enhance security.
 
-## Configuring using TOTP
+## Configuring TOTP for MFA
 
-To test a browser journey that uses TOTP for MFA, you need to first configure the
-Synthetics authenticator token in your application. To do that, you can generate a One
-Time Password (OTP) using the Synthetics CLI, refer to <DocLink slug="/serverless/observability/synthetics-command-reference" section="@elastic/synthetics totp <secret>">.
+To test a browser journey that uses TOTP for MFA, first configure the
+Synthetics authenticator token in the target application. To do this, generate a One-Time
+Password (OTP) using the Synthetics CLI; refer to <DocLink slug="/serverless/observability/synthetics-command-reference" section="@elastic/synthetics totp <secret>">`@elastic/synthetics totp <secret>`</DocLink>.
 
 ```sh
 npx @elastic/synthetics totp <secret>
@@ -33,7 +33,7 @@ npx @elastic/synthetics totp <secret>
 OTP Token: 123456
 ```
 
-## Using TOTP token inside the journeys
+## Applying the TOTP Token in Browser Journeys
 
 Once the Synthetics TOTP Authentication is configured in your application, you can now use the OTP token in the synthetics browser
 journeys using the `mfa` object imported from `@elastic/synthetics`.
@@ -50,7 +50,7 @@ journey("MFA Test", ({ page, params }) => {
 });
 ```
 
-For monitors that are created from the Synthetics UI using the Script editor, `mfa` object can be accessed as shown below:
+For monitors created in the Synthetics UI using the Script editor, the `mfa` object can be accessed as shown below:
 
 ```ts
 step("Login using 2FA", async () => {

--- a/docs/en/serverless/synthetics/synthetics-mfa.mdx
+++ b/docs/en/serverless/synthetics/synthetics-mfa.mdx
@@ -1,0 +1,66 @@
+---
+slug: /serverless/observability/synthetics-mfa
+title: Multi-factor Authentication (MFA) for browser monitors
+# description: Description to be written
+tags: []
+---
+
+<p>
+  <DocBadge template="technical preview" />
+</p>
+
+<div id="synthetics-mfa"></div>
+
+Multi-factor Authentication (MFA) adds an essential layer of security to
+applications login processes, protecting against unauthorized access. A very
+common usecase in Synthetics is testing user journeys that involves websites
+behind protected behind MFA.
+
+Synthetics supports testing websites secured by Time-based One-Time Password
+(TOTP), a common MFA method that provides short lived One Time tokens that are
+desirable for enhancing security. 
+
+## Configuring using TOTP
+
+To test a browser journey that uses TOTP for MFA, you need to first configure the
+Synthetics authenticator token in your application. To do that, you can generate a One
+Time Password (OTP) using the Synthetics CLI, refer to <DocLink slug="/serverless/observability/synthetics-command-reference" section="@elastic/synthetics totp <secret>">.
+
+```sh
+npx @elastic/synthetics totp <secret>
+
+// prints
+OTP Token: 123456
+```
+
+## Using TOTP token inside the journeys
+
+Once the Synhetics TOTP Authentication is configured in your application, you can now use the OTP token in the synthetics browser
+journeys using the `mfa` object imported from `@elastic/synthetics`.
+
+```ts
+import { journey, step, mfa } from "@elastic/synthetics";
+
+journey("MFA Test", ({ page, params }) => {
+  step("Login using TOTP token", async () => {
+    // login using username and pass and go to 2FA in next page
+    const token = mfa.token(params.MFA_GH_SECRET);
+    await page.getByPlaceholder("token-input").fill(token);
+  });
+});
+```
+
+For monitors that are created from the Synthetics UI using the Script editor, `mfa` object can be accessed as shown below:
+
+```ts
+step("Login using 2FA", async () => {
+  const token = mfa.token(params.MFA_GH_SECRET);
+  await page.getByPlaceholder("token-input").fill(token);
+});
+```
+
+<DocCallOut title="Note">
+
+`params.MFA_GH_SECRET` would be the encoded secret that was used for registering the Synthetics Authentication in your web application.
+
+</DocCallOut>


### PR DESCRIPTION
## Description

Add docs around the TOTP based MFA support in Synthetics https://github.com/elastic/synthetics/pull/957 and https://github.com/elastic/synthetics/pull/975 

### Documentation sets edited in this PR

- [x] Stateful (`docs/en/observability/*`)
- [x] Serverless (`docs/en/serverless/*`)
- [ ] Integrations Developer Guide (`docs/en/integrations/*`)
- [ ] None of the above

### Related issue
Closes #4334 

## Checklist

- [ ] Product/Engineering Review
- [ ] Writer Review

### Follow-up tasks

* This PR does _not_ need to be ported to another doc set because:
  - [ ] The concepts in this PR only apply to one doc set (serverless _or_ stateful)
  - [x] The PR contains edits to both doc sets (serverless _and_ stateful)
* This PR needs to be ported to another doc set:
  - [ ] Port to stateful docs: \<link to PR or tracking issue>
  - [ ] Port to serverless docs: \<link to PR or tracking issue>
