### PR TITLE
Clean up new APM known issue

### DIFF
--- a/docs/en/observability/apm/known-issues.asciidoc
+++ b/docs/en/observability/apm/known-issues.asciidoc
@@ -24,10 +24,10 @@ _Versions: XX.XX.XX, YY.YY.YY, ZZ.ZZ.ZZ_
 [discrete]
 == Upgrading to v8.15.x may cause ingestion to fail
 
-_Elastic Stack versions: 8.15.0_ +
+_Elastic Stack versions: 8.15.0+_
     
 // The conditions in which this issue occurs
-The issue only occurs when _upgrading_ the {stack} from <= 8.12.2 directly to any 8.15.x version.
+The issue only occurs when _upgrading_ the {stack} from 8.12.2 or lower directly to any 8.15.x version.
 The issue does _not_ occur when creating a _new_ cluster using any 8.15.x version, or when upgrading
 from 8.12.2 to 8.13.x or 8.14.x and then to 8.15.x.
 

--- a/docs/en/observability/apm/known-issues.asciidoc
+++ b/docs/en/observability/apm/known-issues.asciidoc
@@ -42,7 +42,7 @@ related to https://github.com/elastic/elasticsearch/issues/112781[lazy rollover 
 If the deployment is running 8.15.0, upgrade the deployment to 8.15.1 or above.
 A manual rollover of all APM data streams is required to pick up the new index templates and remove the faulty ingest pipeline version check.
 Perform the following requests to Elasticsearch (they are assuming the `default` namespace is used, adjust if necessary):
-+
+
 [source,txt]
 ----
 POST /traces-apm-default/_rollover


### PR DESCRIPTION
## Description

Removes a rogue `+`.

### Documentation sets edited in this PR

_Check all that apply._

- [x] Stateful (`docs/en/observability/*`)
- [ ] Serverless (`docs/en/serverless/*`)
- [ ] Integrations Developer Guide (`docs/en/integrations/*`)
- [ ] None of the above

### Related issue

N/A

## Checklist

<!--
Add labels to:
1. Backport to other versions (`backport-*`):
    - `backport-8.x` to backport to the latest minor
    - `backport-skip` to not backport (for example, for serverless docs) 
    - `backport-main` to "backport" to `main` if the target branch is _not_ `main`
    - Individual `backport-*` labels to target specific minor versions
2. Surface blocking reviews (`needs-*-review`):
    - `needs-writer-review` for codeowners
    - `needs-dev-review` for dev team
    - `needs-product-review` for PM review
3. Build serverless preview docs: `ci:doc-build`
-->

- [ ] Product/Engineering Review
- [ ] Writer Review

### Follow-up tasks
<!-- If you are updating the Integrations Developer Guide, you can delete this section -->

_Select one._

* This PR does _not_ need to be ported to another doc set because:
  - [x] The concepts in this PR only apply to one doc set (serverless _or_ stateful)
  - [ ] The PR contains edits to both doc sets (serverless _and_ stateful)
* This PR needs to be ported to another doc set:
  - [ ] Port to stateful docs: \<link to PR or tracking issue>
  - [ ] Port to serverless docs: \<link to PR or tracking issue>
