### PR TITLE
[DOCS] Remove links to master

### DIFF
--- a/docs/en/serverless/cases/manage-cases-settings.asciidoc
+++ b/docs/en/serverless/cases/manage-cases-settings.asciidoc
@@ -76,7 +76,7 @@ image::images/observability-cases-add-connector.png[Add a connector to send case
 ** {kibana-ref}/servicenow-action-type.html[{sn-itsm} connector]
 ** {kibana-ref}/servicenow-sir-action-type.html[{sn-sir} connector]
 ** {kibana-ref}/swimlane-action-type.html[{swimlane} connector]
-** https://www.elastic.co/guide/en/kibana/master/thehive-action-type.html[TheHive connector]
+** {kibana-ref}/thehive-action-type.html[TheHive connector]
 ** {kibana-ref}/cases-webhook-action-type.html[{webhook-cm} connector]
 . Click **Save**.
 


### PR DESCRIPTION
## Description

Relates to https://github.com/elastic/docs/pull/3160

This PR fixes the following broken link:

```
INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/serverless/current/observability-case-settings.html contains broken links to:
--
  | INFO:build_docs:   - en/kibana/master/thehive-action-type.html
```

I think this PR only needs to be merged if we assume that we'll want to stop the main branch of the Kibana Guide before we stop building the only branch of the Serverless Guide.

### Documentation sets edited in this PR

_Check all that apply._

- [ ] Stateful (`docs/en/observability/*`)
- [x] Serverless (`docs/en/serverless/*`)
- [ ] Integrations Developer Guide (`docs/en/integrations/*`)
- [ ] None of the above

### Related issue
Closes # <!-- Add the issue this PR closes here -->

## Checklist

<!--
Add labels to:
1. Backport to other versions (`backport-*`):
    - `backport-8.x` to backport to the latest minor
    - `backport-skip` to not backport (for example, for serverless docs)
    - `backport-main` to "backport" to `main` if the target branch is _not_ `main`
    - Individual `backport-*` labels to target specific minor versions
2. Surface blocking reviews (`needs-*-review`):
    - `needs-writer-review` for codeowners
    - `needs-dev-review` for dev team
    - `needs-product-review` for PM review
-->

- [ ] Product/Engineering Review
- [ ] Writer Review

### Follow-up tasks
<!-- If you are updating the Integrations Developer Guide, you can delete this section -->

_Select one._

* This PR does _not_ need to be ported to another doc set because:
  - [ ] The concepts in this PR only apply to one doc set (serverless _or_ stateful)
  - [ ] The PR contains edits to both doc sets (serverless _and_ stateful)
* This PR needs to be ported to another doc set:
  - [ ] Port to stateful docs: \<link to PR or tracking issue>
  - [ ] Port to serverless docs: \<link to PR or tracking issue>
