### PR TITLE
Add note on APM Server Personal Data

### DIFF
--- a/docs/en/observability/apm/security/data-security/filtering.asciidoc
+++ b/docs/en/observability/apm/security/data-security/filtering.asciidoc
@@ -72,6 +72,10 @@ see <<apm-derive-client-ip>>.
 The capturing of this data can be turned off by setting
 **Capture personal data** to `false`.
 
+NOTE: This setting only prevents APM Server from capturing already ingested personal data.
+It does not prevent such data from appearing in ingestion logs where applicable.
+See <<apm-filters-in-agent,APM agent filters>> for redacting data on ingestion.
+
 [discrete]
 [[apm-filters-real-user-data]]
 == Real user monitoring data


### PR DESCRIPTION
## Description

Add note on APM Server about capturing personal data.

### Documentation sets edited in this PR

_Check all that apply._

- [x] Stateful (`docs/en/observability/*`)
- [ ] Serverless (`docs/en/serverless/*`)
- [ ] Integrations Developer Guide (`docs/en/integrations/*`)
- [ ] None of the above

### Related issue

Resolves https://github.com/elastic/apm-server/issues/13622.

## Checklist

<!--
Add labels to:
1. Backport to other versions (`backport-*`):
    - `backport-8.x` to backport to the latest minor
    - `backport-skip` to not backport (for example, for serverless docs)
    - `backport-main` to "backport" to `main` if the target branch is _not_ `main`
    - Individual `backport-*` labels to target specific minor versions
2. Surface blocking reviews (`needs-*-review`):
    - `needs-writer-review` for codeowners
    - `needs-dev-review` for dev team
    - `needs-product-review` for PM review
-->

- [ ] Product/Engineering Review
- [ ] Writer Review

### Follow-up tasks
<!-- If you are updating the Integrations Developer Guide, you can delete this section -->

_Select one._

* This PR does _not_ need to be ported to another doc set because:
  - [x] The concepts in this PR only apply to one doc set (serverless _or_ stateful)
  - [ ] The PR contains edits to both doc sets (serverless _and_ stateful)
* This PR needs to be ported to another doc set:
  - [ ] Port to stateful docs: \<link to PR or tracking issue>
  - [ ] Port to serverless docs: \<link to PR or tracking issue>
