### PR TITLE
[apm] Remove mentions of secret token in APM agent snippets in serverless docs

### DIFF
--- a/docs/en/serverless/apm-agents/apm-agents-aws-lambda-functions.asciidoc
+++ b/docs/en/serverless/apm-agents/apm-agents-aws-lambda-functions.asciidoc
@@ -41,7 +41,7 @@ To get started with monitoring AWS Lambda functions, refer to the APM agent docu
 
 [IMPORTANT]
 ====
-The APM agent documentation states that you can use either an APM secret token or API key to authorize requests to the managed intake service. **However, when sending data to an {obs-serverless} project, you _must_ use an API key**.
+When sending data to an {obs-serverless} project, you _must_ use an API key.
 
 Read more about API keys in <<observability-apm-keep-data-secure>>.
 ====

--- a/docs/en/serverless/apm-agents/apm-agents-aws-lambda-functions.asciidoc
+++ b/docs/en/serverless/apm-agents/apm-agents-aws-lambda-functions.asciidoc
@@ -41,7 +41,7 @@ To get started with monitoring AWS Lambda functions, refer to the APM agent docu
 
 [IMPORTANT]
 ====
-The APM agent documentation states that you can use either an APM secret token or API key to authorize requests to the managed intake service. **However, when sending data to a project, you _must_ use an API key**.
+The APM agent documentation states that you can use either an APM secret token or API key to authorize requests to the managed intake service. **However, when sending data to an {obs-serverless} project, you _must_ use an API key**.
 
 Read more about API keys in <<observability-apm-keep-data-secure>>.
 ====

--- a/docs/en/serverless/transclusion/apm/guide/install-agents/go.asciidoc
+++ b/docs/en/serverless/transclusion/apm/guide/install-agents/go.asciidoc
@@ -25,8 +25,8 @@ export ELASTIC_APM_SERVER_URL=
 # service will be identified as "my-app".
 export ELASTIC_APM_SERVICE_NAME=
 
-# Secret tokens are used to authorize requests to the APM integration
-export ELASTIC_APM_SECRET_TOKEN=
+# API keys are used to authorize requests to the APM integration
+export ELASTIC_APM_API_KEY=
 ----
 
 **3. Instrument your application**

--- a/docs/en/serverless/transclusion/apm/guide/install-agents/node.asciidoc
+++ b/docs/en/serverless/transclusion/apm/guide/install-agents/node.asciidoc
@@ -25,10 +25,7 @@ var apm = require('elastic-apm-node').start({
   // Allowed characters: a-z, A-Z, 0-9, -, _, and space
   serviceName: '',
 
-  // Use if APM integration requires a token
-  secretToken: '',
-
-  // Use if APM integration uses API keys for authentication
+  // API keys are used to authorize requests to the APM integration
   apiKey: '',
 
   // Set custom APM integration host and port (default: http://127.0.0.1:8200)

--- a/docs/en/serverless/transclusion/apm/guide/install-agents/python.asciidoc
+++ b/docs/en/serverless/transclusion/apm/guide/install-agents/python.asciidoc
@@ -38,8 +38,8 @@ ELASTIC_APM = {
   # a-z, A-Z, 0-9, -, _, and space
   'SERVICE_NAME': '',
 
-  # Use if APM integration requires a token
-  'SECRET_TOKEN': '',
+  # API keys are used to authorize requests to the APM integration
+  'API_KEY': '',
 
   # Set custom APM integration host and port (default: http://localhost:8200)
   'SERVER_URL': '',
@@ -82,8 +82,8 @@ app.config['ELASTIC_APM'] = {
   # a-z, A-Z, 0-9, -, _, and space
   'SERVICE_NAME': '',
 
-  # Use if APM integration requires a token
-  'SECRET_TOKEN': '',
+  # API keys are used to authorize requests to the APM integration
+  'API_KEY': '',
 
   # Set custom APM integration host and port (default: http://localhost:8200)
   'SERVER_URL': '',

--- a/docs/en/serverless/transclusion/apm/guide/install-agents/ruby.asciidoc
+++ b/docs/en/serverless/transclusion/apm/guide/install-agents/ruby.asciidoc
@@ -24,8 +24,8 @@ Configure the agent by creating the config file `config/elastic_apm.yml`:
 # Defaults to the name of your Rails app
 service_name: 'my-service'
 
-# Use if APM integration requires a token
-secret_token: ''
+# API keys are used to authorize requests to the APM integration
+api_key: ''
 
 # Set custom APM integration host and port (default: http://localhost:8200)
 server_url: 'http://localhost:8200'
@@ -66,8 +66,8 @@ Create a config file `config/elastic_apm.yml`:
 # Defaults to the name of your Rack app's class.
 service_name: 'my-service'
 
-# Use if APM integration requires a token
-secret_token: ''
+# API keys are used to authorize requests to the APM integration
+api_key: ''
 
 # Set custom APM integration host and port (default: http://localhost:8200)
 server_url: 'http://localhost:8200'


### PR DESCRIPTION
## Description

Removes mentions of secret token in APM agent snippets in serverless docs.

### Documentation sets edited in this PR

_Check all that apply._

- [ ] Stateful (`docs/en/observability/*`)
- [x] Serverless (`docs/en/serverless/*`)
- [ ] Integrations Developer Guide (`docs/en/integrations/*`)
- [ ] None of the above

### Related issue

Closes #4381

## Checklist

<!--
Add labels to:
1. Backport to other versions (`backport-*`):
    - `backport-8.x` to backport to the latest minor
    - `backport-skip` to not backport (for example, for serverless docs)
    - `backport-main` to "backport" to `main` if the target branch is _not_ `main`
    - Individual `backport-*` labels to target specific minor versions
2. Surface blocking reviews (`needs-*-review`):
    - `needs-writer-review` for codeowners
    - `needs-dev-review` for dev team
    - `needs-product-review` for PM review
-->

- [ ] Product/Engineering Review
- [ ] Writer Review

### Follow-up tasks
<!-- If you are updating the Integrations Developer Guide, you can delete this section -->

_Select one._

* This PR does _not_ need to be ported to another doc set because:
  - [x] The concepts in this PR only apply to one doc set (serverless _or_ stateful)
  - [ ] The PR contains edits to both doc sets (serverless _and_ stateful)
* This PR needs to be ported to another doc set:
  - [ ] Port to stateful docs: \<link to PR or tracking issue>
  - [ ] Port to serverless docs: \<link to PR or tracking issue>
