### PR TITLE
[8.19.x] Rename Kibana API key toggle references to “Control security privileges”

### DIFF
--- a/docs/en/observability/apm/security/elastic-stack/access-api-keys.asciidoc
+++ b/docs/en/observability/apm/security/elastic-stack/access-api-keys.asciidoc
@@ -25,7 +25,7 @@ To create an API key:
 [role="screenshot"]
 image::images/server-api-key-create.png[API key creation]
 +
-. Enter a name for your API key and select **Restrict privileges**.
+. Enter a name for your API key and select **Control security privileges**.
 In the role descriptors box, assign the appropriate privileges to the new API key. For example:
 +
 [source,json,subs="attributes,callouts"]
@@ -92,7 +92,7 @@ Click **Create API key**.
 [role="screenshot"]
 image::images/server-api-key-create.png[API key creation]
 
-Enter a name for your API key and select **Restrict privileges**.
+Enter a name for your API key and select **Control security privileges**.
 In the role descriptors box, assign the appropriate privileges to the new API key.
 For example:
 

--- a/docs/en/observability/cloud-monitoring/aws/ingest-aws-firehose.asciidoc
+++ b/docs/en/observability/cloud-monitoring/aws/ingest-aws-firehose.asciidoc
@@ -55,7 +55,7 @@ NOTE: For advanced use cases, source records can be transformed by invoking a cu
 +
 * *Elastic endpoint URL*: Enter the Elastic endpoint URL of your Elasticsearch cluster. To find the Elasticsearch endpoint, go to the Elastic Cloud console and select *Connection details*. Here is an example of how it looks like: `https://my-deployment.es.us-east-1.aws.elastic-cloud.com`.
 +
-* *API key*: Enter the encoded Elastic API key. To create an API key, go to the Elastic Cloud console, select *Connection details* and click *Create and manage API keys*. If you are using an API key with *Restrict privileges*, make sure to review the Indices privileges to provide at least "auto_configure" & "write" permissions for the indices you will be using with this delivery stream.
+* *API key*: Enter the encoded Elastic API key. To create an API key, go to the Elastic Cloud console, select *Connection details* and click *Create and manage API keys*. If you are using an API key with *Control security privileges*, make sure to review the Indices privileges to provide at least "auto_configure" & "write" permissions for the indices you will be using with this delivery stream.
 +
 * *Content encoding*: For a better network efficiency, leave content encoding set to GZIP.
 +

--- a/docs/en/observability/cloud-monitoring/aws/monitor-aws-cloudtrail-firehose.asciidoc
+++ b/docs/en/observability/cloud-monitoring/aws/monitor-aws-cloudtrail-firehose.asciidoc
@@ -93,7 +93,7 @@ For more information on how to set up a Amazon Data Firehose delivery stream to 
 - *To create the API key*: 
 .. Go to the https://cloud.elastic.co/[Elastic Cloud] console
 .. Select *Open Kibana*.
-.. Expand the left-hand menu, under *Management* select *Stack management > API Keys* and click *Create API key*. If you are using an API key with *Restrict privileges*, make sure to review the Indices privileges to provide at least `auto_configure` and `write` permissions for the indices you will be using with this delivery stream.
+.. Expand the left-hand menu, under *Management* select *Stack management > API Keys* and click *Create API key*. If you are using an API key with *Control security privileges*, make sure to review the Indices privileges to provide at least `auto_configure` and `write` permissions for the indices you will be using with this delivery stream.
 
 . Set up the delivery stream by specifying the following data:
 +

--- a/docs/en/observability/cloud-monitoring/aws/monitor-aws-cloudwatch-firehose.asciidoc
+++ b/docs/en/observability/cloud-monitoring/aws/monitor-aws-cloudwatch-firehose.asciidoc
@@ -110,7 +110,7 @@ NOTE: For advanced use cases, source records can be transformed by invoking a cu
 * *To create the API key*: 
 .. Go to the https://cloud.elastic.co/[Elastic Cloud] console
 .. Select *Open Kibana*.
-.. Expand the left-hand menu, under *Management* select *Stack management > API Keys* and click *Create API key*. If you are using an API key with *Restrict privileges*, make sure to review the Indices privileges to provide at least `auto_configure` and `write` permissions for the indices you will be using with this delivery stream.
+.. Expand the left-hand menu, under *Management* select *Stack management > API Keys* and click *Create API key*. If you are using an API key with *Control security privileges*, make sure to review the Indices privileges to provide at least `auto_configure` and `write` permissions for the indices you will be using with this delivery stream.
 +
 * *Content encoding*: For a better network efficiency, leave content encoding set to GZIP.
 +

--- a/docs/en/observability/cloud-monitoring/aws/monitor-aws-firewall-firehose.asciidoc
+++ b/docs/en/observability/cloud-monitoring/aws/monitor-aws-firewall-firehose.asciidoc
@@ -65,7 +65,7 @@ image::firehose-networkfirewall-stream.png[Firehose stream]
 - *To create the API key*: 
 .. Go to the https://cloud.elastic.co/[Elastic Cloud] console
 .. Select *Open Kibana*.
-.. Expand the left-hand menu, under *Management* select *Stack management > API Keys* and click *Create API key*. If you are using an API key with *Restrict privileges*, make sure to review the Indices privileges to provide at least `auto_configure` and `write` permissions for the indices you will be using with this delivery stream.
+.. Expand the left-hand menu, under *Management* select *Stack management > API Keys* and click *Create API key*. If you are using an API key with *Control security privileges*, make sure to review the Indices privileges to provide at least `auto_configure` and `write` permissions for the indices you will be using with this delivery stream.
 
 . Set up the delivery stream by specifying the following data:
 +

--- a/docs/en/observability/cloud-monitoring/aws/monitor-aws-waf-firehose.asciidoc
+++ b/docs/en/observability/cloud-monitoring/aws/monitor-aws-waf-firehose.asciidoc
@@ -62,7 +62,7 @@ NOTE: For advanced use cases, source records can be transformed by invoking a cu
 * *To create the API key*: 
 .. Go to the https://cloud.elastic.co/[Elastic Cloud] console
 .. Select *Open Kibana*.
-.. Expand the left-hand menu, under *Management* select *Stack management > API Keys* and click *Create API key*. If you are using an API key with *Restrict privileges*, make sure to review the Indices privileges to provide at least `auto_configure` and `write` permissions for the indices you will be using with this delivery stream.
+.. Expand the left-hand menu, under *Management* select *Stack management > API Keys* and click *Create API key*. If you are using an API key with *Control security privileges*, make sure to review the Indices privileges to provide at least `auto_configure` and `write` permissions for the indices you will be using with this delivery stream.
 +
 * *Content encoding*: For a better network efficiency, leave content encoding set to GZIP.
 +


### PR DESCRIPTION
## Description
<!-- Add a description here -->

Recent ECH versions renamed the API key dialog toggle from **Restrict privileges** to **Control security privileges**. This PR aligns all remaining references in the affected docs and updates toggle action wording to match the current UI behavior.

### Documentation sets edited in this PR

_Check all that apply._

- [x] Stateful (`docs/en/observability/*`)
- [ ] Serverless (`docs/en/serverless/*`)
- [ ] Integrations Developer Guide (`docs/en/integrations/*`)
- [ ] None of the above

### Related issue
Closes https://github.com/elastic/docs-content/issues/6182

## Checklist

<!--
Add labels to:
1. Backport to other versions (`backport-*`):
    - `backport-8.x` to backport to the latest minor
    - `backport-skip` to not backport (for example, for serverless docs)
    - `backport-main` to "backport" to `main` if the target branch is _not_ `main`
    - Individual `backport-*` labels to target specific minor versions
2. Surface blocking reviews (`needs-*-review`):
    - `needs-writer-review` for codeowners
    - `needs-dev-review` for dev team
    - `needs-product-review` for PM review
-->

- [ ] Product/Engineering Review
- [x] Writer Review

### Follow-up tasks
<!-- If you are updating the Integrations Developer Guide, you can delete this section -->

_Select one._

* This PR does _not_ need to be ported to another doc set because:
  - [ ] The concepts in this PR only apply to one doc set (serverless _or_ stateful)
  - [ ] The PR contains edits to both doc sets (serverless _and_ stateful)
* This PR needs to be ported to another doc set:
  - [ ] Port to stateful docs: \<link to PR or tracking issue>
  - [x] Port to serverless docs: https://github.com/elastic/docs-content/pull/6593
