### PR TITLE
mergify: 8.17 backports

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -339,3 +339,16 @@ pull_request_rules:
         branches:
           - "8.16"
         title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"
+  - name: backport patches to 8.17 branch
+    conditions:
+      - merged
+      - label=backport-8.17
+    actions:
+      backport:
+        assignees:
+          - "{{ author }}"
+        labels:
+          - "backport"
+        branches:
+          - "8.17"
+        title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"


### PR DESCRIPTION
## Description
Update the labels supported to backport to the just created 8.17 branch.