### PR TITLE
Update explore-logs.asciidoc missing permissions

### DIFF
--- a/docs/en/observability/explore-logs.asciidoc
+++ b/docs/en/observability/explore-logs.asciidoc
@@ -16,7 +16,7 @@ image::images/log-explorer.png[Screen capture of the Logs Explorer]
 [[logs-explorer-privileges]]
 == Required {kib} privileges
 
-Viewing data in Logs Explorer requires `read` privileges for *Discover* and *Integrations*. For more on assigning {kib} privileges, refer to the {kibana-ref}/kibana-privileges.html[{kib} privileges] docs.
+Viewing data in Logs Explorer requires `read` privileges for *Discover*, *Logs* and *Integrations*. For more on assigning {kib} privileges, refer to the {kibana-ref}/kibana-privileges.html[{kib} privileges] docs.
 
 [discrete]
 [[find-your-logs]]

--- a/docs/en/observability/explore-logs.asciidoc
+++ b/docs/en/observability/explore-logs.asciidoc
@@ -16,7 +16,7 @@ image::images/log-explorer.png[Screen capture of the Logs Explorer]
 [[logs-explorer-privileges]]
 == Required {kib} privileges
 
-Viewing data in Logs Explorer requires `read` privileges for *Discover*, *Logs* and *Integrations*. For more on assigning {kib} privileges, refer to the {kibana-ref}/kibana-privileges.html[{kib} privileges] docs.
+Viewing data in Logs Explorer requires `read` privileges for *Discover*, *Index*, *Logs*, and *Integrations*. For more on assigning {kib} privileges, refer to the {kibana-ref}/kibana-privileges.html[{kib} privileges] docs.
 
 [discrete]
 [[find-your-logs]]


### PR DESCRIPTION
The Kibana permission Observability --> Logs (read) is also required as per internal tests on 8.16.1.

## Description
<!-- Add a description here -->

### Documentation sets edited in this PR

_Check all that apply._

- [ ] Stateful (`docs/en/observability/*`)
- [ ] Serverless (`docs/en/serverless/*`)
- [ ] Integrations Developer Guide (`docs/en/integrations/*`)
- [ ] None of the above

### Related issue
Closes # <!-- Add the issue this PR closes here -->

## Checklist

<!--
Add labels to:
1. Backport to other versions (`backport-*`):
    - `backport-8.x` to backport to the latest minor
    - `backport-skip` to not backport (for example, for serverless docs)
    - `backport-main` to "backport" to `main` if the target branch is _not_ `main`
    - Individual `backport-*` labels to target specific minor versions
2. Surface blocking reviews (`needs-*-review`):
    - `needs-writer-review` for codeowners
    - `needs-dev-review` for dev team
    - `needs-product-review` for PM review
-->

- [ ] Product/Engineering Review
- [ ] Writer Review

### Follow-up tasks
<!-- If you are updating the Integrations Developer Guide, you can delete this section -->

_Select one._

* This PR does _not_ need to be ported to another doc set because:
  - [ ] The concepts in this PR only apply to one doc set (serverless _or_ stateful)
  - [ ] The PR contains edits to both doc sets (serverless _and_ stateful)
* This PR needs to be ported to another doc set:
  - [ ] Port to stateful docs: \<link to PR or tracking issue>
  - [ ] Port to serverless docs: \<link to PR or tracking issue>
