### PR TITLE
Raise prefer_ilm configuration as a known issue

### DIFF
--- a/docs/en/observability/apm/known-issues.asciidoc
+++ b/docs/en/observability/apm/known-issues.asciidoc
@@ -41,7 +41,7 @@ ILM policies using `@custom` component templates for the conditions mentioned ab
 
 // How to fix it
 To override ILM policies for these new clusters using component template, set the `prefer_ilm` configuration
-to `true` by following the {ref}/apm-ilm-how-to.html[updated guide to customize ILM].
+to `true` by following the {observability-guide}/apm-ilm-how-to.html[updated guide to customize ILM].
 
 [discrete]
 == Upgrading to v8.15.x may cause ingestion to fail

--- a/docs/en/observability/apm/known-issues.asciidoc
+++ b/docs/en/observability/apm/known-issues.asciidoc
@@ -27,9 +27,9 @@ _Versions: XX.XX.XX, YY.YY.YY, ZZ.ZZ.ZZ_
 _Elastic Stack versions: 8.15.1+_
     
 // The conditions in which this issue occurs
-The issue occurs when creating a _new_ cluster using any 8.15.x version.
-The issue occurs for any APM data streams created from 8.15.x.
-The issue does _not_ occur if custom component template has been created before 8.15.0.
+The issue occurs when creating a _new_ cluster using version 8.15.1+.
+The issue occurs for any APM data streams created in 8.15.1+.
+The issue does _not_ occur if custom component template has been created in or before version 8.15.0.
 
 // Describe why it happens
 In 8.15.0, APM Server switched to use https://github.com/elastic/elasticsearch/tree/main/x-pack/plugin/apm-data[apm-data plugin]

--- a/docs/en/observability/apm/known-issues.asciidoc
+++ b/docs/en/observability/apm/known-issues.asciidoc
@@ -22,6 +22,28 @@ _Versions: XX.XX.XX, YY.YY.YY, ZZ.ZZ.ZZ_
 ////
 
 [discrete]
+== `prefer_ilm` required in component templates to create custom lifecycle policies
+
+_Elastic Stack versions: 8.15.0+_
+    
+// The conditions in which this issue occurs
+The issue occurs when creating a _new_ cluster using any 8.15.x version.
+The issue occurs for any APM data streams created from 8.15.x.
+The issue does _not_ occur if custom component template has been created before 8.15.0.
+
+// Describe why it happens
+In 8.15.0, APM Server switched to use https://github.com/elastic/elasticsearch/tree/main/x-pack/plugin/apm-data[apm-data plugin]
+to manage data streams, ingest pipelines, lifecycle policies, etc. In 8.15.1, to fix older clusters using
+default ILM policies and producing unmanaged indices, a fix was added to fallback to default ILM policy if
+it exists. As part of the fix `prefer_ilm` configuration was set to `false`. This setting would have an
+effect if both ILM and DSL were in play - a condition that would occur when trying to configure custom
+ILM policies using `@custom` component templates for the conditions mentioned above.
+
+// How to fix it
+To override ILM policies for these new clusters using component template, set the `prefer_ilm` configuration
+to `true` by following the {ref}/apm-ilm-how-to.html[updated guide to customize ILM].
+
+[discrete]
 == Upgrading to v8.15.x may cause ingestion to fail
 
 _Elastic Stack versions: 8.15.0+_

--- a/docs/en/observability/apm/known-issues.asciidoc
+++ b/docs/en/observability/apm/known-issues.asciidoc
@@ -24,7 +24,7 @@ _Versions: XX.XX.XX, YY.YY.YY, ZZ.ZZ.ZZ_
 [discrete]
 == `prefer_ilm` required in component templates to create custom lifecycle policies
 
-_Elastic Stack versions: 8.15.0+_
+_Elastic Stack versions: 8.15.1+_
     
 // The conditions in which this issue occurs
 The issue occurs when creating a _new_ cluster using any 8.15.x version.

--- a/docs/en/observability/apm/known-issues.asciidoc
+++ b/docs/en/observability/apm/known-issues.asciidoc
@@ -32,12 +32,12 @@ The issue occurs for any APM data streams created in 8.15.1+.
 The issue does _not_ occur if custom component template has been created in or before version 8.15.0.
 
 // Describe why it happens
-In 8.15.0, APM Server switched to use https://github.com/elastic/elasticsearch/tree/main/x-pack/plugin/apm-data[apm-data plugin]
-to manage data streams, ingest pipelines, lifecycle policies, etc. In 8.15.1, to fix older clusters using
-default ILM policies and producing unmanaged indices, a fix was added to fallback to default ILM policy if
-it exists. As part of the fix `prefer_ilm` configuration was set to `false`. This setting would have an
-effect if both ILM and DSL were in play - a condition that would occur when trying to configure custom
-ILM policies using `@custom` component templates for the conditions mentioned above.
+In 8.15.0, APM Server began using the https://github.com/elastic/elasticsearch/tree/main/x-pack/plugin/apm-data[apm-data plugin] 
+to manage data streams, ingest pipelines, lifecycle policies, and more. In 8.15.1, a fix was introduced to address 
+unmanaged indices in older clusters using default ILM policies. This fix added a fallback to the default ILM policy 
+(if it exists) and set the `prefer_ilm` configuration to `false`. This setting impacts clusters where both ILM and 
+data stream lifecycles (DSL) are in effect—such as when configuring custom ILM policies using `@custom` component 
+templates, under the conditions mentioned above.
 
 // How to fix it
 To override ILM policies for these new clusters using component template, set the `prefer_ilm` configuration


### PR DESCRIPTION
## Description
`prefer_ilm` setting was set to `false` in 8.15.1. This is not exactly a known issue but documenting it as one to raise awareness. Note that, `prefer_ilm` does not affect clusters using APM and upgrading to 8.15.x and the expectation was that the new guide would be followed for any new use-cases to customize ILM policies however, IaC based setups using the older way to customize ILM policies were affected due to the issue causing their **newly** created custom ILM configs to not apply.

### Documentation sets edited in this PR

_Check all that apply._

- [x] Stateful (`docs/en/observability/*`)
- [ ] Serverless (`docs/en/serverless/*`)
- [ ] Integrations Developer Guide (`docs/en/integrations/*`)
- [ ] None of the above

### Related issue
NA

## Checklist

<!--
Add labels to:
1. Backport to other versions (`backport-*`):
    - `backport-8.x` to backport to the latest minor
    - `backport-skip` to not backport (for example, for serverless docs)
    - `backport-main` to "backport" to `main` if the target branch is _not_ `main`
    - Individual `backport-*` labels to target specific minor versions
2. Surface blocking reviews (`needs-*-review`):
    - `needs-writer-review` for codeowners
    - `needs-dev-review` for dev team
    - `needs-product-review` for PM review
-->

- [ ] Product/Engineering Review
- [ ] Writer Review

### Follow-up tasks
<!-- If you are updating the Integrations Developer Guide, you can delete this section -->

_Select one._

* This PR does _not_ need to be ported to another doc set because:
  - [ ] The concepts in this PR only apply to one doc set (serverless _or_ stateful)
  - [ ] The PR contains edits to both doc sets (serverless _and_ stateful)
* This PR needs to be ported to another doc set:
  - [ ] Port to stateful docs: \<link to PR or tracking issue>
  - [ ] Port to serverless docs: \<link to PR or tracking issue>
