### PR TITLE
Add common pipeline and mapping issues and mitigations

### DIFF
--- a/docs/en/observability/logs-troubleshooting.asciidoc
+++ b/docs/en/observability/logs-troubleshooting.asciidoc
@@ -1,7 +1,7 @@
 [[logs-troubleshooting]]
 = Troubleshoot logs
 
-Use this page to find possible solutions for errors your encountering with your logs. This troubleshooting page is broken into two sections:
+Use this page to find possible solutions for errors your encountering with your logs. This troubleshooting page is broken into the following sections:
 
 - <<logs-onboarding-troubleshooting>>
 - <<logs-common-mapping-troubleshooting, Mapping and pipeline issues>>
@@ -149,11 +149,34 @@ Inspect the {agent} logs for errors. See the {fleet-guide}/debug-standalone-agen
 [[logs-common-mapping-troubleshooting]]
 == Mapping and pipeline issues
 
-This section provides possible solutions for errors you might encounter while onboarding your logs.
+This section provides possible solutions for mapping and pipeline issues you might encounter with your logs.
 
-[[logs-mapping-troubleshooting-keyword]]
+[[logs-mapping-troubleshooting-keyword-limit]]
 === Keyword fields are too long
+The `keyword` field limit is 32,766 bytes. When indexing a document, if your `keyword` field length exceeds this limit, you'll see an error similar to the following:
 
+```
+max_bytes_length_exceeded_exception: bytes can be at most 32766 in length
+```
+
+[discrete]
+[[logs-mapping-troubleshooting-keyword-limit-solution]]
+==== Solution
+Avoid this error using one of the following options:
+
+*Stop indexing the field:* If you don't need the `keyword` field for aggregation or search, set `"index":false` in the index template to stop indexing the field.
+
+*Increase `ignore_above`:* To index any `keyword` fields under the field limit, but not those over the limit, set the `ignore_above` setting in the index template.
+
+NOTE: The value for `ignore_above` is the _character count_, but Lucene counts bytes.
+If you use UTF-8 text with many non-ASCII characters, you may want to set the limit to `32766 / 4 = 8191` since UTF-8 characters may occupy at most 4 bytes.
+
+Refer to the {ref}/ignore-above.html[`ignore_above`] docs for more information.
+
+*Convert the `keyword` field to a `text` field:* To continue indexing the field while avoiding length limits, you can convert the `keyword` field to a `text` field. To do this:
+
+. Create a new index with the `text` field data type.
+. Reindex from the `_source` field of the source index using the {ref}/docs-reindex.html[`_reindex` API].
 
 [[logs-mapping-troubleshooting-format-mismatch]]
 === Date format mismatch

--- a/docs/en/observability/logs-troubleshooting.asciidoc
+++ b/docs/en/observability/logs-troubleshooting.asciidoc
@@ -155,9 +155,10 @@ This section provides possible solutions for mapping and pipeline issues you mig
 === Keyword fields are too long
 The `keyword` field limit is 32,766 bytes. When indexing a document, if your `keyword` field length exceeds this limit, you'll see an error similar to the following:
 
-```
+[source, plaintext]
+----
 max_bytes_length_exceeded_exception: bytes can be at most 32766 in length
-```
+----
 
 [discrete]
 [[logs-mapping-troubleshooting-keyword-limit-solution]]
@@ -178,8 +179,40 @@ Refer to the {ref}/ignore-above.html[`ignore_above`] docs for more information.
 . Create a new index with the `text` field data type.
 . Reindex from the `_source` field of the source index using the {ref}/docs-reindex.html[`_reindex` API].
 
-[[logs-mapping-troubleshooting-format-mismatch]]
+[discrete]
+[[logs-mapping-troubleshooting-date-mismatch]]
 === Date format mismatch
+If the format of the `date` field in your document doesn't match the format set in your index template, you'll see an error similar to the following:
+
+[source, plaintext]
+----
+failed to parse field [date] of type [date] in document with id 'KGcZb3cBqhj6kAxank_x'.
+----
+
+[discrete]
+[[logs-mapping-troubleshooting-date-solution]]
+==== Solution
+Avoid this error by adding the format of the mismatched date to your index template.
+Multiple formats can be specified by separating them with `||` as a separator.
+Each format will be tried in turn until a matching format is found.
+For example:
+
+[source,console,id=date-format-example]
+----
+PUT my-index-000001
+{
+  "mappings": {
+    "properties": {
+      "date": {
+        "type":   "date",
+        "format": "yyyy-MM-dd HH:mm:ss||yyyy-MM-dd||epoch_millis"
+      }
+    }
+  }
+}
+------
+
+Refer to the {ref}/date.html[`date` field type] docs for more information.
 
 [[logs-mapping-troubleshooting-grok-mismatch]]
 === Grok or dissect pattern mismatch

--- a/docs/en/observability/logs-troubleshooting.asciidoc
+++ b/docs/en/observability/logs-troubleshooting.asciidoc
@@ -167,14 +167,11 @@ Avoid this error using one of the following options:
 
 *Stop indexing the field:* If you don't need the `keyword` field for aggregation or search, set `"index":false` in the index template to stop indexing the field.
 
-*Increase `ignore_above`:* To index any `keyword` fields under the field limit, but not those over the limit, set the `ignore_above` setting in the index template.
+*Convert the `keyword` field to a `text` field:* To continue indexing the field while avoiding length limits, you can convert the `keyword` field to a `text` field.
 
-NOTE: The value for `ignore_above` is the _character count_, but Lucene counts bytes.
-If you use UTF-8 text with many non-ASCII characters, you may want to set the limit to `32766 / 4 = 8191` since UTF-8 characters may occupy at most 4 bytes.
+NOTE: Aggregations on this field would no longer be supported, but the contents would be searchable.
 
-Refer to the {ref}/ignore-above.html[`ignore_above`] docs for more information.
-
-*Convert the `keyword` field to a `text` field:* To continue indexing the field while avoiding length limits, you can convert the `keyword` field to a `text` field. To do this:
+To convert the `keyword` field to a `text` field:
 
 . Create a new index with the `text` field data type.
 . Reindex from the `_source` field of the source index using the {ref}/docs-reindex.html[`_reindex` API].
@@ -220,7 +217,7 @@ If the pattern in your grok or dissect processor doesn't match the format of you
 
 [source, plaintext]
 ----
-Provided Grok patterns do not match data in the input
+Provided Grok patterns do not match field value...
 ----
 
 [discrete]
@@ -234,6 +231,3 @@ navigation menu or the global search field.
 From here, you can enter sample data representative of the log document you're trying to ingest and the Grok pattern you want to apply to the data.
 
 If you don't see any *Structured Data* when you simulate the grok pattern, iterate on the pattern until you find the error.
-
-[[logs-mapping-troubleshooting-string-mismatch]]
-=== String/number or Float/int mismatch

--- a/docs/en/observability/logs-troubleshooting.asciidoc
+++ b/docs/en/observability/logs-troubleshooting.asciidoc
@@ -6,6 +6,7 @@ Use this page to find possible solutions for errors your encountering with your 
 - <<logs-onboarding-troubleshooting>>
 - <<logs-common-mapping-troubleshooting, Mapping and pipeline issues>>
 
+[discrete]
 [[logs-onboarding-troubleshooting]]
 == Common onboarding issues
 

--- a/docs/en/observability/logs-troubleshooting.asciidoc
+++ b/docs/en/observability/logs-troubleshooting.asciidoc
@@ -130,6 +130,7 @@ Failed to install Elastic Agent, see script for error.
 [discrete]
 [[logs-troubleshooting-install-agent-solution]]
 ==== Solution
+
 You can uninstall the current {agent} using the `elastic-agent uninstall` command, and run the script again.
 
 WARNING: Uninstalling the current {agent} removes the entire current setup, including the existing configuration.
@@ -146,13 +147,16 @@ If the *Waiting for Logs to be shipped...* step never completes, logs are not be
 
 Inspect the {agent} logs for errors. See the {fleet-guide}/debug-standalone-agents.html#inspect-standalone-agent-logs[Debug standalone {agent}s] documentation for more on finding errors in {agent} logs.
 
+[discrete]
 [[logs-common-mapping-troubleshooting]]
 == Mapping and pipeline issues
 
 This section provides possible solutions for mapping and pipeline issues you might encounter with your logs.
 
+[discrete]
 [[logs-mapping-troubleshooting-keyword-limit]]
 === Keyword fields are too long
+
 The `keyword` field limit is 32,766 bytes. When indexing a document, if your `keyword` field length exceeds this limit, you'll see an error similar to the following:
 
 [source, plaintext]
@@ -163,6 +167,7 @@ max_bytes_length_exceeded_exception: bytes can be at most 32766 in length
 [discrete]
 [[logs-mapping-troubleshooting-keyword-limit-solution]]
 ==== Solution
+
 Avoid this error using one of the following options:
 
 *Stop indexing the field:* If you don't need the `keyword` field for aggregation or search, set `"index":false` in the index template to stop indexing the field.
@@ -179,6 +184,7 @@ To convert the `keyword` field to a `text` field:
 [discrete]
 [[logs-mapping-troubleshooting-date-mismatch]]
 === Date format mismatch
+
 If the format of the `date` field in your document doesn't match the format set in your index template, you'll see an error similar to the following:
 
 [source, plaintext]
@@ -189,6 +195,7 @@ failed to parse field [date] of type [date] in document with id 'KGcZb3cBqhj6kAx
 [discrete]
 [[logs-mapping-troubleshooting-date-solution]]
 ==== Solution
+
 Add the format of the mismatched date to your index template.
 Multiple formats can be specified by separating them with `||` as a separator.
 Each format will be tried in turn until a matching format is found.
@@ -211,8 +218,10 @@ PUT my-index-000001
 
 Refer to the {ref}/date.html[`date` field type] docs for more information.
 
+[discrete]
 [[logs-mapping-troubleshooting-grok-mismatch]]
 === Grok or dissect pattern mismatch
+
 If the pattern in your grok or dissect processor doesn't match the format of your document, you'll see an error similar to the following:
 
 [source, plaintext]
@@ -223,6 +232,7 @@ Provided Grok patterns do not match field value...
 [discrete]
 [[logs-mapping-troubleshooting-grok-solution]]
 ==== Solution
+
 Make sure your {ref}/grok-processor.html[grok] or {ref}/dissect-processor.html[dissect] processor pattern matches your log document format.
 
 You can build and debug grok patterns in {kib} using the {kibana-ref}/xpack-grokdebugger.html[Grok Debugger]. Find the *Grok Debugger* by navigating to the *Developer tools* page using the

--- a/docs/en/observability/logs-troubleshooting.asciidoc
+++ b/docs/en/observability/logs-troubleshooting.asciidoc
@@ -192,7 +192,7 @@ failed to parse field [date] of type [date] in document with id 'KGcZb3cBqhj6kAx
 [discrete]
 [[logs-mapping-troubleshooting-date-solution]]
 ==== Solution
-Avoid this error by adding the format of the mismatched date to your index template.
+Add the format of the mismatched date to your index template.
 Multiple formats can be specified by separating them with `||` as a separator.
 Each format will be tried in turn until a matching format is found.
 For example:
@@ -216,6 +216,24 @@ Refer to the {ref}/date.html[`date` field type] docs for more information.
 
 [[logs-mapping-troubleshooting-grok-mismatch]]
 === Grok or dissect pattern mismatch
+If the pattern in your grok or dissect processor doesn't match the format of your document, you'll see an error similar to the following:
+
+[source, plaintext]
+----
+Provided Grok patterns do not match data in the input
+----
+
+[discrete]
+[[logs-mapping-troubleshooting-grok-solution]]
+==== Solution
+Make sure your {ref}/grok-processor.html[grok] or {ref}/dissect-processor.html[dissect] processor pattern matches your log document format.
+
+You can build and debug grok patterns in {kib} using the {kibana-ref}/xpack-grokdebugger.html[Grok Debugger]. Find the *Grok Debugger* by navigating to the *Developer tools* page using the
+navigation menu or the global search field.
+
+From here, you can enter sample data representative of the log document you're trying to ingest and the Grok pattern you want to apply to the data.
+
+If you don't see any *Structured Data* when you simulate the grok pattern, iterate on the pattern until you find the error.
 
 [[logs-mapping-troubleshooting-string-mismatch]]
 === String/number or Float/int mismatch

--- a/docs/en/observability/logs-troubleshooting.asciidoc
+++ b/docs/en/observability/logs-troubleshooting.asciidoc
@@ -1,7 +1,7 @@
 [[logs-troubleshooting]]
 = Troubleshoot logs
 
-Use this page to find possible solutions for errors your encountering with your logs. This troubleshooting page is broken into the following sections:
+Use this page to find possible solutions for errors your encountering with your logs. This troubleshooting page is divided into the following sections:
 
 - <<logs-onboarding-troubleshooting>>
 - <<logs-common-mapping-troubleshooting, Mapping and pipeline issues>>

--- a/docs/en/observability/logs-troubleshooting.asciidoc
+++ b/docs/en/observability/logs-troubleshooting.asciidoc
@@ -210,7 +210,7 @@ PUT my-index-000001
     }
   }
 }
-------
+----
 
 Refer to the {ref}/date.html[`date` field type] docs for more information.
 

--- a/docs/en/observability/logs-troubleshooting.asciidoc
+++ b/docs/en/observability/logs-troubleshooting.asciidoc
@@ -1,11 +1,19 @@
 [[logs-troubleshooting]]
 = Troubleshoot logs
 
+Use this page to find possible solutions for errors your encountering with your logs. This troubleshooting page is broken into two sections:
+
+- <<logs-onboarding-troubleshooting>>
+- <<logs-common-mapping-troubleshooting, Mapping and pipeline issues>>
+
+[[logs-onboarding-troubleshooting]]
+== Common onboarding issues
+
 This section provides possible solutions for errors you might encounter while onboarding your logs.
 
 [discrete]
 [[logs-troubleshooting-insufficient-priv]]
-== User does not have permissions to create API key
+=== User does not have permissions to create API key
 
 If you don't have the required privileges to create an API key, you'll see the following error message:
 
@@ -21,7 +29,7 @@ to the role of the authenticated user.
 
 [discrete]
 [[logs-troubleshooting-insufficient-priv-solution]]
-=== Solution
+==== Solution
 
 You need to either:
 
@@ -30,7 +38,7 @@ You need to either:
 
 [discrete]
 [[logs-troubleshooting-API-key-failed]]
-== Failed to create API key
+=== Failed to create API key
 
 If you don't have the privileges to create `savedObjects` in {kib}, you'll see the following error message:
 
@@ -43,14 +51,14 @@ Something went wrong: Unable to create observability-onboarding-state
 
 [discrete]
 [[logs-troubleshooting-API-key-failed-solution]]
-=== Solution
+==== Solution
 
 You need an administrator to give you the `Saved Objects Management` {kib} privilege to generate the required `observability-onboarding-state` flow state.
 Once you have the necessary privileges, restart the onboarding flow.
 
 [discrete]
 [[logs-troubleshooting-kib-not-accessible]]
-== {kib} not accessible from host
+=== {kib} not accessible from host
 
 If {kib} is not accessible from the host, you'll see the following error message after pasting the *Install the {agent}* instructions into the host:
 
@@ -61,7 +69,7 @@ Failed to connect to {host} port {port} after 0 ms: Connection refused
 
 [discrete]
 [[logs-troubleshooting-kib-not-accessible-solution]]
-=== Solution
+==== Solution
 
 The host needs access to {kib}. Port `443` must be open and the deployment's {es} endpoint must be reachable. Locate your project's endpoint from *Help menu (image:images/help-icon.png[]) → Connection details*.
 
@@ -73,7 +81,7 @@ curl https://your-endpoint.elastic.cloud
 
 [discrete]
 [[logs-troubleshooting-download-agent]]
-== Download {agent} failed
+=== Download {agent} failed
 
 If the host was able to download the installation script but cannot connect to the public artifact repository, you'll see the following error message:
 
@@ -86,7 +94,7 @@ Failed to download Elastic Agent, see script for error.
 
 [discrete]
 [[logs-troubleshooting-download-agent-solution]]
-=== Solutions
+==== Solutions
 
 * If the combination of the {agent} version and operating system architecture is not available, you'll see the following error message:
 +
@@ -108,7 +116,7 @@ To fix this, delete previous downloads and restart the onboarding.
 
 [discrete]
 [[logs-troubleshooting-install-agent]]
-== Install {agent} failed
+=== Install {agent} failed
 
 If an {agent} already exists on your host, you'll see the following error message:
 
@@ -121,19 +129,37 @@ Failed to install Elastic Agent, see script for error.
 
 [discrete]
 [[logs-troubleshooting-install-agent-solution]]
-=== Solution
+==== Solution
 You can uninstall the current {agent} using the `elastic-agent uninstall` command, and run the script again.
 
 WARNING: Uninstalling the current {agent} removes the entire current setup, including the existing configuration.
 
 [discrete]
 [[logs-troubleshooting-wait-for-logs]]
-== Waiting for Logs to be shipped... step never completes
+=== Waiting for Logs to be shipped... step never completes
 
 If the *Waiting for Logs to be shipped...* step never completes, logs are not being shipped to {es}, and there is most likely an issue with your {agent} configuration.
 
 [discrete]
 [[logs-troubleshooting-wait-for-logs-solution]]
-=== Solution
+==== Solution
 
 Inspect the {agent} logs for errors. See the {fleet-guide}/debug-standalone-agents.html#inspect-standalone-agent-logs[Debug standalone {agent}s] documentation for more on finding errors in {agent} logs.
+
+[[logs-common-mapping-troubleshooting]]
+== Mapping and pipeline issues
+
+This section provides possible solutions for errors you might encounter while onboarding your logs.
+
+[[logs-mapping-troubleshooting-keyword]]
+=== Keyword fields are too long
+
+
+[[logs-mapping-troubleshooting-format-mismatch]]
+=== Date format mismatch
+
+[[logs-mapping-troubleshooting-grok-mismatch]]
+=== Grok or dissect pattern mismatch
+
+[[logs-mapping-troubleshooting-string-mismatch]]
+=== String/number or Float/int mismatch

--- a/docs/en/serverless/logging/troubleshoot-logs.asciidoc
+++ b/docs/en/serverless/logging/troubleshoot-logs.asciidoc
@@ -9,6 +9,7 @@ Use this page to find possible solutions for errors your encountering with your 
 - <<logs-onboarding-troubleshooting>>
 - <<logs-common-mapping-troubleshooting, Mapping and pipeline issues>>
 
+[discrete]
 [[logs-onboarding-troubleshooting]]
 == Common onboarding issues
 
@@ -147,13 +148,16 @@ If the **Waiting for Logs to be shipped...** step never completes, logs are not 
 
 Inspect the {agent} logs for errors. See the {fleet-guide}/debug-standalone-agents.html#inspect-standalone-agent-logs[Debug standalone {agent}s] documentation for more on finding errors in {agent} logs.
 
+[discrete]
 [[logs-common-mapping-troubleshooting]]
 == Mapping and pipeline issues
 
 This section provides possible solutions for mapping and pipeline issues you might encounter with your logs.
 
+[discrete]
 [[logs-mapping-troubleshooting-keyword-limit]]
 === Keyword fields are too long
+
 The `keyword` field limit is 32,766 bytes. When indexing a document, if your `keyword` field length exceeds this limit, you'll see an error similar to the following:
 
 [source, plaintext]
@@ -164,6 +168,7 @@ max_bytes_length_exceeded_exception: bytes can be at most 32766 in length
 [discrete]
 [[logs-mapping-troubleshooting-keyword-limit-solution]]
 ==== Solution
+
 Avoid this error using one of the following options:
 
 *Stop indexing the field:* If you don't need the `keyword` field for aggregation or search, set `"index":false` in the index template to stop indexing the field.
@@ -180,6 +185,7 @@ To convert the `keyword` field to a `text` field:
 [discrete]
 [[logs-mapping-troubleshooting-date-mismatch]]
 === Date format mismatch
+
 If the format of the `date` field in your document doesn't match the format set in your index template, you'll see an error similar to the following:
 
 [source, plaintext]
@@ -190,6 +196,7 @@ failed to parse field [date] of type [date] in document with id 'KGcZb3cBqhj6kAx
 [discrete]
 [[logs-mapping-troubleshooting-date-solution]]
 ==== Solution
+
 Add the format of the mismatched date to your index template.
 Multiple formats can be specified by separating them with `||` as a separator.
 Each format will be tried in turn until a matching format is found.
@@ -212,8 +219,10 @@ PUT my-index-000001
 
 Refer to the {ref}/date.html[`date` field type] docs for more information.
 
+[discrete]
 [[logs-mapping-troubleshooting-grok-mismatch]]
 === Grok or dissect pattern mismatch
+
 If the pattern in your grok or dissect processor doesn't match the format of your document, you'll see an error similar to the following:
 
 [source, plaintext]
@@ -224,6 +233,7 @@ Provided Grok patterns do not match field value...
 [discrete]
 [[logs-mapping-troubleshooting-grok-solution]]
 ==== Solution
+
 Make sure your {ref}/grok-processor.html[grok] or {ref}/dissect-processor.html[dissect] processor pattern matches your log document format.
 
 You can build and debug grok patterns in {kib} using the {kibana-ref}/xpack-grokdebugger.html[Grok Debugger]. Find the *Grok Debugger* by navigating to the *Developer tools* page using the

--- a/docs/en/serverless/logging/troubleshoot-logs.asciidoc
+++ b/docs/en/serverless/logging/troubleshoot-logs.asciidoc
@@ -16,7 +16,7 @@ This section provides possible solutions for errors you might encounter while on
 
 [discrete]
 [[observability-troubleshoot-logs-user-does-not-have-permissions-to-create-api-key]]
-== User does not have permissions to create API key
+=== User does not have permissions to create API key
 
 When adding a new data using the guided instructions in your project (**Add data** → **Collect and analyze logs** → **Stream log files**),
 if you don't have the required privileges to create an API key, you'll see the following error message:
@@ -28,7 +28,7 @@ You need permission to manage API keys
 
 [discrete]
 [[observability-troubleshoot-logs-solution]]
-=== Solution
+==== Solution
 
 You need to either:
 
@@ -56,7 +56,7 @@ Once you have the necessary privileges, restart the onboarding flow. */
 
 [discrete]
 [[observability-troubleshoot-logs-observability-project-not-accessible-from-host]]
-== Observability project not accessible from host
+=== Observability project not accessible from host
 
 If your Observability project is not accessible from the host, you'll see the following error message after pasting the **Install the {agent}** instructions into the host:
 
@@ -67,7 +67,7 @@ Failed to connect to {host} port {port} after 0 ms: Connection refused
 
 [discrete]
 [[observability-troubleshoot-logs-solution-1]]
-=== Solution
+==== Solution
 
 The host needs access to your project. Port `443` must be open and the project's {es} endpoint must be reachable. You can locate your project's endpoint by clicking the help icon (image:images/icons/help.svg[Help icon]) and selecting **Endpoints**. Run the following command, replacing the URL with your endpoint, and you should get an authentication error with more details on resolving your issue:
 
@@ -78,7 +78,7 @@ curl https://your-endpoint.elastic.cloud
 
 [discrete]
 [[observability-troubleshoot-logs-download-agent-failed]]
-== Download {agent} failed
+=== Download {agent} failed
 
 If the host was able to download the installation script but cannot connect to the public artifact repository, you'll see the following error message:
 
@@ -91,7 +91,7 @@ Failed to download Elastic Agent, see script for error.
 
 [discrete]
 [[observability-troubleshoot-logs-solutions]]
-=== Solutions
+==== Solutions
 
 * If the combination of the {agent} version and operating system architecture is not available, you'll see the following error message:
 +
@@ -113,7 +113,7 @@ To fix this, delete previous downloads and restart the onboarding.
 
 [discrete]
 [[observability-troubleshoot-logs-install-agent-failed]]
-== Install {agent} failed
+=== Install {agent} failed
 
 If an {agent} already exists on your host, you'll see the following error message:
 
@@ -126,7 +126,7 @@ Failed to install Elastic Agent, see script for error.
 
 [discrete]
 [[observability-troubleshoot-logs-solution-2]]
-=== Solution
+==== Solution
 
 You can uninstall the current {agent} using the `elastic-agent uninstall` command, and run the script again.
 
@@ -137,13 +137,13 @@ Uninstalling the current {agent} removes the entire current setup, including the
 
 [discrete]
 [[observability-troubleshoot-logs-waiting-for-logs-to-be-shipped-step-never-completes]]
-== Waiting for Logs to be shipped... step never completes
+=== Waiting for Logs to be shipped... step never completes
 
 If the **Waiting for Logs to be shipped...** step never completes, logs are not being shipped to your Observability project, and there is most likely an issue with your {agent} configuration.
 
 [discrete]
 [[observability-troubleshoot-logs-solution-3]]
-=== Solution
+==== Solution
 
 Inspect the {agent} logs for errors. See the {fleet-guide}/debug-standalone-agents.html#inspect-standalone-agent-logs[Debug standalone {agent}s] documentation for more on finding errors in {agent} logs.
 

--- a/docs/en/serverless/logging/troubleshoot-logs.asciidoc
+++ b/docs/en/serverless/logging/troubleshoot-logs.asciidoc
@@ -4,6 +4,14 @@
 // :description: Find solutions to errors you might encounter while onboarding your logs.
 // :keywords: serverless, observability, troubleshooting
 
+Use this page to find possible solutions for errors your encountering with your logs. This troubleshooting page is broken into the following sections:
+
+- <<logs-onboarding-troubleshooting>>
+- <<logs-common-mapping-troubleshooting, Mapping and pipeline issues>>
+
+[[logs-onboarding-troubleshooting]]
+== Common onboarding issues
+
 This section provides possible solutions for errors you might encounter while onboarding your logs.
 
 [discrete]
@@ -138,3 +146,89 @@ If the **Waiting for Logs to be shipped...** step never completes, logs are not 
 === Solution
 
 Inspect the {agent} logs for errors. See the {fleet-guide}/debug-standalone-agents.html#inspect-standalone-agent-logs[Debug standalone {agent}s] documentation for more on finding errors in {agent} logs.
+
+[[logs-common-mapping-troubleshooting]]
+== Mapping and pipeline issues
+
+This section provides possible solutions for mapping and pipeline issues you might encounter with your logs.
+
+[[logs-mapping-troubleshooting-keyword-limit]]
+=== Keyword fields are too long
+The `keyword` field limit is 32,766 bytes. When indexing a document, if your `keyword` field length exceeds this limit, you'll see an error similar to the following:
+
+[source, plaintext]
+----
+max_bytes_length_exceeded_exception: bytes can be at most 32766 in length
+----
+
+[discrete]
+[[logs-mapping-troubleshooting-keyword-limit-solution]]
+==== Solution
+Avoid this error using one of the following options:
+
+*Stop indexing the field:* If you don't need the `keyword` field for aggregation or search, set `"index":false` in the index template to stop indexing the field.
+
+*Convert the `keyword` field to a `text` field:* To continue indexing the field while avoiding length limits, you can convert the `keyword` field to a `text` field.
+
+NOTE: Aggregations on this field would no longer be supported, but the contents would be searchable.
+
+To convert the `keyword` field to a `text` field:
+
+. Create a new index with the `text` field data type.
+. Reindex from the `_source` field of the source index using the {ref}/docs-reindex.html[`_reindex` API].
+
+[discrete]
+[[logs-mapping-troubleshooting-date-mismatch]]
+=== Date format mismatch
+If the format of the `date` field in your document doesn't match the format set in your index template, you'll see an error similar to the following:
+
+[source, plaintext]
+----
+failed to parse field [date] of type [date] in document with id 'KGcZb3cBqhj6kAxank_x'.
+----
+
+[discrete]
+[[logs-mapping-troubleshooting-date-solution]]
+==== Solution
+Add the format of the mismatched date to your index template.
+Multiple formats can be specified by separating them with `||` as a separator.
+Each format will be tried in turn until a matching format is found.
+For example:
+
+[source,console,id=date-format-example]
+----
+PUT my-index-000001
+{
+  "mappings": {
+    "properties": {
+      "date": {
+        "type":   "date",
+        "format": "yyyy-MM-dd HH:mm:ss||yyyy-MM-dd||epoch_millis"
+      }
+    }
+  }
+}
+----
+
+Refer to the {ref}/date.html[`date` field type] docs for more information.
+
+[[logs-mapping-troubleshooting-grok-mismatch]]
+=== Grok or dissect pattern mismatch
+If the pattern in your grok or dissect processor doesn't match the format of your document, you'll see an error similar to the following:
+
+[source, plaintext]
+----
+Provided Grok patterns do not match field value...
+----
+
+[discrete]
+[[logs-mapping-troubleshooting-grok-solution]]
+==== Solution
+Make sure your {ref}/grok-processor.html[grok] or {ref}/dissect-processor.html[dissect] processor pattern matches your log document format.
+
+You can build and debug grok patterns in {kib} using the {kibana-ref}/xpack-grokdebugger.html[Grok Debugger]. Find the *Grok Debugger* by navigating to the *Developer tools* page using the
+navigation menu or the global search field.
+
+From here, you can enter sample data representative of the log document you're trying to ingest and the Grok pattern you want to apply to the data.
+
+If you don't see any *Structured Data* when you simulate the grok pattern, iterate on the pattern until you find the error.


### PR DESCRIPTION
## Description
Adding common mapping and pipeline issues to the Logs troubleshooting page.

### Documentation sets edited in this PR

_Check all that apply._

- [x] Stateful (`docs/en/observability/*`)
- [x] Serverless (`docs/en/serverless/*`)
- [ ] Integrations Developer Guide (`docs/en/integrations/*`)
- [ ] None of the above

### Related issue
Closes #4529 

## Checklist

<!--
Add labels to:
1. Backport to other versions (`backport-*`):
    - `backport-8.x` to backport to the latest minor
    - `backport-skip` to not backport (for example, for serverless docs)
    - `backport-main` to "backport" to `main` if the target branch is _not_ `main`
    - Individual `backport-*` labels to target specific minor versions
2. Surface blocking reviews (`needs-*-review`):
    - `needs-writer-review` for codeowners
    - `needs-dev-review` for dev team
    - `needs-product-review` for PM review
-->

- [ ] Product/Engineering Review
- [ ] Writer Review

### Follow-up tasks
<!-- If you are updating the Integrations Developer Guide, you can delete this section -->

_Select one._

* This PR does _not_ need to be ported to another doc set because:
  - [ ] The concepts in this PR only apply to one doc set (serverless _or_ stateful)
  - [x] The PR contains edits to both doc sets (serverless _and_ stateful)
* This PR needs to be ported to another doc set:
  - [ ] Port to stateful docs: \<link to PR or tracking issue>
  - [ ] Port to serverless docs: \<link to PR or tracking issue>
