### PR TITLE
apm: Fix typo in cipher name

### DIFF
--- a/docs/en/observability/apm/shared-ssl-config.asciidoc
+++ b/docs/en/observability/apm/shared-ssl-config.asciidoc
@@ -85,7 +85,7 @@ The following cipher suites are available:
 | ECDHE-RSA-AES-128-GCM-SHA256 | TLS 1.2 only.
 | ECDHE-RSA-AES-256-CBC-SHA |
 | ECDHE-RSA-AES-256-GCM-SHA384 | TLS 1.2 only.
-| ECDHE-RSA-CHACHA20-POLY1205 | TLS 1.2 only.
+| ECDHE-RSA-CHACHA20-POLY1305 | TLS 1.2 only.
 | ECDHE-RSA-RC4-128-SHA | Disabled by default. RC4 not recommended.
 | RSA-3DES-CBC3-SHA |
 | RSA-AES-128-CBC-SHA |


### PR DESCRIPTION
## Description
<!-- Add a description here -->
`ECDHE-RSA-CHACHA20-POLY1205` -> `ECDHE-RSA-CHACHA20-POLY1305`

### Documentation sets edited in this PR

_Check all that apply._

- [x] Stateful (`docs/en/observability/*`)
- [ ] Serverless (`docs/en/serverless/*`)
- [ ] Integrations Developer Guide (`docs/en/integrations/*`)
- [ ] None of the above

### Related issue
Closes https://github.com/elastic/apm-server/issues/20876

## Checklist

<!--
Add labels to:
1. Backport to other versions (`backport-*`):
    - `backport-8.x` to backport to the latest minor
    - `backport-skip` to not backport (for example, for serverless docs)
    - `backport-main` to "backport" to `main` if the target branch is _not_ `main`
    - Individual `backport-*` labels to target specific minor versions
2. Surface blocking reviews (`needs-*-review`):
    - `needs-writer-review` for codeowners
    - `needs-dev-review` for dev team
    - `needs-product-review` for PM review
-->

- [x] Product/Engineering Review
- [ ] Writer Review

### Follow-up tasks
<!-- If you are updating the Integrations Developer Guide, you can delete this section -->

_Select one._

* This PR does _not_ need to be ported to another doc set because:
  - [ ] The concepts in this PR only apply to one doc set (serverless _or_ stateful)
  - [ ] The PR contains edits to both doc sets (serverless _and_ stateful)
* This PR needs to be ported to another doc set:
  - [ ] Port to stateful docs: \<link to PR or tracking issue>
  - [ ] Port to serverless docs: \<link to PR or tracking issue>
