### PR TITLE
[Synthetics]: fix MFA totp method for browser monitors

### DIFF
--- a/docs/en/observability/synthetics-mfa.asciidoc
+++ b/docs/en/observability/synthetics-mfa.asciidoc
@@ -41,7 +41,7 @@ import { journey, step, mfa} from '@elastic/synthetics';
 journey('MFA Test', ({ page, params }) => {
   step('Login using TOTP token', async () => {
     // login using username and pass and go to 2FA in next page
-    const token = mfa.token(params.MFA_GH_SECRET);
+    const token = mfa.totp(params.MFA_SECRET);
     await page.getByPlaceholder("token-input").fill(token)
   });
 });
@@ -51,12 +51,12 @@ For monitors created in the Synthetics UI using the Script editor, the `mfa` obj
 
 ```ts
 step('Login using 2FA', async () => {
-  const token = mfa.token(params.MFA_GH_SECRET);
+  const token = mfa.totp(params.MFA_SECRET);
   await page.getByPlaceholder("token-input").fill(token)
 });
 ```
 
 [NOTE]
 ====
-`params.MFA_GH_SECRET` would be the encoded secret that was used for registering the Synthetics Authentication in your web application.
+`params.MFA_SECRET` would be the encoded secret that was used for registering the Synthetics Authentication in your web application.
 ====

--- a/docs/en/serverless/synthetics/synthetics-mfa.asciidoc
+++ b/docs/en/serverless/synthetics/synthetics-mfa.asciidoc
@@ -44,7 +44,7 @@ import { journey, step, mfa } from "@elastic/synthetics";
 journey("MFA Test", ({ page, params }) => {
   step("Login using TOTP token", async () => {
     // login using username and pass and go to 2FA in next page
-    const token = mfa.token(params.MFA_GH_SECRET);
+    const token = mfa.totp(params.MFA_SECRET);
     await page.getByPlaceholder("token-input").fill(token);
   });
 });
@@ -55,12 +55,12 @@ For monitors created in the Synthetics UI using the Script editor, the `mfa` obj
 [source,ts]
 ----
 step("Login using 2FA", async () => {
-  const token = mfa.token(params.MFA_GH_SECRET);
+  const token = mfa.totp(params.MFA_SECRET);
   await page.getByPlaceholder("token-input").fill(token);
 });
 ----
 
 [NOTE]
 ====
-`params.MFA_GH_SECRET` would be the encoded secret that was used for registering the Synthetics Authentication in your web application.
+`params.MFA_SECRET` would be the encoded secret that was used for registering the Synthetics Authentication in your web application.
 ====


### PR DESCRIPTION
## Description
+ Fix the `mfa.totp` method which was incorrectly pointing to a method that was changed during the development process and updated incorrectly https://github.com/elastic/synthetics/pull/957#issuecomment-2496885901

### Documentation sets edited in this PR

_Check all that apply._

- [x] Stateful (`docs/en/observability/*`)
- [x] Serverless (`docs/en/serverless/*`)
- [ ] Integrations Developer Guide (`docs/en/integrations/*`)
- [ ] None of the above

## Checklist

<!--
Add labels to:
1. Backport to other versions (`backport-*`):
    - `backport-8.x` to backport to the latest minor
    - `backport-skip` to not backport (for example, for serverless docs)
    - `backport-main` to "backport" to `main` if the target branch is _not_ `main`
    - Individual `backport-*` labels to target specific minor versions
2. Surface blocking reviews (`needs-*-review`):
    - `needs-writer-review` for codeowners
    - `needs-dev-review` for dev team
    - `needs-product-review` for PM review
-->

- [ ] Product/Engineering Review
- [x] Writer Review
