### PR TITLE
[otel] Use GitHub pages links

### DIFF
--- a/docs/en/observability/apm/collect-application-data/open-telemetry/index.asciidoc
+++ b/docs/en/observability/apm/collect-application-data/open-telemetry/index.asciidoc
@@ -7,7 +7,7 @@
 
 [NOTE]
 ====
-*For a complete overview of using OpenTelemetry with Elastic, explore* https://github.com/elastic/opentelemetry[*Elastic Distributions of OpenTelemetry*].
+*For a complete overview of using OpenTelemetry with Elastic, explore* https://elastic.github.io/opentelemetry/[*Elastic Distributions of OpenTelemetry*].
 ====
 
 https://opentelemetry.io/docs/concepts/what-is-opentelemetry/[OpenTelemetry] is a set of APIs, SDKs, tooling,

--- a/docs/en/observability/quickstarts/monitor-hosts-with-otel.asciidoc
+++ b/docs/en/observability/quickstarts/monitor-hosts-with-otel.asciidoc
@@ -19,7 +19,7 @@ You'll also learn how to use {observability} features to gain deeper insight int
 
 [discrete]
 == Limitations
-Refer to https://github.com/elastic/opentelemetry/blob/main/docs/collector-limitations.md[Elastic OpenTelemetry Collector limitations] for known limitations when using the EDOT Collector.
+Refer to https://elastic.github.io/opentelemetry/edot-collector/edot-collector-limitations.html[Elastic OpenTelemetry Collector limitations] for known limitations when using the EDOT Collector.
 
 [discrete]
 == Collect your data

--- a/docs/en/observability/quickstarts/monitor-hosts-with-otel.asciidoc
+++ b/docs/en/observability/quickstarts/monitor-hosts-with-otel.asciidoc
@@ -19,7 +19,7 @@ You'll also learn how to use {observability} features to gain deeper insight int
 
 [discrete]
 == Limitations
-Refer to https://elastic.github.io/opentelemetry/edot-collector/edot-collector-limitations.html[Elastic OpenTelemetry Collector limitations] for known limitations when using the EDOT Collector.
+Refer to https://elastic.github.io/opentelemetry/compatibility/limitations.html[Elastic OpenTelemetry Collector limitations] for known limitations when using the EDOT Collector.
 
 [discrete]
 == Collect your data

--- a/docs/en/observability/quickstarts/monitor-k8s-otel.asciidoc
+++ b/docs/en/observability/quickstarts/monitor-k8s-otel.asciidoc
@@ -3,7 +3,7 @@
 
 preview::[]
 
-In this quickstart guide, you'll learn how to send Kubernetes logs, metrics, and application traces to Elasticsearch, using the https://github.com/open-telemetry/opentelemetry-operator/[OpenTelemetry Operator] to orchestrate https://github.com/elastic/opentelemetry/tree/main[Elastic Distributions of OpenTelemetry] (EDOT) Collectors and SDK instances.
+In this quickstart guide, you'll learn how to send Kubernetes logs, metrics, and application traces to Elasticsearch, using the https://github.com/open-telemetry/opentelemetry-operator/[OpenTelemetry Operator] to orchestrate https://elastic.github.io/opentelemetry/[Elastic Distributions of OpenTelemetry] (EDOT) Collectors and SDK instances.
 
 All the components will be deployed through the https://github.com/open-telemetry/opentelemetry-helm-charts/tree/main/charts/opentelemetry-kube-stack[opentelemetry-kube-stack] helm chart. They include:
 
@@ -12,7 +12,7 @@ All the components will be deployed through the https://github.com/open-telemetr
 * `Deployment` EDOT Collector configured for cluster level metrics.
 * `Instrumentation` object for applications https://opentelemetry.io/docs/kubernetes/operator/automatic/[auto-instrumentation].
 
-For a more detailed description of the components and advanced configuration, refer to the https://github.com/elastic/opentelemetry/blob/main/docs/kubernetes/operator/README.md[elastic/opentelemetry] GitHub repository.
+For a more detailed description of the components and advanced configuration, refer to the https://elastic.github.io/opentelemetry/[EDOT documentation].
 
 [discrete]
 == Prerequisites
@@ -37,7 +37,7 @@ image::images/quickstart-k8s-otel-entry-point.png[Kubernetes-OTel entry point]
 +
 [NOTE]
 ====
-The default installation deploys the OpenTelemetry Operator with a self-signed TLS certificate valid for 365 days. This certificate **won't be renewed** unless the Helm Chart release is manually updated. Refer to the https://github.com/elastic/opentelemetry/blob/main/docs/kubernetes/operator/README.md#cert-manager[cert-manager integrated installation] guide to enable automatic certificate generation and renewal using https://cert-manager.io/docs/installation/[cert-manager].
+The default installation deploys the OpenTelemetry Operator with a self-signed TLS certificate valid for 365 days. This certificate **won't be renewed** unless the Helm Chart release is manually updated. Refer to the https://elastic.github.io/opentelemetry/use-cases/kubernetes/customization.html#cert-manager-integrated-installation[cert-manager integrated installation] guide to enable automatic certificate generation and renewal using https://cert-manager.io/docs/installation/[cert-manager].
 ====
 +
 Deploy the OpenTelemetry Operator and EDOT Collectors using the kube-stack Helm chart with the provided `values.yaml` file. You will run a few commands to:
@@ -60,7 +60,7 @@ image::images/quickstart-k8s-otel-dashboard.png[Kubernetes overview dashboard]
 [discrete]
 == Troubleshooting and more
 
-* To troubleshoot deployment and installation, refer to https://github.com/elastic/opentelemetry/tree/main/docs/kubernetes/operator#installation-verification[installation verification].
-* For application instrumentation details, refer to https://github.com/elastic/opentelemetry/blob/main/docs/kubernetes/operator/instrumenting-applications.md[Instrumenting applications with EDOT SDKs on Kubernetes].
-* To customize the configuration, refer to https://github.com/elastic/opentelemetry/tree/main/docs/kubernetes/operator#custom-configuration[custom configuration].
+* To troubleshoot deployment and installation, refer to https://elastic.github.io/opentelemetry/use-cases/kubernetes/deployment.html#installation-verification[installation verification].
+* For application instrumentation details, refer to https://elastic.github.io/opentelemetry/use-cases/kubernetes/instrumenting-applications.html[Instrumenting applications with EDOT SDKs on Kubernetes].
+* To customize the configuration, refer to https://elastic.github.io/opentelemetry/use-cases/kubernetes/customization.html[custom configuration].
 * Refer to <<observability-introduction>> for a description of other useful features.


### PR DESCRIPTION
## Description

Use GitHub pages links instead of links to Markdown files in the elastic/opentelemetry repo. A larger reworking of OpenTelemetry content in the Observability docs is happening in https://github.com/elastic/docs-content/pull/985, but this fixes existing broken links in the pre-9.0 docs.

### Documentation sets edited in this PR

_Check all that apply._

- [x] Stateful (`docs/en/observability/*`)
- [ ] Serverless (`docs/en/serverless/*`)
- [ ] Integrations Developer Guide (`docs/en/integrations/*`)
- [ ] None of the above

### Related issue

N/A

## Checklist

<!--
Add labels to:
1. Backport to other versions (`backport-*`):
    - `backport-8.x` to backport to the latest minor
    - `backport-skip` to not backport (for example, for serverless docs)
    - `backport-main` to "backport" to `main` if the target branch is _not_ `main`
    - Individual `backport-*` labels to target specific minor versions
2. Surface blocking reviews (`needs-*-review`):
    - `needs-writer-review` for codeowners
    - `needs-dev-review` for dev team
    - `needs-product-review` for PM review
-->

- [ ] Product/Engineering Review
- [ ] Writer Review

### Follow-up tasks
<!-- If you are updating the Integrations Developer Guide, you can delete this section -->

_Select one._

* This PR does _not_ need to be ported to another doc set because:
  - [x] The concepts in this PR only apply to one doc set (serverless _or_ stateful)
  - [ ] The PR contains edits to both doc sets (serverless _and_ stateful)
* This PR needs to be ported to another doc set:
  - [ ] Port to stateful docs: \<link to PR or tracking issue>
  - [ ] Port to serverless docs: \<link to PR or tracking issue>
