### PR TITLE
Note features that are not supported in serverless

### DIFF
--- a/docs/en/observability/apm/collect-application-data/agents/agent-configuration.asciidoc
+++ b/docs/en/observability/apm/collect-application-data/agents/agent-configuration.asciidoc
@@ -5,6 +5,11 @@
 <titleabbrev>Centrally configure APM agents in Kibana</titleabbrev>
 ++++
 
+[NOTE]
+====
+APM agent central configuration is _not_ compatible with {serverless-docs}[{serverless-full}].
+====
+
 APM Agent configuration allows you to fine-tune your APM agent configuration from within the Applications UI.
 Changes are automatically propagated to your APM agents, so there's no need to redeploy.
 

--- a/docs/en/observability/apm/data-model/transactions/sampling.asciidoc
+++ b/docs/en/observability/apm/data-model/transactions/sampling.asciidoc
@@ -116,9 +116,12 @@ Refer to the documentation of your favorite OpenTelemetry agent or SDK for more 
 == Tail-based sampling
 
 [NOTE]
+.Support for tail-based sampling
 ====
 Tail-based sampling is only supported when writing to {es}.
 If you are using a different <<apm-configuring-output,output>>, tail-based sampling is _not_ supported.
+
+Tail-based sampling is _not_ compatible with {serverless-docs}[{serverless-full}].
 ====
 
 In tail-based sampling, the sampling decision for each trace is made after the trace has completed.

--- a/docs/en/observability/apm/security/elastic-stack/feature-roles.asciidoc
+++ b/docs/en/observability/apm/security/elastic-stack/feature-roles.asciidoc
@@ -5,6 +5,11 @@
 <titleabbrev>Use feature roles</titleabbrev>
 ++++
 
+[NOTE]
+====
+Kibana custom roles are _not_ compatible with {serverless-docs}[{serverless-full}].
+====
+
 Manage access on a feature-by-feature basis by creating several custom feature-related _roles_ and assigning one or more of these roles to each _user or group_ based on which features they need to access.
 
 [TIP]


### PR DESCRIPTION
## Description

Add notes to features that are not supported in serverless.

### Documentation sets edited in this PR

_Check all that apply._

- [x] Stateful (`docs/en/observability/*`)
- [ ] Serverless (`docs/en/serverless/*`)
- [ ] Integrations Developer Guide (`docs/en/integrations/*`)
- [ ] None of the above

### Related issue

Closes #4764

## Checklist

<!--
Add labels to:
1. Backport to other versions (`backport-*`):
    - `backport-8.x` to backport to the latest minor
    - `backport-skip` to not backport (for example, for serverless docs)
    - `backport-main` to "backport" to `main` if the target branch is _not_ `main`
    - Individual `backport-*` labels to target specific minor versions
2. Surface blocking reviews (`needs-*-review`):
    - `needs-writer-review` for codeowners
    - `needs-dev-review` for dev team
    - `needs-product-review` for PM review
-->

- [ ] Product/Engineering Review
- [ ] Writer Review

### Follow-up tasks
<!-- If you are updating the Integrations Developer Guide, you can delete this section -->

_Select one._

* This PR does _not_ need to be ported to another doc set because:
  - [x] The concepts in this PR only apply to one doc set (serverless _or_ stateful)
  - [ ] The PR contains edits to both doc sets (serverless _and_ stateful)
* This PR needs to be ported to another doc set:
  - [ ] Port to stateful docs: \<link to PR or tracking issue>
  - [ ] Port to serverless docs: \<link to PR or tracking issue>

cc @chrisdistasio 