### PR TITLE
apm-server: Add missing TBS monitoring metrics docs

### DIFF
--- a/docs/en/observability/apm/configure/sampling.asciidoc
+++ b/docs/en/observability/apm/configure/sampling.asciidoc
@@ -166,7 +166,7 @@ APM Server produces metrics to monitor the performance and estimate the workload
 
 This metric tracks the number of dynamic services that the tail-based sampler is tracking per policy. Dynamic services are created for tail-based sampling policies that are defined without a `service.name`.
 
-This is a counter metric so, should be visualized with `counter_rate`.
+This is a counter metric, so it should be visualized with `counter_rate`.
 
 [float]
 [[sampling-tail-monitoring-events-processed-ref]]
@@ -174,7 +174,7 @@ This is a counter metric so, should be visualized with `counter_rate`.
 
 This metric tracks the total number of events (including both transaction and span) processed by the tail-based sampler.
 
-This is a counter metric so, should be visualized with `counter_rate`.
+This is a counter metric, so it should be visualized with `counter_rate`.
 
 [float]
 [[sampling-tail-monitoring-events-stored-ref]]
@@ -182,7 +182,7 @@ This is a counter metric so, should be visualized with `counter_rate`.
 
 This metric tracks the total number of events stored by the tail-based sampler in the database. Events are stored when the full trace is not yet available to make the sampling decision. This value is directly proportional to the storage required by the tail-based sampler to function.
 
-This is a counter metric so, should be visualized with `counter_rate`.
+This is a counter metric, so it should be visualized with `counter_rate`.
 
 [float]
 [[sampling-tail-monitoring-events-dropped-ref]]
@@ -190,7 +190,33 @@ This is a counter metric so, should be visualized with `counter_rate`.
 
 This metric tracks the total number of events dropped by the tail-based sampler. Only the events that are actually dropped by the tail-based sampler are reported as dropped. Additionally, any events that were stored by the processor but never indexed will not be counted by this metric.
 
-This is a counter metric so, should be visualized with `counter_rate`.
+This is a counter metric, so it should be visualized with `counter_rate`.
+
+[float]
+[[sampling-tail-monitoring-events-failed-writes-ref]]
+=== `apm-server.sampling.tail.events.failed_writes`
+
+This metric tracks the total number of events that failed to be written to the tail-based sampling storage. Failed writes typically occur when the storage limit is reached or when there are issues with the local sampling database.
+
+The value of this metric should be 0 if tail-based sampling is functioning properly. If it is consistently increasing, check for misconfigured <<sampling-tail-storage_limit-{input-type}>>.
+
+This is a counter metric, so it should be visualized with `counter_rate`.
+
+[float]
+[[sampling-tail-monitoring-events-sampled-ref]]
+=== `apm-server.sampling.tail.events.sampled`
+
+This metric tracks the total number of events that were sampled (kept) by the tail-based sampler after applying the configured policies and were selected for indexing. This includes all events that belong to traces that matched tail-based sampling policies.
+
+This is a counter metric, so it should be visualized with `counter_rate`.
+
+[float]
+[[sampling-tail-monitoring-events-head-unsampled-ref]]
+=== `apm-server.sampling.tail.events.head_unsampled`
+
+This metric tracks the total number of events that were already unsampled by head-based sampling before reaching the tail-based sampler. These events are processed by the tail-based sampler but are not stored or indexed because they were already filtered out by head-based sampling decisions.
+
+This is a counter metric, so it should be visualized with `counter_rate`.
 
 [float]
 [[sampling-tail-monitoring-storage-lsm-size-ref]]


### PR DESCRIPTION
## Description
<!-- Add a description here -->
Mirrors https://github.com/elastic/docs-content/pull/3912

### Documentation sets edited in this PR

_Check all that apply._

- [x] Stateful (`docs/en/observability/*`)
- [ ] Serverless (`docs/en/serverless/*`)
- [ ] Integrations Developer Guide (`docs/en/integrations/*`)
- [ ] None of the above

### Related issue
Closes # <!-- Add the issue this PR closes here -->

## Checklist

<!--
Add labels to:
1. Backport to other versions (`backport-*`):
    - `backport-8.x` to backport to the latest minor
    - `backport-skip` to not backport (for example, for serverless docs)
    - `backport-main` to "backport" to `main` if the target branch is _not_ `main`
    - Individual `backport-*` labels to target specific minor versions
2. Surface blocking reviews (`needs-*-review`):
    - `needs-writer-review` for codeowners
    - `needs-dev-review` for dev team
    - `needs-product-review` for PM review
-->

- [ ] Product/Engineering Review
- [ ] Writer Review

### Follow-up tasks
<!-- If you are updating the Integrations Developer Guide, you can delete this section -->

_Select one._

* This PR does _not_ need to be ported to another doc set because:
  - [ ] The concepts in this PR only apply to one doc set (serverless _or_ stateful)
  - [ ] The PR contains edits to both doc sets (serverless _and_ stateful)
* This PR needs to be ported to another doc set:
  - [ ] Port to stateful docs: \<link to PR or tracking issue>
  - [ ] Port to serverless docs: \<link to PR or tracking issue>
