### PR TITLE
[Observability][8.19] Docs new context.grouping variable added to Obs rules

### DIFF
--- a/docs/en/observability/apm-error-count-threshold-rule.asciidoc
+++ b/docs/en/observability/apm-error-count-threshold-rule.asciidoc
@@ -95,31 +95,34 @@ You an also specify {kibana-ref}/rule-action-variables.html[variables common to 
 Link to the alert troubleshooting view for further context and details. This will be an empty string if the server.publicBaseUrl is not configured.
 
 `context.environment`::
-The transaction type the alert is created for
+The transaction type the alert is created for.
+
+`context.grouping``:: 
+The object containing groups that are reporting data.
 
 `context.errorGroupingKey`::
-The error grouping key the alert is created for
+The error grouping key the alert is created for.
 
 `context.errorGroupingName`::
-The error grouping name the alert is created for
+The error grouping name the alert is created for.
 
 `context.interval`::
-The length and unit of the time period where the alert conditions were met
+The length and unit of the time period where the alert conditions were met.
 
 `context.reason`::
-A concise description of the reason for the alert
+A concise description of the reason for the alert.
 
 `context.serviceName`::
-The service the alert is created for
+The service the alert is created for.
 
 `context.threshold`::
-Any trigger value above this value will cause the alert to fir
+Any trigger value above this value will cause the alert to fire.
 
 `context.transactionName`::
-The transaction name the alert is created for
+The transaction name the alert is created for.
 
 `context.triggerValue`::
-The value that breached the threshold and triggered the alert
+The value that breached the threshold and triggered the alert.
 
 `context.viewInAppUrl`::
-Link to the alert source
+Link to the alert source.

--- a/docs/en/observability/apm-error-count-threshold-rule.asciidoc
+++ b/docs/en/observability/apm-error-count-threshold-rule.asciidoc
@@ -97,7 +97,7 @@ Link to the alert troubleshooting view for further context and details. This wil
 `context.environment`::
 The transaction type the alert is created for.
 
-`context.grouping``:: 
+`context.grouping`:: 
 The object containing groups that are reporting data.
 
 `context.errorGroupingKey`::

--- a/docs/en/observability/apm-failed-transaction-rate-threshold-rule.asciidoc
+++ b/docs/en/observability/apm-failed-transaction-rate-threshold-rule.asciidoc
@@ -88,28 +88,31 @@ You an also specify {kibana-ref}/rule-action-variables.html[variables common to 
 Link to the alert troubleshooting view for further context and details. This will be an empty string if the server.publicBaseUrl is not configured.
 
 `context.environment`::
-The transaction type the alert is created for
+The transaction type the alert is created for.
+
+`context.grouping``:: 
+The object containing groups that are reporting data.
 
 `context.interval`::
-The length and unit of the time period where the alert conditions were met
+The length and unit of the time period where the alert conditions were met.
 
 `context.reason`::
-A concise description of the reason for the alert
+A concise description of the reason for the alert.
 
 `context.serviceName`::
-The service the alert is created for
+The service the alert is created for.
 
 `context.threshold`::
-Any trigger value above this value will cause the alert to fire
+Any trigger value above this value will cause the alert to fire.
 
 `context.transactionName`::
-The transaction name the alert is created for
+The transaction name the alert is created for.
 
 `context.transactionType`::
-The transaction type the alert is created for
+The transaction type the alert is created for.
 
 `context.triggerValue`::
-The value that breached the threshold and triggered the alert
+The value that breached the threshold and triggered the alert.
 
 `context.viewInAppUrl`::
-Link to the alert source
+Link to the alert source.

--- a/docs/en/observability/apm-failed-transaction-rate-threshold-rule.asciidoc
+++ b/docs/en/observability/apm-failed-transaction-rate-threshold-rule.asciidoc
@@ -90,7 +90,7 @@ Link to the alert troubleshooting view for further context and details. This wil
 `context.environment`::
 The transaction type the alert is created for.
 
-`context.grouping``:: 
+`context.grouping`:: 
 The object containing groups that are reporting data.
 
 `context.interval`::

--- a/docs/en/observability/apm-latency-threshold-rule.asciidoc
+++ b/docs/en/observability/apm-latency-threshold-rule.asciidoc
@@ -92,6 +92,9 @@ Link to the alert troubleshooting view for further context and details. This wil
 `context.environment`::
 The transaction type the alert is created for.
 
+`context.grouping``:: 
+The object containing groups that are reporting data.
+
 `context.interval`::
 The length and unit of the time period where the alert conditions were met.
 

--- a/docs/en/observability/apm-latency-threshold-rule.asciidoc
+++ b/docs/en/observability/apm-latency-threshold-rule.asciidoc
@@ -92,7 +92,7 @@ Link to the alert troubleshooting view for further context and details. This wil
 `context.environment`::
 The transaction type the alert is created for.
 
-`context.grouping``:: 
+`context.grouping`:: 
 The object containing groups that are reporting data.
 
 `context.interval`::

--- a/docs/en/observability/metrics-threshold-alert.asciidoc
+++ b/docs/en/observability/metrics-threshold-alert.asciidoc
@@ -104,6 +104,7 @@ You an also specify {kibana-ref}/rule-action-variables.html[variables common to 
 `context.cloud`:: The cloud object defined by ECS if available in the source.
 `context.container`:: The container object defined by ECS if available in the source.
 `context.group`:: Name of the group(s) reporting data. For accessing each group key, use `context.groupByKeys`.
+`context.grouping``:: The object containing groups that are reporting data.
 `context.groupByKeys`:: The object containing groups that are reporting data.
 `context.host`:: The host object defined by ECS if available in the source.
 `context.labels`:: List of labels associated with the entity where this alert triggered.

--- a/docs/en/observability/metrics-threshold-alert.asciidoc
+++ b/docs/en/observability/metrics-threshold-alert.asciidoc
@@ -103,7 +103,6 @@ You an also specify {kibana-ref}/rule-action-variables.html[variables common to 
 `context.alertState`:: Current state of the alert.
 `context.cloud`:: The cloud object defined by ECS if available in the source.
 `context.container`:: The container object defined by ECS if available in the source.
-`context.group`:: Name of the group(s) reporting data. For accessing each group key, use `context.groupByKeys`.
 `context.grouping``:: The object containing groups that are reporting data.
 `context.groupByKeys`:: The object containing groups that are reporting data.
 `context.host`:: The host object defined by ECS if available in the source.

--- a/docs/en/observability/metrics-threshold-alert.asciidoc
+++ b/docs/en/observability/metrics-threshold-alert.asciidoc
@@ -103,7 +103,7 @@ You an also specify {kibana-ref}/rule-action-variables.html[variables common to 
 `context.alertState`:: Current state of the alert.
 `context.cloud`:: The cloud object defined by ECS if available in the source.
 `context.container`:: The container object defined by ECS if available in the source.
-`context.grouping``:: The object containing groups that are reporting data.
+`context.group`:: Name of the group(s) reporting data. For accessing each group key, use `context.groupByKeys`.
 `context.groupByKeys`:: The object containing groups that are reporting data.
 `context.host`:: The host object defined by ECS if available in the source.
 `context.labels`:: List of labels associated with the entity where this alert triggered.

--- a/docs/en/observability/slo-burn-rate-alert.asciidoc
+++ b/docs/en/observability/slo-burn-rate-alert.asciidoc
@@ -64,6 +64,7 @@ You an also specify {kibana-ref}/rule-action-variables.html[variables common to 
 
 `context.alertDetailsUrl`:: Link to the alert troubleshooting view for further context and details. This will be an empty string if the `server.publicBaseUrl` is not configured.
 `context.burnRateThreshold`:: The burn rate threshold value.
+`context.grouping``:: The object containing groups that are reporting data.
 `context.longWindow`:: The window duration with the associated burn rate value.
 `context.reason`:: A concise description of the reason for the alert.
 `context.shortWindow`:: The window duration with the associated burn rate value.

--- a/docs/en/observability/slo-burn-rate-alert.asciidoc
+++ b/docs/en/observability/slo-burn-rate-alert.asciidoc
@@ -64,7 +64,7 @@ You an also specify {kibana-ref}/rule-action-variables.html[variables common to 
 
 `context.alertDetailsUrl`:: Link to the alert troubleshooting view for further context and details. This will be an empty string if the `server.publicBaseUrl` is not configured.
 `context.burnRateThreshold`:: The burn rate threshold value.
-`context.grouping``:: The object containing groups that are reporting data.
+`context.grouping`:: The object containing groups that are reporting data.
 `context.longWindow`:: The window duration with the associated burn rate value.
 `context.reason`:: A concise description of the reason for the alert.
 `context.shortWindow`:: The window duration with the associated burn rate value.


### PR DESCRIPTION
## Description
Adds docs for the new `context.grouping` action variable that was added to the following Observability rules:

- [Custom threshold](https://observability-docs_bk_4921.docs-preview.app.elstc.co/guide/en/observability/8.19/custom-threshold-alert.html#custom-threshold-action-variables) (This didn't need new docs. The action variable was already doc'd.)
- [SLO burn rate](https://observability-docs_bk_4921.docs-preview.app.elstc.co/guide/en/observability/8.19/slo-burn-rate-alert.html#action-variables-slo)
- [APM Latency threshold](https://observability-docs_bk_4921.docs-preview.app.elstc.co/guide/en/observability/8.19/apm-latency-threshold-rule.html#_action_variables_4)
- [APM Failed transaction rate threshold](https://observability-docs_bk_4921.docs-preview.app.elstc.co/guide/en/observability/8.19/apm-failed-transaction-rate-threshold-rule.html#_action_variables_2)
- [APM Error count threshold](https://observability-docs_bk_4921.docs-preview.app.elstc.co/guide/en/observability/8.19/apm-error-count-threshold-rule.html#_action_variables) 

Also makes minor fixes to typos and adds missing periods.

### Documentation sets edited in this PR

_Check all that apply._

- [x] Stateful (`docs/en/observability/*`)
- [ ] Serverless (`docs/en/serverless/*`)
- [ ] Integrations Developer Guide (`docs/en/integrations/*`)
- [ ] None of the above

### Related issue
https://github.com/elastic/docs-content/issues/2195

## Checklist

<!--
Add labels to:
1. Backport to other versions (`backport-*`):
    - `backport-8.x` to backport to the latest minor
    - `backport-skip` to not backport (for example, for serverless docs)
    - `backport-main` to "backport" to `main` if the target branch is _not_ `main`
    - Individual `backport-*` labels to target specific minor versions
2. Surface blocking reviews (`needs-*-review`):
    - `needs-writer-review` for codeowners
    - `needs-dev-review` for dev team
    - `needs-product-review` for PM review

-->

- [ ] Product/Engineering Review
- [ ] Writer Review

### Follow-up tasks
<!-- If you are updating the Integrations Developer Guide, you can delete this section -->

_Select one._

* This PR does _not_ need to be ported to another doc set because:
  - [x] The concepts in this PR only apply to one doc set (serverless _or_ stateful)
  - [ ] The PR contains edits to both doc sets (serverless _and_ stateful)
* This PR needs to be ported to another doc set:
  - [ ] Port to stateful docs: 
  - [x] Port to serverless docs: https://github.com/elastic/docs-content/pull/2336