### PR TITLE
[Synthetics]: fix lightweight http configuration

### DIFF
--- a/docs/en/observability/synthetics-reference/lightweight-config/http.asciidoc
+++ b/docs/en/observability/synthetics-reference/lightweight-config/http.asciidoc
@@ -4,8 +4,8 @@
 |===
 | Option (type) | Description
 
-// hosts
-| [[monitor-http-hosts]] *`hosts`*
+// urls
+| [[monitor-http-urls]] *`urls`*
 (<<synthetics-lightweight-data-string,string>>)
 a| *Required*. The URL to ping.
 
@@ -70,7 +70,7 @@ a| The TLS/SSL connection settings for use with the HTTPS endpoint. If you don't
 - type: http
   id: my-http-service
   name: My HTTP Service
-  hosts: "https://myhost:443"
+  urls: "https://myhost:443"
   schedule: '@every 5s'
   ssl:
     certificate_authorities: ['/etc/ca.crt']

--- a/docs/en/serverless/transclusion/synthetics/reference/lightweight-config/http.asciidoc
+++ b/docs/en/serverless/transclusion/synthetics/reference/lightweight-config/http.asciidoc
@@ -1,7 +1,7 @@
 |===
 | Option (type) | Description
 
-| [[monitor-http-hosts]]**`hosts`**
+| [[monitor-http-urls]]**`urls`**
 (<<synthetics-lightweight-data-string,string>>)
 | **Required**. The URL to ping.
 
@@ -50,7 +50,7 @@ a| The TLS/SSL connection settings for use with the HTTPS endpoint. If you don't
 - type: http
   id: my-http-service
   name: My HTTP Service
-  hosts: "https://myhost:443"
+  urls: "https://myhost:443"
   schedule: '@every 5s'
   ssl:
     certificate_authorities: ['/etc/ca.crt']


### PR DESCRIPTION
## Description

Synthetics HTTP monitors doesnt support configuring URL endpoint via `hosts` instead its configurable via `urls`. This is a bug and only applicable to TCP and ICMP monitors. 

### Documentation sets edited in this PR

_Check all that apply._

- [x] Stateful (`docs/en/observability/*`)
- [x] Serverless (`docs/en/serverless/*`)
- [ ] Integrations Developer Guide (`docs/en/integrations/*`)
- [ ] None of the above

### Related issue

Raised by support https://elastic.slack.com/archives/CE4MRBU48/p1732062458578599

## Checklist

<!--
Add labels to:
1. Backport to other versions (`backport-*`):
    - `backport-8.x` to backport to the latest minor
    - `backport-skip` to not backport (for example, for serverless docs)
    - `backport-main` to "backport" to `main` if the target branch is _not_ `main`
    - Individual `backport-*` labels to target specific minor versions
2. Surface blocking reviews (`needs-*-review`):
    - `needs-writer-review` for codeowners
    - `needs-dev-review` for dev team
    - `needs-product-review` for PM review
-->

- [ ] Product/Engineering Review
- [ ] Writer Review

### Follow-up tasks
<!-- If you are updating the Integrations Developer Guide, you can delete this section -->

_Select one._

* This PR does _not_ need to be ported to another doc set because:
  - [ ] The concepts in this PR only apply to one doc set (serverless _or_ stateful)
  - [ ] The PR contains edits to both doc sets (serverless _and_ stateful)
* This PR needs to be ported to another doc set:
  - [ ] Port to stateful docs: \<link to PR or tracking issue>
  - [ ] Port to serverless docs: \<link to PR or tracking issue>
