### PR TITLE
[OBSERVABILITY][ResponseOps][Alerting][8.19] Alert Deletion Docs

### DIFF
--- a/docs/en/observability/view-observability-alerts.asciidoc
+++ b/docs/en/observability/view-observability-alerts.asciidoc
@@ -123,4 +123,4 @@ with an option to view the updated case. To view the case details, click the not
 [[clean-up-alerts-obs]]
 === Clean up alerts
 
-Manage the size of alert indices in your space by clearing out alerts that are older or infrequently accessed. You can do this by {kibana-ref}/run-alert-clean-up-task.html/[running an alert cleanup task], which deletes alerts according to the criteria that you define.
+Manage the size of alert indices in your space by clearing out alerts that are older or infrequently accessed. You can do this by {kibana-ref}/run-alert-clean-up-task.html[running an alert cleanup task], which deletes alerts according to the criteria that you define.

--- a/docs/en/observability/view-observability-alerts.asciidoc
+++ b/docs/en/observability/view-observability-alerts.asciidoc
@@ -123,4 +123,4 @@ with an option to view the updated case. To view the case details, click the not
 [[clean-up-alerts-obs]]
 === Clean up alerts
 
-Manage the size of alert indices in your space by clearing out alerts that are older or infrequently accessed. You can do this by {kibana-ref}/run-alert-clean-up-task.html[running an alert cleanup task], which deletes alerts according to the criteria that you define.
+Manage the size of alert indices in your space by clearing out alerts that are older or infrequently accessed. You can do this by {kibana-ref}/view-alerts.html#clean-up-alerts.html[running an alert cleanup task], which deletes alerts according to the criteria that you define.

--- a/docs/en/observability/view-observability-alerts.asciidoc
+++ b/docs/en/observability/view-observability-alerts.asciidoc
@@ -1,5 +1,5 @@
 [[view-observability-alerts]]
-= View alerts
+= View and manage alerts
 
 The Alerts page lists all the alerts that have met a condition defined by a rule you created using
 one of the Observability apps.
@@ -118,3 +118,9 @@ To add an alert to an existing case:
 . Select **Add to existing case**.
 . From the Select case pane, select the case for which to attach an alert. A confirmation message displays
 with an option to view the updated case. To view the case details, click the notification link or go to the <<create-cases,Cases>> page.
+
+[discrete]
+[[clean-up-alerts-obs]]
+=== Clean up alerts
+
+Manage the size of alert indices in your space by clearing out alerts that are older or infrequently accessed. You can do this by {kibana-ref}/run-alert-clean-up-task.html/[running an alert cleanup task], which deletes alerts according to the criteria that you define.

--- a/docs/en/observability/view-observability-alerts.asciidoc
+++ b/docs/en/observability/view-observability-alerts.asciidoc
@@ -123,4 +123,4 @@ with an option to view the updated case. To view the case details, click the not
 [[clean-up-alerts-obs]]
 === Clean up alerts
 
-Manage the size of alert indices in your space by clearing out alerts that are older or infrequently accessed. You can do this by {kibana-ref}/view-alerts.html#clean-up-alerts.html[running an alert cleanup task], which deletes alerts according to the criteria that you define.
+Manage the size of alert indices in your space by clearing out alerts that are older or infrequently accessed. You can do this by {kibana-ref}/view-alerts.html#clean-up-alerts[running an alert cleanup task], which deletes alerts according to the criteria that you define.


### PR DESCRIPTION
⚠️ **NOTE: Must be merged _after_ https://github.com/elastic/kibana/pull/229230.** ⚠️

## Description
Added a new section about cleaning up old alerts. Also expanded the page's title. 

### Documentation sets edited in this PR

_Check all that apply._

- [x] Stateful (`docs/en/observability/*`)
- [ ] Serverless (`docs/en/serverless/*`)
- [ ] Integrations Developer Guide (`docs/en/integrations/*`)
- [ ] None of the above

### Related issue
Closes https://github.com/elastic/docs-content/issues/1716

## Checklist

<!--
Add labels to:
1. Backport to other versions (`backport-*`):
    - `backport-8.x` to backport to the latest minor
    - `backport-skip` to not backport (for example, for serverless docs)
    - `backport-main` to "backport" to `main` if the target branch is _not_ `main`
    - Individual `backport-*` labels to target specific minor versions
2. Surface blocking reviews (`needs-*-review`):
    - `needs-writer-review` for codeowners
    - `needs-dev-review` for dev team
    - `needs-product-review` for PM review

-->

- [ ] Product/Engineering Review
- [ ] Writer Review

### Follow-up tasks
<!-- If you are updating the Integrations Developer Guide, you can delete this section -->

_Select one._

* This PR does _not_ need to be ported to another doc set because:
  - [ ] The concepts in this PR only apply to one doc set (serverless _or_ stateful)
  - [ ] The PR contains edits to both doc sets (serverless _and_ stateful)
* This PR needs to be ported to another doc set:
  - [x] Port to stateful docs: https://github.com/elastic/kibana/pull/229230 and https://github.com/elastic/security-docs/pull/6952
  - [x] Port to serverless docs: https://github.com/elastic/docs-content/pull/2138
