### PR TITLE
Obs AI Assistant supports other models than ELSER when field type semantic_text is used

### DIFF
--- a/docs/en/observability/observability-ai-assistant.asciidoc
+++ b/docs/en/observability/observability-ai-assistant.asciidoc
@@ -173,7 +173,10 @@ For example, if you create a {ref}/es-connectors-github.html[GitHub connector] y
 +
 Learn more about configuring and {ref}/es-connectors-usage.html[using connectors] in the Elasticsearch documentation.
 
-After creating your connector, create the embeddings needed by the AI Assistant. You can do this using either <<obs-ai-search-connectors-ml-embeddings, a machine learning (ML) pipeline>>, which requires the ELSER model, or <<obs-ai-search-connectors-semantic-text, a `semantic_text` field type>>, which can use any available model (ELSER, E5, or a custom model).
+After creating your connector, create the embeddings needed by the AI Assistant. You can do this using either:
+
+* <<obs-ai-search-connectors-ml-embeddings, a machine learning (ML) pipeline>>: requires the ELSER ML model.
+* <<obs-ai-search-connectors-semantic-text, a `semantic_text` field type>>: can use any available ML model (ELSER, E5, or a custom model).
 
 [discrete]
 [[obs-ai-search-connectors-ml-embeddings]]
@@ -182,9 +185,9 @@ After creating your connector, create the embeddings needed by the AI Assistant.
 To create the embeddings needed by the AI Assistant (weights and tokens into a sparse vector field) using an *ML Inference Pipeline*:
 
 . Open the previously created connector, and select the *Pipelines* tab.
-. Select *Copy and customize* button at the `Unlock your custom pipelines` box.
-. Select *Add Inference Pipeline* button at the `Machine Learning Inference Pipelines` box.
-. Select *ELSER (Elastic Learned Sparse EncodeR)* ML model to add the necessary embeddings to the data.
+. Select *Copy and customize* under `Unlock your custom pipelines`.
+. Select *Add Inference Pipeline* under `Machine Learning Inference Pipelines`.
+. Select the *ELSER (Elastic Learned Sparse EncodeR)* ML model to add the necessary embeddings to the data.
 . Select the fields that need to be evaluated as part of the inference pipeline.
 . Test and save the inference pipeline and the overall pipeline.
 
@@ -194,8 +197,8 @@ After creating the pipeline, complete the following steps:
 +
 Once the pipeline is set up, perform a *Full Content Sync* of the connector. The inference pipeline will process the data as follows:
 +
-* As data comes in, ELSER is applied to the data, and embeddings (weights and tokens into a sparse vector field) are added to capture semantic meaning and context of the data.
-* When you look at the documents that are ingested, you can see how the weights and token are added to the `predicted_value` field in the documents.
+* As data comes in, ELSER is applied to the data, and embeddings (weights and tokens into a {ref}/query-dsl-sparse-vector-query.html[sparse vector field]) are added to capture semantic meaning and context of the data.
+* When you look at the ingested documents, you can see the embeddings are added to the `predicted_value` field in the documents.
 . Check if AI Assistant can use the index (optional).
 +
 Ask something to the AI Assistant related with the indexed data.
@@ -214,7 +217,8 @@ To create the embeddings needed by the AI Assistant using a {ref}/semantic-text.
 . Add the field to your mapping by selecting *Add field*.
 . Sync the data by selecting *Full Content* from the *Sync* menu.
 
-The AI Assistant will now query the connector you've set up using the model you've selected. Check if the AI Assistant is using the index by asking it something related to the indexed data.
+The AI Assistant will now query the connector you've set up using the model you've selected.
+Check that the AI Assistant is using the index by asking it something related to the indexed data.
 
 [discrete]
 [[obs-ai-interact]]

--- a/docs/en/observability/observability-ai-assistant.asciidoc
+++ b/docs/en/observability/observability-ai-assistant.asciidoc
@@ -212,6 +212,9 @@ To create the embeddings needed by the AI Assistant using a {ref}/semantic-text.
 . Under *Reference field*, select the field you want to use for model inference.
 . Under *Select an inference endpoint*, select the model you want to use to add the embeddings to the data.
 . Add the field to your mapping by selecting *Add field*.
+. Sync the data by selecting *Full Content* from the *Sync* menu.
+
+The AI Assistant will now query the connector you've set up using the model you've selected. Check if the AI Assistant is using the index by asking it something related to the indexed data.
 
 [discrete]
 [[obs-ai-interact]]

--- a/docs/en/observability/observability-ai-assistant.asciidoc
+++ b/docs/en/observability/observability-ai-assistant.asciidoc
@@ -173,25 +173,27 @@ For example, if you create a {ref}/es-connectors-github.html[GitHub connector] y
 +
 Learn more about configuring and {ref}/es-connectors-usage.html[using connectors] in the Elasticsearch documentation.
 +
-. Create a pipeline and process the data with a machine learning model.
+. Create a pipeline and process the data with a machine learning model. When querying search connectors using `semantic_text`, you can use any model such as E5. For search connectors not using `semantic_text`, use ELSER.
 +
 To create the embeddings needed by the AI Assistant (weights and tokens into a sparse vector field), you have to create an *ML Inference Pipeline*:
 +
 .. Open the previously created connector and select the *Pipelines* tab.
 .. Select *Copy and customize* button at the `Unlock your custom pipelines` box.
 .. Select *Add Inference Pipeline* button at the `Machine Learning Inference Pipelines` box.
-.. Select your preferred machine learning model (ELSER, E5).
+.. Select your preferred machine learning model such as ELSER or E5.
 .. Select the fields that need to be evaluated as part of the inference pipeline.
 .. Test and save the inference pipeline and the overall pipeline.
 . Sync the data.
 +
 Once the pipeline is set up, perform a *Full Content Sync* of the connector. The inference pipeline will process the data as follows:
 +
-* As data comes in, the machine learning model (ELSER, E5) is applied to the data, and embeddings (weights and tokens into a sparse vector field) are added to capture semantic meaning and context of the data.
+* As data comes in, the machine learning model is applied to the data, and embeddings (weights and tokens into a sparse vector field) are added to capture semantic meaning and context of the data.
 * When you look at the documents that are ingested, you can see how the weights and token are added to the `predicted_value` field in the documents.
 . Check if AI Assistant can use the index (optional).
 +
 Ask something to the AI Assistant related with the indexed data.
+
+Add
 
 [discrete]
 [[obs-ai-interact]]

--- a/docs/en/observability/observability-ai-assistant.asciidoc
+++ b/docs/en/observability/observability-ai-assistant.asciidoc
@@ -172,28 +172,46 @@ If your {kib} Space doesn't include the Search solution you will have to create 
 For example, if you create a {ref}/es-connectors-github.html[GitHub connector] you have to set a `name`, attach it to a new or existing `index`, add your `personal access token` and include the `list of repositories` to synchronize.
 +
 Learn more about configuring and {ref}/es-connectors-usage.html[using connectors] in the Elasticsearch documentation.
-+
-. Create a pipeline and process the data with a machine learning model. When querying search connectors using `semantic_text`, you can use any model such as E5. For search connectors not using `semantic_text`, use ELSER.
-+
-To create the embeddings needed by the AI Assistant (weights and tokens into a sparse vector field), you have to create an *ML Inference Pipeline*:
-+
-.. Open the previously created connector and select the *Pipelines* tab.
-.. Select *Copy and customize* button at the `Unlock your custom pipelines` box.
-.. Select *Add Inference Pipeline* button at the `Machine Learning Inference Pipelines` box.
-.. Select your preferred machine learning model such as ELSER or E5.
-.. Select the fields that need to be evaluated as part of the inference pipeline.
-.. Test and save the inference pipeline and the overall pipeline.
+
+After creating your connector, create the embeddings needed by the AI Assistant. You can do this using either <<obs-ai-search-connectors-ml-embeddings, a machine learning (ML) pipeline>>, which requires the ELSER model, or <<obs-ai-search-connectors-semantic-text, a `semantic_text` field type>>, which can use any available model (ELSER, E5, or a custom model).
+
+[discrete]
+[[obs-ai-search-connectors-ml-embeddings]]
+==== Use machine learning pipelines to create AI Assistant embeddings
+
+To create the embeddings needed by the AI Assistant (weights and tokens into a sparse vector field) using an *ML Inference Pipeline*:
+
+. Open the previously created connector, and select the *Pipelines* tab.
+. Select *Copy and customize* button at the `Unlock your custom pipelines` box.
+. Select *Add Inference Pipeline* button at the `Machine Learning Inference Pipelines` box.
+. Select *ELSER (Elastic Learned Sparse EncodeR)* ML model to add the necessary embeddings to the data.
+. Select the fields that need to be evaluated as part of the inference pipeline.
+. Test and save the inference pipeline and the overall pipeline.
+
+After creating the pipeline, complete the following steps:
+
 . Sync the data.
 +
 Once the pipeline is set up, perform a *Full Content Sync* of the connector. The inference pipeline will process the data as follows:
 +
-* As data comes in, the machine learning model is applied to the data, and embeddings (weights and tokens into a sparse vector field) are added to capture semantic meaning and context of the data.
+* As data comes in, ELSER is applied to the data, and embeddings (weights and tokens into a sparse vector field) are added to capture semantic meaning and context of the data.
 * When you look at the documents that are ingested, you can see how the weights and token are added to the `predicted_value` field in the documents.
 . Check if AI Assistant can use the index (optional).
 +
 Ask something to the AI Assistant related with the indexed data.
 
-Add
+[discrete]
+[[obs-ai-search-connectors-semantic-text]]
+==== Use a `semantic_text` field type to create AI Assistant embeddings
+
+To create the embeddings needed by the AI Assistant using a {ref}/semantic-text.html[`semantic_text`] field type:
+
+. Open the previously created connector, and select the *Mappings* tab.
+. Select *Add field*.
+. Under *Field type*, select *Semantic text*.
+. Under *Reference field*, select the field you want to use for model inference.
+. Under *Select an inference endpoint*, select the model you want to use to add the embeddings to the data.
+. Add the field to your mapping by selecting *Add field*.
 
 [discrete]
 [[obs-ai-interact]]

--- a/docs/en/observability/observability-ai-assistant.asciidoc
+++ b/docs/en/observability/observability-ai-assistant.asciidoc
@@ -152,7 +152,7 @@ Search connectors are only needed when importing external data into the Knowledg
 
 {ref}/es-connectors.html[Connectors] allow you to index content from external sources thereby making it available for the AI Assistant. This can greatly improve the relevance of the AI Assistant’s responses. Data can be integrated from sources such as GitHub, Confluence, Google Drive, Jira, AWS S3, Microsoft Teams, Slack, and more.
 
-UI affordances for creating and managing search connectors are available in the Search Solution in {kib}. 
+UI affordances for creating and managing search connectors are available in the Search Solution in {kib}.
 You can also use the {es} {ref}/connector-apis.html[Connector APIs] to create and manage search connectors.
 
 The infrastructure for deploying connectors can be managed by Elastic or self-managed. Managed connectors require an {enterprise-search-ref}/server.html[Enterprise Search] server connected to the Elastic Stack. Self-managed connectors are run on your own infrastructure and don't require the Enterprise Search service.
@@ -173,21 +173,21 @@ For example, if you create a {ref}/es-connectors-github.html[GitHub connector] y
 +
 Learn more about configuring and {ref}/es-connectors-usage.html[using connectors] in the Elasticsearch documentation.
 +
-. Create a pipeline and process the data with ELSER.
+. Create a pipeline and process the data with a machine learning model.
 +
 To create the embeddings needed by the AI Assistant (weights and tokens into a sparse vector field), you have to create an *ML Inference Pipeline*:
 +
 .. Open the previously created connector and select the *Pipelines* tab.
 .. Select *Copy and customize* button at the `Unlock your custom pipelines` box.
 .. Select *Add Inference Pipeline* button at the `Machine Learning Inference Pipelines` box.
-.. Select *ELSER (Elastic Learned Sparse EncodeR)* ML model to add the necessary embeddings to the data.
+.. Select your preferred machine learning model (ELSER, E5).
 .. Select the fields that need to be evaluated as part of the inference pipeline.
 .. Test and save the inference pipeline and the overall pipeline.
 . Sync the data.
 +
 Once the pipeline is set up, perform a *Full Content Sync* of the connector. The inference pipeline will process the data as follows:
 +
-* As data comes in, ELSER is applied to the data, and embeddings (weights and tokens into a sparse vector field) are added to capture semantic meaning and context of the data.
+* As data comes in, the machine learning model (ELSER, E5) is applied to the data, and embeddings (weights and tokens into a sparse vector field) are added to capture semantic meaning and context of the data.
 * When you look at the documents that are ingested, you can see how the weights and token are added to the `predicted_value` field in the documents.
 . Check if AI Assistant can use the index (optional).
 +


### PR DESCRIPTION
## Description
The Obs AI Assistant supports other models than ELSER when field type semantic_text is used and the docs need to be updated to show this.

### Documentation sets edited in this PR

_Check all that apply._

- [x] Stateful (`docs/en/observability/*`)
- [ ] Serverless (`docs/en/serverless/*`)
- [ ] Integrations Developer Guide (`docs/en/integrations/*`)
- [ ] None of the above

### Related issue
Closes #4608 

## Checklist

<!--
Add labels to:
1. Backport to other versions (`backport-*`):
    - `backport-8.x` to backport to the latest minor
    - `backport-skip` to not backport (for example, for serverless docs)
    - `backport-main` to "backport" to `main` if the target branch is _not_ `main`
    - Individual `backport-*` labels to target specific minor versions
2. Surface blocking reviews (`needs-*-review`):
    - `needs-writer-review` for codeowners
    - `needs-dev-review` for dev team
    - `needs-product-review` for PM review
-->

- [ ] Product/Engineering Review
- [ ] Writer Review

### Follow-up tasks
<!-- If you are updating the Integrations Developer Guide, you can delete this section -->

_Select one._

* This PR does _not_ need to be ported to another doc set because:
  - [ ] The concepts in this PR only apply to one doc set (serverless _or_ stateful)
  - [ ] The PR contains edits to both doc sets (serverless _and_ stateful)
* This PR needs to be ported to another doc set:
  - [ ] Port to stateful docs: \<link to PR or tracking issue>
  - [x] Port to serverless docs: \<link to PR or tracking issue>
