### PR TITLE
[Observability][Cases][BUG]: Case templates were GA'd in 8.18

### DIFF
--- a/docs/en/observability/create-cases.asciidoc
+++ b/docs/en/observability/create-cases.asciidoc
@@ -7,7 +7,7 @@ add assignees and tags to your cases, set their severity and status, and add ale
 comments, and visualizations. You can also send cases to third party systems by
 <<cases-external-connectors,configuring external connectors>>.
 
-You can also optionally add custom fields and case templates. preview:[]
+You can also optionally add custom fields and case templates.
 
 [role="screenshot"]
 image::images/cases.png[Cases page]

--- a/docs/en/observability/manage-cases-settings.asciidoc
+++ b/docs/en/observability/manage-cases-settings.asciidoc
@@ -100,8 +100,6 @@ You can subsequently remove or edit custom fields on the *Settings* page.
 [[observability-case-templates]]
 == Templates
 
-preview::[]
-
 You can make the case creation process faster and more consistent by adding templates.
 A template defines values for one or all of the case fields (such as severity, tags, description, and title) as well as any <<case-custom-fields,custom fields>>.
 


### PR DESCRIPTION
## Description
<!-- Add a description here -->

### Documentation sets edited in this PR

_Check all that apply._

- [x] Stateful (`docs/en/observability/*`)
- [ ] Serverless (`docs/en/serverless/*`)
- [ ] Integrations Developer Guide (`docs/en/integrations/*`)
- [ ] None of the above

### Related issue
Closes # https://github.com/elastic/docs-content/issues/5209

## Checklist

<!--
Add labels to:
1. Backport to other versions (`backport-*`):
    - `backport-8.x` to backport to the latest minor
    - `backport-skip` to not backport (for example, for serverless docs)
    - `backport-main` to "backport" to `main` if the target branch is _not_ `main`
    - Individual `backport-*` labels to target specific minor versions
2. Surface blocking reviews (`needs-*-review`):
    - `needs-writer-review` for codeowners
    - `needs-dev-review` for dev team
    - `needs-product-review` for PM review
-->

- [ ] Product/Engineering Review
- [x] Writer Review

### Follow-up tasks
<!-- If you are updating the Integrations Developer Guide, you can delete this section -->

_Select one._

* This PR does _not_ need to be ported to another doc set because:
  - [ ] The concepts in this PR only apply to one doc set (serverless _or_ stateful)
  - [ ] The PR contains edits to both doc sets (serverless _and_ stateful)
* This PR needs to be ported to another doc set:
  - [x] Port to stateful docs: https://github.com/elastic/docs-content/pull/5210
  - [x] Port to serverless docs: https://github.com/elastic/docs-content/pull/5210
