### PR TITLE
Add deprecation warning to Jaeger API docs

### DIFF
--- a/docs/en/observability/apm/api/apm-server/api-jaeger.asciidoc
+++ b/docs/en/observability/apm/api/apm-server/api-jaeger.asciidoc
@@ -1,6 +1,10 @@
 [[apm-api-jaeger]]
 = Jaeger event intake
 
+[float]
+==== Deprecations
+- Support for Jaeger is now deprecated, and will be removed in a future release {pull}13809[13809]
+
 Elastic APM natively supports Jaeger, an open-source, distributed tracing system.
 <<apm-jaeger-integration,Learn more>>.
 

--- a/docs/en/observability/apm/api/apm-server/api-jaeger.asciidoc
+++ b/docs/en/observability/apm/api/apm-server/api-jaeger.asciidoc
@@ -3,7 +3,7 @@
 
 [WARNING]
 ====
-- Support for Jaeger is now deprecated, and will be removed in a future release https://github.com/elastic/apm-server/issues/11671[#1167]
+- Support for Jaeger is deprecated, and will be removed in a future release https://github.com/elastic/apm-server/issues/11671[#1167]
 ====
 
 Elastic APM natively supports Jaeger, an open-source, distributed tracing system.

--- a/docs/en/observability/apm/api/apm-server/api-jaeger.asciidoc
+++ b/docs/en/observability/apm/api/apm-server/api-jaeger.asciidoc
@@ -3,7 +3,7 @@
 
 [WARNING]
 ====
-- Support for Jaeger is now deprecated, and will be removed in a future release {pull}13809[13809]
+- Support for Jaeger is now deprecated, and will be removed in a future release https://github.com/elastic/apm-server/issues/11671[#1167]
 ====
 
 Elastic APM natively supports Jaeger, an open-source, distributed tracing system.

--- a/docs/en/observability/apm/api/apm-server/api-jaeger.asciidoc
+++ b/docs/en/observability/apm/api/apm-server/api-jaeger.asciidoc
@@ -1,9 +1,10 @@
 [[apm-api-jaeger]]
 = Jaeger event intake
 
-[float]
-==== Deprecations
+[WARNING]
+====
 - Support for Jaeger is now deprecated, and will be removed in a future release {pull}13809[13809]
+====
 
 Elastic APM natively supports Jaeger, an open-source, distributed tracing system.
 <<apm-jaeger-integration,Learn more>>.


### PR DESCRIPTION
## Description
<!-- Add a description here -->

### Documentation sets edited in this PR

_Check all that apply._

- [x] Stateful (`docs/en/observability/*`)
- [ ] Serverless (`docs/en/serverless/*`)
- [ ] Integrations Developer Guide (`docs/en/integrations/*`)
- [ ] None of the above

### Related issue
Closes https://github.com/elastic/apm-server/issues/14767

## Checklist

<!--
Add labels to:
1. Backport to other versions (`backport-*`):
    - `backport-8.x` to backport to the latest minor
    - `backport-skip` to not backport (for example, for serverless docs)
    - `backport-main` to "backport" to `main` if the target branch is _not_ `main`
    - Individual `backport-*` labels to target specific minor versions
2. Surface blocking reviews (`needs-*-review`):
    - `needs-writer-review` for codeowners
    - `needs-dev-review` for dev team
    - `needs-product-review` for PM review
-->

- [x] Product/Engineering Review
- [x] Writer Review

### Follow-up tasks
<!-- If you are updating the Integrations Developer Guide, you can delete this section -->

_Select one._

* This PR does _not_ need to be ported to another doc set because:
  - [ ] The concepts in this PR only apply to one doc set (serverless _or_ stateful)
  - [ ] The PR contains edits to both doc sets (serverless _and_ stateful)
* This PR needs to be ported to another doc set:
  - [ ] Port to stateful docs: \<link to PR or tracking issue>
  - [ ] Port to serverless docs: \<link to PR or tracking issue>
