### PR TITLE
Remove Enterprise subscription mention

### DIFF
--- a/docs/en/observability/observability-ai-assistant.asciidoc
+++ b/docs/en/observability/observability-ai-assistant.asciidoc
@@ -1,7 +1,7 @@
 [[obs-ai-assistant]]
 = Observability AI Assistant
 
-IMPORTANT: To run Universal Profiling on self-hosted Elastic stack, you need an {subscriptions}[appropriate license].
+IMPORTANT: To run the Observability AI Assistant on self-hosted Elastic stack, you need an {subscriptions}[appropriate license].
 
 The AI Assistant uses generative AI to provide:
 

--- a/docs/en/observability/observability-ai-assistant.asciidoc
+++ b/docs/en/observability/observability-ai-assistant.asciidoc
@@ -1,6 +1,8 @@
 [[obs-ai-assistant]]
 = Observability AI Assistant
 
+IMPORTANT: To run Universal Profiling on self-hosted Elastic stack, you need an {subscriptions}[appropriate license].
+
 The AI Assistant uses generative AI to provide:
 
 * *Contextual insights* — open prompts throughout {observability} that explain errors and messages and suggest remediation.
@@ -35,7 +37,6 @@ Also, the data you provide to the Observability AI assistant is _not_ anonymized
 The AI assistant requires the following:
 
 * {stack} version 8.9 and later.
-* An https://www.elastic.co/pricing[Enterprise subscription].
 * An account with a third-party generative AI provider that supports function calling. The Observability AI Assistant supports the following providers:
 ** OpenAI `gpt-4`+.
 ** Azure OpenAI Service `gpt-4`(0613) or `gpt-4-32k`(0613) with API version `2023-07-01-preview` or more recent.


### PR DESCRIPTION
## Description
We no longer mention specific licenses in the docs and instead link users to the subscriptions page.
This PR adds the link to the subscriptions page and removes the mention of the Enterprise license in the prereqs.

### Documentation sets edited in this PR

_Check all that apply._

- [x] Stateful (`docs/en/observability/*`)
- [ ] Serverless (`docs/en/serverless/*`)
- [ ] Integrations Developer Guide (`docs/en/integrations/*`)
- [ ] None of the above

<!--
Add labels to:
1. Backport to other versions (`backport-*`):
    - `backport-8.x` to backport to the latest minor
    - `backport-skip` to not backport (for example, for serverless docs)
    - `backport-main` to "backport" to `main` if the target branch is _not_ `main`
    - Individual `backport-*` labels to target specific minor versions
2. Surface blocking reviews (`needs-*-review`):
    - `needs-writer-review` for codeowners
    - `needs-dev-review` for dev team
    - `needs-product-review` for PM review
-->

- [ ] Product/Engineering Review
- [ ] Writer Review
