### PR TITLE
[APM] Add known issue for HTTP/2 strict client framing failures

### DIFF
--- a/docs/en/observability/apm/known-issues.asciidoc
+++ b/docs/en/observability/apm/known-issues.asciidoc
@@ -22,18 +22,23 @@ _Versions: XX.XX.XX, YY.YY.YY, ZZ.ZZ.ZZ_
 ////
 
 [discrete]
-== HTTP/2 connections may fail with strict clients due to framing issues
+== HTTP/2 connections can fail with strict clients due to framing errors
 
-_Elastic Stack versions: 8.19.12, 8.19.13, 8.19.14_ +
-_Fixed in Elastic Stack version 8.19.15_
+_Elastic Stack versions: >=8.19.12 and <8.19.15_
 
-The issue occurs when using APM Server over HTTP/2 with strict clients.
-Affected clients may report errors such as `Error in the HTTP2 framing layer`,
-`Failure when receiving data from the peer`, or browser `net::ERR_HTTP2_PROTOCOL_ERROR`.
+APM Server can fail HTTP/2 requests from strict clients (for example, curl/nghttp2) after ALPN negotiates `h2`.
+In affected versions, APM Server can send inconsistent SETTINGS values at connection start (an initial empty/default SETTINGS frame followed by a different SETTINGS set), and strict clients treat that sequence as an HTTP/2 protocol error and close the connection.
+When this occurs, clients can report framing/connection errors such as `Error in the HTTP2 framing layer` or `Failure when receiving data from the peer`.
+Browser-based HTTP requests from the RUM agent can also fail with `net::ERR_HTTP2_PROTOCOL_ERROR`.
+When clients close the HTTP/2 connection due to this issue, APM Server logs an error: `http2: received GOAWAY [FrameHeader GOAWAY len=66], starting graceful shutdown`.
 
-As a workaround, use HTTP/1.1 between clients and APM Server, or offload HTTP/2 through a non-strict load balancer or proxy.
+For more information, check https://github.com/elastic/apm-server/issues/20887[issue #20887].
 
-This issue is fixed in 8.19.15 (https://github.com/elastic/apm-server/pull/20908[elastic/apm-server#20908]).
+Use HTTP/1.1 to communicate with APM Server on affected versions.
+
+If clients require HTTP/2, place a non-strict load balancer in front of APM Server and stop HTTP/2 at the load balancer (for example, on some load balancers this can be done by switching from TCP mode to HTTP mode).
+
+This bug will be fixed in 8.19.15.
 
 [discrete]
 == Tail Sampling may not compact / expired TTLs as quickly as desired, causing increased storage usage.

--- a/docs/en/observability/apm/known-issues.asciidoc
+++ b/docs/en/observability/apm/known-issues.asciidoc
@@ -34,6 +34,8 @@ When clients close the HTTP/2 connection due to this issue, APM Server logs an e
 
 For more information, check https://github.com/elastic/apm-server/issues/20887[issue #20887].
 
+*Workaround*
+
 Use HTTP/1.1 to communicate with APM Server on affected versions.
 
 If clients require HTTP/2, place a non-strict load balancer in front of APM Server and terminate HTTP/2 at the load balancer (for example, on some load balancers this can be done by switching from TCP mode to HTTP mode).

--- a/docs/en/observability/apm/known-issues.asciidoc
+++ b/docs/en/observability/apm/known-issues.asciidoc
@@ -27,18 +27,19 @@ _Versions: XX.XX.XX, YY.YY.YY, ZZ.ZZ.ZZ_
 _Elastic Stack versions: >=8.19.12 and <8.19.15_
 
 APM Server can fail HTTP/2 requests from strict clients (for example, curl/nghttp2) after ALPN negotiates `h2`.
+
 In affected versions, APM Server can send inconsistent SETTINGS values at connection start (an initial empty/default SETTINGS frame followed by a different SETTINGS set), and strict clients treat that sequence as an HTTP/2 protocol error and close the connection.
-When this occurs, clients can report framing/connection errors such as `Error in the HTTP2 framing layer` or `Failure when receiving data from the peer`.
-Browser-based HTTP requests from the RUM agent can also fail with `net::ERR_HTTP2_PROTOCOL_ERROR`.
+
+When this occurs, clients can report framing/connection errors such as `Error in the HTTP2 framing layer` or `Failure when receiving data from the peer`. Browser-based HTTP requests from the RUM agent can also fail with `net::ERR_HTTP2_PROTOCOL_ERROR`.
+
 When clients close the HTTP/2 connection due to this issue, APM Server logs an error: `http2: received GOAWAY [FrameHeader GOAWAY len=66], starting graceful shutdown`.
 
 For more information, check https://github.com/elastic/apm-server/issues/20887[issue #20887].
 
 There are two workarounds:
 
-Use HTTP/1.1 to communicate with APM Server on affected versions.
-
-If clients require HTTP/2, place a non-strict load balancer in front of APM Server and terminate HTTP/2 at the load balancer (for example, on some load balancers this can be done by switching from TCP mode to HTTP mode).
+* Use HTTP/1.1 to communicate with APM Server on affected versions.
+* If clients require HTTP/2, place a non-strict load balancer in front of APM Server and terminate HTTP/2 at the load balancer (for example, on some load balancers this can be done by switching from TCP mode to HTTP mode).
 
 This bug will be fixed in 8.19.15.
 

--- a/docs/en/observability/apm/known-issues.asciidoc
+++ b/docs/en/observability/apm/known-issues.asciidoc
@@ -34,7 +34,7 @@ When clients close the HTTP/2 connection due to this issue, APM Server logs an e
 
 For more information, check https://github.com/elastic/apm-server/issues/20887[issue #20887].
 
-*Workaround*
+There are two workarounds:
 
 Use HTTP/1.1 to communicate with APM Server on affected versions.
 

--- a/docs/en/observability/apm/known-issues.asciidoc
+++ b/docs/en/observability/apm/known-issues.asciidoc
@@ -22,6 +22,20 @@ _Versions: XX.XX.XX, YY.YY.YY, ZZ.ZZ.ZZ_
 ////
 
 [discrete]
+== HTTP/2 connections may fail with strict clients due to framing issues
+
+_Elastic Stack versions: 8.19.12, 8.19.13, 8.19.14_ +
+_Fixed in Elastic Stack version 8.19.15_
+
+The issue occurs when using APM Server over HTTP/2 with strict clients.
+Affected clients may report errors such as `Error in the HTTP2 framing layer`,
+`Failure when receiving data from the peer`, or browser `net::ERR_HTTP2_PROTOCOL_ERROR`.
+
+As a workaround, use HTTP/1.1 between clients and APM Server, or offload HTTP/2 through a non-strict load balancer or proxy.
+
+This issue is fixed in 8.19.15 (https://github.com/elastic/apm-server/pull/20908[elastic/apm-server#20908]).
+
+[discrete]
 == Tail Sampling may not compact / expired TTLs as quickly as desired, causing increased storage usage.
 
 _Elastic Stack versions: All 8.x versions_

--- a/docs/en/observability/apm/known-issues.asciidoc
+++ b/docs/en/observability/apm/known-issues.asciidoc
@@ -36,7 +36,7 @@ For more information, check https://github.com/elastic/apm-server/issues/20887[i
 
 Use HTTP/1.1 to communicate with APM Server on affected versions.
 
-If clients require HTTP/2, place a non-strict load balancer in front of APM Server and stop HTTP/2 at the load balancer (for example, on some load balancers this can be done by switching from TCP mode to HTTP mode).
+If clients require HTTP/2, place a non-strict load balancer in front of APM Server and terminate HTTP/2 at the load balancer (for example, on some load balancers this can be done by switching from TCP mode to HTTP mode).
 
 This bug will be fixed in 8.19.15.
 


### PR DESCRIPTION
## Summary
- Add an APM known-issue entry for HTTP/2 framing/protocol failures seen with strict clients.
- Document affected 8.x versions, user-visible symptoms, workaround guidance, and the 8.19.15 fix version.
- Exclude 9.x version mentions to keep this scoped to the 8.x docs stream.

Corresponds to 9.x doc change https://github.com/elastic/apm-server/pull/20911

Part of https://github.com/elastic/apm-server/issues/20887

Made with [Cursor](https://cursor.com)