### PR TITLE
Add known issue for APM Server version 8.6 and older with ES 8.15

### DIFF
--- a/docs/en/observability/apm/known-issues.asciidoc
+++ b/docs/en/observability/apm/known-issues.asciidoc
@@ -22,6 +22,44 @@ _Versions: XX.XX.XX, YY.YY.YY, ZZ.ZZ.ZZ_
 ////
 
 [discrete]
+== APM Server v8.6.x and prior with Elasticsearch v8.15.x and later has broken APM UI
+
+_Elastic Stack versions: 8.15.0+_
+
+// The conditions in which this issue occurs
+The issue occurs when using APM Server versions <= 8.6.x with {stack} versions 8.15.x and later.
+
+// Describe why it happens
+In APM Server versions prior to 8.7.0, the aggregated metrics were indexed in APM's internal data stream. The aggregated metrics require some additional mappings to properly index the data and allow the APM UI to be able to use the data to populate service inventory page properly. From APM Server version 8.7.0, aggregated metrics were moved to their dedicated datastreams (https://github.com/elastic/apm-server/issues/9703[ref]), however, the internal mappings were kept to support backward compatibility. In APM Server version 8.15.0 we migrated to the https://github.com/elastic/elasticsearch/tree/main/x-pack/plugin/apm-data[apm-data plugin] and the internal mappings required to make aggregated metrics work were dropped.
+
+// How to fix it
+If the deployment is running 8.15.0 and APM Server versions are still at 8.6.x or older then the recommendation would be to upgrade the APM Server to the same version as the stack version. If upgrade is not possible then the custom component template should be updated to include custom mappings for making internal datastreams support aggregated metrics:
+
+[source,txt]
+----
+PUT _component_template/metrics-apm.internal@custom
+{
+  "template": {
+    "mappings": {
+      "dynamic_templates": [],
+      "properties": {
+        "transaction.duration.histogram": {
+          "type": "histogram"
+        }
+      }
+    }
+  },
+  "_meta": {
+    "package": {
+      "name": "apm"
+    },
+    "managed_by": "fleet",
+    "managed": true
+  }
+}
+----
+
+[discrete]
 == `prefer_ilm` required in component templates to create custom lifecycle policies
 
 _Elastic Stack versions: 8.15.1+_


### PR DESCRIPTION
## Description
<!-- Add a description here -->
See https://github.com/elastic/apm-server/issues/16084

### Documentation sets edited in this PR

_Check all that apply._

- [x] Stateful (`docs/en/observability/*`)
- [ ] Serverless (`docs/en/serverless/*`)
- [ ] Integrations Developer Guide (`docs/en/integrations/*`)
- [ ] None of the above

### Related issue
Closes https://github.com/elastic/apm-server/issues/16084

## Checklist

<!--
Add labels to:
1. Backport to other versions (`backport-*`):
    - `backport-8.x` to backport to the latest minor
    - `backport-skip` to not backport (for example, for serverless docs)
    - `backport-main` to "backport" to `main` if the target branch is _not_ `main`
    - Individual `backport-*` labels to target specific minor versions
2. Surface blocking reviews (`needs-*-review`):
    - `needs-writer-review` for codeowners
    - `needs-dev-review` for dev team
    - `needs-product-review` for PM review
-->

- [ ] Product/Engineering Review
- [ ] Writer Review

### Follow-up tasks
<!-- If you are updating the Integrations Developer Guide, you can delete this section -->

_Select one._

* This PR does _not_ need to be ported to another doc set because:
  - [x] The concepts in this PR only apply to one doc set (serverless _or_ stateful)
  - [ ] The PR contains edits to both doc sets (serverless _and_ stateful)
