### PR TITLE
Remove technical preview related notices

### DIFF
--- a/docs/en/serverless/alerting/create-manage-rules.asciidoc
+++ b/docs/en/serverless/alerting/create-manage-rules.asciidoc
@@ -126,8 +126,6 @@ this state.
 
 To temporarily suppress notifications for _all_ rules, create a <<maintenance-windows,maintenance window>>.
 
-// Remove tech preview?
-
 [discrete]
 [[observability-create-manage-rules-import-and-export-rules]]
 == Import and export rules

--- a/docs/en/serverless/elastic-entity-model.asciidoc
+++ b/docs/en/serverless/elastic-entity-model.asciidoc
@@ -20,8 +20,7 @@ The concept of an entity is important as a means to unify observability signals 
 .Notes
 [NOTE]
 ====
-* The Elastic Entity Model currently supports the <<observability-inventory,new inventory experience>> limited to service, host, and container entities.
-* During Technical Preview, Entity Discovery Framework components are not enabled by default.
+The Elastic Entity Model currently supports the <<observability-inventory,new inventory experience>> limited to service, host, and container entities.
 ====
 
 [discrete]

--- a/docs/en/serverless/index.asciidoc
+++ b/docs/en/serverless/index.asciidoc
@@ -156,4 +156,4 @@ include::./ai-assistant/ai-assistant.asciidoc[leveloffset=+2]
 
 include::./elastic-entity-model.asciidoc[leveloffset=+2]
 
-include::./technical-preview-limitations.asciidoc[leveloffset=+2]
+include::./limitations.asciidoc[leveloffset=+2]

--- a/docs/en/serverless/limitations.asciidoc
+++ b/docs/en/serverless/limitations.asciidoc
@@ -1,5 +1,5 @@
-[[observability-technical-preview-limitations]]
-= Technical preview limitations
+[[observability-limitations]]
+= Limitations
 
 // :description: Review the limitations that apply to Elastic Observability projects in technical preview.
 // :keywords: serverless, observability


### PR DESCRIPTION
## Description
Completes changes requested in #4350. Related to https://github.com/elastic/observability-docs/pull/4533.

### Documentation sets edited in this PR

_Check all that apply._

- [ ] Stateful (`docs/en/observability/*`)
- [ ] Serverless (`docs/en/serverless/*`)
- [ ] Integrations Developer Guide (`docs/en/integrations/*`)
- [ ] None of the above

### Related issue
#4350

## Checklist

<!--
Add labels to:
1. Backport to other versions (`backport-*`):
    - `backport-8.x` to backport to the latest minor
    - `backport-skip` to not backport (for example, for serverless docs)
    - `backport-main` to "backport" to `main` if the target branch is _not_ `main`
    - Individual `backport-*` labels to target specific minor versions
2. Surface blocking reviews (`needs-*-review`):
    - `needs-writer-review` for codeowners
    - `needs-dev-review` for dev team
    - `needs-product-review` for PM review
-->

- [ ] Product/Engineering Review
- [ ] Writer Review

### Follow-up tasks
<!-- If you are updating the Integrations Developer Guide, you can delete this section -->

_Select one._

* This PR does _not_ need to be ported to another doc set because:
  - [x] The concepts in this PR only apply to one doc set (serverless _or_ stateful)
  - [ ] The PR contains edits to both doc sets (serverless _and_ stateful)
* This PR needs to be ported to another doc set:
  - [ ] Port to stateful docs: \<link to PR or tracking issue>
  - [ ] Port to serverless docs: \<link to PR or tracking issue>
