### PR TITLE
[apm] Clarify doc on configuring APM agent central configuration

### DIFF
--- a/docs/en/observability/apm/configure/agent-config.asciidoc
+++ b/docs/en/observability/apm/configure/agent-config.asciidoc
@@ -1,22 +1,29 @@
 [[apm-configure-agent-config]]
-= Configure APM agent configuration
+= Configure APM agent central configuration
 
 ++++
-<titleabbrev>APM agent configuration</titleabbrev>
+<titleabbrev>APM agent central configuration</titleabbrev>
 ++++
 
 ****
 image:./binary-yes-fm-yes.svg[supported deployment methods]
 
-APM agent configuration is supported by all APM Server deployment methods.
+APM agent central configuration is supported by all APM Server deployment methods,
+but some options are only supported for APM Server binary users.
 ****
 
-APM agent configuration allows you to fine-tune your APM agents from within the Applications UI.
+APM agent central configuration allows you to fine-tune your APM agents from within the Applications UI.
 Changes are automatically propagated to your APM agents, so there's no need to redeploy your applications.
 
-To learn more about this feature, see <<apm-agent-configuration,APM agent configuration>>.
+To learn more about this feature, see <<apm-agent-configuration,APM agent central configuration>>.
 
-Here's a sample configuration:
+[float]
+== APM agent configuration options
+
+*The following options are only supported for APM Server binary users*.
+
+You can specify APM agent configuration options in the `apm-server.agent.config` section of the
+`apm-server.yml` config file. Here's a sample configuration:
 
 [source,yaml]
 ----
@@ -25,17 +32,10 @@ apm-server.agent.config.elasticsearch.api_key: TiNAGG4BaaMdaH1tRfuU:KnR6yE41RrSo
 ----
 
 [float]
-== APM agent configuration options
-
-The following options are only supported for APM Server binary users.
-You can specify these options in the `apm-server.agent.config` section of the
-+apm-server.yml+ config file:
-
-[float]
 [[apm-agent-config-cache]]
 === `apm-server.agent.config.cache.expiration`
 
-When using APM agent configuration, information fetched from {es} will be cached in memory for some time.
+When using APM agent central configuration, information fetched from {es} will be cached in memory for some time.
 Specify the cache expiration time via this setting. Defaults to `30s` (30 seconds).
 
 [float]
@@ -45,14 +45,15 @@ Specify the cache expiration time via this setting. Defaults to `30s` (30 second
 Takes the same options as <<apm-elasticsearch-output,output.elasticsearch>>.
 
 For APM Server binary users and Elastic Agent standalone-managed APM Server,
-APM agent configuration is automatically fetched from {es} using the `output.elasticsearch`
+APM agent central configuration is automatically fetched from {es} using the `output.elasticsearch`
 configuration. If `output.elasticsearch` isn't set or doesn't have sufficient privileges,
 use these {es} options to provide {es} access.
 
 [float]
 === Common problems
 
-You may see either of the following HTTP 403 errors from APM Server when it attempts to fetch APM agent configuration:
+You may see either of the following HTTP 403 errors from APM Server when it attempts to fetch
+the APM agent central configuration:
 
 APM agent log:
 
@@ -71,4 +72,5 @@ rejecting fetch request: no valid elasticsearch config
 This occurs because the user or API key set in either `apm-server.agent.config.elasticsearch` or `output.elasticsearch`
 (if `apm-server.agent.config.elasticsearch` is not set) does not have adequate permissions to read source maps from {es}.
 
-To fix this error, ensure that APM Server has all the required privileges. See <<apm-privileges-agent-central-config-server>> for more details.
+To fix this error, ensure that APM Server has all the required privileges. For more details, refer to
+<<apm-privileges-agent-central-config-server,Create a _central configuration management_ role>>.


### PR DESCRIPTION
## Description

In https://github.com/elastic/observability-docs/issues/4724, @eedugon brought up a couple points of confusion in [Configure APM agent configuration](https://www.elastic.co/guide/en/observability/current/apm-configure-agent-config.html):

* It's not clear that while some configuration options listed on this page are only supported for APM Server binary users, APM agent configuration as a feature is supported by all APM Server deployment methods.
  * I updated the note at the beginning make this clearer.
* The title and first paragraph are confusing.
  * I talked through this with @bmorelli25 today. Both [APM agent central configuration](https://www.elastic.co/guide/en/observability/current/apm-agent-configuration.html)  and [Configure APM agent configuration](https://www.elastic.co/guide/en/observability/current/apm-configure-agent-config.html) are about centrally configuring APM agents (i.e. "APM agent central configuration"). The former is about the feature in general, while the latter is about how to configure APM agent central configuration in your APM Server configuration. 😵‍💫 

### Documentation sets edited in this PR

_Check all that apply._

- [x] Stateful (`docs/en/observability/*`)
- [ ] Serverless (`docs/en/serverless/*`)
- [ ] Integrations Developer Guide (`docs/en/integrations/*`)
- [ ] None of the above

### Related issue

Closes #4724

## Checklist

<!--
Add labels to:
1. Backport to other versions (`backport-*`):
    - `backport-8.x` to backport to the latest minor
    - `backport-skip` to not backport (for example, for serverless docs)
    - `backport-main` to "backport" to `main` if the target branch is _not_ `main`
    - Individual `backport-*` labels to target specific minor versions
2. Surface blocking reviews (`needs-*-review`):
    - `needs-writer-review` for codeowners
    - `needs-dev-review` for dev team
    - `needs-product-review` for PM review
-->

- [ ] Product/Engineering Review
- [ ] Writer Review

### Follow-up tasks
<!-- If you are updating the Integrations Developer Guide, you can delete this section -->

_Select one._

* This PR does _not_ need to be ported to another doc set because:
  - [x] The concepts in this PR only apply to one doc set (serverless _or_ stateful)
  - [ ] The PR contains edits to both doc sets (serverless _and_ stateful)
* This PR needs to be ported to another doc set:
  - [ ] Port to stateful docs: \<link to PR or tracking issue>
  - [ ] Port to serverless docs: \<link to PR or tracking issue>
