### PR TITLE
[Synthetics] Fix step async declaration in snippets

### DIFF
--- a/docs/en/observability/synthetics-create-test.asciidoc
+++ b/docs/en/observability/synthetics-create-test.asciidoc
@@ -106,10 +106,10 @@ A basic two-step journey would look like this:
 [source,js]
 ----
 journey('Journey name', ({ page, browser, client, params, request }) => {
-    step('Step 1 name', () => {
+    step('Step 1 name', async () => {
       // Do something here
     });
-    step('Step 2 name', () => {
+    step('Step 2 name', async () => {
       // Do something else here
     });
 });
@@ -120,7 +120,7 @@ For example, a basic first step might load a web page:
 
 [source,js]
 ----
-step('Load the demo page', () => {
+step('Load the demo page', async () => {
   await page.goto('https://elastic.github.io/synthetics-demo/'); <1>
 });
 ----


### PR DESCRIPTION
## Description
<!-- Add a description here -->

Fix Synthetics step async declaration in provided examples.

### Documentation sets edited in this PR

_Check all that apply._

- [x] Stateful (`docs/en/observability/*`)
- [ ] Serverless (`docs/en/serverless/*`)
- [ ] Integrations Developer Guide (`docs/en/integrations/*`)
- [ ] None of the above

## Checklist

<!--
Add labels to:
1. Backport to other versions (`backport-*`):
    - `backport-8.x` to backport to the latest minor
    - `backport-skip` to not backport (for example, for serverless docs)
    - `backport-main` to "backport" to `main` if the target branch is _not_ `main`
    - Individual `backport-*` labels to target specific minor versions
2. Surface blocking reviews (`needs-*-review`):
    - `needs-writer-review` for codeowners
    - `needs-dev-review` for dev team
    - `needs-product-review` for PM review
-->

- [ ] Product/Engineering Review
- [ ] Writer Review

### Follow-up tasks
<!-- If you are updating the Integrations Developer Guide, you can delete this section -->

_Select one._

* This PR does _not_ need to be ported to another doc set because:
  - [x] The concepts in this PR only apply to one doc set (serverless _or_ stateful)
  - [ ] The PR contains edits to both doc sets (serverless _and_ stateful)
* This PR needs to be ported to another doc set:
  - [ ] Port to stateful docs: \<link to PR or tracking issue>
  - [ ] Port to serverless docs: \<link to PR or tracking issue>
