### PR TITLE
Tell users to contact support for rate limiting issues

### DIFF
--- a/docs/en/serverless/limitations.asciidoc
+++ b/docs/en/serverless/limitations.asciidoc
@@ -7,4 +7,4 @@
 Currently, the maximum ingestion rate for the Managed Intake Service (APM and OpenTelemetry ingest) is 11.5 MB/s of uncompressed data (roughly 1TB/d uncompressed equivalent). Ingestion at a higher rate may experience rate limiting or ingest failures.
 
 If you believe you are experiencing rate limiting or other ingest-based failures,
-please {estc-welcome}/get-support-help.html[open a support case] for assistance.
+please {estc-welcome}/get-support-help.html[contact Elastic Support] for assistance.

--- a/docs/en/serverless/limitations.asciidoc
+++ b/docs/en/serverless/limitations.asciidoc
@@ -5,3 +5,10 @@
 // :keywords: serverless, observability
 
 Currently, the maximum ingestion rate for the Managed Intake Service (APM and OpenTelemetry ingest) is 11.5 MB/s of uncompressed data (roughly 1TB/d uncompressed equivalent). Ingestion at a higher rate may experience rate limiting or ingest failures.
+
+If you believe you are experiencing rate limiting or other ingest-based failures,
+please contact support@elastic.co for assistance.
+
+// TODO: Find out  the right way to tell users to reach out for support. Should we also mention the support portal...something like;
+// If you believe you are experiencing rate limiting or other ingest-based failures,
+// please contact support@elastic.co for assistance, or open a support case in the http://support.elastic.co[Support Portal]

--- a/docs/en/serverless/limitations.asciidoc
+++ b/docs/en/serverless/limitations.asciidoc
@@ -7,8 +7,4 @@
 Currently, the maximum ingestion rate for the Managed Intake Service (APM and OpenTelemetry ingest) is 11.5 MB/s of uncompressed data (roughly 1TB/d uncompressed equivalent). Ingestion at a higher rate may experience rate limiting or ingest failures.
 
 If you believe you are experiencing rate limiting or other ingest-based failures,
-please contact support@elastic.co for assistance.
-
-// TODO: Find out  the right way to tell users to reach out for support. Should we also mention the support portal...something like;
-// If you believe you are experiencing rate limiting or other ingest-based failures,
-// please contact support@elastic.co for assistance, or open a support case in the http://support.elastic.co[Support Portal]
+please {estc-welcome}/get-support-help.html[open a support case] for assistance.


### PR DESCRIPTION
## Description
Adds text to help users understand that they can reach out to support for help if they run into rate limiting or ingest failures related to severless limitations.

### Documentation sets edited in this PR

_Check all that apply._

- [ ] Stateful (`docs/en/observability/*`)
- [x] Serverless (`docs/en/serverless/*`)
- [ ] Integrations Developer Guide (`docs/en/integrations/*`)
- [ ] None of the above

### Related issue
Closes #4583 

## Checklist

<!--
Add labels to:
1. Backport to other versions (`backport-*`):
    - `backport-8.x` to backport to the latest minor
    - `backport-skip` to not backport (for example, for serverless docs)
    - `backport-main` to "backport" to `main` if the target branch is _not_ `main`
    - Individual `backport-*` labels to target specific minor versions
2. Surface blocking reviews (`needs-*-review`):
    - `needs-writer-review` for codeowners
    - `needs-dev-review` for dev team
    - `needs-product-review` for PM review
-->

- [ ] Product/Engineering Review
- [ ] Writer Review

### Follow-up tasks
<!-- If you are updating the Integrations Developer Guide, you can delete this section -->

_Select one._

* This PR does _not_ need to be ported to another doc set because:
  - [x] The concepts in this PR only apply to one doc set (serverless _or_ stateful)
  - [ ] The PR contains edits to both doc sets (serverless _and_ stateful)
* This PR needs to be ported to another doc set:
  - [ ] Port to stateful docs: \<link to PR or tracking issue>
  - [ ] Port to serverless docs: \<link to PR or tracking issue>
