### PR TITLE
Add note about quickstart to logs stream docs

### DIFF
--- a/docs/en/observability/logs-stream.asciidoc
+++ b/docs/en/observability/logs-stream.asciidoc
@@ -1,7 +1,11 @@
 [[logs-stream]]
 = Stream any log file
 
-This guide shows you how to send a log file to Elasticsearch using a standalone {agent} and configure the {agent} and your data streams using the `elastic-agent.yml` file, and query your logs using the data streams you've set up.
+This guide shows you how to manually configure a standalone {agent} to send your log data to {es} using the `elastic-agent.yml` file..
+
+If you don't want to manually configure the {agent}, you can use the **Monitor hosts with {agent}** quickstart. Refer to the <<quickstart-monitor-hosts-with-elastic-agent,quickstart documentation>> for more information.
+
+Continue with this guide for instructions on manual configuration.
 
 [discrete]
 [[logs-stream-prereq]]


### PR DESCRIPTION
## Description
This PR clarifies that the Logs stream docs show how to manually configure a standalone agent, and users also have the option of using the automatic log detection in the quickstart.

### Documentation sets edited in this PR

_Check all that apply._

- [x] Stateful (`docs/en/observability/*`)
- [ ] Serverless (`docs/en/serverless/*`)
- [ ] Integrations Developer Guide (`docs/en/integrations/*`)
- [ ] None of the above

## Checklist

<!--
Add labels to:
1. Backport to other versions (`backport-*`):
    - `backport-8.x` to backport to the latest minor
    - `backport-skip` to not backport (for example, for serverless docs)
    - `backport-main` to "backport" to `main` if the target branch is _not_ `main`
    - Individual `backport-*` labels to target specific minor versions
2. Surface blocking reviews (`needs-*-review`):
    - `needs-writer-review` for codeowners
    - `needs-dev-review` for dev team
    - `needs-product-review` for PM review
-->

- [ ] Product/Engineering Review
- [ ] Writer Review

_Select one._

* This PR does _not_ need to be ported to another doc set because:
  - [x] The concepts in this PR only apply to one doc set (serverless _or_ stateful)
  - [ ] The PR contains edits to both doc sets (serverless _and_ stateful)
