### PR TITLE
Add reference to prefer-ilm setting for apm lifeycle known bug

### DIFF
--- a/docs/en/observability/apm/known-issues.asciidoc
+++ b/docs/en/observability/apm/known-issues.asciidoc
@@ -24,7 +24,7 @@ _Versions: XX.XX.XX, YY.YY.YY, ZZ.ZZ.ZZ_
 [discrete]
 == Upgrading to v8.15.x may cause ingestion to fail
 
-_Elastic Stack versions: 8.15.0+_
+_Elastic Stack versions: 8.15.0, 8.15.1, 8.15.2, 8.15.3_ +
 _Fixed in Elastic Stack version 8.15.4_
     
 // The conditions in which this issue occurs

--- a/docs/en/observability/apm/known-issues.asciidoc
+++ b/docs/en/observability/apm/known-issues.asciidoc
@@ -93,7 +93,7 @@ To fix these unmanaged indices, consider one of the following approaches:
 . Explicitly configure APM data streams to use the default data stream lifecycle configuration.
 This approach migrates all affected data streams to use data stream lifecycles,
 maintaining behavior equivalent to the default ILM policies.
-Apply this fix only to data streams that are currently unmanaged due to default ILM policies.
+Apply this fix only to data streams that have unmanaged indices due to missing default ILM policies.
 +
 [source,txt]
 ----

--- a/docs/en/observability/apm/known-issues.asciidoc
+++ b/docs/en/observability/apm/known-issues.asciidoc
@@ -25,9 +25,10 @@ _Versions: XX.XX.XX, YY.YY.YY, ZZ.ZZ.ZZ_
 == Upgrading to v8.15.x may cause ingestion to fail
 
 _Elastic Stack versions: 8.15.0+_
+_Fixed in Elastic Stack version 8.15.4_
     
 // The conditions in which this issue occurs
-The issue only occurs when _upgrading_ the {stack} from 8.12.2 or lower directly to any 8.15.x version.
+The issue only occurs when _upgrading_ the {stack} from 8.12.2 or lower directly to any 8.15.x version prior to 8.15.4.
 The issue does _not_ occur when creating a _new_ cluster using any 8.15.x version, or when upgrading
 from 8.12.2 to 8.13.x or 8.14.x and then to 8.15.x.
 

--- a/docs/en/observability/apm/known-issues.asciidoc
+++ b/docs/en/observability/apm/known-issues.asciidoc
@@ -89,60 +89,21 @@ indices created in version 8.15.0 would remain unmanaged if the default ILM poli
 used. One of the following approaches can be adopted to fix the unmanaged indices:
 
 . Manually delete the indices when they are no longer needed.
-. Explicitly configure APM data streams with the default data stream lifecycle config.
-Using this approach would migrate all data streams to use data stream lifecycles,
-which should be equivalent to the default ILM policies. Note that if you have a custom
-lifecycle policy in place for any of the datastreams then you don't need to do anything
-for those datastreams as they are not affected by this bug. Going forward, for using
-custom ILM policies with new datastreams, please consult the {ref}/apm-ilm-how-to.html[updated guide].
+. Explicitly configure APM data streams with the default data stream lifecycle config
+for the data streams configured to use default ILM policies. Using this approach would
+migrate all affected data streams to use data stream lifecycles, which should be equivalent
+to the default ILM policies. Note that the fix should be applied only to data streams that
+are resulting in unmanaged indices due to default ILM policies.
 +
 [source,txt]
 ----
-PUT _data_stream/traces-apm-*/_lifecycle
+PUT _data_stream/{{data_stream_name}}-{{data_stream_namespace}}/_lifecycle
 {
-  "data_retention": "10d"
-}
-
-PUT _data_stream/traces-apm.rum*/_lifecycle
-{
-  "data_retention": "90d"
-}
-
-PUT _data_stream/traces-apm.sampled*/_lifecycle
-{
-  "data_retention": "1h"
-}
-
-PUT _data_stream/metrics-apm.*.1m-*/_lifecycle
-{
-  "data_retention": "90d"
-}
-
-PUT _data_stream/metrics-apm.*.10m-*/_lifecycle
-{
-  "data_retention": "180d"
-}
-
-PUT _data_stream/metrics-apm.*.60m-*/_lifecycle
-{
-  "data_retention": "390d"
-}
-
-PUT _data_stream/metrics-apm.internal-*/_lifecycle
-{
-  "data_retention": "90d"
-}
-
-PUT _data_stream/metrics-apm.app.*/_lifecycle
-{
-  "data_retention": "90d"
-}
-
-PUT _data_stream/logs-apm.*/_lifecycle
-{
-  "data_retention": "10d"
+  "data_retention": <data_retention_period>
 }
 ----
+
+Default `<data_retention_period>` for each data stream is available in {observability-guide}/apm-ilm-how-to.html[this guide].
 
 // Link to fix if it exists
 This issue is fixed in 8.15.1 (https://github.com/elastic/elasticsearch/pull/112432[elastic/elasticsearch#112432]).

--- a/docs/en/observability/apm/known-issues.asciidoc
+++ b/docs/en/observability/apm/known-issues.asciidoc
@@ -91,7 +91,10 @@ used. One of the following approaches can be adopted to fix the unmanaged indice
 . Manually delete the indices when they are no longer needed.
 . Explicitly configure APM data streams with the default data stream lifecycle config.
 Using this approach would migrate all data streams to use data stream lifecycles,
-which should be equivalent to the default ILM policies:
+which should be equivalent to the default ILM policies. Note that if you have a custom
+lifecycle policy in place for any of the datastreams then you don't need to do anything
+for those datastreams as they are not affected by this bug. Going forward, for using
+custom ILM policies with new datastreams, please consult the {ref}/apm-ilm-how-to.html[updated guide].
 +
 [source,txt]
 ----

--- a/docs/en/observability/apm/known-issues.asciidoc
+++ b/docs/en/observability/apm/known-issues.asciidoc
@@ -85,16 +85,15 @@ stream lifecycle configuration, such existing data streams become unmanaged for 
 lifecycle configurations.
 
 // How to fix it
-Upgrading to 8.15.1 should fix any new indices created for the data stream. However,
-indices created in version 8.15.0 would remain unmanaged if the default ILM policy is
-used. One of the following approaches can be adopted to fix the unmanaged indices:
+Upgrading to 8.15.1 resolves the lifecycle issue for any new indices created for APM data streams.
+However, indices created in version 8.15.0 will remain unmanaged if the default ILM policy is in place.
+To fix these unmanaged indices, consider one of the following approaches:
 
-. Manually delete the indices when they are no longer needed.
-. Explicitly configure APM data streams with the default data stream lifecycle config
-for the data streams configured to use default ILM policies. Using this approach would
-migrate all affected data streams to use data stream lifecycles, which should be equivalent
-to the default ILM policies. Note that the fix should be applied only to data streams that
-are resulting in unmanaged indices due to default ILM policies.
+. Manually delete the unmanaged indices when they are no longer needed.
+. Explicitly configure APM data streams to use the default data stream lifecycle configuration.
+This approach migrates all affected data streams to use data stream lifecycles,
+maintaining behavior equivalent to the default ILM policies.
+Apply this fix only to data streams that are currently unmanaged due to default ILM policies.
 +
 [source,txt]
 ----


### PR DESCRIPTION
## Description
<!-- Add a description here -->

Clarify that one of the suggested fix for the unmanaged indices bug introduced in 8.15.0 and fixed in 8.15.1 should only be applied for datatreams with default policies (as they are the only ones affected). If the suggested fix was applied to a datastream using custom ILM policy then the `prefer_ilm` setting needs to be added to the custom ILM policy.

### Documentation sets edited in this PR

_Check all that apply._

- [x] Stateful (`docs/en/observability/*`)
- [ ] Serverless (`docs/en/serverless/*`)
- [ ] Integrations Developer Guide (`docs/en/integrations/*`)
- [ ] None of the above

### Related issue
Closes # <!-- Add the issue this PR closes here -->

## Checklist

<!--
Add labels to:
1. Backport to other versions (`backport-*`):
    - `backport-8.x` to backport to the latest minor
    - `backport-skip` to not backport (for example, for serverless docs)
    - `backport-main` to "backport" to `main` if the target branch is _not_ `main`
    - Individual `backport-*` labels to target specific minor versions
2. Surface blocking reviews (`needs-*-review`):
    - `needs-writer-review` for codeowners
    - `needs-dev-review` for dev team
    - `needs-product-review` for PM review
-->

- [ ] Product/Engineering Review
- [ ] Writer Review

### Follow-up tasks
<!-- If you are updating the Integrations Developer Guide, you can delete this section -->

_Select one._

* This PR does _not_ need to be ported to another doc set because:
  - [ ] The concepts in this PR only apply to one doc set (serverless _or_ stateful)
  - [ ] The PR contains edits to both doc sets (serverless _and_ stateful)
* This PR needs to be ported to another doc set:
  - [ ] Port to stateful docs: \<link to PR or tracking issue>
  - [ ] Port to serverless docs: \<link to PR or tracking issue>
