### PR TITLE
Update serverless billing dimensions for GA

### DIFF
--- a/docs/en/serverless/projects/billing.asciidoc
+++ b/docs/en/serverless/projects/billing.asciidoc
@@ -11,11 +11,16 @@ Your monthly bill is based on the capabilities you use.
 When you use {obs-serverless}, your bill is calculated based on data volume, which has these components:
 
 * **Ingest** — Measured by the number of GB of log/event/info data that you send to your Observability project over the course of a month.
-* **Storage/Retention** — This is known as Search AI Lake.
-* In addition to the core ingest and retention dimensions, there is an optional charge to execute synthetic monitors on our testing infrastructure.
-Browser (journey) based tests are charged on a per-test-run basis,
-and Ping (lightweight) tests have an all-you-can-use model per location used.
+* **Retention** — Measured by the total amount of ingested data stored in your Observability project.
 
-For more information, refer to <<general-serverless-billing>>.
+Ingest and retention metering is based on the uncompressed, normalized, fully enriched data volume you ingest into your Serverless project. This allows you flexibility and consistency when choosing your preferred ingest architecture for enrichment, whether through {agent}, {ls}, OpenTelemetry, or collectors—without considering the possible impact on the cost.
 
-For detailed {obs-serverless} project rates, check the https://www.elastic.co/pricing/serverless-observability[{obs-serverless} pricing page].
+NOTE: One consequence of this metering method is that the absolute volume of data reported in your usage statement can be much larger than the "raw" data size or the compressed data size "on the wire." Your monthly bill will transparently display exactly how much data has been ingested, including valuable metadata added by your data shipper, and contextual enrichment performed by your ingest processing. Don't worry, we've taken all that into account with our Serverless per GB prices, so we think you'll find Elastic Serverless to be a very cost-effective service.
+
+[discrete]
+[[synthetics-billing]]
+== Synthetics
+
+<<observability-monitor-synthetics,Synthetic monitoring>> is an optional add-on to Observability Serverless projects that allows you to periodically check the status of your services and applications. In addition to the core ingest and retention dimensions, there is a charge to execute synthetic monitors on our testing infrastructure. Browser (journey) based tests are charged per-test-run, and ping (lightweight) tests have an all-you-can-use model per location used.
+
+Refer to <<general-serverless-billing,Serverless billing dimensions>> and the https://cloud.elastic.co/cloud-pricing-table?productType=serverless&project=observability[Elastic Cloud pricing table] for more details about Elastic Observability serverless billing dimensions and rates.

--- a/docs/en/serverless/projects/billing.asciidoc
+++ b/docs/en/serverless/projects/billing.asciidoc
@@ -13,7 +13,7 @@ When you use {obs-serverless}, your bill is calculated based on data volume, whi
 * **Ingest** — Measured by the number of GB of log/event/info data that you send to your Observability project over the course of a month.
 * **Retention** — Measured by the total amount of ingested data stored in your Observability project.
 
-Ingest and retention metering is based on the uncompressed, normalized, fully enriched data volume you ingest into your Serverless project. This allows you flexibility and consistency when choosing your preferred ingest architecture for enrichment, whether through {agent}, {ls}, OpenTelemetry, or collectors—without considering the possible impact on the cost.
+Ingest and retention metering is based on the uncompressed, normalized, fully enriched data volume you ingest into your Serverless project. This allows you flexibility and consistency when choosing your preferred ingest architecture for enrichment, whether through {agent}, {ls}, OpenTelemetry, or collectors—without the need to consider possible impacts on the cost.
 
 NOTE: One consequence of this metering method is that the absolute volume of data reported in your usage statement can be much larger than the "raw" data size or the compressed data size "on the wire." Your monthly bill will transparently display exactly how much data has been ingested, including valuable metadata added by your data shipper, and contextual enrichment performed by your ingest processing. Don't worry, we've taken all that into account with our Serverless per GB prices, so we think you'll find Elastic Serverless to be a very cost-effective service.
 

--- a/docs/en/serverless/projects/billing.asciidoc
+++ b/docs/en/serverless/projects/billing.asciidoc
@@ -23,4 +23,4 @@ NOTE: One consequence of this metering method is that the absolute volume of dat
 
 <<observability-monitor-synthetics,Synthetic monitoring>> is an optional add-on to Observability Serverless projects that allows you to periodically check the status of your services and applications. In addition to the core ingest and retention dimensions, there is a charge to execute synthetic monitors on our testing infrastructure. Browser (journey) based tests are charged per-test-run, and ping (lightweight) tests have an all-you-can-use model per location used.
 
-Refer to <<general-serverless-billing,Serverless billing dimensions>> and the https://cloud.elastic.co/cloud-pricing-table?productType=serverless&project=observability[Elastic Cloud pricing table] for more details about Elastic Observability serverless billing dimensions and rates.
+Refer to <<general-serverless-billing,Serverless billing dimensions>> and the https://cloud.elastic.co/cloud-pricing-table?productType=serverless&project=observability[Elastic Cloud pricing table] for more details about {obs-serverless} billing dimensions and rates.

--- a/docs/en/serverless/projects/billing.asciidoc
+++ b/docs/en/serverless/projects/billing.asciidoc
@@ -15,7 +15,7 @@ When you use {obs-serverless}, your bill is calculated based on data volume, whi
 
 Ingest and retention metering is based on the uncompressed, normalized, fully enriched data volume you ingest into your Serverless project. This allows you flexibility and consistency when choosing your preferred ingest architecture for enrichment, whether through {agent}, {ls}, OpenTelemetry, or collectors—without the need to consider possible impacts on the cost.
 
-NOTE: One consequence of this metering method is that the absolute volume of data reported in your usage statement can be much larger than the "raw" data size or the compressed data size "on the wire." Your monthly bill will transparently display exactly how much data has been ingested, including valuable metadata added by your data shipper, and contextual enrichment performed by your ingest processing. Don't worry, we've taken all that into account with our Serverless per GB prices, so we think you'll find Elastic Serverless to be a very cost-effective service.
+NOTE: One consequence of this metering method is that the absolute volume of data reported in your usage statement can be much larger than the "raw" data size or the compressed data size "on the wire." Your monthly bill will transparently display exactly how much data has been ingested, including valuable metadata added by your data shipper, and contextual enrichment performed by your ingest processing. Please note that we took the cost of metadata and enrichment into consideration while determining our Serverless per GB prices to help make {obs-serverless} a cost-effective service.
 
 [discrete]
 [[synthetics-billing]]


### PR DESCRIPTION
## Description
Adds content changes requested in #4640.

I've applied a few very minor edits to the recommended text (capitalization, comma fixes, removed redundant text).

[Preview link](https://observability-docs_bk_4641.docs-preview.app.elstc.co/guide/en/serverless/main/observability-billing.html)

### Documentation sets edited in this PR

_Check all that apply._

- [ ] Stateful (`docs/en/observability/*`)
- [x] Serverless (`docs/en/serverless/*`)
- [ ] Integrations Developer Guide (`docs/en/integrations/*`)
- [ ] None of the above

### Related issue
Closes #4640

## Checklist

<!--
Add labels to:
1. Backport to other versions (`backport-*`):
    - `backport-8.x` to backport to the latest minor
    - `backport-skip` to not backport (for example, for serverless docs)
    - `backport-main` to "backport" to `main` if the target branch is _not_ `main`
    - Individual `backport-*` labels to target specific minor versions
2. Surface blocking reviews (`needs-*-review`):
    - `needs-writer-review` for codeowners
    - `needs-dev-review` for dev team
    - `needs-product-review` for PM review
-->

- [ ] Product/Engineering Review
- [ ] Writer Review

### Follow-up tasks
<!-- If you are updating the Integrations Developer Guide, you can delete this section -->

_Select one._

* This PR does _not_ need to be ported to another doc set because:
  - [x] The concepts in this PR only apply to one doc set (serverless _or_ stateful)
  - [ ] The PR contains edits to both doc sets (serverless _and_ stateful)
* This PR needs to be ported to another doc set:
  - [ ] Port to stateful docs: \<link to PR or tracking issue>
  - [ ] Port to serverless docs: \<link to PR or tracking issue>
