### PR TITLE
Clarify that tail-based sampling is only available for ES output

### DIFF
--- a/docs/en/observability/apm/configure/sampling.asciidoc
+++ b/docs/en/observability/apm/configure/sampling.asciidoc
@@ -4,7 +4,8 @@
 ****
 image:./binary-yes-fm-yes.svg[supported deployment methods]
 
-Most options on this page are supported by all APM Server deployment methods.
+Most options on this page are supported by all APM Server deployment methods when writing to {es}.
+If you are using a different <<apm-configuring-output,output>>, tail-based sampling is _not_ supported.
 ****
 
 Tail-based sampling configuration options.

--- a/docs/en/observability/apm/data-model/transactions/sampling.asciidoc
+++ b/docs/en/observability/apm/data-model/transactions/sampling.asciidoc
@@ -115,6 +115,12 @@ Refer to the documentation of your favorite OpenTelemetry agent or SDK for more 
 [[apm-tail-based-sampling]]
 == Tail-based sampling
 
+[NOTE]
+====
+Tail-based sampling is only supported when writing to {es}.
+If you are using a different <<apm-configuring-output,output>>, tail-based sampling is _not_ supported.
+====
+
 In tail-based sampling, the sampling decision for each trace is made after the trace has completed.
 This means all traces will be analyzed against a set of rules, or policies, which will determine the rate at which they are sampled.
 


### PR DESCRIPTION
## Description

Clarifies that tail-based sampling is only supported when writing to Elasticsearch.

### Documentation sets edited in this PR

_Check all that apply._

- [x] Stateful (`docs/en/observability/*`)
- [ ] Serverless (`docs/en/serverless/*`)
- [ ] Integrations Developer Guide (`docs/en/integrations/*`)
- [ ] None of the above

### Related issue

Closes #4724 

## Checklist

<!--
Add labels to:
1. Backport to other versions (`backport-*`):
    - `backport-8.x` to backport to the latest minor
    - `backport-skip` to not backport (for example, for serverless docs)
    - `backport-main` to "backport" to `main` if the target branch is _not_ `main`
    - Individual `backport-*` labels to target specific minor versions
2. Surface blocking reviews (`needs-*-review`):
    - `needs-writer-review` for codeowners
    - `needs-dev-review` for dev team
    - `needs-product-review` for PM review
-->

- [ ] Product/Engineering Review
- [ ] Writer Review

### Follow-up tasks
<!-- If you are updating the Integrations Developer Guide, you can delete this section -->

_Select one._

* This PR does _not_ need to be ported to another doc set because:
  - [x] The concepts in this PR only apply to one doc set (serverless _or_ stateful)
  - [ ] The PR contains edits to both doc sets (serverless _and_ stateful)
* This PR needs to be ported to another doc set:
  - [ ] Port to stateful docs: \<link to PR or tracking issue>
  - [ ] Port to serverless docs: \<link to PR or tracking issue>
