### PR TITLE
apm-server: Update compression documentation

### DIFF
--- a/docs/en/observability/apm/configure/outputs/elasticsearch.asciidoc
+++ b/docs/en/observability/apm/configure/outputs/elasticsearch.asciidoc
@@ -115,7 +115,7 @@ The compression level must be in the range of `1` (best speed) to `9` (best comp
 
 Increasing the compression level will reduce the network usage but will increase the CPU usage.
 
-The default value is `0`.
+The default value is `5`.
 
 [float]
 ==== `escape_html`
@@ -337,6 +337,7 @@ endif::[]
 ==== `flush_bytes`
 
 The bulk request size threshold, in bytes, before flushing to {es}.
+If compression is enabled, this is compressed bytes.
 The value must have a suffix, e.g. `"2MB"`. The default is `1MB`.
 
 [float]


### PR DESCRIPTION
## Description
<!-- Add a description here -->
Part of https://github.com/elastic/apm-server/issues/19077

### Documentation sets edited in this PR

_Check all that apply._

- [x] Stateful (`docs/en/observability/*`)
- [ ] Serverless (`docs/en/serverless/*`)
- [ ] Integrations Developer Guide (`docs/en/integrations/*`)
- [ ] None of the above

### Related issue
Closes # <!-- Add the issue this PR closes here -->

## Checklist

<!--
Add labels to:
1. Backport to other versions (`backport-*`):
    - `backport-8.x` to backport to the latest minor
    - `backport-skip` to not backport (for example, for serverless docs)
    - `backport-main` to "backport" to `main` if the target branch is _not_ `main`
    - Individual `backport-*` labels to target specific minor versions
2. Surface blocking reviews (`needs-*-review`):
    - `needs-writer-review` for codeowners
    - `needs-dev-review` for dev team
    - `needs-product-review` for PM review
-->

- [ ] Product/Engineering Review
- [ ] Writer Review

### Follow-up tasks
<!-- If you are updating the Integrations Developer Guide, you can delete this section -->

_Select one._

* This PR does _not_ need to be ported to another doc set because:
  - [x] The concepts in this PR only apply to one doc set (serverless _or_ stateful)
  - [ ] The PR contains edits to both doc sets (serverless _and_ stateful)
* This PR needs to be ported to another doc set:
  - [ ] Port to stateful docs: \<link to PR or tracking issue>
  - [ ] Port to serverless docs: \<link to PR or tracking issue>
