### PR TITLE
[Internal][Obs UX Management][8.x]: Note filter limitation for metric threshold rules

### DIFF
--- a/docs/en/observability/metrics-threshold-alert.asciidoc
+++ b/docs/en/observability/metrics-threshold-alert.asciidoc
@@ -45,7 +45,10 @@ image::images/metrics-alert-filters-and-group.png[Metric threshold filter and gr
 
 The *Filters* control the scope of the rule. If used, the rule will only evaluate metric data that matches the query in this field. In this example, the rule will only alert on metrics reported from a Cloud region called `us-east`.
 
-NOTE: Filters that you've added to the rule using the (https://www.elastic.co/docs/api/doc/kibana/operation/operation-post-alerting-rule-id)[create rule API] won't display in the UI when you're editing a rule. If you want to modify them, you must manually re-add the filters by entering a KQL query in the rule's **Filter** field.
+NOTE: If you've made a rule with the (https://www.elastic.co/docs/api/doc/kibana/operation/operation-post-alerting-rule-id)[create rule API] and added Query DSL filters using the `filterQuery` parameter, the filters won't appear in the UI for editing a rule. As a workaround, manually re-add the filters through the UI and save the rule. As you're modifying the rule's filters from the UI, be mindful of the following:
+
+ - The **Filter** field only accepts KQL syntax, meaning you may need to manually convert your Query DSL filters to KQL. 
+ - After you save the rule, filters you've added to the **Filter** field are converted appropriately and specified in the rule's `filterQuery` parameter.  
 
 The *Group alerts by* creates an instance of the alert for every unique value of the `field` added. For example, you can create a rule per host or every mount point of each host. You can also add multiple fields. In this example, the rule will individually track the status of each `host.name` in your infrastructure. You will only receive an alert about `host-1`, if `host.name: host-1` passes the threshold, but `host-2` and `host-3` do not.
 

--- a/docs/en/observability/metrics-threshold-alert.asciidoc
+++ b/docs/en/observability/metrics-threshold-alert.asciidoc
@@ -47,7 +47,7 @@ The *Filters* control the scope of the rule. If used, the rule will only evaluat
 
 [NOTE]
 =====
-If you've made a rule with the (https://www.elastic.co/docs/api/doc/kibana/operation/operation-post-alerting-rule-id)[create rule API] and added Query DSL filters using the `filterQuery` parameter, the filters won't appear in the UI for editing a rule. As a workaround, manually re-add the filters through the UI and save the rule. As you're modifying the rule's filters from the UI, be mindful of the following:
+If you've made a rule with the https://www.elastic.co/docs/api/doc/kibana/operation/operation-post-alerting-rule-id[create rule API] and added Query DSL filters using the `filterQuery` parameter, the filters won't appear in the UI for editing a rule. As a workaround, manually re-add the filters through the UI and save the rule. As you're modifying the rule's filters from the UI, be mindful of the following:
 
 - The **Filter** field only accepts KQL syntax, meaning you may need to manually convert your Query DSL filters to KQL. 
 - After you save the rule, filters you've added to the **Filter** field are converted appropriately and specified in the rule's `filterQuery` parameter.  

--- a/docs/en/observability/metrics-threshold-alert.asciidoc
+++ b/docs/en/observability/metrics-threshold-alert.asciidoc
@@ -45,10 +45,14 @@ image::images/metrics-alert-filters-and-group.png[Metric threshold filter and gr
 
 The *Filters* control the scope of the rule. If used, the rule will only evaluate metric data that matches the query in this field. In this example, the rule will only alert on metrics reported from a Cloud region called `us-east`.
 
-NOTE: If you've made a rule with the (https://www.elastic.co/docs/api/doc/kibana/operation/operation-post-alerting-rule-id)[create rule API] and added Query DSL filters using the `filterQuery` parameter, the filters won't appear in the UI for editing a rule. As a workaround, manually re-add the filters through the UI and save the rule. As you're modifying the rule's filters from the UI, be mindful of the following:
+[NOTE]
+=====
+If you've made a rule with the (https://www.elastic.co/docs/api/doc/kibana/operation/operation-post-alerting-rule-id)[create rule API] and added Query DSL filters using the `filterQuery` parameter, the filters won't appear in the UI for editing a rule. As a workaround, manually re-add the filters through the UI and save the rule. As you're modifying the rule's filters from the UI, be mindful of the following:
 
 - The **Filter** field only accepts KQL syntax, meaning you may need to manually convert your Query DSL filters to KQL. 
 - After you save the rule, filters you've added to the **Filter** field are converted appropriately and specified in the rule's `filterQuery` parameter.  
+
+=====
 
 The *Group alerts by* creates an instance of the alert for every unique value of the `field` added. For example, you can create a rule per host or every mount point of each host. You can also add multiple fields. In this example, the rule will individually track the status of each `host.name` in your infrastructure. You will only receive an alert about `host-1`, if `host.name: host-1` passes the threshold, but `host-2` and `host-3` do not.
 

--- a/docs/en/observability/metrics-threshold-alert.asciidoc
+++ b/docs/en/observability/metrics-threshold-alert.asciidoc
@@ -47,8 +47,8 @@ The *Filters* control the scope of the rule. If used, the rule will only evaluat
 
 NOTE: If you've made a rule with the (https://www.elastic.co/docs/api/doc/kibana/operation/operation-post-alerting-rule-id)[create rule API] and added Query DSL filters using the `filterQuery` parameter, the filters won't appear in the UI for editing a rule. As a workaround, manually re-add the filters through the UI and save the rule. As you're modifying the rule's filters from the UI, be mindful of the following:
 
- - The **Filter** field only accepts KQL syntax, meaning you may need to manually convert your Query DSL filters to KQL. 
- - After you save the rule, filters you've added to the **Filter** field are converted appropriately and specified in the rule's `filterQuery` parameter.  
+- The **Filter** field only accepts KQL syntax, meaning you may need to manually convert your Query DSL filters to KQL. 
+- After you save the rule, filters you've added to the **Filter** field are converted appropriately and specified in the rule's `filterQuery` parameter.  
 
 The *Group alerts by* creates an instance of the alert for every unique value of the `field` added. For example, you can create a rule per host or every mount point of each host. You can also add multiple fields. In this example, the rule will individually track the status of each `host.name` in your infrastructure. You will only receive an alert about `host-1`, if `host.name: host-1` passes the threshold, but `host-2` and `host-3` do not.
 

--- a/docs/en/observability/metrics-threshold-alert.asciidoc
+++ b/docs/en/observability/metrics-threshold-alert.asciidoc
@@ -45,6 +45,8 @@ image::images/metrics-alert-filters-and-group.png[Metric threshold filter and gr
 
 The *Filters* control the scope of the rule. If used, the rule will only evaluate metric data that matches the query in this field. In this example, the rule will only alert on metrics reported from a Cloud region called `us-east`.
 
+NOTE: Filters that you've added to the rule using the [create rule API](https://www.elastic.co/docs/api/doc/kibana/operation/operation-post-alerting-rule-id) won't display in the UI when you're editing a rule. If you want to modify them, you must manually re-add the filters by entering a KQL query in the rule's **Filter** field.
+
 The *Group alerts by* creates an instance of the alert for every unique value of the `field` added. For example, you can create a rule per host or every mount point of each host. You can also add multiple fields. In this example, the rule will individually track the status of each `host.name` in your infrastructure. You will only receive an alert about `host-1`, if `host.name: host-1` passes the threshold, but `host-2` and `host-3` do not.
 
 When you select *Alert me if a group stops reporting data*, the rule is triggered if a group that previously reported metrics does not report them again over the expected time period.

--- a/docs/en/observability/metrics-threshold-alert.asciidoc
+++ b/docs/en/observability/metrics-threshold-alert.asciidoc
@@ -45,7 +45,7 @@ image::images/metrics-alert-filters-and-group.png[Metric threshold filter and gr
 
 The *Filters* control the scope of the rule. If used, the rule will only evaluate metric data that matches the query in this field. In this example, the rule will only alert on metrics reported from a Cloud region called `us-east`.
 
-NOTE: Filters that you've added to the rule using the [create rule API](https://www.elastic.co/docs/api/doc/kibana/operation/operation-post-alerting-rule-id) won't display in the UI when you're editing a rule. If you want to modify them, you must manually re-add the filters by entering a KQL query in the rule's **Filter** field.
+NOTE: Filters that you've added to the rule using the (https://www.elastic.co/docs/api/doc/kibana/operation/operation-post-alerting-rule-id)[create rule API] won't display in the UI when you're editing a rule. If you want to modify them, you must manually re-add the filters by entering a KQL query in the rule's **Filter** field.
 
 The *Group alerts by* creates an instance of the alert for every unique value of the `field` added. For example, you can create a rule per host or every mount point of each host. You can also add multiple fields. In this example, the rule will individually track the status of each `host.name` in your infrastructure. You will only receive an alert about `host-1`, if `host.name: host-1` passes the threshold, but `host-2` and `host-3` do not.
 


### PR DESCRIPTION
## Description
<!-- Add a description here -->

### Documentation sets edited in this PR

_Check all that apply._

- [x] Stateful (`docs/en/observability/*`)
- [ ] Serverless (`docs/en/serverless/*`)
- [ ] Integrations Developer Guide (`docs/en/integrations/*`)
- [ ] None of the above

### Related issue
Contributes to https://github.com/elastic/docs-content/issues/3701

## Checklist

<!--
Add labels to:
1. Backport to other versions (`backport-*`):
    - `backport-8.x` to backport to the latest minor
    - `backport-skip` to not backport (for example, for serverless docs)
    - `backport-main` to "backport" to `main` if the target branch is _not_ `main`
    - Individual `backport-*` labels to target specific minor versions
2. Surface blocking reviews (`needs-*-review`):
    - `needs-writer-review` for codeowners
    - `needs-dev-review` for dev team
    - `needs-product-review` for PM review
-->

- [ ] Product/Engineering Review
- [ ] Writer Review

### Follow-up tasks
<!-- If you are updating the Integrations Developer Guide, you can delete this section -->

_Select one._

* This PR does _not_ need to be ported to another doc set because:
  - [ ] The concepts in this PR only apply to one doc set (serverless _or_ stateful)
  - [ ] The PR contains edits to both doc sets (serverless _and_ stateful)
* This PR needs to be ported to another doc set:
  - [x] Port to stateful docs: https://github.com/elastic/docs-content/pull/3702
  - [x] Port to serverless docs: https://github.com/elastic/docs-content/pull/3702
