### PR TITLE
Fix stateful vs serverless attribute conflicts

### DIFF
--- a/docs/en/serverless/ai-assistant/ai-assistant.asciidoc
+++ b/docs/en/serverless/ai-assistant/ai-assistant.asciidoc
@@ -8,7 +8,7 @@ preview:[]
 The AI Assistant uses generative AI to provide:
 
 * **Chat**: Have conversations with the AI Assistant. Chat uses function calling to request, analyze, and visualize your data.
-* **Contextual insights**: Open prompts throughout {observability} that explain errors and messages and suggest remediation.
+* **Contextual insights**: Open prompts throughout {obs-serverless} that explain errors and messages and suggest remediation.
 
 [role="screenshot"]
 image::images/ai-assistant-overview.gif[Observability AI assistant preview]
@@ -77,7 +77,7 @@ To set up the AI Assistant:
 ** {kibana-ref}/openai-action-type.html[OpenAI]
 ** {kibana-ref}/bedrock-action-type.html[Amazon Bedrock]
 ** {kibana-ref}/gemini-action-type.html[Google Gemini]
-. Authenticate communication between {observability} and the AI provider by providing the following information:
+. Authenticate communication between {obs-serverless} and the AI provider by providing the following information:
 +
 .. In the **URL** field, enter the AI provider's API endpoint URL.
 .. Under **Authentication**, enter the key or secret you created in the previous step.
@@ -175,7 +175,7 @@ POST _reindex
 [[observability-ai-assistant-interact-with-the-ai-assistant]]
 == Interact with the AI Assistant
 
-You can chat with the AI Assistant or interact with contextual insights located throughout {observability}.
+You can chat with the AI Assistant or interact with contextual insights located throughout {obs-serverless}.
 See the following sections for more on interacting with the AI Assistant.
 
 [TIP]
@@ -219,7 +219,7 @@ You can suggest the following functions:
 | Function | Description
 
 | `alerts`
-| Get alerts for {observability}.
+| Get alerts for {obs-serverless}.
 
 | `elasticsearch`
 | Call {es} APIs on your behalf.
@@ -262,7 +262,7 @@ Additional functions are available when your cluster has APM data:
 [[observability-ai-assistant-use-contextual-prompts]]
 === Use contextual prompts
 
-AI Assistant contextual prompts throughout {observability} provide the following information:
+AI Assistant contextual prompts throughout {obs-serverless} provide the following information:
 
 * **Alerts**: Provides possible causes and remediation suggestions for log rate changes.
 * **Application performance monitoring (APM)**: Explains APM errors and provides remediation suggestions.

--- a/docs/en/serverless/aiops/aiops-analyze-spikes.asciidoc
+++ b/docs/en/serverless/aiops/aiops-analyze-spikes.asciidoc
@@ -8,13 +8,13 @@ preview:[]
 
 // <DocCallOut template="technical preview" />
 
-{observability} provides built-in log rate analysis capabilities,
+{obs-serverless} provides built-in log rate analysis capabilities,
 based on advanced statistical methods,
 to help you find and investigate the causes of unusual spikes or drops in log rates.
 
 To analyze log spikes and drops:
 
-. In your {observability} project, go to **AIOps** → **Log rate analysis**.
+. In your {obs-serverless} project, go to **AIOps** → **Log rate analysis**.
 . Choose a data view or saved search to access the log data you want to analyze.
 . In the histogram chart, click a spike (or drop) to start the analysis.
 +

--- a/docs/en/serverless/aiops/aiops-detect-anomalies.asciidoc
+++ b/docs/en/serverless/aiops/aiops-detect-anomalies.asciidoc
@@ -13,7 +13,7 @@ include::../partials/roles.asciidoc[]
 
 :goal!:
 
-The anomaly detection feature in {observability} automatically models the normal behavior of your time series data — learning trends,
+The anomaly detection feature in {obs-serverless} automatically models the normal behavior of your time series data — learning trends,
 periodicity, and more — in real time to identify anomalies, streamline root cause analysis, and reduce false positives.
 
 To set up anomaly detection, you create and run anomaly detection jobs.
@@ -51,7 +51,7 @@ To learn more about anomaly detection, refer to the {ml-docs}/ml-ad-overview.htm
 [[create-anomaly-detection-job]]
 == Create and run an anomaly detection job
 
-. In your {observability} project, go to **AIOps** → **Anomaly detection**.
+. In your {obs-serverless} project, go to **AIOps** → **Anomaly detection**.
 . Click **Create anomaly detection job** (or **Create job** if other jobs exist).
 . Choose a data view or saved search to access the data you want to analyze.
 . Select the wizard for the type of job you want to create.
@@ -114,7 +114,7 @@ When an event occurs outside of the baselines of normal behavior, that event is 
 == View the results
 
 After the anomaly detection job has processed some data,
-you can view the results in {observability}.
+you can view the results in {obs-serverless}.
 
 [TIP]
 ====

--- a/docs/en/serverless/aiops/aiops-detect-change-points.asciidoc
+++ b/docs/en/serverless/aiops/aiops-detect-change-points.asciidoc
@@ -8,12 +8,12 @@ preview:[]
 
 // <DocCallOut template="technical preview" />
 
-The change point detection feature in {observability} detects distribution changes,
+The change point detection feature in {obs-serverless} detects distribution changes,
 trend changes, and other statistically significant change points in time series data.
 Unlike anomaly detection, change point detection does not require you to configure a job or generate a model.
 Instead  you select a metric and immediately see a visual representation that splits the time series into two parts, before and after the change point.
 
-{observability} uses a {ref}/search-aggregations-change-point-aggregation.html[change point aggregation]
+{obs-serverless} uses a {ref}/search-aggregations-change-point-aggregation.html[change point aggregation]
 to detect change points. This aggregation can detect change points when:
 
 * a significant dip or spike occurs
@@ -23,7 +23,7 @@ to detect change points. This aggregation can detect change points when:
 
 To detect change points:
 
-. In your {observability} project, go to **AIOps** → **Change point detection**.
+. In your {obs-serverless} project, go to **AIOps** → **Change point detection**.
 . Choose a data view or saved search to access the data you want to analyze.
 . Select a function: **avg**, **max**, **min**, or **sum**.
 . In the time filter, specify a time range over which you want to detect change points.

--- a/docs/en/serverless/aiops/aiops-tune-anomaly-detection-job.asciidoc
+++ b/docs/en/serverless/aiops/aiops-tune-anomaly-detection-job.asciidoc
@@ -44,7 +44,7 @@ The {ml} model is not ill-affected, and you do not receive spurious results.
 
 To create a calendar and add scheduled events:
 
-. In your {observability} project, go to **AIOps** → **Anomaly detection**.
+. In your {obs-serverless} project, go to **AIOps** → **Anomaly detection**.
 . Click **Settings**.
 . Under **Calendars**, click **Create**.
 . Enter an ID and description for the calendar.
@@ -110,7 +110,7 @@ This gives you much greater control over which anomalous events affect the {ml} 
 
 To create a job rule, first create any filter lists you want to use in the rule, then configure the rule:
 
-. In your {observability} project, go to **AIOps** → **Anomaly detection**.
+. In your {obs-serverless} project, go to **AIOps** → **Anomaly detection**.
 . (Optional) Create one or more filter lists:
 +
 .. Click **Settings**.
@@ -144,7 +144,7 @@ For example, you can define a custom URL that enables users to drill down to the
 
 To add a custom URL to the **Actions** menu:
 
-. In your {observability} project, go to **AIOps** → **Anomaly detection**.
+. In your {obs-serverless} project, go to **AIOps** → **Anomaly detection**.
 . From the **Actions** menu in the job list, select **Edit job**.
 . Select the **Custom URLs** tab, then click **Add custom URL**.
 . Enter the label to use for the link text.

--- a/docs/en/serverless/aiops/aiops.asciidoc
+++ b/docs/en/serverless/aiops/aiops.asciidoc
@@ -6,7 +6,7 @@
 
 preview:[]
 
-The AIOps capabilities available in {observability} enable you to consume and process large observability data sets at scale, reducing the time and effort required to detect, understand, investigate, and resolve incidents.
+The AIOps capabilities available in {obs-serverless} enable you to consume and process large observability data sets at scale, reducing the time and effort required to detect, understand, investigate, and resolve incidents.
 Built on predictive analytics and {ml}, our AIOps capabilities require no prior experience with {ml}.
 DevOps engineers, SREs, and security analysts can get started right away using these AIOps features with little or no advanced configuration:
 

--- a/docs/en/serverless/alerting/aiops-generate-anomaly-alerts.asciidoc
+++ b/docs/en/serverless/alerting/aiops-generate-anomaly-alerts.asciidoc
@@ -27,7 +27,7 @@ For example, you can create a rule to check every fifteen minutes for critical a
 
 To create an anomaly detection rule:
 
-. In your {observability} project, go to **AIOps** → **Anomaly detection**.
+. In your {obs-serverless} project, go to **AIOps** → **Anomaly detection**.
 . In the list of anomaly detection jobs, find the job you want to check for anomalies.
 Haven't created a job yet? <<observability-aiops-detect-anomalies,Create one now>>.
 . From the **Actions** menu next to the job, select **Create alert rule**.
@@ -194,6 +194,6 @@ The typical value for the bucket, according to analytical modeling.
 
 To edit an anomaly detection rule:
 
-. In your {observability} project, go to **AIOps** → **Anomaly detection**.
+. In your {obs-serverless} project, go to **AIOps** → **Anomaly detection**.
 . Expand the job that uses the rule you want to edit.
 . On the **Job settings** tab, under **Alert rules**, click the rule to edit it.

--- a/docs/en/serverless/alerting/alerting.asciidoc
+++ b/docs/en/serverless/alerting/alerting.asciidoc
@@ -25,7 +25,7 @@ Once you've defined your rules, you can monitor any alerts triggered by these ru
 On the **Alerts** page, the Alerts table provides a snapshot of alerts occurring within the specified time frame. The table includes the alert status, when it was last updated, the reason for the alert, and more.
 
 [role="screenshot"]
-image::images/observability-alerts-overview.png[Summary of Alerts on the {observability} overview page]
+image::images/observability-alerts-overview.png[Summary of Alerts on the {obs-serverless} overview page]
 
 You can filter this table by alert status or time period, customize the visible columns, and search for specific alerts (for example, alerts related to a specific service or environment) using KQL. Select **View alert detail** from the **More actions** menu image:images/icons/boxesHorizontal.svg[action menu], or click the Reason link for any alert to <<observability-view-alerts,view alert>> in detail, and you can then either **View in app** or **View rule details**.
 

--- a/docs/en/serverless/alerting/create-anomaly-alert-rule.asciidoc
+++ b/docs/en/serverless/alerting/create-anomaly-alert-rule.asciidoc
@@ -30,7 +30,7 @@ You can also create an anomaly rule directly from any page within **Applications
 
 To create your anomaly rule:
 
-. In your {observability} project, go to **Alerts**.
+. In your {obs-serverless} project, go to **Alerts**.
 . Select **Manage Rules** from the **Alerts** page, and select **Create rule**.
 . Enter a **Name** for your rule, and any optional **Tags** for more granular reporting (leave blank if unsure).
 . Select the **APM Anomaly** rule type.

--- a/docs/en/serverless/alerting/create-custom-threshold-alert-rule.asciidoc
+++ b/docs/en/serverless/alerting/create-custom-threshold-alert-rule.asciidoc
@@ -17,7 +17,7 @@ include::../partials/roles.asciidoc[]
 
 :goal!:
 
-Create a custom threshold rule to trigger an alert when an {observability} data type reaches or exceeds a given value.
+Create a custom threshold rule to trigger an alert when an {obs-serverless} data type reaches or exceeds a given value.
 
 . To access this page, from your project go to **Alerts**.
 . Click **Manage Rules** -> **Create rule**.

--- a/docs/en/serverless/alerting/create-error-count-threshold-alert-rule.asciidoc
+++ b/docs/en/serverless/alerting/create-error-count-threshold-alert-rule.asciidoc
@@ -30,7 +30,7 @@ You can also create an error count threshold rule directly from any page within 
 
 To create your error count threshold rule:
 
-. In your {observability} project, go to **Alerts**.
+. In your {obs-serverless} project, go to **Alerts**.
 . Select **Manage Rules** from the **Alerts** page, and select **Create rule**.
 . Enter a **Name** for your rule, and any optional **Tags** for more granular reporting (leave blank if unsure).
 . Select the **Error count threshold** rule type from the APM use case.

--- a/docs/en/serverless/alerting/create-failed-transaction-rate-threshold-alert-rule.asciidoc
+++ b/docs/en/serverless/alerting/create-failed-transaction-rate-threshold-alert-rule.asciidoc
@@ -30,7 +30,7 @@ You can also create a failed transaction rate threshold rule directly from any p
 
 To create your failed transaction rate threshold rule:
 
-. In your {observability} project, go to **Alerts**.
+. In your {obs-serverless} project, go to **Alerts**.
 . Select **Manage Rules** from the **Alerts** page, and select **Create rule**.
 . Enter a **Name** for your rule, and any optional **Tags** for more granular reporting (leave blank if unsure).
 . Select the **Failed transaction rate threshold** rule type from the APM use case.

--- a/docs/en/serverless/alerting/create-latency-threshold-alert-rule.asciidoc
+++ b/docs/en/serverless/alerting/create-latency-threshold-alert-rule.asciidoc
@@ -30,7 +30,7 @@ You can also create a latency threshold rule directly from any page within **App
 
 To create your latency threshold rule:
 
-. In your {observability} project, go to **Alerts**.
+. In your {obs-serverless} project, go to **Alerts**.
 . Select **Manage Rules** from the **Alerts** page, and select **Create rule**.
 . Enter a **Name** for your rule, and any optional **Tags** for more granular reporting (leave blank if unsure).
 . Select the **Latency threshold** rule type from the APM use case.

--- a/docs/en/serverless/alerting/create-slo-burn-rate-alert-rule.asciidoc
+++ b/docs/en/serverless/alerting/create-slo-burn-rate-alert-rule.asciidoc
@@ -36,7 +36,7 @@ You must configure a connector if you want to receive alerts for SLO breaches.
 
 To create an SLO burn rate rule:
 
-. In your {observability} project, go to **Alerts**.
+. In your {obs-serverless} project, go to **Alerts**.
 . Select **Manage Rules** from the **Alerts** page, and select **Create rule**.
 . Enter a **Name** for your rule, and any optional **Tags** for more granular reporting (leave blank if unsure).
 . Select **SLO burn rate** from the **Select rule type** list.

--- a/docs/en/serverless/alerting/triage-threshold-breaches.asciidoc
+++ b/docs/en/serverless/alerting/triage-threshold-breaches.asciidoc
@@ -8,7 +8,7 @@
 <titleabbrev>Threshold breaches</titleabbrev>
 ++++
 
-Threshold breaches occur when an {observability} data type reaches or exceeds the threshold set in your <<observability-create-custom-threshold-alert-rule,custom threshold rule>>.
+Threshold breaches occur when an {obs-serverless} data type reaches or exceeds the threshold set in your <<observability-create-custom-threshold-alert-rule,custom threshold rule>>.
 For example, you might have a custom threshold rule that triggers an alert when the total number of log documents with a log level of `error` reaches 100.
 
 To triage issues quickly, go to the alert details page:

--- a/docs/en/serverless/alerting/view-alerts.asciidoc
+++ b/docs/en/serverless/alerting/view-alerts.asciidoc
@@ -72,7 +72,7 @@ You can choose to move active alerts to this state when you disable or delete ru
 [NOTE]
 ====
 The flapping state is possible only if you have enabled alert flapping detection.
-Go to the **Alerts** page and click **Manage Rules** to navigate to the {observability} **{rules-app}** page.
+Go to the **Alerts** page and click **Manage Rules** to navigate to the {obs-serverless} **{rules-app}** page.
 Click **Settings** then set the look back window and threshold that are used to determine whether alerts are flapping.
 For example, you can specify that the alert must change status at least 6 times in the last 10 runs.
 If the rule has actions that run when the alert status changes, those actions are suppressed while the alert is flapping.

--- a/docs/en/serverless/apm-agents/apm-agents-opentelemetry-collect-metrics.asciidoc
+++ b/docs/en/serverless/apm-agents/apm-agents-opentelemetry-collect-metrics.asciidoc
@@ -38,7 +38,7 @@ for more information.
 Use **Discover** to validate that metrics are successfully reported to your project.
 
 . Open your Observability project.
-. In your {observability} project, go to **Discover**, and select the **Logs Explorer** tab.
+. In your {obs-serverless} project, go to **Discover**, and select the **Logs Explorer** tab.
 . Click **All logs** → **Data Views** then select **APM**.
 . Filter the data to only show documents with metrics: `processor.name :"metric"`
 . Narrow your search with a known OpenTelemetry field. For example, if you have an `order_value` field, add `order_value: *` to your search to return
@@ -52,7 +52,7 @@ Use **Lens** to create visualizations for OpenTelemetry metrics. Lens enables yo
 
 To get started with a new Lens visualization:
 
-. In your {observability} project, go to **Visualizations**.
+. In your {obs-serverless} project, go to **Visualizations**.
 . Click **Create new visualization**.
 . Select **Lens**.
 

--- a/docs/en/serverless/apm-agents/apm-agents-opentelemetry-opentelemetry-native-support.asciidoc
+++ b/docs/en/serverless/apm-agents/apm-agents-opentelemetry-opentelemetry-native-support.asciidoc
@@ -22,7 +22,7 @@ be sent directly to Elastic.
 [[observability-apm-agents-opentelemetry-opentelemetry-native-support-send-data-from-an-upstream-opentelemetry-collector]]
 == Send data from an upstream OpenTelemetry Collector
 
-Connect your OpenTelemetry Collector instances to {observability} using the OTLP exporter:
+Connect your OpenTelemetry Collector instances to {obs-serverless} using the OTLP exporter:
 
 [source,yaml]
 ----
@@ -70,7 +70,7 @@ https://github.com/open-telemetry/opentelemetry-collector/tree/main/receiver/otl
 
 <3> The https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter/loggingexporter[logging exporter] is helpful for troubleshooting and supports various logging levels, like `debug`, `info`, `warn`, and `error`.
 
-<4> {observability} endpoint configuration.
+<4> {obs-serverless} endpoint configuration.
 Elastic supports a ProtoBuf payload via both the OTLP protocol over gRPC transport https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/otlp.md#otlpgrpc[(OTLP/gRPC)]
 and the OTLP protocol over HTTP transport https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/otlp.md#otlphttp[(OTLP/HTTP)].
 To learn more about these exporters, see the OpenTelemetry Collector documentation:

--- a/docs/en/serverless/apm/apm-find-transaction-latency-and-failure-correlations.asciidoc
+++ b/docs/en/serverless/apm/apm-find-transaction-latency-and-failure-correlations.asciidoc
@@ -16,7 +16,7 @@ address or region, is facing increased latency due to local data center issues.
 
 To find correlations:
 
-. In your {observability} project, go to **Applications** → **Services**.
+. In your {obs-serverless} project, go to **Applications** → **Services**.
 . Select a service.
 . Select the **Transactions** tab.
 . Select a transaction group in the **Transactions** table.

--- a/docs/en/serverless/apm/apm-get-started.asciidoc
+++ b/docs/en/serverless/apm/apm-get-started.asciidoc
@@ -26,7 +26,7 @@ written in several languages and supports OpenTelemetry. Which agent you'll use 
 To send APM data to Elastic, you must install an APM agent and configure it to send data to
 your project:
 
-. <<observability-create-an-observability-project,Create a new {observability} project>>, or open an existing one.
+. <<observability-create-an-observability-project,Create a new {obs-serverless} project>>, or open an existing one.
 . To install and configure one or more APM agents, do one of following:
 +
 ** In your Observability project, go to **Add data** → **Monitor my application performance** → **Elastic APM** and follow the prompts.

--- a/docs/en/serverless/apm/apm-integrate-with-machine-learning.asciidoc
+++ b/docs/en/serverless/apm/apm-integrate-with-machine-learning.asciidoc
@@ -38,7 +38,7 @@ image::images/service-maps/service-map-anomaly.png[Example view of anomaly score
 
 To enable machine learning anomaly detection:
 
-. In your {observability} project, go to any **Applications** page.
+. In your {obs-serverless} project, go to any **Applications** page.
 . Click **Anomaly detection**.
 . Click **Create Job**.
 . Machine learning jobs are created at the environment level.

--- a/docs/en/serverless/apm/apm-keep-data-secure.asciidoc
+++ b/docs/en/serverless/apm/apm-keep-data-secure.asciidoc
@@ -31,7 +31,7 @@ Requests without a valid API key will be denied.
 
 To create a new API key:
 
-. In your {observability} project, go to any **Applications** page.
+. In your {obs-serverless} project, go to any **Applications** page.
 . Click **Settings**.
 . Select the **APM agent keys** tab.
 . Click **Create APM agent key**.

--- a/docs/en/serverless/apm/apm-ui-services.asciidoc
+++ b/docs/en/serverless/apm/apm-ui-services.asciidoc
@@ -45,7 +45,7 @@ image::images/services/apm-service-group.png[Example view of service group in th
 
 To create a service group:
 
-. In your {observability} project, go to **Applications** → **Services**.
+. In your {obs-serverless} project, go to **Applications** → **Services**.
 . Switch to **Service groups**.
 . Click **Create group**.
 . Specify a name, color, and description.

--- a/docs/en/serverless/cases/create-manage-cases.asciidoc
+++ b/docs/en/serverless/cases/create-manage-cases.asciidoc
@@ -16,7 +16,7 @@ include::../partials/roles.asciidoc[]
 Open a new case to keep track of issues and share the details with colleagues.
 To create a case in your Observability project:
 
-. In your {observability} project, go to **Cases**.
+. In your {obs-serverless} project, go to **Cases**.
 . Click **Create case**.
 . (Optional) If you defined <<observability-case-settings-templates,templates>>, select one to use its default field values. preview:[]
 . Give the case a name, severity, and description.

--- a/docs/en/serverless/cases/manage-cases-settings.asciidoc
+++ b/docs/en/serverless/cases/manage-cases-settings.asciidoc
@@ -78,7 +78,7 @@ image::images/observability-cases-add-connector.png[Add a connector to send case
 ** {kibana-ref}/servicenow-action-type.html[{sn-itsm} connector]
 ** {kibana-ref}/servicenow-sir-action-type.html[{sn-sir} connector]
 ** {kibana-ref}/swimlane-action-type.html[{swimlane} connector]
-** {kibana-ref}/thehive-action-type.html[TheHive connector]
+** https://www.elastic.co/guide/en/kibana/master/thehive-action-type.html[TheHive connector]
 ** {kibana-ref}/cases-webhook-action-type.html[{webhook-cm} connector]
 . Click **Save**.
 

--- a/docs/en/serverless/cases/manage-cases-settings.asciidoc
+++ b/docs/en/serverless/cases/manage-cases-settings.asciidoc
@@ -1,7 +1,7 @@
 [[observability-case-settings]]
 = Configure case settings
 
-// :description: Change the default behavior of {observability} cases by adding connectors, custom fields, templates, and closure options.
+// :description: Change the default behavior of {obs-serverless} cases by adding connectors, custom fields, templates, and closure options.
 // :keywords: serverless, observability, how-to
 
 preview:[]
@@ -13,7 +13,7 @@ include::../partials/roles.asciidoc[]
 
 :goal!:
 
-To access case settings in an {observability} project, go to **Cases** → **Settings**.
+To access case settings in an {obs-serverless} project, go to **Cases** → **Settings**.
 
 [role="screenshot"]
 image::images/observability-cases-settings.png[View case settings]

--- a/docs/en/serverless/index.asciidoc
+++ b/docs/en/serverless/index.asciidoc
@@ -1,8 +1,3 @@
-:doctype: book
-
-include::{asciidoc-dir}/../../shared/versions/stack/master.asciidoc[]
-include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
-
 [[what-is-observability-serverless]]
 == Elastic Observability serverless
 

--- a/docs/en/serverless/index.asciidoc
+++ b/docs/en/serverless/index.asciidoc
@@ -1,3 +1,6 @@
+include::{asciidoc-dir}/../../shared/versions/stack/current.asciidoc[]
+include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
+
 [[what-is-observability-serverless]]
 == Elastic Observability serverless
 

--- a/docs/en/serverless/infra-monitoring/analyze-hosts.asciidoc
+++ b/docs/en/serverless/infra-monitoring/analyze-hosts.asciidoc
@@ -19,7 +19,7 @@ health and performance metrics to help you quickly:
 * View historical data to rule out false alerts and identify root causes.
 * Filter and search the data to focus on the hosts you care about the most.
 
-To access the **Hosts** page, in your {observability} project, go to
+To access the **Hosts** page, in your {obs-serverless} project, go to
 **Infrastructure** → **Hosts**.
 
 [role="screenshot"]

--- a/docs/en/serverless/infra-monitoring/configure-infra-settings.asciidoc
+++ b/docs/en/serverless/infra-monitoring/configure-infra-settings.asciidoc
@@ -13,7 +13,7 @@ include::../partials/roles.asciidoc[]
 
 :goal!:
 
-From the main {observability} menu, go to **Infrastructure** → **Inventory** or **Hosts**,
+From the main {obs-serverless} menu, go to **Infrastructure** → **Inventory** or **Hosts**,
 and click the **Settings** link at the top of the page.
 The following settings are available:
 

--- a/docs/en/serverless/infra-monitoring/detect-metric-anomalies.asciidoc
+++ b/docs/en/serverless/infra-monitoring/detect-metric-anomalies.asciidoc
@@ -30,7 +30,7 @@ However, you will remove any previously detected anomalies.
 
 // lint ignore anomaly-detection observability
 
-. In your {observability} project, go to **Infrastructure** → **Inventory**
+. In your {obs-serverless} project, go to **Infrastructure** → **Inventory**
 and click the **Anomaly detection** link at the top of the page.
 . Under **Hosts** or **Kubernetes Pods**, click **Enable** to create a {ml} job.
 . Choose a start date for the {ml} analysis. {ml-cap} jobs analyze the last four weeks of data and continue to run indefinitely.

--- a/docs/en/serverless/infra-monitoring/get-started-with-metrics.asciidoc
+++ b/docs/en/serverless/infra-monitoring/get-started-with-metrics.asciidoc
@@ -14,12 +14,12 @@ include::../partials/roles.asciidoc[]
 :goal!:
 
 In this guide you'll learn how to onboard system metrics data from a machine or server,
-then observe the data in {observability}.
+then observe the data in {obs-serverless}.
 
 To onboard system metrics data:
 
-. <<observability-create-an-observability-project,Create a new {observability} project>>, or open an existing one.
-. In your {observability} project, go to **Project Settings** → **Integrations**.
+. <<observability-create-an-observability-project,Create a new {obs-serverless} project>>, or open an existing one.
+. In your {obs-serverless} project, go to **Project Settings** → **Integrations**.
 . Type **System** in the search bar, then select the integration to see more details about it.
 . Click **Add System**.
 . Follow the in-product steps to install the System integration and deploy an {agent}.

--- a/docs/en/serverless/infra-monitoring/handle-no-results-found-message.asciidoc
+++ b/docs/en/serverless/infra-monitoring/handle-no-results-found-message.asciidoc
@@ -6,7 +6,7 @@
 
 preview:[]
 
-To correctly render visualizations in the {observability} UI,
+To correctly render visualizations in the {obs-serverless} UI,
 all metrics used by the UI must be present in the collected data.
 For a description of these metrics,
 refer to <<observability-metrics-reference>>.

--- a/docs/en/serverless/infra-monitoring/infra-monitoring.asciidoc
+++ b/docs/en/serverless/infra-monitoring/infra-monitoring.asciidoc
@@ -6,7 +6,7 @@
 
 preview:[]
 
-{observability} allows you to visualize infrastructure metrics to help diagnose problematic spikes,
+{obs-serverless} allows you to visualize infrastructure metrics to help diagnose problematic spikes,
 identify high resource utilization, automatically discover and track pods,
 and unify your metrics with logs and APM data.
 

--- a/docs/en/serverless/infra-monitoring/view-infrastructure-metrics.asciidoc
+++ b/docs/en/serverless/infra-monitoring/view-infrastructure-metrics.asciidoc
@@ -11,7 +11,7 @@ the resources you are monitoring. All monitored resources emitting
 a core set of infrastructure metrics are displayed to give you a quick view of the overall health
 of your infrastructure.
 
-To access the **Infrastructure Inventory** page, in your {observability} project,
+To access the **Infrastructure Inventory** page, in your {obs-serverless} project,
 go to **Infrastructure inventory**.
 
 [role="screenshot"]

--- a/docs/en/serverless/inventory.asciidoc
+++ b/docs/en/serverless/inventory.asciidoc
@@ -43,7 +43,7 @@ Inventory allows you to:
 [[observability-inventory-explore-your-entities]]
 == Explore your entities
 
-. In your {observability} project, go to **Inventory** to view all of your entities.
+. In your {obs-serverless} project, go to **Inventory** to view all of your entities.
 +
 When you open the Inventory for the first time, you'll be asked to enable the EEM. Once enabled, the Inventory will be accessible to anyone with the appropriate privileges.
 +

--- a/docs/en/serverless/logging/ecs-application-logs.asciidoc
+++ b/docs/en/serverless/logging/ecs-application-logs.asciidoc
@@ -156,7 +156,7 @@ Add the custom logs integration to ingest and centrally manage your logs using {
 
 To add the custom logs integration to your project:
 
-. In your {observability} project, go to **Project Settings** → **Integrations**.
+. In your {obs-serverless} project, go to **Project Settings** → **Integrations**.
 . Type `custom` in the search bar and select **Custom Logs**.
 . Click **Install {agent}** at the bottom of the page, and follow the instructions for your system to install the {agent}. If you've already installed an {agent}, you'll be taken directly to configuring your integration.
 . After installing the {agent}, click **Save and continue** to configure the integration from the **Add Custom Logs integration** page.

--- a/docs/en/serverless/logging/get-started-with-logs.asciidoc
+++ b/docs/en/serverless/logging/get-started-with-logs.asciidoc
@@ -18,8 +18,8 @@ then observe the data in **Logs Explorer**.
 
 To onboard system log data:
 
-. <<observability-create-an-observability-project,Create a new {observability} project>>, or open an existing one.
-. In your {observability} project, go to **Add data**.
+. <<observability-create-an-observability-project,Create a new {obs-serverless} project>>, or open an existing one.
+. In your {obs-serverless} project, go to **Add data**.
 . Under **Collect and analyze logs**, click **Stream host system logs**.
 When the page loads, the system integration is installed automatically, and a new API key is created.
 Make sure you copy the API key and store it in a secure location.

--- a/docs/en/serverless/logging/plaintext-application-logs.asciidoc
+++ b/docs/en/serverless/logging/plaintext-application-logs.asciidoc
@@ -189,7 +189,7 @@ Follow these steps to ingest and centrally manage your logs using {agent} and {f
 
 To add the custom logs integration to your project:
 
-. In your {observability} project, go to **Project Settings** → **Integrations**.
+. In your {obs-serverless} project, go to **Project Settings** → **Integrations**.
 . Type `custom` in the search bar and select **Custom Logs**.
 . Click **Add Custom Logs**.
 . Click **Install {agent}** at the bottom of the page, and follow the instructions for your system to install the {agent}.

--- a/docs/en/serverless/logging/run-log-pattern-analysis.asciidoc
+++ b/docs/en/serverless/logging/run-log-pattern-analysis.asciidoc
@@ -18,7 +18,7 @@ Log pattern analysis works on every text field.
 
 To run a log pattern analysis:
 
-. In your {observability} project, go to **Discover** and select the **Logs Explorer** tab.
+. In your {obs-serverless} project, go to **Discover** and select the **Logs Explorer** tab.
 . Select an integration, for example **Elastic APM error_logs**, and apply any filters that you want.
 . If you don't see any results, expand the time range, for example, to **Last 15 days**.
 . In the **Available fields** list, select the text field you want to analyze, then click **Run pattern analysis**.

--- a/docs/en/serverless/observability-overview.asciidoc
+++ b/docs/en/serverless/observability-overview.asciidoc
@@ -6,15 +6,15 @@
 
 preview:[]
 
-{observability} provides granular insights and context into the behavior of applications running in your environments.
+{obs-serverless} provides granular insights and context into the behavior of applications running in your environments.
 It's an important part of any system that you build and want to monitor.
 Being able to detect and fix root cause events quickly within an observable system is a minimum requirement for any analyst.
 
-{observability} provides a single stack to unify your logs, metrics, and application traces.
+{obs-serverless} provides a single stack to unify your logs, metrics, and application traces.
 Ingest your data directly to your Observability project, where you can further process and enhance the data,
 before visualizing it and adding alerts.
 
-image::images/serverless-capabilities.svg[{observability} overview diagram]
+image::images/serverless-capabilities.svg[{obs-serverless} overview diagram]
 
 [discrete]
 [[apm-overview]]
@@ -41,7 +41,7 @@ image::images/log-explorer-overview.png[Logs Explorer showing log events]
 == Application performance monitoring (APM)
 
 Instrument your code and collect performance data and errors at runtime by installing APM agents like Java, Go, .NET, and many more.
-Then use {observability} to monitor your software services and applications in real time:
+Then use {obs-serverless} to monitor your software services and applications in real time:
 
 * Visualize detailed performance information on your services.
 * Identify and analyze errors.
@@ -91,7 +91,7 @@ For more information, see <<observability-monitor-synthetics,Synthetic monitorin
 [[observability-serverless-observability-overview-alerting]]
 == Alerting
 
-Stay aware of potential issues in your environments with {observability}’s alerting
+Stay aware of potential issues in your environments with {obs-serverless}’s alerting
 and actions feature that integrates with log monitoring and APM.
 It provides a set of built-in actions and specific threshold rules
 and enables central management of all rules.
@@ -99,7 +99,7 @@ and enables central management of all rules.
 On the **Alerts** page, the **Alerts** table provides a snapshot of alerts occurring within the specified time frame. The table includes the alert status, when it was last updated, the reason for the alert, and more.
 
 [role="screenshot"]
-image::images/observability-alerts-overview.png[Summary of Alerts on the {observability} overview page]
+image::images/observability-alerts-overview.png[Summary of Alerts on the {obs-serverless} overview page]
 
 <<observability-alerting,Learn more about alerting → >>
 

--- a/docs/en/serverless/projects/create-an-observability-project.asciidoc
+++ b/docs/en/serverless/projects/create-an-observability-project.asciidoc
@@ -1,7 +1,7 @@
 [[observability-create-an-observability-project]]
-= Create an {observability} project
+= Create an {obs-serverless} project
 
-// :description: Create a fully-managed {observability} project to monitor the health of your applications.
+// :description: Create a fully-managed {obs-serverless} project to monitor the health of your applications.
 // :keywords: serverless, observability, how-to
 
 ++++
@@ -17,7 +17,7 @@ include::../partials/roles.asciidoc[]
 
 preview:[]
 
-An {observability} project allows you to run {observability} in an autoscaled and fully-managed environment,
+An {obs-serverless} project allows you to run {obs-serverless} in an autoscaled and fully-managed environment,
 where you don't have to manage the underlying {es} cluster or {kib} instances.
 
 . Navigate to https://cloud.elastic.co/[cloud.elastic.co] and log in to your account.
@@ -42,7 +42,7 @@ To return to the onboarding page later, select **Add data** from the main menu.
 [[observability-create-an-observability-project-next-steps]]
 == Next steps
 
-Learn how to add data to your project and start using {observability} features:
+Learn how to add data to your project and start using {obs-serverless} features:
 
 * <<observability-get-started-with-logs>>
 * <<observability-apm-get-started>>

--- a/docs/en/serverless/quickstarts/k8s-logs-metrics.asciidoc
+++ b/docs/en/serverless/quickstarts/k8s-logs-metrics.asciidoc
@@ -16,7 +16,7 @@ The kubectl command installs the standalone Elastic Agent in your Kubernetes clu
 [[observability-quickstarts-k8s-logs-metrics-prerequisites]]
 == Prerequisites
 
-* An {observability} project. To learn more, refer to <<observability-create-an-observability-project>>.
+* An {obs-serverless} project. To learn more, refer to <<observability-create-an-observability-project>>.
 * A user with the **Admin** role or higher—required to onboard system logs and metrics. To learn more, refer to <<general-assign-user-roles>>.
 * A running Kubernetes cluster.
 * https://kubernetes.io/docs/reference/kubectl/[Kubectl].
@@ -25,8 +25,8 @@ The kubectl command installs the standalone Elastic Agent in your Kubernetes clu
 [[observability-quickstarts-k8s-logs-metrics-collect-your-data]]
 == Collect your data
 
-. <<observability-create-an-observability-project,Create a new {observability} project>>, or open an existing one.
-. In your {observability} project, go to **Add Data**.
+. <<observability-create-an-observability-project,Create a new {obs-serverless} project>>, or open an existing one.
+. In your {obs-serverless} project, go to **Add Data**.
 . Select **Monitor infrastructure**, and then select **Kubernetes**.
 +
 [role="screenshot"]

--- a/docs/en/serverless/quickstarts/monitor-hosts-with-elastic-agent.asciidoc
+++ b/docs/en/serverless/quickstarts/monitor-hosts-with-elastic-agent.asciidoc
@@ -19,7 +19,7 @@ The script also generates an {agent} configuration file that you can use with yo
 [[observability-quickstarts-monitor-hosts-with-elastic-agent-prerequisites]]
 == Prerequisites
 
-* An {observability} project. To learn more, refer to <<observability-create-an-observability-project>>.
+* An {obs-serverless} project. To learn more, refer to <<observability-create-an-observability-project>>.
 * A user with the **Admin** role or higher—required to onboard system logs and metrics. To learn more, refer to <<general-assign-user-roles>>.
 * Root privileges on the host—required to run the auto-detection script used in this quickstart.
 
@@ -37,8 +37,8 @@ It also scans for custom log files.
 [[observability-quickstarts-monitor-hosts-with-elastic-agent-collect-your-data]]
 == Collect your data
 
-. <<observability-create-an-observability-project,Create a new {observability} project>>, or open an existing one.
-. In your {observability} project, go to **Add Data**.
+. <<observability-create-an-observability-project,Create a new {obs-serverless} project>>, or open an existing one.
+. In your {obs-serverless} project, go to **Add Data**.
 . Select **Collect and analyze logs**, and then select **Auto-detect logs and metrics**.
 . Copy the command that's shown. For example:
 +
@@ -103,7 +103,7 @@ image::images/quickstart-host-overview.png[Host overview dashboard]
 == Get value out of your data
 
 After using the dashboards to examine your data and confirm you've ingested all the host logs and metrics you want to monitor,
-you can use {observability} to gain deeper insight into your data.
+you can use {obs-serverless} to gain deeper insight into your data.
 
 For host monitoring, the following capabilities and features are recommended:
 

--- a/docs/en/serverless/slos/create-an-slo.asciidoc
+++ b/docs/en/serverless/slos/create-an-slo.asciidoc
@@ -13,7 +13,7 @@ include::../partials/roles.asciidoc[]
 
 :goal!:
 
-To create an SLO, in your {observability} project, go to **Observability** → **SLOs**:
+To create an SLO, in your {obs-serverless} project, go to **Observability** → **SLOs**:
 
 * If you're creating your first SLO, you'll see an introductory page. Click the **Create SLO** button.
 * If you've created SLOs before, click the **Create new SLO** button in the upper-right corner of the page.


### PR DESCRIPTION
⚠️  Do not merge before https://github.com/elastic/docs/pull/3109 merges! 

## Description

Uses `obs-serverless` instead of `observability` in the serverless docs in most cases.

### Documentation sets edited in this PR

_Check all that apply._

- [ ] Stateful (`docs/en/observability/*`)
- [x] Serverless (`docs/en/serverless/*`)
- [ ] Integrations Developer Guide (`docs/en/integrations/*`)
- [ ] None of the above

### Related issue

N/A

## Checklist

<!--
Add labels to:
1. Backport to other versions (`backport-*`):
    - `backport-8.x` to backport to the latest minor
    - `backport-skip` to not backport (for example, for serverless docs)
    - `backport-main` to "backport" to `main` if the target branch is _not_ `main`
    - Individual `backport-*` labels to target specific minor versions
2. Surface blocking reviews (`needs-*-review`):
    - `needs-writer-review` for codeowners
    - `needs-dev-review` for dev team
    - `needs-product-review` for PM review
-->

- [ ] ~~Product/Engineering Review~~
- [x] Writer Review

### Follow-up tasks
<!-- If you are updating the Integrations Developer Guide, you can delete this section -->

_Select one._

* This PR does _not_ need to be ported to another doc set because:
  - [x] The concepts in this PR only apply to one doc set (serverless _or_ stateful)
  - [ ] The PR contains edits to both doc sets (serverless _and_ stateful)
* This PR needs to be ported to another doc set:
  - [ ] Port to stateful docs: \<link to PR or tracking issue>
  - [ ] Port to serverless docs: \<link to PR or tracking issue>
