### PR TITLE
[DOCS] Fix hard-coded links to master

### DIFF
--- a/docs/en/ingest-management/elastic-agent/run-container-common/kibana-fleet-data.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/run-container-common/kibana-fleet-data.asciidoc
@@ -9,7 +9,7 @@ include::{observability-docs-root}/docs/en/shared/open-kibana/widget.asciidoc[]
 [role="screenshot"]
 image::images/kibana-fleet-agents-overview.png[{agent}s {fleet} page]
 
-. To view data flowing in, go to *Analytics -> Discover* and select the index `metrics-*`, or even more specific, `metrics-kubernetes.*`. If you can't see these indexes, https://www.elastic.co/guide/en/kibana/master/data-views.html[create a data view] for them.
+. To view data flowing in, go to *Analytics -> Discover* and select the index `metrics-*`, or even more specific, `metrics-kubernetes.*`. If you can't see these indexes, {kibana-ref}/data-views.html[create a data view] for them.
 
 . To view predefined dashboards, either select *Analytics->Dashboard* or <<view-integration-assets,install assets through an integration>>.
 

--- a/docs/en/ingest-management/elastic-agent/running-on-kubernetes-standalone.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/running-on-kubernetes-standalone.asciidoc
@@ -68,7 +68,7 @@ include::run-container-common/deploy-elastic-agent.asciidoc[]
 include::{observability-docs-root}/docs/en/shared/open-kibana/widget.asciidoc[]
 --
 
-. You can see data flowing in by going to *Analytics -> Discover* and selecting the index `metrics-*`, or even more specific, `metrics-kubernetes.*`. If you can't see these indexes, https://www.elastic.co/guide/en/kibana/master/data-views.html[create a data view] for them.
+. You can see data flowing in by going to *Analytics -> Discover* and selecting the index `metrics-*`, or even more specific, `metrics-kubernetes.*`. If you can't see these indexes, {kibana-ref}/data-views.html[create a data view] for them.
 
 . You can see predefined dashboards by selecting *Analytics->Dashboard*, or by <<view-integration-assets,installing assets through an integration>>.
 

--- a/docs/en/observability/whats-new.asciidoc
+++ b/docs/en/observability/whats-new.asciidoc
@@ -26,7 +26,7 @@ eliminating the need for manual alert closure and management.
 [role="screenshot"]
 image::images/alert-connector-opsgenie.png[Create or close an alert in Opsgenie]
 
-For more information, refer to the https://www.elastic.co/guide/en/kibana/master/opsgenie-action-type.html[Opsgenie connector documentation].
+For more information, refer to the {kibana-ref}/opsgenie-action-type.html[Opsgenie connector documentation].
 
 [discrete]
 == New Operations view for APM Dependencies (Beta)


### PR DESCRIPTION
## Description

Relates to https://github.com/elastic/docs/pull/3160

This PR fixes the following type of documentation build error, which occurs when we retire the master documentation:

```
INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/observability/8.6/whats-new.html contains broken links to:
--
  | INFO:build_docs:   - en/kibana/master/opsgenie-action-type.html
```

### Documentation sets edited in this PR

_Check all that apply._

- [x] Stateful (`docs/en/observability/*`)
- [ ] Serverless (`docs/en/serverless/*`)
- [ ] Integrations Developer Guide (`docs/en/integrations/*`)
- [ ] None of the above

### Related issue

Relates to https://github.com/elastic/docs/pull/3160

## Checklist

<!--
Add labels to:
1. Backport to other versions (`backport-*`):
    - `backport-8.x` to backport to the latest minor
    - `backport-skip` to not backport (for example, for serverless docs)
    - `backport-main` to "backport" to `main` if the target branch is _not_ `main`
    - Individual `backport-*` labels to target specific minor versions
2. Surface blocking reviews (`needs-*-review`):
    - `needs-writer-review` for codeowners
    - `needs-dev-review` for dev team
    - `needs-product-review` for PM review
-->

- [ ] Product/Engineering Review
- [ ] Writer Review

### Follow-up tasks
<!-- If you are updating the Integrations Developer Guide, you can delete this section -->

_Select one._

* This PR does _not_ need to be ported to another doc set because:
  - [ ] The concepts in this PR only apply to one doc set (serverless _or_ stateful)
  - [ ] The PR contains edits to both doc sets (serverless _and_ stateful)
* This PR needs to be ported to another doc set:
  - [ ] Port to stateful docs: \<link to PR or tracking issue>
  - [ ] Port to serverless docs: \<link to PR or tracking issue>
