### PR TITLE
typo: samling->sampling

### DIFF
--- a/docs/en/apm-server/redirects.asciidoc
+++ b/docs/en/apm-server/redirects.asciidoc
@@ -991,12 +991,12 @@ Refer to {observability-guide}/apm-configuration-ssl.html[SSL/TLS output setting
 
 Refer to {observability-guide}/apm-agent-server-ssl.html[SSL/TLS input settings].
 
-[role="exclude",id="tail-based-samling-config"]
+[role="exclude",id="tail-based-sampling-config"]
 === Tail-based sampling
 
 {move-notice}
 
-Refer to {observability-guide}/apm-tail-based-samling-config.html[Tail-based sampling].
+Refer to {observability-guide}/apm-tail-based-sampling-config.html[Tail-based sampling].
 
 [role="exclude",id="config-env"]
 === Use environment variables in the configuration

--- a/docs/en/observability/apm/configure/index.asciidoc
+++ b/docs/en/observability/apm/configure/index.asciidoc
@@ -22,7 +22,7 @@ The following topics describe how to configure APM Server:
 * <<apm-configuration-path>>
 * <<apm-configuration-rum>>
 * <<apm-configuration-ssl-landing>>
-* <<apm-tail-based-samling-config>>
+* <<apm-tail-based-sampling-config>>
 * <<apm-config-env>>
 
 include::general.asciidoc[leveloffset=+1]

--- a/docs/en/observability/apm/configure/sampling.asciidoc
+++ b/docs/en/observability/apm/configure/sampling.asciidoc
@@ -1,4 +1,4 @@
-[[apm-tail-based-samling-config]]
+[[apm-tail-based-sampling-config]]
 = Tail-based sampling
 
 ****

--- a/docs/en/observability/redirects.asciidoc
+++ b/docs/en/observability/redirects.asciidoc
@@ -540,10 +540,10 @@ Refer to <<apm-configuration-ssl>>.
 
 Refer to <<apm-agent-server-ssl>>.
 
-[role="exclude",id="tail-based-samling-config"]
+[role="exclude",id="tail-based-sampling-config"]
 === Tail-based sampling
 
-Refer to <<apm-tail-based-samling-config>>.
+Refer to <<apm-tail-based-sampling-config>>.
 
 [role="exclude",id="config-env"]
 === Use environment variables in the configuration


### PR DESCRIPTION
## Description
<!-- Add a description here -->
Correct typo "samling" to "sampling".

### Documentation sets edited in this PR

_Check all that apply._

- [x] Stateful (`docs/en/observability/*`)
- [ ] Serverless (`docs/en/serverless/*`)
- [ ] Integrations Developer Guide (`docs/en/integrations/*`)
- [ ] None of the above

### Related issue

## Checklist

<!--
Add labels to:
1. Backport to other versions (`backport-*`):
    - `backport-8.x` to backport to the latest minor
    - `backport-skip` to not backport (for example, for serverless docs)
    - `backport-main` to "backport" to `main` if the target branch is _not_ `main`
    - Individual `backport-*` labels to target specific minor versions
2. Surface blocking reviews (`needs-*-review`):
    - `needs-writer-review` for codeowners
    - `needs-dev-review` for dev team
    - `needs-product-review` for PM review
-->

- [ ] Product/Engineering Review
- [ ] Writer Review

### Follow-up tasks
<!-- If you are updating the Integrations Developer Guide, you can delete this section -->

_Select one._

* This PR does _not_ need to be ported to another doc set because:
  - [ ] The concepts in this PR only apply to one doc set (serverless _or_ stateful)
  - [ ] The PR contains edits to both doc sets (serverless _and_ stateful)
* This PR needs to be ported to another doc set:
  - [ ] Port to stateful docs: \<link to PR or tracking issue>
  - [ ] Port to serverless docs: \<link to PR or tracking issue>
