### PR TITLE
apm shared-docker: add note for wolfi image

### DIFF
--- a/docs/en/observability/apm/shared-docker.asciidoc
+++ b/docs/en/observability/apm/shared-docker.asciidoc
@@ -37,7 +37,7 @@ ifeval::["{release-state}"!="unreleased"]
 docker pull docker.elastic.co/apm/apm-server:{version}
 ------------------------------------------------
 +
-Alternately, you can use the hardened https://wolfi.dev/[Wolfi] image. Using Wolfi images requires Docker version 20.10.10 or higher.
+Alternately, you can use the hardened https://wolfi.dev/[Wolfi] image.
 +
 ["source", "sh", subs="attributes"]
 ------------------------------------------------

--- a/docs/en/observability/apm/shared-docker.asciidoc
+++ b/docs/en/observability/apm/shared-docker.asciidoc
@@ -36,6 +36,13 @@ ifeval::["{release-state}"!="unreleased"]
 ------------------------------------------------
 docker pull docker.elastic.co/apm/apm-server:{version}
 ------------------------------------------------
++
+Alternately, you can use the hardened https://wolfi.dev/[Wolfi] image. Using Wolfi images requires Docker version 20.10.10 or higher.
++
+["source", "sh", subs="attributes"]
+------------------------------------------------
+docker pull docker.elastic.co/apm/apm-server-wolfi:{version}
+------------------------------------------------
 
 . Verify the Docker image:
 +


### PR DESCRIPTION
## Description
<!-- Add a description here -->

Add a note for alternative wolfi images for APM Server.

### Documentation sets edited in this PR

_Check all that apply._

- [ ] Stateful (`docs/en/observability/*`)
- [ ] Serverless (`docs/en/serverless/*`)
- [ ] Integrations Developer Guide (`docs/en/integrations/*`)
- [x] None of the above

### Related issue
Closes # <!-- Add the issue this PR closes here -->

## Checklist

<!--
Add labels to:
1. Backport to other versions (`backport-*`):
    - `backport-8.x` to backport to the latest minor
    - `backport-skip` to not backport (for example, for serverless docs)
    - `backport-main` to "backport" to `main` if the target branch is _not_ `main`
    - Individual `backport-*` labels to target specific minor versions
2. Surface blocking reviews (`needs-*-review`):
    - `needs-writer-review` for codeowners
    - `needs-dev-review` for dev team
    - `needs-product-review` for PM review
-->

- [ ] Product/Engineering Review
- [ ] Writer Review

### Follow-up tasks
<!-- If you are updating the Integrations Developer Guide, you can delete this section -->

_Select one._

* This PR does _not_ need to be ported to another doc set because:
  - [ ] The concepts in this PR only apply to one doc set (serverless _or_ stateful)
  - [x] The PR contains edits to both doc sets (serverless _and_ stateful)
* This PR needs to be ported to another doc set:
  - [ ] Port to stateful docs: \<link to PR or tracking issue>
  - [ ] Port to serverless docs: \<link to PR or tracking issue>
