### PR TITLE
[DOCS] Update kafka.asciidoc

### DIFF
--- a/docs/en/observability/apm/configure/outputs/kafka.asciidoc
+++ b/docs/en/observability/apm/configure/outputs/kafka.asciidoc
@@ -41,7 +41,7 @@ NOTE: Events bigger than <<apm-kafka-max_message_bytes,`max_message_bytes`>> wil
 [[apm-kafka-compatibility]]
 === Compatibility
 
-This output works with all Kafka versions in between 0.11 and 2.2.2. Older versions
+This output works with all Kafka versions in between 0.11 and 3.x Older versions
 might work as well, but are not supported.
 
 [float]


### PR DESCRIPTION
## Description
The document says the Kafka output works with all Kafka versions in between 0.11 and 2.2.2. But as per the conversation and confirmation with the developer team in slack thread below it also supports kakfka versions 3.x https://elastic.slack.com/archives/C0D8SUKB2/p1739435486447789 Hence we need to update our document accordingly.


## Special Notes for the reviewer 
Kindly check the slack discussion in the thread https://elastic.slack.com/archives/C0D8SUKB2/p1739435486447789 
