### PR TITLE
Reword ILM how to guide for revert to ILM policies

### DIFF
--- a/docs/en/observability/apm/manage-storage/ilm-how-to.asciidoc
+++ b/docs/en/observability/apm/manage-storage/ilm-how-to.asciidoc
@@ -16,14 +16,10 @@ In the latest version of Elastic APM, clusters are managed by
 to provide the default data retention settings for APM data as well as allow
 customization for lifecycle.
 
-[IMPORTANT]
+[NOTE]
 ====
-*If you created a new cluster in 8.15 or 8.16*, that cluster will use
-{ref}/data-stream-lifecycle.html[data stream lifecycle (DSL)] to provide default
-data retention settings, but the customization for lifecycle is still performed
-using ILM policies, which are configured to override the default DSL polices.
-
-Read more in <<apm-known-issues>>.
+Some older indices might be managed by {ref}/data-stream-lifecycle.html[data stream lifecycle (DSL)] if cluster is upgraded to 8.17.
+More details are available in <<apm-release-notes>>.
 ====
 
 [discrete]

--- a/docs/en/observability/apm/manage-storage/ilm-how-to.asciidoc
+++ b/docs/en/observability/apm/manage-storage/ilm-how-to.asciidoc
@@ -15,20 +15,6 @@ A default policy is applied to each APM data stream, but can be customized depen
 [id="index-lifecycle-policies-default{append-legacy}"]
 == Default policies
 
-[NOTE]
-====
-// Explain what changed
-Clusters are managed by {ref}/index-lifecycle-management.html[index lifecycle management (ILM)] to provide the default data retention settings for APM data as well as allow customization for lifecycle.
-
-New clusters created in 8.15 and 8.16 will use {ref}/data-stream-lifecycle.html[data stream lifecycle (DSL)] to provide default data retention settings, but the customization for lifecycle is still performed using ILM policies, which are configured to override the default DSL polices. When these clusters are upgraded to 8.17 the default will revert back to ILM, however, the indices created will continue to use DSL. The changes only affect default lifecycle policies, so, if you have custom ILM policies configured then there are expected to be no changes and the custom ILM policy will continue to be used.
-
-// What this means for existing clusters that are upgraded
-On upgrade to 8.17, _all_ APM indicies will be managed by ILM. This includes the clusters upgrading from 8.15 and 8.16, however, the indicies created during 8.15 and 8.16 will continue to use DSL. If you have custom ILM policies configured, then, there are expected to be NO changes and the custom ILM policies will continue to manage the APM indicies.
-
-// What this means for new clusters that are created
-To customize ILM policies follow the steps in this guide to create a custom ILM policy and add it to the `*@custom` component template for each data stream.
-====
-
 Each APM data stream has its own default lifecycle policy including a delete definition and a rollover definition.
 
 The table below describes the delete definition for each APM data stream.

--- a/docs/en/observability/apm/manage-storage/ilm-how-to.asciidoc
+++ b/docs/en/observability/apm/manage-storage/ilm-how-to.asciidoc
@@ -11,6 +11,21 @@
 Lifecycle policies allow you to automate the lifecycle of your APM indices as they grow and age.
 A default policy is applied to each APM data stream, but can be customized depending on your business needs.
 
+In the latest version of Elastic APM, clusters are managed by
+{ref}/index-lifecycle-management.html[index lifecycle management (ILM)]
+to provide the default data retention settings for APM data as well as allow
+customization for lifecycle.
+
+[IMPORTANT]
+====
+*If you created a new cluster in 8.15 or 8.16*, that cluster will use
+{ref}/data-stream-lifecycle.html[data stream lifecycle (DSL)] to provide default
+data retention settings, but the customization for lifecycle is still performed
+using ILM policies, which are configured to override the default DSL polices.
+
+Read more in <<apm-known-issues>>.
+====
+
 [discrete]
 [id="index-lifecycle-policies-default{append-legacy}"]
 == Default policies

--- a/docs/en/observability/apm/manage-storage/ilm-how-to.asciidoc
+++ b/docs/en/observability/apm/manage-storage/ilm-how-to.asciidoc
@@ -18,7 +18,7 @@ A default policy is applied to each APM data stream, but can be customized depen
 [NOTE]
 ====
 // Explain what changed
-Clusters are managed by {ref}/index-lifecycle-management.html[index lifecycle management (ILM)] to provide the default data retention settings for APM data. as well as allow customization for lifecycle.
+Clusters are managed by {ref}/index-lifecycle-management.html[index lifecycle management (ILM)] to provide the default data retention settings for APM data as well as allow customization for lifecycle.
 
 New clusters created in 8.15 and 8.16 will use {ref}/data-stream-lifecycle.html[data stream lifecycle (DSL)] to provide default data retention settings, but the customization for lifecycle is still performed using ILM policies, which are configured to override the default DSL polices. When these clusters are upgraded to 8.17 the default will revert back to ILM, however, the indices created will continue to use DSL. The changes only affect default lifecycle policies, so, if you have custom ILM policies configured then there are expected to be no changes and the custom ILM policy will continue to be used.
 

--- a/docs/en/observability/apm/manage-storage/ilm-how-to.asciidoc
+++ b/docs/en/observability/apm/manage-storage/ilm-how-to.asciidoc
@@ -19,7 +19,7 @@ customization for lifecycle.
 [NOTE]
 ====
 Some older indices might be managed by {ref}/data-stream-lifecycle.html[data stream lifecycle (DSL)] if a cluster is upgraded to 8.17.
-More details are available in <<apm-release-notes>>.
+More details are available in <<apm-release-notes-8.17>>.
 ====
 
 [discrete]

--- a/docs/en/observability/apm/manage-storage/ilm-how-to.asciidoc
+++ b/docs/en/observability/apm/manage-storage/ilm-how-to.asciidoc
@@ -18,18 +18,15 @@ A default policy is applied to each APM data stream, but can be customized depen
 [NOTE]
 ====
 // Explain what changed
-// Before
-Before 8.15, clusters used {ref}/index-lifecycle-management.html[index lifecycle management (ILM)] to provide the default data retention settings for APM data.
-// After
-As of 8.15, new clusters use {ref}/data-stream-lifecycle.html[data stream lifecycle (DSL)] to provide default data retention settings, but the customization for lifecycle is still performed using ILM policies, which are now configured to override the default DSL polices.
+Clusters are managed by {ref}/index-lifecycle-management.html[index lifecycle management (ILM)] to provide the default data retention settings for APM data. as well as allow customization for lifecycle.
+
+New clusters created in 8.15 and 8.16 will use {ref}/data-stream-lifecycle.html[data stream lifecycle (DSL)] to provide default data retention settings, but the customization for lifecycle is still performed using ILM policies, which are configured to override the default DSL polices. When these clusters are upgraded to 8.17 the default will revert back to ILM, however, the indices created will continue to use DSL. The changes only affect default lifecycle policies, so, if you have custom ILM policies configured then there are expected to be no changes and the custom ILM policy will continue to be used.
 
 // What this means for existing clusters that are upgraded
-For _existing_ clusters upgrading to 8.15, the default ILM policies should still work as expected.
-You can can continue using ILM or switch the default to DSL explicitly using the {ref}/data-stream-apis.html[data stream API].
+On upgrade to 8.17, _all_ APM indicies will be managed by ILM. This includes the clusters upgrading from 8.15 and 8.16, however, the indicies created during 8.15 and 8.16 will continue to use DSL. If you have custom ILM policies configured, then, there are expected to be NO changes and the custom ILM policies will continue to manage the APM indicies.
 
 // What this means for new clusters that are created
-For _new_ clusters created in 8.15 or later, if you prefer to continue using ILM,
-follow the steps in this guide to create a custom ILM policy and add it to the `*@custom` component template for each data stream.
+To customize ILM policies follow the steps in this guide to create a custom ILM policy and add it to the `*@custom` component template for each data stream.
 ====
 
 Each APM data stream has its own default lifecycle policy including a delete definition and a rollover definition.
@@ -119,14 +116,6 @@ The delete phase permanently removes the index after a time threshold is met.
 
 Rollover (writing to a new index) prevents a single index from growing too large and optimizes indexing and search performance.
 Rollover occurs after either an age or size metric is met.
-The default rollover definition for each APM data stream is applied based on {ref}/data-stream-lifecycle-settings.html#cluster-lifecycle-default-rollover[`cluster.lifecycle.default.rollover`].
-
-The APM data stream lifecycle policies can be viewed in {kib}:
-
-. To open **Index Management**, find **Stack Management** in the main menu or use the {kibana-ref}/introduction.html#kibana-navigation-search[global search field].
-. Select **Component Templates**.
-. Search for `apm`.
-. Look for templates with `@lifecycle` suffix.
 
 TIP: Default lifecycle policies can change between minor versions. This is not considered a breaking change as index management should continually improve and adapt to new features.
 

--- a/docs/en/observability/apm/manage-storage/ilm-how-to.asciidoc
+++ b/docs/en/observability/apm/manage-storage/ilm-how-to.asciidoc
@@ -18,7 +18,7 @@ customization for lifecycle.
 
 [NOTE]
 ====
-Some older indices might be managed by {ref}/data-stream-lifecycle.html[data stream lifecycle (DSL)] if cluster is upgraded to 8.17.
+Some older indices might be managed by {ref}/data-stream-lifecycle.html[data stream lifecycle (DSL)] if a cluster is upgraded to 8.17.
 More details are available in <<apm-release-notes>>.
 ====
 


### PR DESCRIPTION
## Description
<!-- Add a description here -->

Rewords the ILM how-to guide for APM to mention revert to ILM policies (from DSL introduced in 8.15).
CC: @elastic/obs-ds-intake-services (not able to add as reviewers)

### Documentation sets edited in this PR

### Related issue
Closes https://github.com/elastic/apm-server/issues/14708

## Checklist

<!--
Add labels to:
1. Backport to other versions (`backport-*`):
    - `backport-8.x` to backport to the latest minor
    - `backport-skip` to not backport (for example, for serverless docs)
    - `backport-main` to "backport" to `main` if the target branch is _not_ `main`
    - Individual `backport-*` labels to target specific minor versions
2. Surface blocking reviews (`needs-*-review`):
    - `needs-writer-review` for codeowners
    - `needs-dev-review` for dev team
    - `needs-product-review` for PM review
-->

- [ ] Product/Engineering Review
- [ ] Writer Review

