### PR TITLE
[8.18] New sub-feature priv for case assignees

### DIFF
--- a/docs/en/observability/grant-cases-access.asciidoc
+++ b/docs/en/observability/grant-cases-access.asciidoc
@@ -21,7 +21,7 @@ a|
 ====
 Roles without `All` *{connectors-feature}* feature privileges cannot create, add, delete, or modify case connectors.
 
-By default, `All` for the *Cases* feature includes authority to delete cases, delete alerts and comments from cases, edit case settings, add case comments and attachments, and re-open cases unless you customize the sub-feature privileges.
+By default, `All` for the **Cases** feature allows you to have full control over cases, including deleting them, editing case settings, and more. You can customize the sub-feature privileges to limit feature access.
 ====
 
 | Give assignee access to cases


### PR DESCRIPTION
Partially addresses https://github.com/elastic/docs-content/issues/333. Makes minor changes to future-proof docs for giving full access to manage cases and settings.

Preview: [Cases requirements](https://security-docs_bk_6641.docs-preview.app.elstc.co/guide/en/security/8.x/case-permissions.html)


**Related PRs:**

- 9.0 and Serverless docs (all): https://github.com/elastic/docs-content/pull/831
- Kibana docs: https://github.com/elastic/kibana/pull/215162
- Security docs: https://github.com/elastic/security-docs/pull/6641