### PR TITLE
[apm] Improve instructions for monitoring APM on premise

### DIFF
--- a/docs/en/observability/apm/monitor-apm-server/monitor.asciidoc
+++ b/docs/en/observability/apm/monitor-apm-server/monitor.asciidoc
@@ -29,9 +29,8 @@ Alternatively, open the **{stack-monitor-app}** app in {kib} and follow the in-p
 *Only use this option if you have _not_ yet enrolled {agent}.*
 If you edit and re-enroll {agent}, you will likely lose the state of the agent.
 
-If you have already enrolled the {agent}, consider using the Fleet UI to change the
-HTTP monitoring port of the agent using the processed outlined in
-{fleet-guide}/agent-policy.html#agent-policy-http-monitoring[Override the default monitoring port].
+If you have already enrolled the {agent}, consider using the Fleet UI to change the agent's HTTP monitoring endpoint
+using {fleet-guide}/agent-policy.html#advanced-agent-monitoring-settings[Advanced agent monitoring settings].
 ====
 
 . Enable monitoring of {agent} by adding the following settings to your `elastic-agent.yml` configuration file:

--- a/docs/en/observability/apm/monitor-apm-server/monitor.asciidoc
+++ b/docs/en/observability/apm/monitor-apm-server/monitor.asciidoc
@@ -24,6 +24,16 @@ To learn how, see {ref}/configuring-metricbeat.html[Collect {es} monitoring data
 Alternatively, open the **{stack-monitor-app}** app in {kib} and follow the in-product guide.
 ****
 
+[WARNING]
+====
+*Only use this option if you have _not_ yet enrolled {agent}.*
+If you edit and re-enroll {agent}, you will likely lose the state of the agent.
+
+If you have already enrolled the {agent}, consider using the Fleet UI to change the
+HTTP monitoring port of the agent using the processed outlined in
+{fleet-guide}/agent-policy.html#agent-policy-http-monitoring[Override the default monitoring port].
+====
+
 . Enable monitoring of {agent} by adding the following settings to your `elastic-agent.yml` configuration file:
 +
 --
@@ -86,8 +96,6 @@ When complete, your `modules.d/beat-xpack.yml` file should look similar to this:
   period: 10s
   hosts: ["http://localhost:6791"]
   basepath: "/processes/apm-server-default"
-  username: remote_monitoring_user
-  password: your_password
 ----
 
 .. Do not change the  `module` name or `xpack.enabled` boolean;
@@ -107,18 +115,6 @@ If you configured {agent} to use encrypted communications, you must access
 it via HTTPS. For example, use a `hosts` setting like `https://localhost:5066`.
 
 .. APM Server metrics are exposed at `/processes/apm-server-default`. Add this location as the `basepath`.
-
-.. Set the `username` and `password` settings as required by your
-environment. If Elastic {security-features} are enabled, you must provide a username
-and password so that {metricbeat} can collect metrics successfully:
-
-... Create a user on the {es} cluster that has the
-`remote_monitoring_collector` {ref}/built-in-roles.html[built-in role].
-Alternatively, if it's available in your environment, use the
-`remote_monitoring_user` {ref}/built-in-users.html[built-in user].
-
-... Add the `username` and `password` settings to the beat module configuration
-file.
 --
 
 . Optional: Disable the system module in the {metricbeat}.


### PR DESCRIPTION
## Description

@lucabelluccini shared a few ways we could improve the instructions for monitoring APM on premise:

- [x] Warn users that if they have already enrolled Elastic Agent, following these instructions will likely cause them to lose the state of the agent.
- [x] Suggest that users who have already enrolled Elastic Agent, use Fleet UI to change the agent's HTTP monitoring endpoint.
- [x] Remove `username` and `password` from the sample `modules.d/beat-xpack.yml`.

### Documentation sets edited in this PR

_Check all that apply._

- [x] Stateful (`docs/en/observability/*`)
- [ ] Serverless (`docs/en/serverless/*`)
- [ ] Integrations Developer Guide (`docs/en/integrations/*`)
- [ ] None of the above

### Related issue

Closes elastic/docs-content#1859

## Checklist

<!--
Add labels to:
1. Backport to other versions (`backport-*`):
    - `backport-8.x` to backport to the latest minor
    - `backport-skip` to not backport (for example, for serverless docs)
    - `backport-main` to "backport" to `main` if the target branch is _not_ `main`
    - Individual `backport-*` labels to target specific minor versions
2. Surface blocking reviews (`needs-*-review`):
    - `needs-writer-review` for codeowners
    - `needs-dev-review` for dev team
    - `needs-product-review` for PM review
-->

- [ ] Product/Engineering Review
- [ ] Writer Review

### Follow-up tasks
<!-- If you are updating the Integrations Developer Guide, you can delete this section -->

_Select one._

* This PR does _not_ need to be ported to another doc set because:
  - [x] The concepts in this PR only apply to one doc set (serverless _or_ stateful)
  - [ ] The PR contains edits to both doc sets (serverless _and_ stateful)
* This PR needs to be ported to another doc set:
  - [ ] Port to stateful docs: \<link to PR or tracking issue>
  - [ ] Port to serverless docs: \<link to PR or tracking issue>
