### PR TITLE
[apm] Clarify requirements in the Fleet-managed APM Server guide

### DIFF
--- a/docs/en/observability/apm/getting-started-apm/get-started-with-fleet-apm-server.asciidoc
+++ b/docs/en/observability/apm/getting-started-apm/get-started-with-fleet-apm-server.asciidoc
@@ -15,8 +15,15 @@ include::{ingest-docs-root}/docs/en/ingest-management/tab-widgets/prereq.asciido
 == Step 1: Set up Fleet
 
 Use {fleet} in {kib} to get APM data into the {stack}.
-The first time you use {fleet}, you'll need to set it up and add a
-{fleet-server}:
+
+[NOTE]
+====
+If you already have a {fleet-server} set up, you can choose to skip this step.
+====
+
+The first time you use {fleet}, you'll need to set it up and add a {fleet-server} using the
+steps outlined below.
+
 
 include::{ingest-docs-root}/docs/en/ingest-management/tab-widgets/add-fleet-server/content.asciidoc[tag=self-managed]
 
@@ -25,6 +32,13 @@ For more information, refer to {fleet-guide}/fleet-server.html[{fleet-server}].
 [float]
 [[add-apm-integration]]
 == Step 2: Add and configure the APM integration
+
+[NOTE]
+====
+If you don't have a {fleet} setup already in place, the easiest way to get started
+is to run the APM integration in the same {agent} that acts as the {fleet-server}.
+However, it is _not mandatory_ for the APM integration to run in the same {agent} that acts as the {fleet-server}.
+====
 
 include::{observability-docs-root}/docs/en/observability/tab-widgets/add-apm-integration/content.asciidoc[tag=self-managed]
 


### PR DESCRIPTION
## Description

Updates the  Fleet-managed APM Server guide to address feedback from @eedugon including:

* Let users know that they don't _have_ to set up a Fleet Server if they already have one set up.
* Let users know that that the APM integration doesn't _have_ to run in the same agent that acts as the Fleet Server, but that is the easiest way to get started.

There are some points that @eedugon brought up in https://github.com/elastic/observability-docs/issues/4668 that are not addressed here including:

* _Shouldn't we rely and refer to the Fleet documentation for the Fleet Setup (if it's not already done)?_
  The content for both the [Prerequisites](https://www.elastic.co/guide/en/observability/current/get-started-with-fleet-apm-server.html#_prerequisites_5) and [Step 1: Set up Fleet](https://www.elastic.co/guide/en/observability/current/get-started-with-fleet-apm-server.html#_step_1_set_up_fleet) sections come from the Fleet docs ([here](https://github.com/elastic/observability-docs/blob/8.17/docs/en/observability/apm/getting-started-apm/get-started-with-fleet-apm-server.asciidoc?plain=1#L12) and [here](https://github.com/elastic/observability-docs/blob/8.17/docs/en/observability/apm/getting-started-apm/get-started-with-fleet-apm-server.asciidoc?plain=1#L21)). We could link out to the Fleet guide instead of importing this content into this APM doc, but in my opinion we should only do that if it's the best user experience, not because of maintenance concerns. However, it would probably be a good idea to review the content in the [elastic/ingest-docs](https://github.com/elastic/ingest-docs) repo to make sure it's up to date and as clear as possible.
* _Regarding the diagram on the [getting started overview page](https://www.elastic.co/guide/en/observability/8.17/apm-getting-started-apm-server.html#apm-setup-fleet-managed-apm)_: I don't think we should over complicate this diagram. The goal of this diagram is to help a new user get a high-level understanding of how the pieces relate to each other. If we're adding clarification in the step-by-step guide, I think it's ok if this diagram shows the simplest implementation.

@eedugon @bmorelli25 thoughts on this approach?

### Documentation sets edited in this PR

_Check all that apply._

- [x] Stateful (`docs/en/observability/*`)
- [ ] Serverless (`docs/en/serverless/*`)
- [ ] Integrations Developer Guide (`docs/en/integrations/*`)
- [ ] None of the above

### Related issue

Closes #4668

## Checklist

<!--
Add labels to:
1. Backport to other versions (`backport-*`):
    - `backport-8.x` to backport to the latest minor
    - `backport-skip` to not backport (for example, for serverless docs)
    - `backport-main` to "backport" to `main` if the target branch is _not_ `main`
    - Individual `backport-*` labels to target specific minor versions
2. Surface blocking reviews (`needs-*-review`):
    - `needs-writer-review` for codeowners
    - `needs-dev-review` for dev team
    - `needs-product-review` for PM review
-->

- [ ] Product/Engineering Review
- [ ] Writer Review

### Follow-up tasks
<!-- If you are updating the Integrations Developer Guide, you can delete this section -->

_Select one._

* This PR does _not_ need to be ported to another doc set because:
  - [x] The concepts in this PR only apply to one doc set (serverless _or_ stateful)
  - [ ] The PR contains edits to both doc sets (serverless _and_ stateful)
* This PR needs to be ported to another doc set:
  - [ ] Port to stateful docs: \<link to PR or tracking issue>
  - [ ] Port to serverless docs: \<link to PR or tracking issue>
