### PR TITLE
ci: move from dependabot reviewers to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,4 +3,4 @@
 # For more info, see https://help.github.com/articles/about-codeowners/
 
 * @elastic/obs-docs
-/.github/workflows/co-docs-builder.yml @elastic/docs-engineering
+/.github/workflows @elastic/observablt-ci

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,3 +4,5 @@
 
 * @elastic/obs-docs
 /.github/workflows/co-docs-builder.yml @elastic/docs-engineering
+
+/.github @elastic/observablt-ci

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,5 +4,3 @@
 
 * @elastic/obs-docs
 /.github/workflows/co-docs-builder.yml @elastic/docs-engineering
-
-/.github @elastic/observablt-ci

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,8 +9,6 @@ updates:
       interval: "weekly"
       day: "sunday"
       time: "22:00"
-    reviewers:
-      - "elastic/observablt-ci"
     groups:
       github-actions:
         patterns:


### PR DESCRIPTION
## Description
Removed reviewers section in dependabot.yml and moved it's definition to CODEOWNERS.

Removed `/.github/workflows/co-docs-builder.yml @elastic/docs-engineering` since workflow [does not exist](https://github.com/elastic/observability-docs/pull/4915#discussion_r2190276538) anymore.

Reviewers dependabot.yml configuration is being retired option because the functionality overlaps with [GitHub code owners](https://docs.github.com/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners).
See: https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/

### Documentation sets edited in this PR

_Check all that apply._

- [ ] Stateful (`docs/en/observability/*`)
- [ ] Serverless (`docs/en/serverless/*`)
- [ ] Integrations Developer Guide (`docs/en/integrations/*`)
- [x] None of the above

## Checklist

<!--
Add labels to:
1. Backport to other versions (`backport-*`):
    - `backport-8.x` to backport to the latest minor
    - `backport-skip` to not backport (for example, for serverless docs)
    - `backport-main` to "backport" to `main` if the target branch is _not_ `main`
    - Individual `backport-*` labels to target specific minor versions
2. Surface blocking reviews (`needs-*-review`):
    - `needs-writer-review` for codeowners
    - `needs-dev-review` for dev team
    - `needs-product-review` for PM review
-->

- ~[ ] Product/Engineering Review~
- ~[ ] Writer Review~

### Follow-up tasks
<!-- If you are updating the Integrations Developer Guide, you can delete this section -->

_Select one._

* This PR does _not_ need to be ported to another doc set because:
  - ~[ ] The concepts in this PR only apply to one doc set (serverless _or_ stateful)~
  - ~[ ] The PR contains edits to both doc sets (serverless _and_ stateful)~
* This PR needs to be ported to another doc set:
  - ~[ ] Port to stateful docs: \<link to PR or tracking issue>~
  - ~[ ] Port to serverless docs: \<link to PR or tracking issue>~
