### PR TITLE
Update profiling-get-started.asciidoc

### DIFF
--- a/docs/en/observability/profiling-get-started.asciidoc
+++ b/docs/en/observability/profiling-get-started.asciidoc
@@ -22,7 +22,7 @@ See the <<profiling-send-feedback, send feedback>> section of the troubleshootin
 
 Before setting up Universal Profiling, make sure you meet the following requirements:
 
-* An {stack} deployment on http://cloud.elastic.co[{ecloud}] at version 8.7.0 or higher. Universal Profiling is currently only available on Elastic Cloud.
+* An {stack} deployment on http://cloud.elastic.co[{ecloud}] at version 8.7.0 or higher or 8.16.0 and higher for self-managed.
 * The workloads you're profiling must be running on Linux machines with x86_64 or ARM64 CPUs.
 * The minimum supported kernel version is either 4.19 for x86_64 or 5.5 for ARM64 machines.
 * The Integrations Server must be enabled on your {ecloud} deployment.


### PR DESCRIPTION
Reflect that Profiling is available in self-managed as well as cloud.

## Description
<!-- Add a description here -->

### Documentation sets edited in this PR

_Check all that apply._

- [ ] Stateful (`docs/en/observability/*`)
- [ ] Serverless (`docs/en/serverless/*`)
- [ ] Integrations Developer Guide (`docs/en/integrations/*`)
- [ ] None of the above

### Related issue
Closes # <!-- Add the issue this PR closes here -->

## Checklist

<!--
Add labels to:
1. Backport to other versions (`backport-*`):
    - `backport-8.x` to backport to the latest minor
    - `backport-skip` to not backport (for example, for serverless docs)
    - `backport-main` to "backport" to `main` if the target branch is _not_ `main`
    - Individual `backport-*` labels to target specific minor versions
2. Surface blocking reviews (`needs-*-review`):
    - `needs-writer-review` for codeowners
    - `needs-dev-review` for dev team
    - `needs-product-review` for PM review
-->

- [ ] Product/Engineering Review
- [ ] Writer Review

### Follow-up tasks
<!-- If you are updating the Integrations Developer Guide, you can delete this section -->

_Select one._

* This PR does _not_ need to be ported to another doc set because:
  - [ ] The concepts in this PR only apply to one doc set (serverless _or_ stateful)
  - [ ] The PR contains edits to both doc sets (serverless _and_ stateful)
* This PR needs to be ported to another doc set:
  - [ ] Port to stateful docs: \<link to PR or tracking issue>
  - [ ] Port to serverless docs: \<link to PR or tracking issue>
