### PR TITLE
docs: Update 8.19.0 apm integration unreachable known issue

### DIFF
--- a/docs/en/observability/apm/known-issues.asciidoc
+++ b/docs/en/observability/apm/known-issues.asciidoc
@@ -22,27 +22,29 @@ _Versions: XX.XX.XX, YY.YY.YY, ZZ.ZZ.ZZ_
 ////
 
 [discrete]
-== APM Integration / Server might get removed after upgrading to 8.19.0 and 9.1.0
+== APM Integration might be unreachable after upgrading to 8.19.0 and 9.1.0
 
 _Elastic Stack versions: 8.19.0 and 9.1.0_
 _Environments: ECH, ECE, ECK, and self-managed when running Fleet_
 
-The APM Integration might sometimes get removed from the Elastic Agent on Cloud policy.
+APM Integration, which is APM Server managed by Fleet, might sometimes be unreachable after reloading due to an integration policy change. Standalone APM Server is not affected by this issue.
 
-When this happens, APM intake and OTLP intake through APM Server / APM Integration will stop working.
+When this happens, APM and OTLP intake through APM Integration will stop working, and there will be little to no logs from it. On ECH and ECE cloud, "Copy endpoint" will be grayed out.
 
 *Workaround*
 
 To work around this issue you can either:
 
 * Restart the Integration servers through Force Restart in the Cloud Admin UI.
-* Save a copy of the Elastic APM Integration policy within the Elastic Agent on Cloud policy in the Fleet UI:
-** Go to *Kibana* > *Fleet* > *Elastic Cloud agent policy*.
+* Save a copy of the Elastic APM Integration policy within the affected policy, for example the Elastic Cloud agent policy, in the Fleet UI:
+** Go to *Kibana* > *Fleet* > the affected policy (e.g. *Elastic Cloud agent policy*).
 ** Select the *...* icon, then *Edit Integration*.
 ** Add a blank space to the *Description*, then remove it.
 ** Select *Save Integration*.
 
-In both cases, the settings of APM Integration are maintained. 
+In both cases, the settings of APM Integration are maintained. However, these workarounds will only keep APM Integration healthy until next integration policy change.
+
+This bug will be fixed in 8.19.1 and 9.1.1.
 
 [discrete]
 == Tail Sampling may not compact / expired TTLs as quickly as desired, causing increased storage usage.


### PR DESCRIPTION
## Description
<!-- Add a description here -->

Align with https://github.com/elastic/apm-server/pull/17973

### Documentation sets edited in this PR

_Check all that apply._

- [x] Stateful (`docs/en/observability/*`)
- [ ] Serverless (`docs/en/serverless/*`)
- [ ] Integrations Developer Guide (`docs/en/integrations/*`)
- [ ] None of the above

### Related issue

## Checklist

<!--
Add labels to:
1. Backport to other versions (`backport-*`):
    - `backport-8.x` to backport to the latest minor
    - `backport-skip` to not backport (for example, for serverless docs)
    - `backport-main` to "backport" to `main` if the target branch is _not_ `main`
    - Individual `backport-*` labels to target specific minor versions
2. Surface blocking reviews (`needs-*-review`):
    - `needs-writer-review` for codeowners
    - `needs-dev-review` for dev team
    - `needs-product-review` for PM review
-->

- [x] Product/Engineering Review
- [ ] Writer Review

### Follow-up tasks
<!-- If you are updating the Integrations Developer Guide, you can delete this section -->

_Select one._

* This PR does _not_ need to be ported to another doc set because:
  - [ ] The concepts in this PR only apply to one doc set (serverless _or_ stateful)
  - [ ] The PR contains edits to both doc sets (serverless _and_ stateful)
* This PR needs to be ported to another doc set:
  - [ ] Port to stateful docs: \<link to PR or tracking issue>
  - [ ] Port to serverless docs: \<link to PR or tracking issue>
