### PR TITLE
Replace placeholder URLs 

### DIFF
--- a/docs/en/observability/apm/act-on-data/custom-links.asciidoc
+++ b/docs/en/observability/apm/act-on-data/custom-links.asciidoc
@@ -216,6 +216,6 @@ It only appears on front-end transactions.
 
 |====
 |Label |`View user internally`
-|Link |`https://internal-site.company.com/user/{{user.email}}`
+|Link |`https://example.com/user/{{user.email}}`
 |Filters |`service.name:client`
 |====

--- a/docs/en/observability/apm/shared-ssl-logstash-config.asciidoc
+++ b/docs/en/observability/apm/shared-ssl-logstash-config.asciidoc
@@ -29,7 +29,7 @@ For example:
 [source,yaml]
 ------------------------------------------------------------------------------
 output.logstash:
-  hosts: ["logs.mycompany.com:5044"]
+  hosts: ["logs.example.com:5044"]
   ssl.certificate_authorities: ["/etc/ca.crt"]
   ssl.certificate: "/etc/client.crt"
   ssl.key: "/etc/client.key"
@@ -103,7 +103,7 @@ The following example uses the IP address rather than the hostname to validate t
 curl -v --cacert ca.crt https://192.168.99.100:5044
 ------------------------------------------------------------------------------
 
-Validation for this test fails because the certificate is not valid for the specified IP address. It's only valid for the `logs.mycompany.com`, the hostname that appears in the Subject field of the certificate.
+Validation for this test fails because the certificate is not valid for the specified IP address. It's only valid for the `logs.example.com`, the hostname that appears in the Subject field of the certificate.
 
 [source,shell]
 ------------------------------------------------------------------------------

--- a/docs/en/observability/apm/tab-widgets/install-agents.asciidoc
+++ b/docs/en/observability/apm/tab-widgets/install-agents.asciidoc
@@ -611,7 +611,7 @@ object to initialize the agent:
 
 [source,html]
 ----
-<script src="https://<your-cdn-host>.com/path/to/elastic-apm-rum.umd.min-<version>.js" crossorigin></script>
+<script src="<YOUR_URL>/path/to/elastic-apm-rum.umd.min-<VERSION>.js" crossorigin></script>
 <script>
   elasticApm.init({
     serviceName: '<instrumented-app>',
@@ -632,7 +632,7 @@ resources on the page, however, it will still block browsers `onload` event.
     var j = d.createElement(s),
       t = d.getElementsByTagName(s)[0]
 
-    j.src = 'https://<your-cdn-host>.com/path/to/elastic-apm-rum.umd.min-<version>.js'
+    j.src = '<YOUR_URL>/path/to/elastic-apm-rum.umd.min-<VERSION>.js'
     j.onload = function() {elasticApm.init(c)}
     t.parentNode.insertBefore(j, t)
   })(document, 'script', {serviceName: '<instrumented-app>', serverUrl: '<apm-server-url>'})

--- a/docs/en/observability/synthetics-reference/lightweight-config/http.asciidoc
+++ b/docs/en/observability/synthetics-reference/lightweight-config/http.asciidoc
@@ -38,7 +38,7 @@ a| The HTTP proxy URL. This setting is optional.
 *Example*:
 
 [source,yaml]
-http://proxy.mydomain.com:3128
+http://example.com:3128
 
 ////////////////////////
 username
@@ -114,7 +114,7 @@ Set `response.include_body_max_bytes` to control the maximum size of the stored 
 check
 ////////////////////////
 | [[monitor-http-check]] *`check`*
-a| 
+a|
 ////////////////////////
 // check.request
 ////////////////////////

--- a/docs/en/shared/install-apm-agents/content.asciidoc
+++ b/docs/en/shared/install-apm-agents/content.asciidoc
@@ -454,7 +454,7 @@ and host the file on your Server/CDN before deploying to production.
 
 [source,js]
 ----
-<script src="https://your-cdn-host.com/path/to/elastic-apm-rum.umd.min.js" crossorigin></script>
+<script src="<YOUR_URL>/path/to/elastic-apm-rum.umd.min-<VERSION>.js" crossorigin></script>
 <script>
   elasticApm.init({
     serviceName: 'your-app-name',


### PR DESCRIPTION
Contributes to https://github.com/elastic/docs-content/issues/1734, https://github.com/elastic/docs-content/issues/1801

Replaces placeholder URLs with those reserved by the Internet Engineering Task Force (IETF) in RFC 2606 and RFC 6761 (e.g. `example.com`, `example.net`, `example.org`, `example.edu`,  `.example`).