### PR TITLE
Universal Profiling: on-prem GA additions

### DIFF
--- a/docs/en/observability/profiling-get-started.asciidoc
+++ b/docs/en/observability/profiling-get-started.asciidoc
@@ -86,19 +86,21 @@ If you're upgrading from a previous version with Universal Profiling enabled, se
 === Programmatic configuration
 
 If you prefer to configure data ingestion programmatically, you can use a Kibana API call.
-The API call can be performed either via the "Dev Tools" console in Kibana or any standalone HTTP client (like `curl` or `wget`).
-In both cases, the API call will have tobe executed with the `elastic` user credentials to have the necessary permissions.
+This call can be made either through the "Dev Tools" console in Kibana or with any standalone HTTP client (such as `curl` or `wget`).
+In both cases, the API call must be executed using the `elastic` user credentials to ensure the necessary permissions.
 
 A successful API call will return a `202 Accepted` response with an empty body.
 
-To configure data ingestion from the console, go to *Dev Tools* from the navigation menu and execute the following snippet:
+To configure data ingestion from the console, go to *Dev Tools* in the navigation menu and run the following command:
+
 [source,console]
 ----
 POST kbn:/internal/profiling/setup/es_resources
 {}
 ----
 
-To configure data ingestion programmatically using a standalone HTTP client (e.g. `curl`), execute the following command:
+To configure data ingestion programmatically using a standalone HTTP client (e.g., `curl`), run the following command:
+
 [source,console]
 ----
 curl -u elastic:<PASSWORD> -H "kbn-xsrf: true" -H "Content-Type: application/json" \

--- a/docs/en/observability/profiling-get-started.asciidoc
+++ b/docs/en/observability/profiling-get-started.asciidoc
@@ -82,6 +82,30 @@ NOTE: To configure data ingestion, you need elevated privileges, typically the `
 If you're upgrading from a previous version with Universal Profiling enabled, see the <<profiling-upgrade,upgrade guide>>.
 
 [discrete]
+[[profiling-configure-data-ingestion-programmatic]]
+=== Programmatic configuration
+
+If you prefer to configure data ingestion programmatically, you can use a Kibana API call.
+The API call can be performed either via the "Dev Tools" console in Kibana or any standalone HTTP client (like `curl` or `wget`).
+In both cases, the API call will have tobe executed with the `elastic` user credentials to have the necessary permissions.
+
+A successful API call will return a `202 Accepted` response with an empty body.
+
+To configure data ingestion from the console, go to *Dev Tools* from the navigation menu and execute the following snippet:
+[source,console]
+----
+POST kbn:/internal/profiling/setup/es_resources
+{}
+----
+
+To configure data ingestion programmatically using a standalone HTTP client (e.g. `curl`), execute the following command:
+[source,console]
+----
+curl -u elastic:<PASSWORD> -H "kbn-xsrf: true" -H "Content-Type: application/json" \
+    --data "{}" "https://<kibana-host>:<kibana-port>/internal/profiling/setup/es_resources"
+----
+
+[discrete]
 [[profiling-install-profiling-agent]]
 == Install the Universal Profiling Agent
 You have the following options when installing the Universal Profiling Agent:

--- a/docs/en/observability/profiling-self-managed-ops.asciidoc
+++ b/docs/en/observability/profiling-self-managed-ops.asciidoc
@@ -176,26 +176,25 @@ For example, if the collector is configured with the default value `host: 0.0.0.
 [[profiling-scaling-external-telemetry]]
 == Profiling agent telemetry data
 
-The Universal Profiling collector receives from profiling agent a set of telemetry data that is used to debug the operations performed by the agent,
-as well as collecting product usage statistics.
-We use the data collected to understand the demographics of the profiled machines and to perform investigations when problems are reported to our customer service.
+The Universal Profiling collector receives telemetry data from profiling agents to help debug agent operations and gather product usage statistics.
+This data enables us to understand the demographics of profiled machines and aids in investigations when customers report issues.
 
-By default, telemetry data collected by all profiling agents are sent to the collector then forwarded via the internet to an Elastic endpoint.
-It is possible to opt-out by configuring the `agent_metrics` stanza in the collector configuration YAML file.
-When opting-out, troubleshooting Universal Profiling agent issues by our customer service will require extracting and providing the telemetry data manually.
+By default, telemetry data collected by all profiling agents is sent to the collector, which then forwards it to an Elastic endpoint over the internet.
+You can opt out by configuring the `agent_metrics` stanza in the collector configuration YAML file.
+If you opt out, any troubleshooting by customer service will require manually extracting and providing the telemetry data.
 
-The content of the <<profiling-self-managed-running-linux-configfile-collector, "Collector configuration file">>
-provides a way to configure if telemetry data should be forwarded to Elastic, collected internally, or discarded.
-If you are running the collector in a network that has no internet access, the telemetry data will not be forwarded to Elastic.
+The <<profiling-self-managed-running-linux-configfile-collector,"Collector configuration file">>
+allows you to configure whether telemetry data is forwarded to Elastic, stored internally, or discarded.
+If the collector is deployed in a network without internet access, telemetry data will not be forwarded to Elastic.
 
-Below are some examples of configurations to adopt for each case.
+Below are examples of configurations for each option:
 
 **Forward telemetry data to Elastic**
 
 This is the default configuration.
-When the `agent_metrics` stanza is not present in the collector configuration file, the collector forwards telemetry data to Elastic.
+When the `agent_metrics` stanza is absent from the collector configuration file, the collector forwards telemetry data to Elastic.
 
-Enabling it explicitly has no difference in behavior.
+Explicitly enabling it does not alter the default behavior.
 
 [source,yaml]
 ----
@@ -203,11 +202,11 @@ agent_metrics:
   disabled: false
 ----
 
-**Collect telemetry data internally as well as send them to Elastic**
+**Collect telemetry data internally and send it to Elastic**
 
-In this configuration the same telemetry data gathered by the profiling agent are sent to Elastic and stored internally.
-The telemetry data are stored in the `profiling-metrics*` indices in the same Elasticsearch cluster storing Universal Profiling data,
-and they are subject to the same data retention policies.
+In this configuration, telemetry data from profiling agents is sent to Elastic **and** stored internally.
+The data is stored in the `profiling-metrics*` indices within the same Elasticsearch cluster as Universal Profiling data
+and follows the same data retention policies.
 
 [source,yaml]
 ----
@@ -218,9 +217,9 @@ agent_metrics:
 
 **Collect telemetry data only internally**
 
-To collect telemetry data but not forward it to Elastic, configure the collector to store the telemetry data internally.
-It is possible to customize the Elasticsearch deployment storing the telemetry data by providing a list of Elasticsearch
-hosts and an API key to authenticate the requests.
+To collect telemetry data without forwarding it to Elastic, configure the collector to store the data internally.
+You can specify the Elasticsearch deployment for storing telemetry data by providing a list of Elasticsearch
+hosts and an API key for authentication.
 
 [source,yaml]
 ----

--- a/docs/en/observability/profiling-self-managed-ops.asciidoc
+++ b/docs/en/observability/profiling-self-managed-ops.asciidoc
@@ -243,10 +243,10 @@ agent_metrics:
 == Scale resources
 
 In the <<profiling-self-managed-ops-sizing-guidance, resource guidance table>>, no options use more than one replica for the symbolizer.
-We do not recommend scaling the number of symbolizer replicas because of the technical limitations of the current implementation.
-We recommend scaling the symbolizer vertically, by increasing the memory and CPU cores it uses to process data.
+This is due to how multiple symbolizer replicas have to synchronize over identical frame records to be processed.
+While it still possible to scale horizontally, we recommend scaling the symbolizer vertically first, by increasing the memory and CPU cores it uses to process data.
 
-You can increase the number of collector replicas at will, keeping their vertical sizing smaller, if this is more convenient for your deployment use case.
+You can increase the number of collector replicas at will, keeping their vertical sizing smaller if this is more convenient for your deployment use case.
 The collector has a linear increase in memory usage and CPU threads with the number of Universal Profiling Agents that it serves.
 Keep in mind that since the Universal Profiling Agent/collector communication happens via gRPC, there may be long-lived TCP sessions that are bound to a single collector replica.
 When scaling out the number of replicas, depending on the load balancer that you have in place fronting the collector's endpoint, you may want to shut down the older replicas after adding new replicas.

--- a/docs/en/observability/profiling-self-managed-ops.asciidoc
+++ b/docs/en/observability/profiling-self-managed-ops.asciidoc
@@ -173,6 +173,72 @@ This endpoint is configured through the application's `host` configuration optio
 For example, if the collector is configured with the default value `host: 0.0.0.0:8260`, you can check the health of the application by running `curl -i localhost:8260/live` and `curl -i localhost:8260/ready`.
 
 [discrete]
+[[profiling-scaling-external-telemetry]]
+== Profiling agent telemetry data
+
+The Universal Profiling collector receives from profiling agent a set of telemetry data that is used to debug the operations performed by the agent,
+as well as collecting product usage statistics.
+We use the data collected to understand the demographics of the profiled machines and to perform investigations when problems are reported to our customer service.
+
+By default, telemetry data collected by all profiling agents are sent to the collector then forwarded via the internet to an Elastic endpoint.
+It is possible to opt-out by configuring the `agent_metrics` stanza in the collector configuration YAML file.
+When opting-out, troubleshooting Universal Profiling agent issues by our customer service will require extracting and providing the telemetry data manually.
+
+The content of the <<profiling-self-managed-running-linux-configfile-collector, "Collector configuration file">>
+provides a way to configure if telemetry data should be forwarded to Elastic, collected internally, or discarded.
+If you are running the collector in a network that has no internet access, the telemetry data will not be forwarded to Elastic.
+
+Below are some examples of configurations to adopt for each case.
+
+**Forward telemetry data to Elastic**
+
+This is the default configuration.
+When the `agent_metrics` stanza is not present in the collector configuration file, the collector forwards telemetry data to Elastic.
+
+Enabling it explicitly has no difference in behavior.
+
+[source,yaml]
+----
+agent_metrics:
+  disabled: false
+----
+
+**Collect telemetry data internally as well as send them to Elastic**
+
+In this configuration the same telemetry data gathered by the profiling agent are sent to Elastic and stored internally.
+The telemetry data are stored in the `profiling-metrics*` indices in the same Elasticsearch cluster storing Universal Profiling data,
+and they are subject to the same data retention policies.
+
+[source,yaml]
+----
+agent_metrics:
+  disabled: false
+  write_all: true
+----
+
+**Collect telemetry data only internally**
+
+To collect telemetry data but not forward it to Elastic, configure the collector to store the telemetry data internally.
+It is possible to customize the Elasticsearch deployment storing the telemetry data by providing a list of Elasticsearch
+hosts and an API key to authenticate the requests.
+
+[source,yaml]
+----
+agent_metrics:
+  disabled: false
+  addresses: ["https://internal-telemetry-endpoint.es.company.org:9200"]
+  api_key: "internal-telemetry-api-key"
+----
+
+**Disable telemetry data collection entirely**
+
+[source,yaml]
+----
+agent_metrics:
+  disabled: true
+----
+
+[discrete]
 [[profiling-scaling-backend-resources]]
 == Scale resources
 

--- a/docs/en/observability/profiling-self-managed.asciidoc
+++ b/docs/en/observability/profiling-self-managed.asciidoc
@@ -288,7 +288,7 @@ We also display the default application settings; you can refer to the comments 
 
 [discrete]
 [[profiling-self-managed-running-linux-configfile-collector]]
-==== Collector Configuration file
+==== Collector configuration file
 
 Copy the content of the snippet below in the `/etc/Elastic/universal-profiling/pf-elastic-collector.yml` file.
 
@@ -457,7 +457,7 @@ output:
 
 [discrete]
 [[profiling-self-managed-running-linux-configfile-symbolizer]]
-==== Symbolizer Configuration file
+==== Symbolizer configuration file
 
 Copy the content of the snippet below in the `/etc/Elastic/universal-profiling/pf-elastic-symbolizer.yml` file.
 

--- a/docs/en/observability/profiling-self-managed.asciidoc
+++ b/docs/en/observability/profiling-self-managed.asciidoc
@@ -5,8 +5,6 @@
 <titleabbrev>Self-hosted infrastructure</titleabbrev>
 ++++
 
-beta::[]
-
 IMPORTANT: To run Universal Profiling on self-hosted Elastic stack, you need an {subscriptions}[appropriate license].
 
 Here you'll find information on running Universal Profiling when hosting the Elastic stack on your own infrastructure.


### PR DESCRIPTION
## Description

Remove the beta banner in the on-perm doc, cover areas of Universal Profiling documentation to allow on-perm users to operate the backend.

* host-agent telemetry
* programmatic setup

### Documentation sets edited in this PR

_Check all that apply._

- [X] Stateful (`docs/en/observability/*`)
- [ ] Serverless (`docs/en/serverless/*`)
- [ ] Integrations Developer Guide (`docs/en/integrations/*`)
- [ ] None of the above

### Related issue

closes https://github.com/elastic/prodfiler/issues/5222 and elastic/prodfiler/issues/5319

## Checklist

<!--
Add labels to:
1. Backport to other versions (`backport-*`):
    - `backport-8.x` to backport to the latest minor
    - `backport-skip` to not backport (for example, for serverless docs)
    - `backport-main` to "backport" to `main` if the target branch is _not_ `main`
    - Individual `backport-*` labels to target specific minor versions
2. Surface blocking reviews (`needs-*-review`):
    - `needs-writer-review` for codeowners
    - `needs-dev-review` for dev team
    - `needs-product-review` for PM review
-->

- [ ] Product/Engineering Review
- [X] Writer Review

### Follow-up tasks
<!-- If you are updating the Integrations Developer Guide, you can delete this section -->

_Select one._

* This PR does _not_ need to be ported to another doc set because:
  - [X] The concepts in this PR only apply to one doc set (serverless _or_ stateful)
  - [ ] The PR contains edits to both doc sets (serverless _and_ stateful)
* This PR needs to be ported to another doc set:
  - [ ] Port to stateful docs: \<link to PR or tracking issue>
  - [ ] Port to serverless docs: \<link to PR or tracking issue>
