### PR TITLE
Fix 8.16 links

### DIFF
--- a/docs/en/apm-server/redirects.asciidoc
+++ b/docs/en/apm-server/redirects.asciidoc
@@ -1221,12 +1221,19 @@ Refer to {observability-guide}/apm-api-info.html[APM Server information API].
 
 Refer to {observability-guide}/apm-api-events.html[Elastic APM events intake API].
 
+[role="exclude",id="apm-api-metadata"]
+=== Metadata
+
+{move-notice}
+
+Refer to {observability-guide}/apm-api-events.html#apm-api-metadata-overview[Metadata].
+
 [role="exclude",id="api-metadata"]
 === Metadata
 
 {move-notice}
 
-Refer to {observability-guide}/apm-api-events.html#apm-api-metadata[Metadata].
+Refer to {observability-guide}/apm-api-events.html#apm-api-metadata-overview[Metadata].
 
 [discrete]
 [[api-metadata-schema]]
@@ -1496,3 +1503,10 @@ Refer to {observability-guide}/apm-release-notes-8.1.html[APM version 8.1].
 {move-notice}
 
 Refer to {observability-guide}/apm-release-notes-8.0.html[APM version 8.0].
+
+[role="exclude",id="traces-get-started"]
+=== APM version 8.0
+
+{move-notice}
+
+Refer to {observability-guide}/apm-getting-started-apm-server.html[Quick start with {ecloud}].

--- a/docs/en/observability/apm/api/apm-server/api-events.asciidoc
+++ b/docs/en/observability/apm/api/apm-server/api-events.asciidoc
@@ -138,7 +138,7 @@ If you're developing an agent, these errors can be useful for debugging.
 
 The APM Server uses a collection of JSON Schemas for validating requests to the intake API:
 
-* <<apm-api-metadata>>
+* <<apm-api-metadata-overview>>
 * <<apm-api-transaction>>
 * <<apm-api-span>>
 * <<apm-api-error>>

--- a/docs/en/observability/apm/api/apm-server/api-metadata.asciidoc
+++ b/docs/en/observability/apm/api/apm-server/api-metadata.asciidoc
@@ -1,4 +1,4 @@
-[[apm-api-metadata]]
+[[apm-api-metadata-overview]]
 = Metadata
 
 Every new connection to the APM Server starts with a `metadata` stanza.

--- a/docs/en/observability/redirects.asciidoc
+++ b/docs/en/observability/redirects.asciidoc
@@ -714,7 +714,7 @@ Refer to <<apm-api-events>>.
 [role="exclude",id="api-metadata"]
 === Metadata
 
-Refer to <<apm-api-metadata>>.
+Refer to <<apm-api-metadata-overview>>.
 
 [discrete]
 [[api-metadata-schema]]


### PR DESCRIPTION
### Summary

Closes https://github.com/elastic/observability-docs/issues/4479.

Needs permanent redirects too.