### PR TITLE
[apm] Port apm-data plugin changes from stateful docs

### DIFF
--- a/docs/en/serverless/apm/apm-troubleshooting/common-problems.asciidoc
+++ b/docs/en/serverless/apm/apm-troubleshooting/common-problems.asciidoc
@@ -3,33 +3,7 @@
 This section describes common problems you might encounter.
 
 ////
-/* * <DocLink slug="/serverless/observability/apm-troubleshooting" section="no-data-is-indexed">No data is indexed</DocLink>
-* <DocLink slug="/serverless/observability/apm-troubleshooting">APM Server response codes</DocLink>
-* <DocLink slug="/serverless/observability/apm-troubleshooting" section="common-ssl-related-problems">Common SSL-related problems</DocLink>
-* <DocLink slug="/serverless/observability/apm-troubleshooting" section="io-timeout">I/O Timeout</DocLink>
-* <DocLink slug="/serverless/observability/apm-troubleshooting" section="field-limit-exceeded">Field limit exceeded</DocLink> */
-////
-
-[discrete]
-[[no-data-is-indexed]]
-=== No data is indexed
-
-If no data shows up, first make sure that your APM components are properly connected.
-
-include::../../transclusion/apm/guide/tab-widgets/no-data-indexed/fleet-managed.asciidoc[]
-
-[discrete]
-[[data-indexed-no-apm-legacy]]
-=== Data is indexed but doesn't appear in the Applications UI
-
-Elastic APM relies on default index mappings, data streams, and pipelines to query and display data.
-If your APM data isn't showing up in the Applications UI, but is elsewhere in Elastic, like Discover,
-you've likely made a change that overwrote a default.
-If you've manually changed a data stream, index template, or index pipeline,
-please verify you are not interfering with the default APM setup.
-
-////
-/* ### I/O Timeout
+### I/O Timeout
 
 I/O Timeouts can occur when your timeout settings across the stack are not configured correctly,
 especially when using a load balancer.


### PR DESCRIPTION
## Description

Ports changes in https://github.com/elastic/observability-docs/pull/4333 to serverless docs. (Most of the changes in #4333 were not applicable to serverless docs.)

### Documentation sets edited in this PR

_Check all that apply._

- [ ] Stateful (`docs/en/observability/*`)
- [x] Serverless (`docs/en/serverless/*`)
- [ ] Integrations Developer Guide (`docs/en/integrations/*`)
- [ ] None of the above

### Related issue

Closes #4420 

## Checklist

<!--
Add labels to:
1. Backport to other versions (`backport-*`):
    - `backport-8.x` to backport to the latest minor
    - `backport-skip` to not backport (for example, for serverless docs)
    - `backport-main` to "backport" to `main` if the target branch is _not_ `main`
    - Individual `backport-*` labels to target specific minor versions
2. Surface blocking reviews (`needs-*-review`):
    - `needs-writer-review` for codeowners
    - `needs-dev-review` for dev team
    - `needs-product-review` for PM review
-->

- [ ] Product/Engineering Review
- [ ] Writer Review

### Follow-up tasks
<!-- If you are updating the Integrations Developer Guide, you can delete this section -->

_Select one._

* This PR does _not_ need to be ported to another doc set because:
  - [x] The concepts in this PR only apply to one doc set (serverless _or_ stateful)
  - [ ] The PR contains edits to both doc sets (serverless _and_ stateful)
* This PR needs to be ported to another doc set:
  - [ ] Port to stateful docs: \<link to PR or tracking issue>
  - [ ] Port to serverless docs: \<link to PR or tracking issue>
