### PR TITLE
[OBSERVABILITY][ResponseOps][Cases][8.x] Improves docs for alerting statuses

### DIFF
--- a/docs/en/observability/view-observability-alerts.asciidoc
+++ b/docs/en/observability/view-observability-alerts.asciidoc
@@ -64,29 +64,27 @@ To view the alert in the app that triggered it:
 
 There are four common alert statuses:
 
-`active`
-:   The conditions for the rule are met. If the rule has {kibana-ref}/create-and-manage-rules.html#defining-rules-actions-details[recovery actions], {kib} generates notifications based on the actions' notification settings. 
+`active`::
+The conditions for the rule are met. If the rule has {kibana-ref}/create-and-manage-rules.html#defining-rules-actions-details[actions], {kib} generates notifications based on the actions' notification settings. 
 
-`flapping`
-
-:   The alert is switching repeatedly between active and recovered states. If the rule has actions that run when the alert status changes states, those actions are suppressed while the alert is flapping.
+`flapping`::
+The alert is switching repeatedly between active and recovered states. If the rule has actions that run when the alert status changes states, those actions are suppressed while the alert is flapping.
 
 NOTE: Alert flapping is turned on by default. You can modify the criteria for changing an alert's status to the flapping state by configuring the **Alert flapping detection** settings. To do this, navigate to the **Alerts** page in the main menu, or use the {kibana-ref}/introduction.html#kibana-navigation-search[global search field]. Next, click **Manage Rules**, then **Settings** to open the global rule settings for the space. In the **Alert flapping detection** section, modify the rules' look back window and threshold for alert status changes. For example, you can specify that the alert must change its status at least 6 times in the last 10 runs for it to become a flapping alert. 
 
-`recovered`
-:   The conditions for the rule are no longer met. If the rule has {kibana-ref}/create-and-manage-rules.html#defining-rules-actions-details[recovery actions], {kib} generates notifications based on the actions' notification settings. Recovery actions only run if the rule's conditions aren't met during the current rule execution, but were in the previous one. 
+`recovered`::
+The conditions for the rule are no longer met. If the rule has {kibana-ref}/create-and-manage-rules.html#defining-rules-actions-details[recovery actions], {kib} generates notifications based on the actions' notification settings. Recovery actions only run if the rule's conditions aren't met during the current rule execution, but were in the previous one. 
++
+An active alert changes to recovered if the conditions for the rule that generated it are no longer met. 
++
+A flapping alert changes to recovered when the rule's conditions are unmet for a specific number of consecutive runs. This number is determined by the **Alert status change threshold** setting, which you can configure under the **Alert flapping detection** settings.
++    
+For example, if the threshold requires an alert to change status at least 6 times in the last 10 runs to be considered flapping, then to recover, the rule's conditions must remain unmet for 6 consecutive runs. If the rule's conditions are met at any point during this recovery period, the count of consecutive unmet runs will reset, requiring the alert to remain unmet for an additional 6 consecutive runs to finally be reported as recovered.
++
+Once a flapping alert is recovered, it cannot be changed to flapping again. Only new alerts with repeated status changes are candidates for the flapping status. 
 
-
-    An active alert changes to recovered if the conditions for the rule that generated it are no longer met. 
-
-    A flapping alert changes to recovered when the rule's conditions are unmet for a specific number of consecutive runs. This number is determined by the **Alert status change threshold** setting, which you can configure under the **Alert flapping detection** settings.
-    
-    For example, if the threshold requires an alert to change status at least 6 times in the last 10 runs to be considered flapping, then to recover, the rule's conditions must remain unmet for 6 consecutive runs. If the rule's conditions are met at any point during this recovery period, the count of consecutive unmet runs will reset, requiring the alert to remain unmet for an additional 6 consecutive runs to finally be reported as recovered.
-
-    Once a flapping alert is recovered, it cannot be changed to flapping again. Only new alerts with repeated status changes are candidates for the flapping status. 
-
-`untracked`
-:   The rule is disabled, or you've marked the alert as untracked. To mark the alert as untracked, go to the **Alerts** table, click the image:images/icons/boxesHorizontal.svg[More actions] icon to expand the **More actions** menu, and click **Mark as untracked**. When an alert is marked as untracked, actions are no longer generated. You can choose to move active alerts to this state when you disable or delete rules.
+`untracked`::
+The rule is disabled, or you've marked the alert as untracked. To mark the alert as untracked, go to the **Alerts** table, click the image:images/icons/boxesHorizontal.svg[More actions] icon to expand the **More actions** menu, and click **Mark as untracked**. When an alert is marked as untracked, actions are no longer generated. You can choose to move active alerts to this state when you disable or delete rules.
 
 [discrete]
 [[customize-observability-alerts-table]]

--- a/docs/en/observability/view-observability-alerts.asciidoc
+++ b/docs/en/observability/view-observability-alerts.asciidoc
@@ -28,18 +28,7 @@ You can use the time filter to define a specific date and time range. By default
 for the last 15 minutes.
 
 You can also filter by alert status using the buttons below the KQL bar.
-By default, this filter is set to *Show all* alerts, but you can filter to show only *Active*, *Recovered*, or *Untracked* alerts.
-
-An alert is "Active" when the condition defined in the rule currently matches.
-An alert has "Recovered" when that condition, which previously matched, is currently no longer matching.
-An alert is "Untracked" when its corresponding rule is disabled or you mark the alert as untracked.
-To mark the alert as untracked, go to the Alerts table, click the image:images/icons/boxesHorizontal.svg[More actions] icon to expand the "More actions" menu, and click *Mark as untracked*.
-When an alert is marked as untracked, actions are no longer generated.
-You can choose to move active alerts to this state when you disable or delete rules.
-
-NOTE: There is also a "Flapping" status, which means the alert is switching repeatedly between active and recovered states.
-This status is possible only if you have enabled alert flapping detection.
-For each space, you can choose a look back window and threshold that are used to determine whether alerts are flapping. For example, in *{observability}* > *Alerts* > *Settings* you can specify that the alert must change status at least 6 times in the last 10 runs. If the rule has actions that run when the alert status changes, those actions are suppressed while the alert is flapping.
+By default, this filter is set to *Show all* alerts, but you can filter to show only active, recovered or untracked alerts.
 
 [discrete]
 [[view--alert-details]]
@@ -68,6 +57,36 @@ To view the alert in the app that triggered it:
 
 * From the alert detail flyout, click *View in app*.
 * From the Alerts table, click the image:images/icons/eye.svg[View in app] icon.
+
+[discrete]
+[[understand-alert-statuses]]
+== Understand alert statuses
+
+There are four common alert statuses:
+
+`active`
+:   The conditions for the rule are met. If the rule has {kibana-ref}/create-and-manage-rules.html#defining-rules-actions-details[recovery actions], {kib} generates notifications based on the actions' notification settings. 
+
+`flapping`
+
+:   The alert is switching repeatedly between active and recovered states. If the rule has actions that run when the alert status changes states, those actions are suppressed while the alert is flapping.
+
+NOTE: Alert flapping is turned on by default. You can modify the criteria for changing an alert's status to the flapping state by configuring the **Alert flapping detection** settings. To do this, navigate to the **Alerts** page in the main menu, or use the {kibana-ref}/introduction.html#kibana-navigation-search[global search field]. Next, click **Manage Rules**, then **Settings** to open the global rule settings for the space. In the **Alert flapping detection** section, modify the rules' look back window and threshold for alert status changes. For example, you can specify that the alert must change its status at least 6 times in the last 10 runs for it to become a flapping alert. 
+
+`recovered`
+:   The conditions for the rule are no longer met. If the rule has {kibana-ref}/create-and-manage-rules.html#defining-rules-actions-details[recovery actions], {kib} generates notifications based on the actions' notification settings. Recovery actions only run if the rule's conditions aren't met during the current rule execution, but were in the previous one. 
+
+
+    An active alert changes to recovered if the conditions for the rule that generated it are no longer met. 
+
+    A flapping alert changes to recovered when the rule's conditions are unmet for a specific number of consecutive runs. This number is determined by the **Alert status change threshold** setting, which you can configure under the **Alert flapping detection** settings.
+    
+    For example, if the threshold requires an alert to change status at least 6 times in the last 10 runs to be considered flapping, then to recover, the rule's conditions must remain unmet for 6 consecutive runs. If the rule's conditions are met at any point during this recovery period, the count of consecutive unmet runs will reset, requiring the alert to remain unmet for an additional 6 consecutive runs to finally be reported as recovered.
+
+    Once a flapping alert is recovered, it cannot be changed to flapping again. Only new alerts with repeated status changes are candidates for the flapping status. 
+
+`untracked`
+:   The rule is disabled, or you've marked the alert as untracked. To mark the alert as untracked, go to the **Alerts** table, click the image:images/icons/boxesHorizontal.svg[More actions] icon to expand the **More actions** menu, and click **Mark as untracked**. When an alert is marked as untracked, actions are no longer generated. You can choose to move active alerts to this state when you disable or delete rules.
 
 [discrete]
 [[customize-observability-alerts-table]]


### PR DESCRIPTION
## Description
Elaborates on the logic behind the recovered alert status and providing examples of when statuses change from active -> recovered and flapping -> recovered. 

Also moved the alert status docs to their own dedicated section for easier scanning and reference. This also makes the docs for alert statuses linkable if we ever need to reference the docs from the UI.

### Documentation sets edited in this PR

_Check all that apply._

- [x] Stateful (`docs/en/observability/*`)
- [ ] Serverless (`docs/en/serverless/*`)
- [ ] Integrations Developer Guide (`docs/en/integrations/*`)
- [ ] None of the above

### Related issue
Contributes to https://github.com/elastic/docs-content/issues/2313 and https://github.com/elastic/docs-content/issues/2143

## Checklist

<!--
Add labels to:
1. Backport to other versions (`backport-*`):
    - `backport-8.x` to backport to the latest minor
    - `backport-skip` to not backport (for example, for serverless docs)
    - `backport-main` to "backport" to `main` if the target branch is _not_ `main`
    - Individual `backport-*` labels to target specific minor versions
2. Surface blocking reviews (`needs-*-review`):
    - `needs-writer-review` for codeowners
    - `needs-dev-review` for dev team
    - `needs-product-review` for PM review
-->

- [ ] Product/Engineering Review
- [ ] Writer Review

### Follow-up tasks
<!-- If you are updating the Integrations Developer Guide, you can delete this section -->

_Select one._

* This PR does _not_ need to be ported to another doc set because:
  - [ ] The concepts in this PR only apply to one doc set (serverless _or_ stateful)
  - [ ] The PR contains edits to both doc sets (serverless _and_ stateful)
* This PR needs to be ported to another doc set:
  - [ ] Port to stateful docs: \<link to PR or tracking issue>
  - [x] Port to serverless docs: https://github.com/elastic/docs-content/pull/2597
