### PR TITLE
managed and self-managed connectors mentioned

### DIFF
--- a/docs/en/observability/observability-ai-assistant.asciidoc
+++ b/docs/en/observability/observability-ai-assistant.asciidoc
@@ -11,7 +11,7 @@ The AI Assistant uses generative AI to provide:
 [role="screenshot"]
 image::images/obs-assistant2.gif[Observability AI assistant preview, 60%]
 
-The AI Assistant integrates with your large language model (LLM) provider through our supported Elastic connectors:
+The AI Assistant integrates with your large language model (LLM) provider through our supported {stack} connectors:
 
 * {kibana-ref}/openai-action-type.html[OpenAI connector] for OpenAI or Azure OpenAI Service.
 * {kibana-ref}/bedrock-action-type.html[Amazon Bedrock connector] for Amazon Bedrock, specifically for the Claude models.
@@ -41,7 +41,7 @@ The AI assistant requires the following:
 ** OpenAI `gpt-4`+.
 ** Azure OpenAI Service `gpt-4`(0613) or `gpt-4-32k`(0613) with API version `2023-07-01-preview` or more recent.
 ** AWS Bedrock, specifically the Anthropic Claude models.
-* An {enterprise-search-ref}/server.html[Enterprise Search] server if {ref}/es-connectors.html[search connectors] are used to populate external data into the knowledge base.
+* An {enterprise-search-ref}/server.html[Enterprise Search] server if Elastic managed {ref}/es-native-connectors.html[search connectors] are used to populate external data into the knowledge base.
 * An account with a third-party generative AI provider that preferably supports function calling.
 If your AI provider does not support function calling, you can configure AI Assistant settings under **Stack Management** to simulate function calling, but this might affect performance.
 +
@@ -156,13 +156,13 @@ Search connectors are only needed when importing external data into the Knowledg
 
 {ref}/es-connectors.html[Connectors] allow you to index content from external sources thereby making it available for the AI Assistant. This can greatly improve the relevance of the AI Assistant’s responses. Data can be integrated from sources such as GitHub, Confluence, Google Drive, Jira, AWS S3, Microsoft Teams, Slack, and more.
 
-These connectors are managed under the Search Solution in {kib}, and they require an {enterprise-search-ref}/server.html[Enterprise Search] server connected to the Elastic Stack.
+These connectors can be managed or self-managed, and they are part of the Search Solution in {kib}. Managed connectors require an {enterprise-search-ref}/server.html[Enterprise Search] server connected to the Elastic Stack, while self-managed connectors are run on your own infrastructure.
 
 By default, the AI Assistant queries all search connector indices. To override this behavior and customize which indices are queried, adjust the *Search connector index pattern* setting on the <<obs-ai-settings>> page. This allows precise control over which data sources are included in AI Assistant knowledge base.
 
 To create a connector and make its content available to the AI Assistant knowledge base, follow these steps:
 
-. To open **Connectors**, find `Content / Connectors` in the {kibana-ref}/introduction.html#kibana-navigation-search[global search field].
+. Open **Connectors** by finding `Content / Connectors` in the {kibana-ref}/introduction.html#kibana-navigation-search[global search field].
 +
 [NOTE]
 ====


### PR DESCRIPTION
## Description
Per https://github.com/elastic/observability-docs/issues/4504, we have specified that Enterprise Search server is only needed when using "managed connectors".
Due to that we have also mentioned what self-managed connectors are :)

Closes https://github.com/elastic/observability-docs/issues/4504

### Documentation sets edited in this PR

_Check all that apply._

- [ ] Stateful (`docs/en/observability/*`)
- [ ] Serverless (`docs/en/serverless/*`)
- [ ] Integrations Developer Guide (`docs/en/integrations/*`)
- [ ] None of the above

### Related issue
Closes # <!-- Add the issue this PR closes here -->

## Checklist

<!--
Add labels to:
1. Backport to other versions (`backport-*`):
    - `backport-8.x` to backport to the latest minor
    - `backport-skip` to not backport (for example, for serverless docs)
    - `backport-main` to "backport" to `main` if the target branch is _not_ `main`
    - Individual `backport-*` labels to target specific minor versions
2. Surface blocking reviews (`needs-*-review`):
    - `needs-writer-review` for codeowners
    - `needs-dev-review` for dev team
    - `needs-product-review` for PM review
-->

- [ ] Product/Engineering Review
- [ ] Writer Review

### Follow-up tasks
<!-- If you are updating the Integrations Developer Guide, you can delete this section -->

_Select one._

* This PR does _not_ need to be ported to another doc set because:
  - [ ] The concepts in this PR only apply to one doc set (serverless _or_ stateful)
  - [ ] The PR contains edits to both doc sets (serverless _and_ stateful)
* This PR needs to be ported to another doc set:
  - [ ] Port to stateful docs: \<link to PR or tracking issue>
  - [ ] Port to serverless docs: \<link to PR or tracking issue>
