### PR TITLE
o11y AI assistant: add doc entry about the product doc

### DIFF
--- a/docs/en/observability/observability-ai-assistant.asciidoc
+++ b/docs/en/observability/observability-ai-assistant.asciidoc
@@ -342,6 +342,19 @@ The AI Assistant Settings page contains the following tabs:
 * *Settings*: Configures the main AI Assistant settings, which are explained directly within the interface.
 * *Knowledge base*: Manages <<obs-ai-kb-ui,knowledge base entries>>.
 * *Search Connectors*: Provides a link to {kib} *Search* -> *Content* -> *Connectors* UI for connectors configuration.
+
+[discrete]
+[[obs-ai-product-documentation]]
+== Elastic documentation for the AI Assistant
+
+It is possible to make the Elastic official documentation available to the AI Assistant, which significantly increases
+its efficiency and accuracy in answering questions related to the Elastic stack and Elastic products.
+
+Enabling that feature can be done from the *Settings* tab of the AI Assistant Settings page, using the "Install Elastic Documentation" action.
+
+IMPORTANT: Installing the product documentation in air gapped environments requires specific installation and configuration instructions,
+which are available in the {kibana-ref}/ai-assistant-settings-kb.html[{kib} Kibana AI Assistants settings documentation].
+
 [discrete]
 [[obs-ai-known-issues]]
 == Known issues

--- a/docs/en/serverless/ai-assistant/ai-assistant.asciidoc
+++ b/docs/en/serverless/ai-assistant/ai-assistant.asciidoc
@@ -340,6 +340,15 @@ The Observability AI Assistant connector is called when the alert fires and when
 To learn more about alerting, actions, and connectors, refer to <<observability-alerting>>.
 
 [discrete]
+[[obs-ai-product-documentation]]
+== Elastic documentation for the AI Assistant
+
+It is possible to make the Elastic official documentation available to the AI Assistant, which significantly increases
+its efficiency and accuracy in answering questions related to the Elastic stack and Elastic products.
+
+Enabling that feature can be done from the *Settings* tab of the AI Assistant Settings page, using the "Install Elastic Documentation" action.
+
+[discrete]
 [[observability-ai-assistant-known-issues]]
 == Known issues
 


### PR DESCRIPTION
## Description

Add documentation entry about for Elastic product documentation feature for the o11y AI Assistant, and add link for air-gapped installation (for stateful only)

### Documentation sets edited in this PR

- [x] Stateful (`docs/en/observability/*`)
- [x] Serverless (`docs/en/serverless/*`)
- [ ] Integrations Developer Guide (`docs/en/integrations/*`)
- [ ] None of the above

### Related issue

Part of https://github.com/elastic/kibana/issues/199999

## Checklist

- [ ] Product/Engineering Review
- [x] Writer Review

### Follow-up tasks

* This PR does _not_ need to be ported to another doc set because:
  - [ ] The concepts in this PR only apply to one doc set (serverless _or_ stateful)
  - [x] The PR contains edits to both doc sets (serverless _and_ stateful)
* This PR needs to be ported to another doc set:
  - [ ] Port to stateful docs: \<link to PR or tracking issue>
  - [ ] Port to serverless docs: \<link to PR or tracking issue>
