### PR TITLE
New way of backporting

### DIFF
--- a/.github/workflows/backport-active.yml
+++ b/.github/workflows/backport-active.yml
@@ -1,0 +1,22 @@
+name: Backport to active branches
+
+on:
+  pull_request_target:
+    types: [closed]
+    branches:
+      - main
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  backport:
+    # Only run if the PR was merged (not just closed) and has one of the backport labels
+    if: |
+      github.event.pull_request.merged == true && 
+      contains(toJSON(github.event.pull_request.labels.*.name), 'backport-active-')
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: elastic/oblt-actions/github/backport-active@v1

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,3 +1,17 @@
+commands_restrictions:
+  backport:
+    conditions:
+      - or:
+        - sender-permission>=write
+        - sender=github-actions[bot]
+defaults:
+  actions:
+    backport:
+      title: "[{{ destination_branch }}] (backport #{{ number }}) {{ title }}"
+      assignees:
+        - "{{ author }}"
+      labels:
+        - "backport"
 pull_request_rules:
   - name: ask to resolve conflict
     conditions:


### PR DESCRIPTION
## Proposed commit message

New way of backporting to active branches using new github action.

## Why

No need to support the hardcoded branches in the `.mergify.yml` file anymore.

We use a dynamic approach by fetching https://storage.googleapis.com/artifacts-api/snapshots/branches.json and filtering the branches.

## Issues

Already enabled in Elastic Agent:
- https://github.com/elastic/elastic-agent/actions/workflows/backport-active.yml
