### PR TITLE
Add OTel quickstart to Get started page

### DIFF
--- a/docs/en/observability/observability-get-started.asciidoc
+++ b/docs/en/observability/observability-get-started.asciidoc
@@ -54,6 +54,7 @@ Follow the steps in these guides to get started quickly:
 
 * <<quickstart-monitor-hosts-with-elastic-agent>>
 * <<monitor-k8s-logs-metrics-with-elastic-agent>>
+* <<quickstart-monitor-hosts-with-otel>>
 * <<monitor-k8s-otel-edot>>
 * <<collect-data-with-aws-firehose>>
 

--- a/docs/en/serverless/observability-get-started.asciidoc
+++ b/docs/en/serverless/observability-get-started.asciidoc
@@ -57,6 +57,7 @@ Follow the steps in these guides to get started quickly:
 
 * <<observability-quickstarts-monitor-hosts-with-elastic-agent>>
 * <<observability-quickstarts-k8s-logs-metrics>>
+* <<quickstart-monitor-hosts-with-otel>>
 * <<monitor-k8s-otel-edot>>
 * <<collect-data-with-aws-firehose>>
 


### PR DESCRIPTION
## Description
This PR adds a link to the "Monitor hosts with OTel" quickstart to the Get started page.

### Documentation sets edited in this PR

_Check all that apply._

- [x] Stateful (`docs/en/observability/*`)
- [x] Serverless (`docs/en/serverless/*`)
- [ ] Integrations Developer Guide (`docs/en/integrations/*`)
- [ ] None of the above

### Follow-up tasks
<!-- If you are updating the Integrations Developer Guide, you can delete this section -->

_Select one._

* This PR does _not_ need to be ported to another doc set because:
  - [ ] The concepts in this PR only apply to one doc set (serverless _or_ stateful)
  - [x] The PR contains edits to both doc sets (serverless _and_ stateful)
