### PR TITLE
[AWS Firehose] Clarify where to find ES endpoint

### DIFF
--- a/docs/en/observability/cloud-monitoring/aws/monitor-aws-cloudtrail-firehose.asciidoc
+++ b/docs/en/observability/cloud-monitoring/aws/monitor-aws-cloudtrail-firehose.asciidoc
@@ -85,10 +85,15 @@ For more information on how to set up a Amazon Data Firehose delivery stream to 
 
 . Collect {es} endpoint and API key from your deployment on Elastic Cloud.
 +
-- *Elasticsearch endpoint URL*: Enter the Elasticsearch endpoint URL of your Elasticsearch cluster. To find the Elasticsearch endpoint, go to the https://cloud.elastic.co/[Elastic Cloud] console and: 
-.. Click *Manage* on your deployment.
-.. On *Applications > Elasticsearch*, select *Copy endpoint* to copy the endpoint URL.
-- *API key*: Enter the encoded Elastic API key. To create an API key, go to the https://cloud.elastic.co/[Elastic Cloud] console, click on *Open Kibana*, select *Stack management > API Keys* and click *Create API key*. If you are using an API key with *Restrict privileges*, make sure to review the Indices privileges to provide at least "auto_configure" & "write" permissions for the indices you will be using with this delivery stream.
+- *To find the Elasticsearch endpoint URL*: 
+.. Go to the https://cloud.elastic.co/[Elastic Cloud] console
+.. Find your deployment in the *Hosted deployments* card and select *Manage*.
+.. Under *Applications* click *Copy endpoint* next to *Elasticsearch*.
+
+- *To Create the API key*: 
+.. Go to the https://cloud.elastic.co/[Elastic Cloud] console
+.. Select *Open Kibana*.
+.. Expand the left-hand menu, under *Management* select *Stack management > API Keys* and click *Create API key*. If you are using an API key with *Restrict privileges*, make sure to review the Indices privileges to provide at least `auto_configure` and `write` permissions for the indices you will be using with this delivery stream.
 
 . Set up the delivery stream by specifying the following data:
 +

--- a/docs/en/observability/cloud-monitoring/aws/monitor-aws-cloudtrail-firehose.asciidoc
+++ b/docs/en/observability/cloud-monitoring/aws/monitor-aws-cloudtrail-firehose.asciidoc
@@ -85,8 +85,8 @@ For more information on how to set up a Amazon Data Firehose delivery stream to 
 
 . Collect {es} endpoint and API key from your deployment on Elastic Cloud.
 +
-- Elasticsearch endpoint URL: Enter the Elasticsearch endpoint URL of your Elasticsearch cluster. To find the Elasticsearch endpoint, go to the Elastic Cloud console and select *Connection details*.
-- API key: Enter the encoded Elastic API key. To create an API key, go to the Elastic Cloud console, select *Connection details* and click *Create and manage API keys*. If you are using an API key with *Restrict privileges*, make sure to review the Indices privileges to provide at least "auto_configure" & "write" permissions for the indices you will be using with this delivery stream.
+- *Elasticsearch endpoint URL*: Enter the Elasticsearch endpoint URL of your Elasticsearch cluster. To find the Elasticsearch endpoint, go to the https://cloud.elastic.co/[Elastic Cloud] console, click *Manage* on your deployment, and on *Applications > Elasticsearch* select *Copy endpoint* to copy the endpoint URL.
+- *API key*: Enter the encoded Elastic API key. To create an API key, go to the Elastic Cloud console, select *Stack management > API Keys* and click *Create API key*. If you are using an API key with *Restrict privileges*, make sure to review the Indices privileges to provide at least "auto_configure" & "write" permissions for the indices you will be using with this delivery stream.
 
 . Set up the delivery stream by specifying the following data:
 +
@@ -96,6 +96,8 @@ For more information on how to set up a Amazon Data Firehose delivery stream to 
 - Retry duration: 60 (default)
 - Backup settings: failed data only to s3 bucket
 
+IMPORTANT: Make sure the *Elasticsearch endpoint URL* contains `es` in the URL. For example, `https://my-deployment.es.us-east-1.aws.elastic-cloud.com`.
+
 You now have an Amazon Data Firehose delivery specified with:
 
 - source: direct put
@@ -104,7 +106,7 @@ You now have an Amazon Data Firehose delivery specified with:
 
 [discrete]
 [[firehose-cloudtrail-step-four]]
-== Step 4: Set up a subscription filter to route Cloudtrail events to a delivery stream
+== Step 4: Set up a subscription filter to route CloudTrail events to a delivery stream
 
 image::firehose-subscription-filter.png[Firehose subscription filter]
 

--- a/docs/en/observability/cloud-monitoring/aws/monitor-aws-cloudtrail-firehose.asciidoc
+++ b/docs/en/observability/cloud-monitoring/aws/monitor-aws-cloudtrail-firehose.asciidoc
@@ -98,7 +98,7 @@ For more information on how to set up a Amazon Data Firehose delivery stream to 
 - Retry duration: 60 (default)
 - Backup settings: failed data only to s3 bucket
 
-IMPORTANT: Make sure the *Elasticsearch endpoint* contains `.es.` in the URL. For example, `https://my-deployment.es.us-east-1.aws.elastic-cloud.com` (there is an `es` between `my-deployment` and `us-east-1`).
+IMPORTANT: Verify that your *Elasticsearch endpoint URL* includes `.es.` between the *deployment name* and *region*. Example: `https://my-deployment.es.us-east-1.aws.elastic-cloud.com`
 
 You now have an Amazon Data Firehose delivery specified with:
 

--- a/docs/en/observability/cloud-monitoring/aws/monitor-aws-cloudtrail-firehose.asciidoc
+++ b/docs/en/observability/cloud-monitoring/aws/monitor-aws-cloudtrail-firehose.asciidoc
@@ -98,7 +98,7 @@ For more information on how to set up a Amazon Data Firehose delivery stream to 
 - Retry duration: 60 (default)
 - Backup settings: failed data only to s3 bucket
 
-IMPORTANT: Make sure the *Elasticsearch endpoint* contains `.es.` in the URL. For example, `https://my-deployment.es.us-east-1.aws.elastic-cloud.com`.
+IMPORTANT: Make sure the *Elasticsearch endpoint* contains `.es.` in the URL. For example, `https://my-deployment.es.us-east-1.aws.elastic-cloud.com` (there is an `es` between `my-deployment` and `us-east-1`).
 
 You now have an Amazon Data Firehose delivery specified with:
 

--- a/docs/en/observability/cloud-monitoring/aws/monitor-aws-cloudtrail-firehose.asciidoc
+++ b/docs/en/observability/cloud-monitoring/aws/monitor-aws-cloudtrail-firehose.asciidoc
@@ -85,8 +85,10 @@ For more information on how to set up a Amazon Data Firehose delivery stream to 
 
 . Collect {es} endpoint and API key from your deployment on Elastic Cloud.
 +
-- *Elasticsearch endpoint URL*: Enter the Elasticsearch endpoint URL of your Elasticsearch cluster. To find the Elasticsearch endpoint, go to the https://cloud.elastic.co/[Elastic Cloud] console and click *Manage* on your deployment; on *Applications > Elasticsearch* select *Copy endpoint* to copy the endpoint URL.
-- *API key*: Enter the encoded Elastic API key. To create an API key, go to the Elastic Cloud console, select *Stack management > API Keys* and click *Create API key*. If you are using an API key with *Restrict privileges*, make sure to review the Indices privileges to provide at least "auto_configure" & "write" permissions for the indices you will be using with this delivery stream.
+- *Elasticsearch endpoint URL*: Enter the Elasticsearch endpoint URL of your Elasticsearch cluster. To find the Elasticsearch endpoint, go to the https://cloud.elastic.co/[Elastic Cloud] console and: 
+.. Click *Manage* on your deployment.
+.. On *Applications > Elasticsearch*, select *Copy endpoint* to copy the endpoint URL.
+- *API key*: Enter the encoded Elastic API key. To create an API key, go to the https://cloud.elastic.co/[Elastic Cloud] console, click on *Open Kibana*, select *Stack management > API Keys* and click *Create API key*. If you are using an API key with *Restrict privileges*, make sure to review the Indices privileges to provide at least "auto_configure" & "write" permissions for the indices you will be using with this delivery stream.
 
 . Set up the delivery stream by specifying the following data:
 +

--- a/docs/en/observability/cloud-monitoring/aws/monitor-aws-cloudtrail-firehose.asciidoc
+++ b/docs/en/observability/cloud-monitoring/aws/monitor-aws-cloudtrail-firehose.asciidoc
@@ -85,7 +85,7 @@ For more information on how to set up a Amazon Data Firehose delivery stream to 
 
 . Collect {es} endpoint and API key from your deployment on Elastic Cloud.
 +
-- *Elasticsearch endpoint URL*: Enter the Elasticsearch endpoint URL of your Elasticsearch cluster. To find the Elasticsearch endpoint, go to the https://cloud.elastic.co/[Elastic Cloud] console, click *Manage* on your deployment, and on *Applications > Elasticsearch* select *Copy endpoint* to copy the endpoint URL.
+- *Elasticsearch endpoint URL*: Enter the Elasticsearch endpoint URL of your Elasticsearch cluster. To find the Elasticsearch endpoint, go to the https://cloud.elastic.co/[Elastic Cloud] console and click *Manage* on your deployment; on *Applications > Elasticsearch* select *Copy endpoint* to copy the endpoint URL.
 - *API key*: Enter the encoded Elastic API key. To create an API key, go to the Elastic Cloud console, select *Stack management > API Keys* and click *Create API key*. If you are using an API key with *Restrict privileges*, make sure to review the Indices privileges to provide at least "auto_configure" & "write" permissions for the indices you will be using with this delivery stream.
 
 . Set up the delivery stream by specifying the following data:
@@ -96,7 +96,7 @@ For more information on how to set up a Amazon Data Firehose delivery stream to 
 - Retry duration: 60 (default)
 - Backup settings: failed data only to s3 bucket
 
-IMPORTANT: Make sure the *Elasticsearch endpoint URL* contains `es` in the URL. For example, `https://my-deployment.es.us-east-1.aws.elastic-cloud.com`.
+IMPORTANT: Make sure the *Elasticsearch endpoint* contains `.es.` in the URL. For example, `https://my-deployment.es.us-east-1.aws.elastic-cloud.com`.
 
 You now have an Amazon Data Firehose delivery specified with:
 

--- a/docs/en/observability/cloud-monitoring/aws/monitor-aws-cloudtrail-firehose.asciidoc
+++ b/docs/en/observability/cloud-monitoring/aws/monitor-aws-cloudtrail-firehose.asciidoc
@@ -90,7 +90,7 @@ For more information on how to set up a Amazon Data Firehose delivery stream to 
 .. Find your deployment in the *Hosted deployments* card and select *Manage*.
 .. Under *Applications* click *Copy endpoint* next to *Elasticsearch*.
 
-- *To Create the API key*: 
+- *To create the API key*: 
 .. Go to the https://cloud.elastic.co/[Elastic Cloud] console
 .. Select *Open Kibana*.
 .. Expand the left-hand menu, under *Management* select *Stack management > API Keys* and click *Create API key*. If you are using an API key with *Restrict privileges*, make sure to review the Indices privileges to provide at least `auto_configure` and `write` permissions for the indices you will be using with this delivery stream.

--- a/docs/en/observability/cloud-monitoring/aws/monitor-aws-cloudtrail-firehose.asciidoc
+++ b/docs/en/observability/cloud-monitoring/aws/monitor-aws-cloudtrail-firehose.asciidoc
@@ -97,8 +97,8 @@ For more information on how to set up a Amazon Data Firehose delivery stream to 
 
 . Set up the delivery stream by specifying the following data:
 +
-- Elastic endpoint URL
-- API key
+- Elastic endpoint URL: The URL that you copied in the previous step. 
+- API key: The API key that you created in the previous step.
 - Content encoding: gzip
 - Retry duration: 60 (default)
 - Backup settings: failed data only to s3 bucket

--- a/docs/en/observability/cloud-monitoring/aws/monitor-aws-cloudwatch-firehose.asciidoc
+++ b/docs/en/observability/cloud-monitoring/aws/monitor-aws-cloudwatch-firehose.asciidoc
@@ -100,8 +100,25 @@ image::firehose-cloudwatch-firehose-stream.png[Amazon Firehose Stream]
 +
 NOTE: For advanced use cases, source records can be transformed by invoking a custom Lambda function. When using Elastic integrations, this should not be required.
 
-. In the **Destination settings** section, set the following parameter:
-`es_datastream_name` = `logs-aws.generic-default`
+. From the *Destination settings* panel, specify the following settings:
++
+* *To find the Elasticsearch endpoint URL*: 
+.. Go to the https://cloud.elastic.co/[Elastic Cloud] console
+.. Find your deployment in the *Hosted deployments* card and select *Manage*.
+.. Under *Applications* click *Copy endpoint* next to *Elasticsearch*.
++
+* *To create the API key*: 
+.. Go to the https://cloud.elastic.co/[Elastic Cloud] console
+.. Select *Open Kibana*.
+.. Expand the left-hand menu, under *Management* select *Stack management > API Keys* and click *Create API key*. If you are using an API key with *Restrict privileges*, make sure to review the Indices privileges to provide at least `auto_configure` and `write` permissions for the indices you will be using with this delivery stream.
++
+* *Content encoding*: For a better network efficiency, leave content encoding set to GZIP.
++
+* *Retry duration*: Determines how long Firehose continues retrying the request in the event of an error. A duration of 60-300s should be suitable for most use cases.
++
+* *es_datastream_name*: `logs-aws.generic-default`
+
+IMPORTANT: Verify that your *Elasticsearch endpoint URL* includes `.es.` between the *deployment name* and *region*. Example: `https://my-deployment.es.us-east-1.aws.elastic-cloud.com`
 
 The Firehose stream is now ready to send logs to your Elastic Cloud deployment.
 

--- a/docs/en/observability/cloud-monitoring/aws/monitor-aws-firewall-firehose.asciidoc
+++ b/docs/en/observability/cloud-monitoring/aws/monitor-aws-firewall-firehose.asciidoc
@@ -57,9 +57,15 @@ image::firehose-networkfirewall-stream.png[Firehose stream]
 
 . Collect {es} endpoint and API key from your deployment on Elastic Cloud.
 +
-- Elastic endpoint URL: Enter the Elasticsearch endpoint URL of your Elasticsearch cluster. To find the Elasticsearch endpoint, go to the Elastic Cloud console and select *Connection details*.
-+
-- API key: Enter the encoded Elastic API key. To create an API key, go to the Elastic Cloud console, select *Connection details* and click *Create and manage API keys*. If you are using an API key with *Restrict privileges*, make sure to review the Indices privileges to provide at least "auto_configure" and "write" permissions for the indices you will be using with this delivery stream.
+- *To find the Elasticsearch endpoint URL*: 
+.. Go to the https://cloud.elastic.co/[Elastic Cloud] console
+.. Find your deployment in the *Hosted deployments* card and select *Manage*.
+.. Under *Applications* click *Copy endpoint* next to *Elasticsearch*.
+
+- *To create the API key*: 
+.. Go to the https://cloud.elastic.co/[Elastic Cloud] console
+.. Select *Open Kibana*.
+.. Expand the left-hand menu, under *Management* select *Stack management > API Keys* and click *Create API key*. If you are using an API key with *Restrict privileges*, make sure to review the Indices privileges to provide at least `auto_configure` and `write` permissions for the indices you will be using with this delivery stream.
 
 . Set up the delivery stream by specifying the following data:
 +
@@ -68,7 +74,9 @@ image::firehose-networkfirewall-stream.png[Firehose stream]
 - Content encoding: gzip
 - Retry duration: 60 (default)
 - Parameter *es_datastream_name* = `logs-aws.firewall_logs-default`
-- Backup settings: failed data only to s3 bucket
+- Backup settings: failed data only to S3 bucket
+
+IMPORTANT: Verify that your *Elasticsearch endpoint URL* includes `.es.` between the *deployment name* and *region*. Example: `https://my-deployment.es.us-east-1.aws.elastic-cloud.com`
 
 The Firehose stream is ready to send logs to our Elastic Cloud deployment.
 

--- a/docs/en/observability/cloud-monitoring/aws/monitor-aws-waf-firehose.asciidoc
+++ b/docs/en/observability/cloud-monitoring/aws/monitor-aws-waf-firehose.asciidoc
@@ -54,15 +54,23 @@ NOTE: For advanced use cases, source records can be transformed by invoking a cu
 
 . From the *Destination settings* panel, specify the following settings:
 +
-* *Elastic endpoint URL*: Enter the Elastic endpoint URL of your Elasticsearch cluster. To find the Elasticsearch endpoint, go to the Elastic Cloud console, navigate to the Integrations page, and select *Connection details*. Here is an example of how it looks like: `https://my-deployment.es.us-east-1.aws.elastic-cloud.com`.
+* *To find the Elasticsearch endpoint URL*: 
+.. Go to the https://cloud.elastic.co/[Elastic Cloud] console
+.. Find your deployment in the *Hosted deployments* card and select *Manage*.
+.. Under *Applications* click *Copy endpoint* next to *Elasticsearch*.
 +
-* *API key*: Enter the encoded Elastic API key. To create an API key, go to the Elastic Cloud console, navigate to the Integrations page, select *Connection details* and click *Create and manage API keys*. If you are using an API key with *Restrict privileges*, make sure to review the Indices privileges to provide at least "auto_configure" & "write" permissions for the indices you will be using with this delivery stream.
+* *To create the API key*: 
+.. Go to the https://cloud.elastic.co/[Elastic Cloud] console
+.. Select *Open Kibana*.
+.. Expand the left-hand menu, under *Management* select *Stack management > API Keys* and click *Create API key*. If you are using an API key with *Restrict privileges*, make sure to review the Indices privileges to provide at least `auto_configure` and `write` permissions for the indices you will be using with this delivery stream.
 +
 * *Content encoding*: For a better network efficiency, leave content encoding set to GZIP.
 +
 * *Retry duration*: Determines how long Firehose continues retrying the request in the event of an error. A duration of 60-300s should be suitable for most use cases.
 +
 * *es_datastream_name*: `logs-aws.waf-default`
+
+IMPORTANT: Verify that your *Elasticsearch endpoint URL* includes `.es.` between the *deployment name* and *region*. Example: `https://my-deployment.es.us-east-1.aws.elastic-cloud.com`
 
 [discrete]
 [[firehose-waf-step-four]]


### PR DESCRIPTION

## Description
<!-- Add a description here -->

When setting up an AWS Firehose data stream, users should use the Elasticsearch endpoint URL that contains the .es subdomain. 

While the non-.es URLs currently work and will continue to function, the URL containing the .es subdomain is designed as the dedicated endpoint for connecting to Elasticsearch. These URLs are the best option for future-proofing your setup, and we should recommend using them.

### Documentation sets edited in this PR

_Check all that apply._

- [x] Stateful (`docs/en/observability/*`)
- [ ] Serverless (`docs/en/serverless/*`)
- [ ] Integrations Developer Guide (`docs/en/integrations/*`)
- [ ] None of the above

### Related issue
Closes # <!-- Add the issue this PR closes here -->

## Checklist

<!--
Add labels to:
1. Backport to other versions (`backport-*`):
    - `backport-8.x` to backport to the latest minor
    - `backport-skip` to not backport (for example, for serverless docs)
    - `backport-main` to "backport" to `main` if the target branch is _not_ `main`
    - Individual `backport-*` labels to target specific minor versions
2. Surface blocking reviews (`needs-*-review`):
    - `needs-writer-review` for codeowners
    - `needs-dev-review` for dev team
    - `needs-product-review` for PM review
-->

- [ ] Product/Engineering Review
- [ ] Writer Review

### Follow-up tasks
<!-- If you are updating the Integrations Developer Guide, you can delete this section -->

_Select one._

* This PR does _not_ need to be ported to another doc set because:
  - [ ] The concepts in this PR only apply to one doc set (serverless _or_ stateful)
  - [ ] The PR contains edits to both doc sets (serverless _and_ stateful)
* This PR needs to be ported to another doc set:
  - [ ] Port to stateful docs: \<link to PR or tracking issue>
  - [ ] Port to serverless docs: \<link to PR or tracking issue>
