### PR TITLE
Remove list of supported generative AI providers

### DIFF
--- a/docs/en/observability/observability-ai-assistant.asciidoc
+++ b/docs/en/observability/observability-ai-assistant.asciidoc
@@ -37,10 +37,6 @@ Also, the data you provide to the Observability AI assistant is _not_ anonymized
 The AI assistant requires the following:
 
 * {stack} version 8.9 and later.
-* An account with a third-party generative AI provider that supports function calling. The Observability AI Assistant supports the following providers:
-** OpenAI `gpt-4`+.
-** Azure OpenAI Service `gpt-4`(0613) or `gpt-4-32k`(0613) with API version `2023-07-01-preview` or more recent.
-** AWS Bedrock, specifically the Anthropic Claude models.
 * An {enterprise-search-ref}/server.html[Enterprise Search] server if Elastic managed {ref}/es-native-connectors.html[search connectors] are used to populate external data into the knowledge base.
 * An account with a third-party generative AI provider that preferably supports function calling.
 If your AI provider does not support function calling, you can configure AI Assistant settings under **Stack Management** to simulate function calling, but this might affect performance.


### PR DESCRIPTION
### Summary

The connector docs are to be the source of truth for supported Generative AI providers. https://github.com/elastic/observability-docs/pull/4143 intended to remove a supported providers list from the documentation. Unfortunately, during the cherrypick process (https://github.com/elastic/observability-docs/pull/4407), conflicts prevented this deletion from making it to main. This PR syncs our AI assistant docs with the changes proposed, discussed, and merged in https://github.com/elastic/observability-docs/pull/4143.

A more recent and related comment supporting this decision is in https://github.com/elastic/observability-docs/issues/4410#issuecomment-2489615754. 

* Closes https://github.com/elastic/observability-docs/issues/4410
* Closes https://github.com/elastic/observability-docs/issues/4610