### PR TITLE
Remove Enterprise license message

### DIFF
--- a/docs/en/observability/profiling-self-managed.asciidoc
+++ b/docs/en/observability/profiling-self-managed.asciidoc
@@ -15,8 +15,6 @@ Universal Profiling consists of a client part (the Universal Profiling Agent) an
 [[profiling-self-managed-supported-platforms]]
 == Prerequisites
 
-IMPORTANT: Running Universal Profiling on self hosted infrastructure requires an Elastic **Enterprise license**.
-
 * Elastic stack: minimum version 8.12.0, on any Linux distribution (x86_64 or ARM64 architectures), with a Kernel 4.x or higher.
 * https://www.elastic.co/ece[ECE]: minimum version 3.7.0, using the 8.12.0 stackpack or higher.
 * Kubernetes: version 1.22+, using Helm charts.


### PR DESCRIPTION
## Description
We no longer mention specific licenses in the docs and instead link users to the subscriptions page.
The link to the subscriptions page was added previously, but we need to remove the mention of the Enterprise license in the prereqs.

### Documentation sets edited in this PR

_Check all that apply._

- [x] Stateful (`docs/en/observability/*`)
- [ ] Serverless (`docs/en/serverless/*`)
- [ ] Integrations Developer Guide (`docs/en/integrations/*`)
- [ ] None of the above

### Related issue
Closes # <!-- Add the issue this PR closes here -->

## Checklist

<!--
Add labels to:
1. Backport to other versions (`backport-*`):
    - `backport-8.x` to backport to the latest minor
    - `backport-skip` to not backport (for example, for serverless docs)
    - `backport-main` to "backport" to `main` if the target branch is _not_ `main`
    - Individual `backport-*` labels to target specific minor versions
2. Surface blocking reviews (`needs-*-review`):
    - `needs-writer-review` for codeowners
    - `needs-dev-review` for dev team
    - `needs-product-review` for PM review
-->

- [ ] Product/Engineering Review
- [ ] Writer Review

### Follow-up tasks
<!-- If you are updating the Integrations Developer Guide, you can delete this section -->

_Select one._

* This PR does _not_ need to be ported to another doc set because:
  - [x] The concepts in this PR only apply to one doc set (serverless _or_ stateful)
  - [ ] The PR contains edits to both doc sets (serverless _and_ stateful)
