### PR TITLE
Make hero text on obs landing page smaller

### DIFF
--- a/docs/en/observability/landing-page/temp/style.asciidoc
+++ b/docs/en/observability/landing-page/temp/style.asciidoc
@@ -16,7 +16,7 @@
 }
 #landing-page #intro-section #intro-text p,
 #landing-page #intro-section #intro-text li {
-  font-size: 1.25rem;
+  font-size: 1.125rem;
 }
 #landing-page #intro-section .intro-image {
   background-size: cover;
@@ -154,7 +154,7 @@
   margin-top: 20px;
 }
 #landing-page #use-cases .use-case-item p {
-  font-size: 1.25rem;
+  font-size: 1.125rem;
 }
 #landing-page #use-cases .use-case-item ul li {
   padding-bottom: 15px;


### PR DESCRIPTION
## Description
Changes the font size for hero text so that it's not glaringly large but still stands out a bit from ordinary text.

Note that I didn't make the Logs tab active as mentioned in the issue because I don't think that's the right approach. I think it introduces unexpected behavior that might be confusing to users who expect the first tab in a series to be shown by default.

### Documentation sets edited in this PR

_Check all that apply._

- [x] Stateful (`docs/en/observability/*`)
- [ ] Serverless (`docs/en/serverless/*`)
- [ ] Integrations Developer Guide (`docs/en/integrations/*`)
- [ ] None of the above

### Related issue
Closes #3422 

## Checklist

<!--
Add labels to:
1. Backport to other versions (`backport-*`):
    - `backport-8.x` to backport to the latest minor
    - `backport-skip` to not backport (for example, for serverless docs)
    - `backport-main` to "backport" to `main` if the target branch is _not_ `main`
    - Individual `backport-*` labels to target specific minor versions
2. Surface blocking reviews (`needs-*-review`):
    - `needs-writer-review` for codeowners
    - `needs-dev-review` for dev team
    - `needs-product-review` for PM review
-->

- [ ] Writer Review

### Follow-up tasks
<!-- If you are updating the Integrations Developer Guide, you can delete this section -->

_Select one._

* This PR does _not_ need to be ported to another doc set because:
  - [x] The concepts in this PR only apply to one doc set (serverless _or_ stateful)
  - [ ] The PR contains edits to both doc sets (serverless _and_ stateful)
* This PR needs to be ported to another doc set:
  - [ ] Port to stateful docs: \<link to PR or tracking issue>
  - [ ] Port to serverless docs: \<link to PR or tracking issue>
