### PR TITLE
add logs explorer note to settings page

### DIFF
--- a/docs/en/observability/configure-logs-sources.asciidoc
+++ b/docs/en/observability/configure-logs-sources.asciidoc
@@ -1,6 +1,14 @@
 [[configure-data-sources]]
 = Configure data sources
 
+.There's a new, better way to explore your logs!
+[sidebar]
+--
+These settings only apply to the Logs Stream app. The Logs Stream app and dashboard panel are deactivated by default. We recommend viewing and inspecting your logs with <<explore-logs, Logs Explorer>> as it provides more features, better performance, and more intuitive navigation.
+
+To activate the Logs Stream app, refer to <<activate-logs-stream>>.
+--
+
 Specify the source configuration for logs in the
 {kibana-ref}/logs-ui-settings-kb.html[Logs settings] in the
 {kibana-ref}/settings.html[{kib} configuration file].


### PR DESCRIPTION
## Description
These logs settings only apply to the Logs Stream app, which will be deprecated in an upcoming release.
This PR adds a note that recommends people use Logs Explorer.

### Documentation sets edited in this PR

_Check all that apply._

- [x] Stateful (`docs/en/observability/*`)
- [ ] Serverless (`docs/en/serverless/*`)
- [ ] Integrations Developer Guide (`docs/en/integrations/*`)
- [ ] None of the above

### Related issue
Closes #4540 

## Checklist

- [ ] Product/Engineering Review
- [ ] Writer Review

_Select one._

* This PR does _not_ need to be ported to another doc set because:
  - [x] The concepts in this PR only apply to one doc set (serverless _or_ stateful)
  - [ ] The PR contains edits to both doc sets (serverless _and_ stateful)
