### PR TITLE
[Synthetic monitoring] Add known limitations on vertical scaling

### DIFF
--- a/docs/en/observability/synthetics-private-location.asciidoc
+++ b/docs/en/observability/synthetics-private-location.asciidoc
@@ -176,6 +176,17 @@ However, it is a good practice to set up execution slots with extra capacity. A 
 a factor of 5. In the previous example that would mean allocating 5 slots.
 
 [discrete]
+[[synthetics-known-limitations-vertical-scaling]]
+== Known limitations on vertical scaling 
+
+- A single private location will not scale beyond 10,000 monitors. Exceeding this number will result in agent degradation and inconsistent execution, regardless of the resources allocated.
+
+- Complex monitor configuration can disproportionately increase the private location policy size, leading to agent communication errors and degradation even if the limit mentioned above hasn't been reached. In these edge cases, increasing the `server.limits.checkin_limit.max_body_byte_size` setting on Fleet Server to 8 MB or 16 MB (or setting it to -1 to turn off the limit entirely) might help prevent communication errors.
+
+If you're facing one of these scenarios, it is likely that the private location has grown too large and needs to be split into smaller locations, each alloted a portion of the original location monitors.
+
+
+[discrete]
 [[synthetics-private-location-next]]
 = Next steps
 


### PR DESCRIPTION
## Description
This PR adds a new section on known limitations on vertical scaling. 

### Related issue
https://github.com/elastic/docs-content/issues/2929

@lucabelluccini is it enough to go back to `8.17`?

### Documentation sets edited in this PR

_Check all that apply._

- [ ] Stateful (`docs/en/observability/*`)
- [ ] Serverless (`docs/en/serverless/*`)
- [ ] Integrations Developer Guide (`docs/en/integrations/*`)
- [ ] None of the above

## Checklist

<!--
Add labels to:
1. Backport to other versions (`backport-*`):
    - `backport-8.x` to backport to the latest minor
    - `backport-skip` to not backport (for example, for serverless docs)
    - `backport-main` to "backport" to `main` if the target branch is _not_ `main`
    - Individual `backport-*` labels to target specific minor versions
2. Surface blocking reviews (`needs-*-review`):
    - `needs-writer-review` for codeowners
    - `needs-dev-review` for dev team
    - `needs-product-review` for PM review
-->

- [ ] Product/Engineering Review
- [ ] Writer Review

### Follow-up tasks
<!-- If you are updating the Integrations Developer Guide, you can delete this section -->

_Select one._

* This PR does _not_ need to be ported to another doc set because:
  - [ ] The concepts in this PR only apply to one doc set (serverless _or_ stateful)
  - [ ] The PR contains edits to both doc sets (serverless _and_ stateful)
* This PR needs to be ported to another doc set:
  - [ ] Port to stateful docs: \<link to PR or tracking issue>
  - [ ] Port to serverless docs: \<link to PR or tracking issue>
