### PR TITLE
Hide EEM and inventory pages

### DIFF
--- a/docs/en/observability/apm/view-and-analyze/inventory.asciidoc
+++ b/docs/en/observability/apm/view-and-analyze/inventory.asciidoc
@@ -1,4 +1,4 @@
-[[inventory]]
+[id="inventory",role="exclude"]
 = Inventory
 
 ++++

--- a/docs/en/observability/elastic-entity-model.asciidoc
+++ b/docs/en/observability/elastic-entity-model.asciidoc
@@ -1,4 +1,4 @@
-[[elastic-entity-model]]
+[id="elastic-entity-model",role="exclude"]
 = Elastic Entity Model
 
 preview::[]


### PR DESCRIPTION
## Description

Hides the [EEM](https://www.elastic.co/guide/en/serverless/current/observability-elastic-entity-model.html) and [Inventory](https://www.elastic.co/guide/en/serverless/current/observability-inventory.html) pages from appearing in the table of contents and from search engines. However, the pages will still be published in case any users have explicitly enabled entityCentricExperience.

### Documentation sets edited in this PR

_Check all that apply._

- [x] Stateful (`docs/en/observability/*`)
- [ ] Serverless (`docs/en/serverless/*`)
- [ ] Integrations Developer Guide (`docs/en/integrations/*`)
- [ ] None of the above

### Related issue

Related to https://github.com/elastic/observability-docs/issues/4690, https://github.com/elastic/docs-content/pull/1057

## Checklist

<!--
Add labels to:
1. Backport to other versions (`backport-*`):
    - `backport-8.x` to backport to the latest minor
    - `backport-skip` to not backport (for example, for serverless docs)
    - `backport-main` to "backport" to `main` if the target branch is _not_ `main`
    - Individual `backport-*` labels to target specific minor versions
2. Surface blocking reviews (`needs-*-review`):
    - `needs-writer-review` for codeowners
    - `needs-dev-review` for dev team
    - `needs-product-review` for PM review
-->

- [ ] Product/Engineering Review
- [ ] Writer Review

### Follow-up tasks
<!-- If you are updating the Integrations Developer Guide, you can delete this section -->

_Select one._

* This PR does _not_ need to be ported to another doc set because:
  - [x] The concepts in this PR only apply to one doc set (serverless _or_ stateful)
  - [ ] The PR contains edits to both doc sets (serverless _and_ stateful)
* This PR needs to be ported to another doc set:
  - [ ] Port to stateful docs: \<link to PR or tracking issue>
  - [ ] Port to serverless docs: \<link to PR or tracking issue>
