### PR TITLE
Explain issue related to L7 load balancers with apm-server

### DIFF
--- a/docs/en/observability/apm/collect-application-data/open-telemetry/otel-direct.asciidoc
+++ b/docs/en/observability/apm/collect-application-data/open-telemetry/otel-direct.asciidoc
@@ -150,6 +150,11 @@ If you use the OTLP/gRPC protocol, requests to the APM Server must use either HT
 
 When using a layer 7 (L7) proxy like AWS ALB, requests must be proxied in a way that ensures requests to the APM Server follow the rules outlined above. For example, with ALB you can create rules to select an alternative backend protocol based on the headers of requests coming into ALB. In this example, you'd select the gRPC protocol when the  `"Content-Type: application/grpc"` header exists on a request.
 
+Many L7 load balancers, including **NGINX K8s Ingress**, handle HTTP and gRPC traffic separately. They rely on explicitly defined routes and service configurations to correctly proxy requests. Since APM Server serves both protocols on the same port, an L7 load balancer may not correctly distinguish between the two. The solution is to either:
+
+1. Use the `otlp` exporter with NGINX ingress, applying the GRPC annotation for APM Server.
+2. Use the `otlphttp` exporter with NGINX ingress, applying the HTTP annotation for APM Server.
+
 For more information on how to configure an AWS ALB to support gRPC, see this AWS blog post:
 https://aws.amazon.com/blogs/aws/new-application-load-balancer-support-for-end-to-end-http-2-and-grpc/[Application Load Balancer Support for End-to-End HTTP/2 and gRPC].
 


### PR DESCRIPTION
## Description
Add explanation of potential issues that can arise when using an L7 load balancer with APM Server.

### Documentation sets edited in this PR

_Check all that apply._

- [x] Stateful (`docs/en/observability/*`)
- [ ] Serverless (`docs/en/serverless/*`)
- [ ] Integrations Developer Guide (`docs/en/integrations/*`)
- [ ] None of the above

### Related issue
Closes https://github.com/elastic/apm-server/issues/13741.

## Checklist

<!--
Add labels to:
1. Backport to other versions (`backport-*`):
    - `backport-8.x` to backport to the latest minor
    - `backport-skip` to not backport (for example, for serverless docs)
    - `backport-main` to "backport" to `main` if the target branch is _not_ `main`
    - Individual `backport-*` labels to target specific minor versions
2. Surface blocking reviews (`needs-*-review`):
    - `needs-writer-review` for codeowners
    - `needs-dev-review` for dev team
    - `needs-product-review` for PM review
-->

- [ ] Product/Engineering Review
- [x] Writer Review

### Follow-up tasks
<!-- If you are updating the Integrations Developer Guide, you can delete this section -->

_Select one._

* This PR does _not_ need to be ported to another doc set because:
  - [x] The concepts in this PR only apply to one doc set (serverless _or_ stateful)
  - [ ] The PR contains edits to both doc sets (serverless _and_ stateful)
* This PR needs to be ported to another doc set:
  - [ ] Port to stateful docs: \<link to PR or tracking issue>
  - [ ] Port to serverless docs: \<link to PR or tracking issue>
