### PR TITLE
mergify: support backport-active-8, backport-active-9, backport-active-all

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -352,3 +352,82 @@ pull_request_rules:
         branches:
           - "8.17"
         title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"
+  - name: backport patches to 8.18 branch
+    conditions:
+      - merged
+      - label=backport-8.18
+    actions:
+      backport:
+        assignees:
+          - "{{ author }}"
+        labels:
+          - "backport"
+        branches:
+          - "8.18"
+        title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"
+  - name: backport patches to 9.0 branch
+    conditions:
+      - merged
+      - label=backport-9.0
+    actions:
+      backport:
+        assignees:
+          - "{{ author }}"
+        labels:
+          - "backport"
+        branches:
+          - "9.0"
+        title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"
+
+  - name: backport patches to all active minor branches for the 8 major.
+    conditions:
+      - merged
+      - label=backport-active-8
+    actions:
+      backport:
+        assignees:
+          - "{{ author }}"
+        # NOTE: this list needs to be changed when a new minor branch is created
+        #       or an existing minor branch reached EOL.
+        branches:
+          - "8.18"
+          - "8.17"
+          - "8.16"
+        labels:
+          - "backport"
+        title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"
+  - name: backport patches to all active minor branches for the 9 major.
+    conditions:
+      - merged
+      - label=backport-active-9
+    actions:
+      backport:
+        assignees:
+          - "{{ author }}"
+        # NOTE: this list needs to be changed when a new minor branch is created
+        #       or an existing minor branch reached EOL.
+        branches:
+          - "9.0"
+        labels:
+          - "backport"
+        title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"
+  - name: backport patches to all active branches
+    conditions:
+      - merged
+      - label=backport-active-all
+    actions:
+      backport:
+        assignees:
+          - "{{ author }}"
+        # NOTE: this list needs to be changed when a new minor branch is created
+        #       or an existing release branch reached EOL.
+        branches:
+          - "9.0"
+          - "8.18"
+          - "8.17"
+          - "8.16"
+          - "8.x"
+          - "7.17"
+        labels:
+          - "backport"
+        title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"


### PR DESCRIPTION

## Description

## What is the problem this PR solves?


> Maybe this is solved already, but is there a way we can get an automatically kept up to date “backport-active-minors” label that auto backports to the set of minor releases that are still supported? I’d want this in Beats, Elastic Agent, and Fleet Server if it already exists. I’ve noticed an increase in forgotten backports because there are more releases to keep track of. If we can abstract this it’d make life easier, I think Kibana does something like this



## How does this PR solve the problem?


Enable `backport-active-all`, `backport-active-8` and `backport-active-9` in mergify to backport to a set of active branches instead of using `backport-<major>.<minor>`. This can help with the current 6 active branches as we have today.



See https://docs.mergify.com/workflow/actions/backport/#parameters


<img width="530" alt="image" src="https://github.com/user-attachments/assets/9a24a72b-2d9b-43ed-bab0-918087aa7273" />


I can find `regexes` too:

<img width="624" alt="image" src="https://github.com/user-attachments/assets/71ef6d2f-f98d-4e7b-a0a0-8e1d7b99b33d" />


But I'm not sure whether that can solve our current release model easily


### Documentation sets edited in this PR

_Check all that apply._

- [ ] Stateful (`docs/en/observability/*`)
- [ ] Serverless (`docs/en/serverless/*`)
- [ ] Integrations Developer Guide (`docs/en/integrations/*`)
- [ ] None of the above

### Related issue
Closes # <!-- Add the issue this PR closes here -->

## Checklist

<!--
Add labels to:
1. Backport to other versions (`backport-*`):
    - `backport-8.x` to backport to the latest minor
    - `backport-skip` to not backport (for example, for serverless docs)
    - `backport-main` to "backport" to `main` if the target branch is _not_ `main`
    - Individual `backport-*` labels to target specific minor versions
2. Surface blocking reviews (`needs-*-review`):
    - `needs-writer-review` for codeowners
    - `needs-dev-review` for dev team
    - `needs-product-review` for PM review
-->

- [ ] Product/Engineering Review
- [ ] Writer Review

### Follow-up tasks
<!-- If you are updating the Integrations Developer Guide, you can delete this section -->

_Select one._

* This PR does _not_ need to be ported to another doc set because:
  - [ ] The concepts in this PR only apply to one doc set (serverless _or_ stateful)
  - [ ] The PR contains edits to both doc sets (serverless _and_ stateful)
* This PR needs to be ported to another doc set:
  - [ ] Port to stateful docs: \<link to PR or tracking issue>
  - [ ] Port to serverless docs: \<link to PR or tracking issue>
