### PR TITLE
[OBSERVABILITY][ResponseOps][8.x] Clarify untracked alerts

### DIFF
--- a/docs/en/observability/view-observability-alerts.asciidoc
+++ b/docs/en/observability/view-observability-alerts.asciidoc
@@ -84,7 +84,7 @@ For example, if the threshold requires an alert to change status at least 6 time
 Once a flapping alert is recovered, it cannot be changed to flapping again. Only new alerts with repeated status changes are candidates for the flapping status. 
 
 `untracked`::
-The rule is disabled, or you've marked the alert as untracked. To mark the alert as untracked, go to the **Alerts** table, click the image:images/icons/boxesHorizontal.svg[More actions] icon to expand the **More actions** menu, and click **Mark as untracked**. When an alert is marked as untracked, actions are no longer generated and the alert's status can no longer be changed. You can choose to move active alerts to this state when you disable or delete rules.
+The rule is disabled, or you've marked the alert as untracked. To mark the alert as untracked, go to the **Alerts** table, click the image:images/icons/boxesHorizontal.svg[More actions] icon to expand the **More actions** menu, and click **Mark as untracked**. When an alert is untracked, its status is no longer updated and actions are no longer generated You can choose to move active alerts to this state when you disable or delete rules.
 
 [discrete]
 [[customize-observability-alerts-table]]

--- a/docs/en/observability/view-observability-alerts.asciidoc
+++ b/docs/en/observability/view-observability-alerts.asciidoc
@@ -84,7 +84,7 @@ For example, if the threshold requires an alert to change status at least 6 time
 Once a flapping alert is recovered, it cannot be changed to flapping again. Only new alerts with repeated status changes are candidates for the flapping status. 
 
 `untracked`::
-The rule is disabled, or you've marked the alert as untracked. To mark the alert as untracked, go to the **Alerts** table, click the image:images/icons/boxesHorizontal.svg[More actions] icon to expand the **More actions** menu, and click **Mark as untracked**. When an alert is marked as untracked, actions are no longer generated. You can choose to move active alerts to this state when you disable or delete rules.
+The rule is disabled, or you've marked the alert as untracked. To mark the alert as untracked, go to the **Alerts** table, click the image:images/icons/boxesHorizontal.svg[More actions] icon to expand the **More actions** menu, and click **Mark as untracked**. When an alert is marked as untracked, actions are no longer generated and the alert's status can no longer be changed. You can choose to move active alerts to this state when you disable or delete rules.
 
 [discrete]
 [[customize-observability-alerts-table]]


### PR DESCRIPTION
## Description
Adds that untracked alerts can no longer have their status updated.

### Documentation sets edited in this PR

_Check all that apply._

- [x] Stateful (`docs/en/observability/*`)
- [ ] Serverless (`docs/en/serverless/*`)
- [ ] Integrations Developer Guide (`docs/en/integrations/*`)
- [ ] None of the above

### Related issue
Contributes to https://github.com/elastic/platform-docs-team/issues/641

## Checklist

<!--
Add labels to:
1. Backport to other versions (`backport-*`):
    - `backport-8.x` to backport to the latest minor
    - `backport-skip` to not backport (for example, for serverless docs)
    - `backport-main` to "backport" to `main` if the target branch is _not_ `main`
    - Individual `backport-*` labels to target specific minor versions
2. Surface blocking reviews (`needs-*-review`):
    - `needs-writer-review` for codeowners
    - `needs-dev-review` for dev team
    - `needs-product-review` for PM review
-->

- [ ] Product/Engineering Review
- [ ] Writer Review

### Follow-up tasks
<!-- If you are updating the Integrations Developer Guide, you can delete this section -->

_Select one._

* This PR does _not_ need to be ported to another doc set because:
  - [ ] The concepts in this PR only apply to one doc set (serverless _or_ stateful)
  - [ ] The PR contains edits to both doc sets (serverless _and_ stateful)
* This PR needs to be ported to another doc set:
  - [ ] Port to stateful docs: \<link to PR or tracking issue>
  - [x] Port to serverless docs: https://github.com/elastic/docs-content/pull/2690
