### PR TITLE
apm: Document apm-server.sampling.tail.ttl

### DIFF
--- a/docs/en/observability/apm/configure/sampling.asciidoc
+++ b/docs/en/observability/apm/configure/sampling.asciidoc
@@ -76,6 +76,18 @@ Default: `3GB`. (text)
 | Fleet-managed     | `Storage limit`
 |====
 
+[float]
+[id="sampling-tail-ttl-{input-type}"]
+=== TTL
+Time-to-live (TTL) for trace events stored in the local storage of the APM Server during tail-based sampling. This TTL determines how long trace events are retained in the local storage while waiting for a sampling decision to be made. A greater TTL value increases storage space requirements. Should be at least 2 * Interval.
+
+Default: `30m` (30 minutes). (duration)
+
+|====
+| APM Server binary | `sampling.tail.ttl`
+| Fleet-managed (version 8.19+) | `TTL`
+|====
+
 // end::tbs-top[]
 
 [float]

--- a/docs/en/observability/apm/configure/sampling.asciidoc
+++ b/docs/en/observability/apm/configure/sampling.asciidoc
@@ -85,7 +85,7 @@ Default: `30m` (30 minutes). (duration)
 
 |====
 | APM Server binary | `sampling.tail.ttl`
-| Fleet-managed (version 8.19+) | `TTL`
+| Fleet-managed     | `TTL`
 |====
 
 // end::tbs-top[]

--- a/docs/en/observability/apm/configure/sampling.asciidoc
+++ b/docs/en/observability/apm/configure/sampling.asciidoc
@@ -79,7 +79,7 @@ Default: `3GB`. (text)
 [float]
 [id="sampling-tail-ttl-{input-type}"]
 === TTL
-Time-to-live (TTL) for trace events stored in the local storage of the APM Server during tail-based sampling. This TTL determines how long trace events are retained in the local storage while waiting for a sampling decision to be made. A greater TTL value increases storage space requirements. Should be at least 2 * Interval.
+Time-to-live (TTL) for trace events stored in the local storage of the APM Server during tail-based sampling. This TTL determines how long trace events are retained in the local storage while waiting for a sampling decision to be made. A greater TTL value increases storage space requirements. Should be at least 2 * Interval (`sampling.tail.interval`).
 
 Default: `30m` (30 minutes). (duration)
 


### PR DESCRIPTION
## Description
<!-- Add a description here -->

### Documentation sets edited in this PR

_Check all that apply._

- [x] Stateful (`docs/en/observability/*`)
- [ ] Serverless (`docs/en/serverless/*`)
- [ ] Integrations Developer Guide (`docs/en/integrations/*`)
- [ ] None of the above

### Related issue

Part of https://github.com/elastic/apm-server/issues/13525

## Checklist

<!--
Add labels to:
1. Backport to other versions (`backport-*`):
    - `backport-8.x` to backport to the latest minor
    - `backport-skip` to not backport (for example, for serverless docs)
    - `backport-main` to "backport" to `main` if the target branch is _not_ `main`
    - Individual `backport-*` labels to target specific minor versions
2. Surface blocking reviews (`needs-*-review`):
    - `needs-writer-review` for codeowners
    - `needs-dev-review` for dev team
    - `needs-product-review` for PM review
-->

- [ ] Product/Engineering Review
- [ ] Writer Review

### Follow-up tasks
<!-- If you are updating the Integrations Developer Guide, you can delete this section -->

_Select one._

* This PR does _not_ need to be ported to another doc set because:
  - [x] The concepts in this PR only apply to one doc set (serverless _or_ stateful)
  - [ ] The PR contains edits to both doc sets (serverless _and_ stateful)
* This PR needs to be ported to another doc set:
  - [ ] Port to stateful docs: \<link to PR or tracking issue>
  - [ ] Port to serverless docs: \<link to PR or tracking issue>
