### PR TITLE
apm: change default sampling.tail.storage_limit

### DIFF
--- a/docs/en/observability/apm/configure/sampling.asciidoc
+++ b/docs/en/observability/apm/configure/sampling.asciidoc
@@ -67,14 +67,17 @@ This final policy is used to catch remaining trace events that don't match a str
 === Storage limit
 The amount of storage space allocated for trace events matching tail sampling policies. Caution: Setting this limit higher than the allowed space may cause APM Server to become unhealthy.
 
-A value of `0` or equivalent (e.g. `0GB`) means unlimited local tail sampling database size
-but enforces a max 80% disk usage limit on the disk where the database is located,
-i.e. the last 20% of disk will not be used by APM Server.
-It is the recommended value as it automatically scales with the disk size by definition.
+A value of `0GB` (or equivalent) does not set a concrete limit,
+but rather allows the APM Server to align its disk usage with the disk size.
+The server uses up to 80% of the disk size limit on the disk where the database is located.
+The last 20% of disk will not be used by APM Server.
+It is the recommended value as it automatically scales with the disk size.
 
-If the configured storage limit is insufficient, it logs "configured storage limit reached". The event will bypass sampling and will always be indexed when storage limit is reached.
+If this is not desired, a concrete `GB` value can be set for the maximum amount of disk used for Tail Based Sampling.
 
-Default: `0`. (text)
+If the configured storage limit is insufficient, it logs "configured limit reached". The event will bypass sampling and will always be indexed when storage limit is reached.
+
+Default: `0GB`. (text)
 
 |====
 | APM Server binary | `sampling.tail.storage_limit`

--- a/docs/en/observability/apm/configure/sampling.asciidoc
+++ b/docs/en/observability/apm/configure/sampling.asciidoc
@@ -69,11 +69,11 @@ The amount of storage space allocated for trace events matching tail sampling po
 
 A value of `0GB` (or equivalent) does not set a concrete limit,
 but rather allows the APM Server to align its disk usage with the disk size.
-The server uses up to 80% of the disk size limit on the disk where the database is located.
+APM server uses up to 80% of the disk size limit on the disk where the local tail-based sampling database is located.
 The last 20% of disk will not be used by APM Server.
 It is the recommended value as it automatically scales with the disk size.
 
-If this is not desired, a concrete `GB` value can be set for the maximum amount of disk used for Tail Based Sampling.
+If this is not desired, a concrete `GB` value can be set for the maximum amount of disk used for tail-based sampling.
 
 If the configured storage limit is insufficient, it logs "configured limit reached". The event will bypass sampling and will always be indexed when storage limit is reached.
 

--- a/docs/en/observability/apm/configure/sampling.asciidoc
+++ b/docs/en/observability/apm/configure/sampling.asciidoc
@@ -67,9 +67,14 @@ This final policy is used to catch remaining trace events that don't match a str
 === Storage limit
 The amount of storage space allocated for trace events matching tail sampling policies. Caution: Setting this limit higher than the allowed space may cause APM Server to become unhealthy.
 
+A value of `0` or equivalent (e.g. `0GB`) means unlimited local tail sampling database size
+but enforces a max 80% disk usage limit on the disk where the database is located,
+i.e. the last 20% of disk will not be used by APM Server.
+It is the recommended value as it automatically scales with the disk size by definition.
+
 If the configured storage limit is insufficient, it logs "configured storage limit reached". The event will bypass sampling and will always be indexed when storage limit is reached.
 
-Default: `3GB`. (text)
+Default: `0`. (text)
 
 |====
 | APM Server binary | `sampling.tail.storage_limit`


### PR DESCRIPTION
## Description
<!-- Add a description here -->
Update default value of apm-server `sampling.tail.storage_limit` to `0` as part of https://github.com/elastic/apm-server/issues/14933
This is the new default from 9.0.

### Documentation sets edited in this PR

_Check all that apply._

- [x] Stateful (`docs/en/observability/*`)
- [ ] Serverless (`docs/en/serverless/*`)
- [ ] Integrations Developer Guide (`docs/en/integrations/*`)
- [ ] None of the above

### Related issue

Part of https://github.com/elastic/apm-server/issues/14933

## Checklist

<!--
Add labels to:
1. Backport to other versions (`backport-*`):
    - `backport-8.x` to backport to the latest minor
    - `backport-skip` to not backport (for example, for serverless docs)
    - `backport-main` to "backport" to `main` if the target branch is _not_ `main`
    - Individual `backport-*` labels to target specific minor versions
2. Surface blocking reviews (`needs-*-review`):
    - `needs-writer-review` for codeowners
    - `needs-dev-review` for dev team
    - `needs-product-review` for PM review
-->

- [ ] Product/Engineering Review
- [ ] Writer Review

### Follow-up tasks
<!-- If you are updating the Integrations Developer Guide, you can delete this section -->

_Select one._

* This PR does _not_ need to be ported to another doc set because:
  - [x] The concepts in this PR only apply to one doc set (serverless _or_ stateful)
  - [ ] The PR contains edits to both doc sets (serverless _and_ stateful)
* This PR needs to be ported to another doc set:
  - [ ] Port to stateful docs: \<link to PR or tracking issue>
  - [ ] Port to serverless docs: \<link to PR or tracking issue>
