### PR TITLE
Update search connectors links

### DIFF
--- a/docs/en/observability/observability-ai-assistant.asciidoc
+++ b/docs/en/observability/observability-ai-assistant.asciidoc
@@ -150,11 +150,11 @@ To add external data to the knowledge base in {kib}:
 
 [TIP]
 ====
-The {enterprise-search-ref}/connectors.html[search connectors] described in this section differ from the {kibana-ref}/action-types.html[Stack management -> Connectors] configured during the <<obs-ai-set-up, AI Assistant setup>>.
+The {ref}/es-connectors.html[search connectors] described in this section differ from the {kibana-ref}/action-types.html[Stack management -> Connectors] configured during the <<obs-ai-set-up, AI Assistant setup>>.
 Search connectors are only needed when importing external data into the Knowledge base of the AI Assistant, while the stack connector to the LLM is required for the AI Assistant to work.
 ====
 
-{enterprise-search-ref}/connectors.html[Connectors] allow you to index content from external sources thereby making it available for the AI Assistant. This can greatly improve the relevance of the AI Assistant’s responses. Data can be integrated from sources such as GitHub, Confluence, Google Drive, Jira, AWS S3, Microsoft Teams, Slack, and more.
+{ref}/es-connectors.html[Connectors] allow you to index content from external sources thereby making it available for the AI Assistant. This can greatly improve the relevance of the AI Assistant’s responses. Data can be integrated from sources such as GitHub, Confluence, Google Drive, Jira, AWS S3, Microsoft Teams, Slack, and more.
 
 These connectors are managed under *Search* -> *Content* -> *Connectors* in {kib}, they are outside of the {observability} Solution, and they require an {enterprise-search-ref}/server.html[Enterprise Search] server connected to the Elastic Stack.
 


### PR DESCRIPTION
There was a couple of stragglers here, they aren't broken links but they are soft redirects as of 8.16.0, so best to replace them. :)

