### PR TITLE
Port #4349 to serverless

### DIFF
--- a/docs/en/serverless/alerting/create-custom-threshold-alert-rule.asciidoc
+++ b/docs/en/serverless/alerting/create-custom-threshold-alert-rule.asciidoc
@@ -99,6 +99,8 @@ Set an equation and threshold to trigger an alert when the number of stateful po
 The preview chart provides a visualization of how many entries match your configuration.
 The shaded area shows the threshold you've set.
 
+If you use the **Group alerts by** option, the maximum bar size will be 3. It will only show the top 3 fields.
+
 [discrete]
 [[custom-threshold-group-by]]
 == Group alerts by (optional)


### PR DESCRIPTION
## Description
Ports #4349 to serverless.

### Documentation sets edited in this PR

_Check all that apply._

- [ ] Stateful (`docs/en/observability/*`)
- [x] Serverless (`docs/en/serverless/*`)
- [ ] Integrations Developer Guide (`docs/en/integrations/*`)
- [ ] None of the above

### Related issue
Closes #4417 

## Checklist

<!--
Add labels to:
1. Backport to other versions (`backport-*`):
    - `backport-8.x` to backport to the latest minor
    - `backport-skip` to not backport (for example, for serverless docs)
    - `backport-main` to "backport" to `main` if the target branch is _not_ `main`
    - Individual `backport-*` labels to target specific minor versions
2. Surface blocking reviews (`needs-*-review`):
    - `needs-writer-review` for codeowners
    - `needs-dev-review` for dev team
    - `needs-product-review` for PM review
-->

- [x] Writer Review

### Follow-up tasks
<!-- If you are updating the Integrations Developer Guide, you can delete this section -->

_Select one._

* This PR does _not_ need to be ported to another doc set because:
  - [x] The concepts in this PR only apply to one doc set (serverless _or_ stateful) 
  - [ ] The PR contains edits to both doc sets (serverless _and_ stateful)
* This PR needs to be ported to another doc set:
  - [ ] Port to stateful docs: \<link to PR or tracking issue>
  - [ ] Port to serverless docs: \<link to PR or tracking issue>
