### PR TITLE
[Obs AI Assistant] Remove reindex note

### DIFF
--- a/docs/en/observability/observability-ai-assistant.asciidoc
+++ b/docs/en/observability/observability-ai-assistant.asciidoc
@@ -99,18 +99,6 @@ To set up the AI Assistant:
 [[obs-ai-add-data]]
 == Add data to the AI Assistant knowledge base
 
-[IMPORTANT]
-====
-*If you started using the AI Assistant in technical preview*,
-any knowledge base articles you created before 8.12 will have to be reindexed or upgraded before they can be used.
-Knowledge base articles created before 8.12 use ELSER v1.
-In 8.12, knowledge base articles must use ELSER v2.
-Options include:
-
-* Clear all old knowledge base articles manually and reindex them.
-* Upgrade all knowledge base articles indexed with ELSER v1 to ELSER v2 using a https://github.com/elastic/elasticsearch-labs/blob/main/notebooks/model-upgrades/upgrading-index-to-use-elser.ipynb[Python script].
-====
-
 The AI Assistant uses {ml-docs}/ml-nlp-elser.html[ELSER], Elastic's semantic search engine, to recall data from its internal knowledge base index to create retrieval augmented generation (RAG) responses. Adding data such as Runbooks, GitHub issues, internal documentation, and Slack messages to the knowledge base gives the AI Assistant context to provide more specific assistance.
 
 NOTE: Your AI provider may collect telemetry when using the AI Assistant. Contact your AI provider for information on how data is collected.


### PR DESCRIPTION
Remove re-index note. The need to reindex only applies to 8.17, in 8.18+ reindexing is done automatically.

