### PR TITLE
APM: add known issue of lazy rollover bug

### DIFF
--- a/docs/en/observability/apm/known-issues.asciidoc
+++ b/docs/en/observability/apm/known-issues.asciidoc
@@ -42,7 +42,7 @@ Thus, the leftover version check remains and prevents the ingestion of data.
 // How to fix it
 If the deployment is running 8.15.0, upgrade the deployment to 8.15.1 or above.
 A manual rollover of all APM data streams is required to pick up the new index templates and remove the faulty ingest pipeline version check.
-Perform the following requests (they are assuming the `default` namespace is used, adjust if necessary):
+Perform the following requests to Elasticsearch (they are assuming the `default` namespace is used, adjust if necessary):
 +
 [source,txt]
 ----

--- a/docs/en/observability/apm/known-issues.asciidoc
+++ b/docs/en/observability/apm/known-issues.asciidoc
@@ -22,7 +22,7 @@ _Versions: XX.XX.XX, YY.YY.YY, ZZ.ZZ.ZZ_
 ////
 
 [discrete]
-== Upgrading to v8.15.0 may cause ingestion to fail
+== Upgrading to v8.15.x may cause ingestion to fail
 
 _Elastic Stack versions: 8.15.0_ +
     

--- a/docs/en/observability/apm/known-issues.asciidoc
+++ b/docs/en/observability/apm/known-issues.asciidoc
@@ -29,7 +29,7 @@ _Elastic Stack versions: 8.15.0_ +
 // The conditions in which this issue occurs
 The issue only occurs when _upgrading_ the {stack} from <= 8.12.2 directly to any 8.15.x version.
 The issue does _not_ occur when creating a _new_ cluster using any 8.15.x version, or when upgrading
-from 8.12.2 to 8.13 or 8.14 and then to 8.15.x.
+from 8.12.2 to 8.13.x or 8.14.x and then to 8.15.x.
 
 // Describe why it happens
 In APM Servers versions prior to 8.13.0, an ingestion pipeline exists to perform a check on the version.

--- a/docs/en/observability/apm/known-issues.asciidoc
+++ b/docs/en/observability/apm/known-issues.asciidoc
@@ -25,8 +25,7 @@ _Versions: XX.XX.XX, YY.YY.YY, ZZ.ZZ.ZZ_
 == Upgrading to v8.15.0 may cause ingestion to fail
 
 _Elastic Stack versions: 8.15.0_ +
-_Fixed in Elastic Stack version 8.15.1_
-
+    
 // The conditions in which this issue occurs
 The issue only occurs when _upgrading_ the {stack} from <= 8.12.2 directly to any 8.15.x version.
 The issue does _not_ occur when creating a _new_ cluster using any 8.15.x version, or when upgrading
@@ -36,8 +35,8 @@ from 8.12.2 to 8.13 or 8.14 and then to 8.15.x.
 In APM Servers versions prior to 8.13.0, an ingestion pipeline exists to perform a check on the version.
 The version check would fail any APM document produced with a different version of APM server compared to the version of the installed APM’s ingest pipeline.
 In 8.13.0 the version check in the ingest pipeline was removed.
-However, in 8.15.0 APM Server has a different way of managing data streams, that is not aware of the version check present in the ingest pipeline.
-Thus, the leftover version check remains and prevents the ingestion of data.
+Due to the combination of an internal change in how apm data management assets are set up from 8.15 onwards and a bug in Elasticsearch, 
+related to https://github.com/elastic/elasticsearch/issues/112781[lazy rollover of data streams], the ingestion pipeline conducting the version check is not removed on upgrade and prevents the ingestion of data.
 
 // How to fix it
 If the deployment is running 8.15.0, upgrade the deployment to 8.15.1 or above.

--- a/docs/en/observability/apm/known-issues.asciidoc
+++ b/docs/en/observability/apm/known-issues.asciidoc
@@ -25,7 +25,7 @@ _Versions: XX.XX.XX, YY.YY.YY, ZZ.ZZ.ZZ_
 == Upgrading to v8.15.0 may cause ingestion to fail
 
 _Elastic Stack versions: 8.15.0_ +
-_Fixed in Elastic Stack version 8.15.2_
+_Fixed in Elastic Stack version 8.15.1_
 
 // The conditions in which this issue occurs
 The issue only occurs when _upgrading_ the {stack} from 8.12.2 directly to any 8.15.x version.

--- a/docs/en/observability/apm/known-issues.asciidoc
+++ b/docs/en/observability/apm/known-issues.asciidoc
@@ -28,9 +28,9 @@ _Elastic Stack versions: 8.15.0_ +
 _Fixed in Elastic Stack version 8.15.1_
 
 // The conditions in which this issue occurs
-The issue only occurs when _upgrading_ the {stack} from 8.12.2 directly to any 8.15.x version.
+The issue only occurs when _upgrading_ the {stack} from <= 8.12.2 directly to any 8.15.x version.
 The issue does _not_ occur when creating a _new_ cluster using any 8.15.x version, or when upgrading
-from 8.12.2 to 8.13.x and then to 8.15.x.
+from 8.12.2 to 8.13 or 8.14 and then to 8.15.x.
 
 // Describe why it happens
 In APM Servers versions prior to 8.13.0, an ingestion pipeline exists to perform a check on the version.

--- a/docs/en/observability/apm/known-issues.asciidoc
+++ b/docs/en/observability/apm/known-issues.asciidoc
@@ -22,6 +22,51 @@ _Versions: XX.XX.XX, YY.YY.YY, ZZ.ZZ.ZZ_
 ////
 
 [discrete]
+== Upgrading to v8.15.0 may cause ingestion to fail
+
+_Elastic Stack versions: 8.15.0_ +
+_Fixed in Elastic Stack version 8.15.2_
+
+// The conditions in which this issue occurs
+The issue only occurs when _upgrading_ the {stack} from 8.12.2 directly to any 8.15.x version.
+The issue does _not_ occur when creating a _new_ cluster using any 8.15.x version, or when upgrading
+from 8.12.2 to 8.13.x and then to 8.15.x.
+
+// Describe why it happens
+In APM Servers versions prior to 8.13.0, an ingestion pipeline exists to perform a check on the version.
+The version check would fail any APM document produced with a different version of APM server compared to the version of the installed APM’s ingest pipeline.
+In 8.13.0 the version check in the ingest pipeline was removed.
+However, in 8.15.0 APM Server has a different way of managing data streams, that is not aware of the version check present in the ingest pipeline.
+Thus, the leftover version check remains and prevents the ingestion of data.
+
+// How to fix it
+If the deployment is running 8.15.0, upgrade the deployment to 8.15.1 or above.
+A manual rollover of all APM data streams is required to pick up the new index templates and remove the faulty ingest pipeline version check.
+Perform the following requests (they are assuming the `default` namespace is used, adjust if necessary):
++
+[source,txt]
+----
+POST /traces-apm-default/_rollover
+POST /traces-apm.rum-default/_rollover
+POST /logs-apm.error-default/_rollover
+POST /logs-apm.app-default/_rollover
+POST /metrics-apm.app-default/_rollover
+POST /metrics-apm.internal-default/_rollover
+POST /metrics-apm.service_destination.1m-default/_rollover
+POST /metrics-apm.service_destination.10m-default/_rollover
+POST /metrics-apm.service_destination.60m-default/_rollover
+POST /metrics-apm.service_summary.1m-default/_rollover
+POST /metrics-apm.service_summary.10m-default/_rollover
+POST /metrics-apm.service_summary.60m-default/_rollover
+POST /metrics-apm.service_transaction.1m-default/_rollover
+POST /metrics-apm.service_transaction.10m-default/_rollover
+POST /metrics-apm.service_transaction.60m-default/_rollover
+POST /metrics-apm.transaction.1m-default/_rollover
+POST /metrics-apm.transaction.10m-default/_rollover
+POST /metrics-apm.transaction.60m-default/_rollover
+----
+
+[discrete]
 == Upgrading to v8.15.0 may cause APM indices to lose their lifecycle policy
 
 _Elastic Stack versions: 8.15.0_ +


### PR DESCRIPTION
## Description

Add a known issue section for APM to explain a problem occurring when upgrading to 8.15.0.

### Documentation sets edited in this PR

_Check all that apply._

- [X] Stateful (`docs/en/observability/*`)
- [ ] Serverless (`docs/en/serverless/*`)
- [ ] Integrations Developer Guide (`docs/en/integrations/*`)
- [ ] None of the above

### Related issue
Closes # <!-- Add the issue this PR closes here -->

## Checklist

- [X] Product/Engineering Review
- [ ] Writer Review

### Follow-up tasks
<!-- If you are updating the Integrations Developer Guide, you can delete this section -->

_Select one._

* This PR does _not_ need to be ported to another doc set because:
  - [ ] The concepts in this PR only apply to one doc set (serverless _or_ stateful)
  - [ ] The PR contains edits to both doc sets (serverless _and_ stateful)
* This PR needs to be ported to another doc set:
  - [ ] Port to stateful docs: \<link to PR or tracking issue>
  - [ ] Port to serverless docs: \<link to PR or tracking issue>
