### PR TITLE
fix: Add changes for upload sourcemaps snippet

### DIFF
--- a/docs/en/observability/apm/collect-application-data/agents/source-map-how-to.asciidoc
+++ b/docs/en/observability/apm/collect-application-data/agents/source-map-how-to.asciidoc
@@ -156,7 +156,7 @@ var formData = {
   service_name: 'service-name’,
   service_version: require("./package.json").version, // Or use 'git-rev-sync' for git commit hash
   bundle_filepath: 'http://localhost/app.min.js',
-  sourcemap: fs.readFileSync(filepath)
+  sourcemap: fs.readFileSync(filepath, { encoding: 'utf-8' })
 }
 request.post({url: 'http://localhost:5601/api/apm/sourcemaps',formData: formData}, function (err, resp, body) {
   if (err) {

--- a/docs/en/observability/apm/collect-application-data/agents/source-map-how-to.asciidoc
+++ b/docs/en/observability/apm/collect-application-data/agents/source-map-how-to.asciidoc
@@ -156,7 +156,7 @@ var formData = {
   service_name: 'service-name’,
   service_version: require("./package.json").version, // Or use 'git-rev-sync' for git commit hash
   bundle_filepath: 'http://localhost/app.min.js',
-  sourcemap: fs.createReadStream(filepath)
+  sourcemap: fs.readFileSync(filepath)
 }
 request.post({url: 'http://localhost:5601/api/apm/sourcemaps',formData: formData}, function (err, resp, body) {
   if (err) {


### PR DESCRIPTION
## Description
<!-- Add a description here -->
The nodejs snippet provided contains an error on how to pass the file content to the request method. This PR fixes that.

### Documentation sets edited in this PR

_Check all that apply._

- [X] Stateful (`docs/en/observability/*`)
- [ ] Serverless (`docs/en/serverless/*`)
- [ ] Integrations Developer Guide (`docs/en/integrations/*`)
- [ ] None of the above

### Related issue
N/A

## Checklist

<!--
Add labels to:
1. Backport to other versions (`backport-*`):
    - `backport-8.x` to backport to the latest minor
    - `backport-skip` to not backport (for example, for serverless docs)
    - `backport-main` to "backport" to `main` if the target branch is _not_ `main`
    - Individual `backport-*` labels to target specific minor versions
2. Surface blocking reviews (`needs-*-review`):
    - `needs-writer-review` for codeowners
    - `needs-dev-review` for dev team
    - `needs-product-review` for PM review
-->

- [ ] Product/Engineering Review
- [ ] Writer Review

### Follow-up tasks
<!-- If you are updating the Integrations Developer Guide, you can delete this section -->

_Select one._

* This PR does _not_ need to be ported to another doc set because:
  - [X] The concepts in this PR only apply to one doc set (serverless _or_ stateful)
  - [ ] The PR contains edits to both doc sets (serverless _and_ stateful)
* This PR needs to be ported to another doc set:
  - [ ] Port to stateful docs: \<link to PR or tracking issue>
  - [ ] Port to serverless docs: \<link to PR or tracking issue>
