### PR TITLE
apm-ilm: update apm-ilm-how-to expand dsl migration note

### DIFF
--- a/docs/en/observability/apm/manage-storage/ilm-how-to.asciidoc
+++ b/docs/en/observability/apm/manage-storage/ilm-how-to.asciidoc
@@ -22,7 +22,8 @@ Indices created in 8.15.x and 8.16.x might be managed by {ref}/data-stream-lifec
 More details are available in <<apm-release-notes-8.15>>.
 By default, new indices created in 8.17 are managed by ILM.
 More details are available in <<apm-release-notes-8.17>>.
-If you have indices managed by DSL note that your custom DSL settings will not automatically apply to the new indices managed by ILM.
+If you have indices managed by DSL, any custom DSL settings that you specified will _not_ automatically apply to the new indices managed by ILM.
+Instead, you can replicate custom DSL settings in ILM using this guide.
 ====
 
 [discrete]

--- a/docs/en/observability/apm/manage-storage/ilm-how-to.asciidoc
+++ b/docs/en/observability/apm/manage-storage/ilm-how-to.asciidoc
@@ -18,9 +18,9 @@ customization for lifecycle.
 
 [NOTE]
 ====
-The indices that were created in 8.15.x and 8.16.x might be managed by {ref}/data-stream-lifecycle.html[data stream lifecycle (DSL)].
+Indices created in 8.15.x and 8.16.x might be managed by {ref}/data-stream-lifecycle.html[data stream lifecycle (DSL)].
 More details are available in <<apm-release-notes-8.15>>.
-In 8.17 by default the new indices will be managed by ILM again.
+By default, new indices created in 8.17 are managed by ILM.
 More details are available in <<apm-release-notes-8.17>>.
 If you have indices managed by DSL note that your custom DSL settings will not automatically apply to the new indices managed by ILM.
 ====

--- a/docs/en/observability/apm/manage-storage/ilm-how-to.asciidoc
+++ b/docs/en/observability/apm/manage-storage/ilm-how-to.asciidoc
@@ -18,8 +18,11 @@ customization for lifecycle.
 
 [NOTE]
 ====
-Some older indices might be managed by {ref}/data-stream-lifecycle.html[data stream lifecycle (DSL)] if a cluster is upgraded to 8.17.
+The indices that were created in 8.15.x and 8.16.x might be managed by {ref}/data-stream-lifecycle.html[data stream lifecycle (DSL)].
+More details are available in <<apm-release-notes-8.15>>.
+In 8.17 by default the new indices will be managed by ILM again.
 More details are available in <<apm-release-notes-8.17>>.
+If you have indices managed by DSL note that your custom DSL settings will not automatically apply to the new indices managed by ILM.
 ====
 
 [discrete]


### PR DESCRIPTION
## Description
<!-- Add a description here -->

This PR updates `apm-ilm-how-to` page to expand DSL to ILM migration note. 

### Documentation sets edited in this PR

_Check all that apply._

- [x] Stateful (`docs/en/observability/*`)
- [ ] Serverless (`docs/en/serverless/*`)
- [ ] Integrations Developer Guide (`docs/en/integrations/*`)
- [ ] None of the above

### Related issue
Closes # <!-- Add the issue this PR closes here -->

Needs changelog updates https://github.com/elastic/apm-server/pull/14909 to be merged first.  

## Checklist

<!--
Add labels to:
1. Backport to other versions (`backport-*`):
    - `backport-8.x` to backport to the latest minor
    - `backport-skip` to not backport (for example, for serverless docs)
    - `backport-main` to "backport" to `main` if the target branch is _not_ `main`
    - Individual `backport-*` labels to target specific minor versions
2. Surface blocking reviews (`needs-*-review`):
    - `needs-writer-review` for codeowners
    - `needs-dev-review` for dev team
    - `needs-product-review` for PM review
-->

- [ ] Product/Engineering Review
- [ ] Writer Review

### Follow-up tasks
<!-- If you are updating the Integrations Developer Guide, you can delete this section -->

_Select one._

* This PR does _not_ need to be ported to another doc set because:
  - [x] The concepts in this PR only apply to one doc set (serverless _or_ stateful)
  - [ ] The PR contains edits to both doc sets (serverless _and_ stateful)
* This PR needs to be ported to another doc set:
  - [ ] Port to stateful docs: \<link to PR or tracking issue>
  - [ ] Port to serverless docs: \<link to PR or tracking issue>
