### PR TITLE
Clean up APM getting started intro page

### DIFF
--- a/docs/en/observability/apm/getting-started-apm/index.asciidoc
+++ b/docs/en/observability/apm/getting-started-apm/index.asciidoc
@@ -5,14 +5,7 @@
 <titleabbrev>Get started</titleabbrev>
 ++++
 
-****
-The easiest way to get started with Elastic APM is by using our
-{ess-product}[hosted {es} Service] on {ecloud}.
-The {es} Service is available on AWS, GCP, and Azure.
-*To get started in minutes, follow the steps in <<get-started-with-fleet-apm-server>>.*
-****
-
-IMPORTANT: Starting in version 8.15.0, the {es} apm-data plugin manages APM index templates,
+NOTE: Starting in version 8.15.0, the {es} apm-data plugin manages APM index templates,
 lifecycle policies, and ingest pipelines.
 
 The APM Server receives performance data from your APM agents,
@@ -32,8 +25,6 @@ There are two options, and the components required are different for each:
 Fleet is a web-based UI in {kib} that is used to centrally manage {agent}s.
 In this deployment model, use {agent} to spin up APM Server instances that can be centrally-managed in a custom-curated user interface.
 
-NOTE: Fleet-managed APM Server does not have full feature parity with the APM Server binary method of running Elastic APM.
-
 image::./images/fm-ov.png[APM Server fleet overview]
 
 // (outputs, stable APIs)
@@ -49,12 +40,11 @@ integrations from one central {fleet} UI.
 a| * {es}
 * {ess}
 
+NOTE: Fleet-managed APM Server does support all the outputs that are supported by the APM Server binary method of running Elastic APM.
+
 | *Required{nbsp}components*
 a| * APM agents
-* APM Server
-* {agent}
-* Fleet Server
-* {stack}
+* {agent} (which runs multiple subprocesses including APM Server, Fleet Server, and {stack})
 
 | *Configuration method*
 | {kib} UI
@@ -92,49 +82,6 @@ a| * APM agents
 | *Configuration method*
 a| YAML
 |===
-
-// [float]
-// [[apm-setup-apm-server-ea]]
-// === Standalone Elastic Agent-managed APM Server
-// // I really don't know how to sell this option
-// Instead of installing and configuring the APM Server binary, let {agent} orchestrate it for you.
-// Install {agent} and manually configure the agent locally on the system where it's installed.
-// You are responsible for managing and upgrading {agent}. This approach is recommended for advanced users only.
-
-// **Pros**:
-
-// - Easily add integrations for other data sources
-// useful if EA already in place for other integrations, and customers want to customize setup rather than using Fleet for configuration
-// // TODO:
-// // maybe get some more hints on this one from the EA team to align with highlighting the same pros & cons.
-
-// **Available on Elastic Cloud**: ❌
-
-// This supports all of the same outputs as binary
-// see https://github.com/elastic/apm-server/issues/10467
-// **Supported outputs**:
-
-// **Configuration method**: YAML
-
-// image::./images/ea-ov.png[APM Server ea overview]
-
-// @simitt's notes for how to include EA-managed in the decision tree:
-// ****
-// If we generally describe Standalone Elastic Agent managed APM Server then we should also add it to this diagram:
-// Do you want to use other integrations?
-// -> yes: Would you like to use the comfort of Fleet UI based management? -> yes: Fleet managed APM Server; -> no: Standalone Elastic Agent managed APM Server
-// -> no: What is your prefered way of configuration? -> yaml: APM Server binary; -> Kibana UI: Fleet managed APM Server
-// ****
-
-// Components required:
-
-// [options="header"]
-// |====
-// | Installation method                         | APM Server | Elastic Agent | Fleet Server
-// | APM Server binary                           | ✔️          |               |
-// // | Standalone Elastic Agent-managed APM Server | ✔️          | ✔️             |
-// | Fleet-managed APM Server                    | ✔️          | ✔️             | ✔️
-// |====
 
 [float]
 == Help me decide

--- a/docs/en/observability/apm/getting-started-apm/index.asciidoc
+++ b/docs/en/observability/apm/getting-started-apm/index.asciidoc
@@ -40,7 +40,7 @@ integrations from one central {fleet} UI.
 a| * {es}
 * {ess}
 
-NOTE: Fleet-managed APM Server does support all the outputs that are supported by the APM Server binary method of running Elastic APM.
+NOTE: Fleet-managed APM Server does _not_ support all the outputs that are supported by the APM Server binary method of running Elastic APM.
 
 | *Required{nbsp}components*
 a| * APM agents


### PR DESCRIPTION
## Description

Cleans up the [APM getting started intro page](https://observability-docs_bk_4599.docs-preview.app.elstc.co/guide/en/observability/master/apm-getting-started-apm-server.html) as discussed in #4336 including:

* **Which option is the "easiest"**: @simitt @bmorelli25 what do you think about just removing the note at the top and letting users determine which is the easiest method for their situation? If we can't say that one is easier than the other without explaining the context, then I'm not sure it makes sense to have a note at the top. 
* **What's preventing feature parity**: I moved this note to the part of the table that discusses supported outputs.
*  **Required components**: I rephrased the Elastic Agent list item (I was going to use a footnote but I was having trouble using it inside a list that's inside a table).
* I also deleted a big block of commented out content since we can get it from the git history if needed, but let me know if you think we should keep it. 

### Documentation sets edited in this PR

_Check all that apply._

- [x] Stateful (`docs/en/observability/*`)
- [ ] Serverless (`docs/en/serverless/*`)
- [ ] Integrations Developer Guide (`docs/en/integrations/*`)
- [ ] None of the above

### Related issue
Closes #4336

## Checklist

<!--
Add labels to:
1. Backport to other versions (`backport-*`):
    - `backport-8.x` to backport to the latest minor
    - `backport-skip` to not backport (for example, for serverless docs)
    - `backport-main` to "backport" to `main` if the target branch is _not_ `main`
    - Individual `backport-*` labels to target specific minor versions
2. Surface blocking reviews (`needs-*-review`):
    - `needs-writer-review` for codeowners
    - `needs-dev-review` for dev team
    - `needs-product-review` for PM review
-->

- [x] Product/Engineering Review
- [ ] Writer Review

### Follow-up tasks
<!-- If you are updating the Integrations Developer Guide, you can delete this section -->

_Select one._

* This PR does _not_ need to be ported to another doc set because:
  - [x] The concepts in this PR only apply to one doc set (serverless _or_ stateful)
  - [ ] The PR contains edits to both doc sets (serverless _and_ stateful)
* This PR needs to be ported to another doc set:
  - [ ] Port to stateful docs: \<link to PR or tracking issue>
  - [ ] Port to serverless docs: \<link to PR or tracking issue>
