### PR TITLE
Remove stray tech preview references

### DIFF
--- a/docs/en/serverless/limitations.asciidoc
+++ b/docs/en/serverless/limitations.asciidoc
@@ -1,7 +1,7 @@
 [[observability-limitations]]
 = Limitations
 
-// :description: Review the limitations that apply to Elastic Observability projects in technical preview.
+// :description: Review the limitations that apply to Elastic Observability projects.
 // :keywords: serverless, observability
 
 Currently, the maximum ingestion rate for the Managed Intake Service (APM and OpenTelemetry ingest) is 11.5 MB/s of uncompressed data (roughly 1TB/d uncompressed equivalent). Ingestion at a higher rate may experience rate limiting or ingest failures.

--- a/docs/en/serverless/what-is-observability-serverless.asciidoc
+++ b/docs/en/serverless/what-is-observability-serverless.asciidoc
@@ -2,12 +2,6 @@
 
 Elastic Observability accelerates problem resolution with open, flexible, and unified observability powered by advanced machine learning and analytics. Elastic ingests all operational and business telemetry and correlates for faster root cause detection.
 
-.Production workloads
-[IMPORTANT]
-====
-While in technical preview, Elastic Observability serverless projects should not be used for production workloads.
-====
-
 [discrete]
 == Get started
 


### PR DESCRIPTION
## Description


### Documentation sets edited in this PR

_Check all that apply._

- [ ] Stateful (`docs/en/observability/*`)
- [x] Serverless (`docs/en/serverless/*`)
- [ ] Integrations Developer Guide (`docs/en/integrations/*`)
- [ ] None of the above

### Related issue
https://github.com/elastic/observability-docs/pull/4550

## Checklist

<!--
Add labels to:
1. Backport to other versions (`backport-*`):
    - `backport-8.x` to backport to the latest minor
    - `backport-skip` to not backport (for example, for serverless docs)
    - `backport-main` to "backport" to `main` if the target branch is _not_ `main`
    - Individual `backport-*` labels to target specific minor versions
2. Surface blocking reviews (`needs-*-review`):
    - `needs-writer-review` for codeowners
    - `needs-dev-review` for dev team
    - `needs-product-review` for PM review
-->

- [ ] Writer Review

### Follow-up tasks
<!-- If you are updating the Integrations Developer Guide, you can delete this section -->

_Select one._

* This PR does _not_ need to be ported to another doc set because:
  - [x] The concepts in this PR only apply to one doc set (serverless _or_ stateful)
  - [ ] The PR contains edits to both doc sets (serverless _and_ stateful)
* This PR needs to be ported to another doc set:
  - [ ] Port to stateful docs: \<link to PR or tracking issue>
  - [ ] Port to serverless docs: \<link to PR or tracking issue>
