### PR TITLE
[apm]: Document sampling.tail.discard_on_write_failure config

### DIFF
--- a/docs/en/observability/apm/configure/sampling.asciidoc
+++ b/docs/en/observability/apm/configure/sampling.asciidoc
@@ -87,7 +87,7 @@ Default: `false`. (bool)
 
 |====
 | APM Server binary | `sampling.tail.discard_on_write_failure`
-| Fleet-managed (version 8.19+)     | `Discard On Write Failure`
+| Fleet-managed     | `Discard On Write Failure`
 |====
 
 // end::tbs-top[]

--- a/docs/en/observability/apm/configure/sampling.asciidoc
+++ b/docs/en/observability/apm/configure/sampling.asciidoc
@@ -76,6 +76,20 @@ Default: `3GB`. (text)
 | Fleet-managed     | `Storage limit`
 |====
 
+[float]
+[id="sampling-tail-discard_on_write_failure-{input-type}"]
+=== Discard On Write Failure
+Defines the indexing behavior when trace events fail to be written to storage (for example, when the storage limit is reached).
+When set to `false`, traces bypass sampling and are always indexed, which significantly increases the indexing load.
+When set to `true`, traces are discarded, causing data loss which can result in broken traces.
+
+Default: `false`. (bool)
+
+|====
+| APM Server binary | `sampling.tail.discard_on_write_failure`
+| Fleet-managed (version 8.19+)     | `Discard On Write Failure`
+|====
+
 // end::tbs-top[]
 
 [float]

--- a/docs/en/observability/apm/configure/sampling.asciidoc
+++ b/docs/en/observability/apm/configure/sampling.asciidoc
@@ -67,7 +67,7 @@ This final policy is used to catch remaining trace events that don't match a str
 === Storage limit
 The amount of storage space allocated for trace events matching tail sampling policies. Caution: Setting this limit higher than the allowed space may cause APM Server to become unhealthy.
 
-If the configured storage limit is insufficient, it logs "configured storage limit reached". The event will bypass sampling and will always be indexed when storage limit is reached.
+If the configured storage limit is insufficient, it logs "configured storage limit reached". When the storage limit is reached, the event will be indexed or discarded based on the <<sampling-tail-discard_on_write_failure-{input-type},Discard On Write Failure>> configuration.
 
 Default: `3GB`. (text)
 


### PR DESCRIPTION
## Description
Adding description for new config that will be available on v8.19+. The description matches the one provided in the v9.1.0 docs: https://github.com/elastic/docs-content/pull/1453

### Documentation sets edited in this PR

_Check all that apply._

- [x] Stateful (`docs/en/observability/*`)
- [ ] Serverless (`docs/en/serverless/*`)
- [ ] Integrations Developer Guide (`docs/en/integrations/*`)
- [ ] None of the above

### Related issue
Closes https://github.com/elastic/apm-server/issues/15330

## Checklist

<!--
Add labels to:
1. Backport to other versions (`backport-*`):
    - `backport-8.x` to backport to the latest minor
    - `backport-skip` to not backport (for example, for serverless docs)
    - `backport-main` to "backport" to `main` if the target branch is _not_ `main`
    - Individual `backport-*` labels to target specific minor versions
2. Surface blocking reviews (`needs-*-review`):
    - `needs-writer-review` for codeowners
    - `needs-dev-review` for dev team
    - `needs-product-review` for PM review
-->

- [ ] Product/Engineering Review
- [ ] Writer Review

### Follow-up tasks
<!-- If you are updating the Integrations Developer Guide, you can delete this section -->

_Select one._

* This PR does _not_ need to be ported to another doc set because:
  - [ ] The concepts in this PR only apply to one doc set (serverless _or_ stateful)
  - [ ] The PR contains edits to both doc sets (serverless _and_ stateful)
* This PR needs to be ported to another doc set:
  - [ ] Port to stateful docs: \<link to PR or tracking issue>
  - [ ] Port to serverless docs: \<link to PR or tracking issue>


### Testing
I kept getting the below error building the docs locally when running `../docs/build_docs --doc docs/en/observability/apm/configure/sampling.asciidoc  --resource ../apm-server --resource ../ingest-docs/docs --open`
```
INFO:build_docs:/docs_build/resources/asciidoctor/lib/chunker/extension.rb:102:in `page_containing': undefined method `context' for nil:NilClass (NoMethodError)
  ```
  
  I validated with asciidoc plugin instead:
  
<img width="1132" alt="image" src="https://github.com/user-attachments/assets/380a1b48-42a3-480b-bc95-3209539e91be" />

 
