### PR TITLE
[synthetics] Document private locations space awareness

### DIFF
--- a/docs/en/observability/synthetics-private-location.asciidoc
+++ b/docs/en/observability/synthetics-private-location.asciidoc
@@ -148,7 +148,10 @@ When the {agent} is running you can add a new {private-location} in {kib}:
 . Click **Settings**.
 . Click **{private-location}s**.
 . Click **Add location**.
-. Give your new location a unique _Location name_ and select the _Agent policy_ you created above.
+. Give your new location a unique _Location name_.
+. Select the _Agent policy_ you created above.
+. (Optional) In _Tags_, select {kibana-ref}/managing-tags.html[tags] to assign to this location.
+. (Optional) In _Spaces_, specify the {kibana-ref}/xpack-spaces.html[spaces] where this location will be available.
 . Click **Save**.
 
 IMPORTANT: It is not currently possible to use custom CAs for synthetics browser tests in private locations without following a workaround. To learn more about the workaround, refer to the following GitHub issue: https://github.com/elastic/synthetics/issues/717[elastic/synthetics#717].

--- a/docs/en/observability/synthetics-private-location.asciidoc
+++ b/docs/en/observability/synthetics-private-location.asciidoc
@@ -147,7 +147,7 @@ When the {agent} is running you can add a new {private-location} in {kib}:
 . Find `Synthetics` in the {kibana-ref}/introduction.html#kibana-navigation-search[global search field].
 . Click **Settings**.
 . Click **{private-location}s**.
-. Click **Add location**.
+. Click **Create location**.
 . Give your new location a unique _Location name_.
 . Select the _Agent policy_ you created above.
 . (Optional) In _Tags_, select {kibana-ref}/managing-tags.html[tags] to assign to this location.


### PR DESCRIPTION
## Description

Documents that synthetics private locations can now be space aware.

### Documentation sets edited in this PR

_Check all that apply._

- [x] Stateful (`docs/en/observability/*`)
- [ ] Serverless (`docs/en/serverless/*`)
- [ ] Integrations Developer Guide (`docs/en/integrations/*`)
- [ ] None of the above

### Related issue

Related to https://github.com/elastic/observability-docs/issues/4794, https://github.com/elastic/docs-content/pull/1061

## Checklist

<!--
Add labels to:
1. Backport to other versions (`backport-*`):
    - `backport-8.x` to backport to the latest minor
    - `backport-skip` to not backport (for example, for serverless docs)
    - `backport-main` to "backport" to `main` if the target branch is _not_ `main`
    - Individual `backport-*` labels to target specific minor versions
2. Surface blocking reviews (`needs-*-review`):
    - `needs-writer-review` for codeowners
    - `needs-dev-review` for dev team
    - `needs-product-review` for PM review
-->

- [ ] Product/Engineering Review
- [ ] Writer Review

### Follow-up tasks
<!-- If you are updating the Integrations Developer Guide, you can delete this section -->

_Select one._

* This PR does _not_ need to be ported to another doc set because:
  - [x] The concepts in this PR only apply to one doc set (serverless _or_ stateful)
  - [ ] The PR contains edits to both doc sets (serverless _and_ stateful)
* This PR needs to be ported to another doc set:
  - [ ] Port to stateful docs: \<link to PR or tracking issue>
  - [ ] Port to serverless docs: \<link to PR or tracking issue>
