### PR TITLE
Add the OTel quick start to the Observability docs

### DIFF
--- a/docs/en/observability/index.asciidoc
+++ b/docs/en/observability/index.asciidoc
@@ -20,6 +20,8 @@ include::whats-new.asciidoc[leveloffset=+2]
 
 include::quickstarts/monitor-hosts-with-elastic-agent.asciidoc[leveloffset=+2]
 
+include::quickstarts/monitor-hosts-with-otel.asciidoc[leveloffset=+2]
+
 include::quickstarts/monitor-k8s-logs-metrics.asciidoc[leveloffset=+2]
 
 include::splunk-get-started.asciidoc[leveloffset=+2]

--- a/docs/en/observability/quickstarts/monitor-hosts-with-otel.asciidoc
+++ b/docs/en/observability/quickstarts/monitor-hosts-with-otel.asciidoc
@@ -1,0 +1,65 @@
+[[quickstart-monitor-hosts-with-otel]]
+= Quickstart: Monitor hosts with OpenTelemetry
+
+preview::[]
+
+In this quickstart guide, you'll learn how to collect logs and metrics using the Elastic Distribution of OpenTelemetry (EDOT) Collector.
+You'll also learn how to get value out of your observability data after collecting it.
+
+[discrete]
+== Prerequisites
+
+* The Admin role or higher is required to onboard system logs and metrics. To learn more, refer to {cloud}/ec-user-privileges.html[User roles and privileges].
+* Root privileges on the host are required to run the OpenTelemetry collector.
+* The quickstart only provides out-of-the-box deployment and configurations for Kubernetes, Linux, and MacOS systems.
+
+[discrete]
+== Limitations
+Refer to https://github.com/elastic/opentelemetry/blob/main/docs/collector-limitations.md[Elastic OpenTelemetry Collector limitations] for known limitations when using the EDOT Collector.
+
+[discrete]
+== Collect your data
+
+Follow these steps to collect logs and metrics using the EDOT Collector:
+
+. Open an [Elastic Cloud](https://cloud.elastic.co) deployment or a serverless Observability project.
+. To open the guided onboarding, either:
+   . In an Elastic Cloud deployment, open Kibana, and go to **Observability** → **Add Data**.
+   . In a serverless Observability project, go to **Add Data**.
+. Select **Collect and analyze logs**, and then select **OpenTelemetry**.
+. Select the appropriate platform, and complete the following:
+   . For **MacOS and Linux**, copy the command, open a terminal on your host, and run the command to download and configure the OpenTelemetry collector.
+   . For **Kubernetes**, download the manifest.
+. Copy the command under Step 2:
+   . For **MacOS and Linux**, run the command in your terminal to start the EDOT Collector.
+   . For **Kubernetes**, run the command from the directory where you downloaded the manifest to install the EDOT Collector on every node of your cluster.
+
+Logs are collected from setup onward, so you won't see logs that occurred before starting the EDOT Collector.
+The default log path is `/var/log/*`. To update the path, modify `otel.yml`.
+
+Under **Visualize your data**, you'll see links to **Logs Explorer** to view your logs and **Hosts** to view your host metrics.
+
+[discrete]
+== Get value out of your data
+
+After using the Hosts page and Logs Explorer to confirm you've ingested all the host logs and metrics you want to monitor,
+you can use Elastic {observability} to gain deeper insight into your data.
+
+For host monitoring, the following capabilities and features are recommended:
+
+* In the <<analyze-metrics,Infrastructure UI>>, analyze and compare data collected from your hosts.
+You can also:
+** <<inspect-metric-anomalies,Detect anomalies>> for memory usage and network traffic on hosts.
+** <<create-alerts,Create alerts>> that notify you when an anomaly is detected or a metric exceeds a given value.
+* In the <<explore-logs,Logs Explorer>>, search and filter your log data,
+get information about the structure of log fields, and display your findings in a visualization.
+You can also:
+** <<monitor-datasets,Monitor log data set quality>> to find degraded documents.
+** {kibana-ref}/xpack-ml-aiops.html#log-pattern-analysis[Run a pattern analysis] to find patterns in unstructured log messages.
+** <<create-alerts,Create alerts>> that notify you when an Observability data type reaches or exceeds a given value.
+* Use {kibana-ref}/xpack-ml.html[machine learning] to apply predictive analytics to your data:
+** {kibana-ref}/xpack-ml-anomalies.html[Detect anomalies] by comparing real-time and historical data from different sources to look for unusual, problematic patterns.
+** {kibana-ref}/xpack-ml-aiops.html#log-rate-analysis[Analyze log spikes and drops].
+** {kibana-ref}/xpack-ml-aiops.html#change-point-detection[Detect change points] in your time series data.
+
+Refer to the <<observability-introduction>> for a description of other useful features.

--- a/docs/en/serverless/index.asciidoc
+++ b/docs/en/serverless/index.asciidoc
@@ -16,6 +16,7 @@ include::./observability-overview.asciidoc[leveloffset=+2]
 
 include::./quickstarts/overview.asciidoc[leveloffset=+2]
 include::./quickstarts/monitor-hosts-with-elastic-agent.asciidoc[leveloffset=+3]
+include::./quickstarts/monitor-hosts-with-otel.asciidoc[leveloffset=+3]
 include::./quickstarts/k8s-logs-metrics.asciidoc[leveloffset=+3]
 
 include::./projects/billing.asciidoc[leveloffset=+2]

--- a/docs/en/serverless/quickstarts/monitor-hosts-with-otel.asciidoc
+++ b/docs/en/serverless/quickstarts/monitor-hosts-with-otel.asciidoc
@@ -9,8 +9,8 @@ You'll also learn how to get value out of your observability data after collecti
 [discrete]
 == Prerequisites
 
-* A deployment using our hosted {ess} on {ess-trial}[{ecloud}]. The deployment includes an {es} cluster for storing and searching your data, and {kib} for visualizing and managing your data.
-* A user with the **Admin** role or higher—required to onboard system logs and metrics. To learn more, refer to {cloud}/ec-user-privileges.html[User roles and privileges].
+* An {observability} project. To learn more, refer to <<observability-create-an-observability-project>>.
+* A user with the **Admin** role or higher—required to onboard system logs and metrics. To learn more, refer to <<general-assign-user-roles>>.
 * Root privileges on the host are required to run the OpenTelemetry collector.
 * The quickstart only provides out-of-the-box deployment and configurations for Kubernetes, Linux, and MacOS systems.
 
@@ -23,8 +23,8 @@ Refer to https://github.com/elastic/opentelemetry/blob/main/docs/collector-limit
 
 Follow these steps to collect logs and metrics using the EDOT Collector:
 
-. Open an [Elastic Cloud](https://cloud.elastic.co) deployment.
-. To open the quickstart, either open Kibana, and go to **Observability** → **Add Data**.
+. Open a serverless Observability project.
+. To open the quickstart, go to **Add Data**.
 . Select **Collect and analyze logs**, and then select **OpenTelemetry**.
 . Select the appropriate platform, and complete the following:
    . For **MacOS and Linux**, copy the command, open a terminal on your host, and run the command to download and configure the OpenTelemetry collector.


### PR DESCRIPTION
## Description
This PR adds docs for the OTel quickstart to the o11y docs. Not sure if we ever decided if we want this included in 8.16 or not. If not, we can hold off, but I have added the Tech Preview tag to the docs, and since it's in the UI, it might be nice to have these docs available with the other quickstarts.

### Documentation sets edited in this PR

_Check all that apply._

- [x] Stateful (`docs/en/observability/*`)
- [x] Serverless (`docs/en/serverless/*`)
- [ ] Integrations Developer Guide (`docs/en/integrations/*`)
- [ ] None of the above

### Related issue
Closes [#250](https://github.com/elastic/obs-docs-projects/issues/250)

## Checklist

<!--
Add labels to:
1. Backport to other versions (`backport-*`):
    - `backport-8.x` to backport to the latest minor
    - `backport-skip` to not backport (for example, for serverless docs)
    - `backport-main` to "backport" to `main` if the target branch is _not_ `main`
    - Individual `backport-*` labels to target specific minor versions
2. Surface blocking reviews (`needs-*-review`):
    - `needs-writer-review` for codeowners
    - `needs-dev-review` for dev team
    - `needs-product-review` for PM review
-->

- [ ] Product/Engineering Review
- [ ] Writer Review

### Follow-up tasks
<!-- If you are updating the Integrations Developer Guide, you can delete this section -->

_Select one._

* This PR does _not_ need to be ported to another doc set because:
  - [ ] The concepts in this PR only apply to one doc set (serverless _or_ stateful)
  - [ ] The PR contains edits to both doc sets (serverless _and_ stateful)
* This PR needs to be ported to another doc set:
  - [ ] Port to stateful docs: \<link to PR or tracking issue>
  - [ ] Port to serverless docs: \<link to PR or tracking issue>
