### PR TITLE
cleanup(apm): remove old rum deprecations

### DIFF
--- a/docs/en/observability/apm/configure/rum.asciidoc
+++ b/docs/en/observability/apm/configure/rum.asciidoc
@@ -163,43 +163,6 @@ Search source maps stored in an older version with this setting.
 Default: `"apm-*-sourcemap*"`
 
 [float]
-[[apm-rum-deprecated]]
-== Deprecated configuration options
-
-[float]
-[[apm-event_rate.limit]]
-=== `event_rate.limit`
-
-deprecated::[7.15.0, Replaced by <<apm-config-auth-anon-event-limit>>.]
-
-The maximum number of events allowed per second, per agent IP address.
-
-Default: `300`
-
-[float]
-=== `event_rate.lru_size`
-
-deprecated::[7.15.0, Replaced by <<apm-config-auth-anon-ip-limit>>.]
-
-The number of unique IP addresses to track in an LRU cache.
-IP addresses in the cache will be rate limited according to the <<apm-config-auth-anon-event-limit>> setting.
-Consider increasing this default if your site has many concurrent clients.
-
-Default: `1000`
-
-[float]
-[[apm-rum-allow-service-names]]
-=== `allow_service_names`
-
-deprecated::[7.15.0, Replaced by <<apm-config-auth-anon-allow-service>>.]
-A list of permitted service names for RUM support.
-Names in this list must match the agent's `service.name`.
-This can be set to restrict RUM events to those with one of a set of known service names,
-in order to limit the number of service-specific indices or data streams created.
-
-Default: Not set (any service name is accepted)
-
-[float]
 == Ingest pipelines
 
 The default APM Server pipeline includes processors that enrich RUM data prior to indexing in {es}.


### PR DESCRIPTION
## Description

deprecated rum config options have been removed in 8.0 so they no longer apply.
remove the deprecated options from docs

### Documentation sets edited in this PR

_Check all that apply._

- [x] Stateful (`docs/en/observability/*`)
- [ ] Serverless (`docs/en/serverless/*`)
- [ ] Integrations Developer Guide (`docs/en/integrations/*`)
- [ ] None of the above

### Related issue
Closes https://github.com/elastic/apm-server/issues/14126

## Checklist

<!--
Add labels to:
1. Backport to other versions (`backport-*`):
    - `backport-8.x` to backport to the latest minor
    - `backport-skip` to not backport (for example, for serverless docs)
    - `backport-main` to "backport" to `main` if the target branch is _not_ `main`
    - Individual `backport-*` labels to target specific minor versions
2. Surface blocking reviews (`needs-*-review`):
    - `needs-writer-review` for codeowners
    - `needs-dev-review` for dev team
    - `needs-product-review` for PM review
-->

- [ ] Product/Engineering Review
- [ ] Writer Review

### Follow-up tasks
<!-- If you are updating the Integrations Developer Guide, you can delete this section -->

_Select one._

* This PR does _not_ need to be ported to another doc set because:
  - [ ] The concepts in this PR only apply to one doc set (serverless _or_ stateful)
  - [ ] The PR contains edits to both doc sets (serverless _and_ stateful)
* This PR needs to be ported to another doc set:
  - [ ] Port to stateful docs: \<link to PR or tracking issue>
  - [ ] Port to serverless docs: \<link to PR or tracking issue>
